### PR TITLE
build: use tsserver from node_modules instead of vscode's embedded version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,7 @@
   // Performance
   "files.watcherExclude": {
     "**/node_modules/**": true
-  }
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
Reasoning:

With the current setup, if we don't upgrade vscode at the same time, we may have different build errors in the `problems` tab in vscode.

This ensures that we all use the same version of the compiler (it does not change anything for `yarn build`, this is just about vscode)