### PR TITLE
fix: action "select all + apply" are applies only on the related data

### DIFF
--- a/packages/_example/src/customizations/dvd.ts
+++ b/packages/_example/src/customizations/dvd.ts
@@ -5,7 +5,6 @@ import {
   FieldTypes,
   Filter,
   Operator,
-  PaginatedFilter,
   Projection,
 } from '@forestadmin/datasource-toolkit';
 import { Collection } from '@forestadmin/agent';

--- a/packages/agent/src/agent/routes/modification/action.ts
+++ b/packages/agent/src/agent/routes/modification/action.ts
@@ -20,7 +20,7 @@ import QueryStringParser from '../../utils/query-string';
 import SchemaGeneratorActions from '../../utils/forest-schema/generator-actions';
 
 export default class ActionRoute extends CollectionRoute {
-  private actionName: string;
+  private readonly actionName: string;
 
   constructor(
     services: ForestAdminHttpDriverServices,


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [ ] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made


# How to test the bug:

1. Go to rentals > select one > dvds
2. Select all dvs
3. Click on "Increase the rental price"
4. Go to dvd views, the rentals prices must be increased only on the previous selected dvd.

Without the fix: all dvd are increased