### PR TITLE
refactor: remove duplication in test

### DIFF
--- a/packages/agent/test/routes/ip-whitelist.test.ts
+++ b/packages/agent/test/routes/ip-whitelist.test.ts
@@ -14,7 +14,6 @@ describe('IpWhitelist', () => {
     });
     const dataSource = factories.dataSource.build();
     const options = factories.forestAdminHttpDriverOptions.build();
-
     ipWhitelistService = new IpWhitelist(services, dataSource, options);
   });
 


### PR DESCRIPTION
Rules I agree with:
- no shared state (all tests are independent, and can be run in isolation)

Rules I don't agree with:
- no shared code
- all setup must be in the test

New Rules:
- describes() calls describe **application state**, not method names
- no duplication
- no manual function definition (I have no issue using beforeEach and afterEach)
- describe and test strings should make sense when concat together ("if the feature is enabled > and the route bootstraped > checkIp should call next() if x-forwarded-for is valid")

Why?
- Less code to read
- Less code to fix when we change anything in the class we are testing
- IMHO, when adding new tests, it's quicker (don't need to care about initialization/mocks)
- IMHO, easier to see the cases you have not tested by checking jest outputs

Things I did not correct on the initial PR:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#examples
  - the header can contains multiple IPs (only the last one can be trusted)
  - IIRC koa comes with a parser (check the doc for `ctx.request.ips`)
- factories have been introduced in tests to avoid the `as unknown as Context` pattern => why not use them?


before:
testing one method after another
![image](https://user-images.githubusercontent.com/1374063/148980799-06b886b7-2304-46fa-abcc-4fc791c89f63.png)

after:  
jest output actually shows the code paths which have been tested
![image](https://user-images.githubusercontent.com/1374063/148980707-55226a71-7ecc-41b6-af5c-6cb0efca286f.png)
