### PR TITLE
fix: do not crash when operators are not provided by the datasource

### DIFF
--- a/packages/agent/src/builder/collection.ts
+++ b/packages/agent/src/builder/collection.ts
@@ -203,7 +203,7 @@ export default class CollectionBuilder {
     const field = collection.schema.fields[name] as ColumnSchema;
 
     for (const operator of FrontendFilterableUtils.getRequiredOperators(field.columnType)) {
-      if (!field.filterOperators.has(operator)) {
+      if (!field.filterOperators?.has(operator)) {
         this.emulateFieldOperator(name, operator);
       }
     }

--- a/packages/agent/test/agent/routes/access/chart.test.ts
+++ b/packages/agent/test/agent/routes/access/chart.test.ts
@@ -26,7 +26,10 @@ describe('ChartRoute', () => {
       schema: factories.collectionSchema.build({
         fields: {
           id: factories.columnSchema.isPrimaryKey().build(),
-          name: factories.columnSchema.build({ columnType: 'String' }),
+          name: factories.columnSchema.build({
+            columnType: 'String',
+            filterOperators: new Set(['Present']),
+          }),
           publisher: factories.manyToOneSchema.build({
             foreignCollection: 'publisher',
             foreignKey: 'publisherId',
@@ -37,7 +40,10 @@ describe('ChartRoute', () => {
             foreignCollection: 'persons',
             foreignKey: 'authorId',
           }),
-          publishedAt: factories.columnSchema.build({ columnType: 'Date' }),
+          publishedAt: factories.columnSchema.build({
+            columnType: 'Date',
+            filterOperators: new Set(['Today', 'Yesterday']),
+          }),
         },
       }),
     }),

--- a/packages/agent/test/agent/utils/forest-schema/generator-fields_column.test.ts
+++ b/packages/agent/test/agent/utils/forest-schema/generator-fields_column.test.ts
@@ -30,15 +30,24 @@ describe('SchemaGeneratorFields > Column', () => {
         fields: {
           isbn: factories.columnSchema.build({
             columnType: 'String',
+            filterOperators: new Set([
+              'Equal',
+              'NotEqual',
+              'Present',
+              'Blank',
+              'In',
+              'StartsWith',
+              'EndsWith',
+              'Contains',
+              'NotContains',
+            ]),
             isPrimaryKey: true,
             isSortable: true,
             isReadOnly: true,
-
             validation: [{ operator: 'Present' }],
           }),
           originKey: factories.columnSchema.build({
             columnType: 'Number',
-            filterOperators: new Set(),
             isPrimaryKey: false,
             isReadOnly: false,
             isSortable: false,

--- a/packages/agent/test/builder/collection.test.ts
+++ b/packages/agent/test/builder/collection.test.ts
@@ -23,8 +23,13 @@ describe('Builder > Collection', () => {
         name: collectionName,
         schema: factories.collectionSchema.build({
           fields: {
-            firstName: factories.columnSchema.build({ isSortable: true }),
-            lastName: factories.columnSchema.build({ filterOperators: new Set() }),
+            firstName: factories.columnSchema.build({
+              isSortable: true,
+              filterOperators: new Set(['In']),
+            }),
+            lastName: factories.columnSchema.build({
+              filterOperators: new Set(),
+            }),
           },
         }),
       }),

--- a/packages/datasource-toolkit/src/decorators/relation/collection.ts
+++ b/packages/datasource-toolkit/src/decorators/relation/collection.ts
@@ -157,7 +157,7 @@ export default class RelationCollectionDecorator extends CollectionDecorator {
       throw new Error(`Column not found: '${owner.name}.${name}'`);
     }
 
-    if (!column.filterOperators.has('In')) {
+    if (!column.filterOperators?.has('In')) {
       throw new Error(`Column does not support the In operator: '${owner.name}.${name}'`);
     }
   }

--- a/packages/datasource-toolkit/src/interfaces/query/condition-tree/equivalence.ts
+++ b/packages/datasource-toolkit/src/interfaces/query/condition-tree/equivalence.ts
@@ -43,7 +43,7 @@ export default class ConditionTreeEquivalent {
     columnType: ColumnType,
     visited: unknown[] = [],
   ): Replacer {
-    if (filterOperators.has(op)) return leaf => leaf;
+    if (filterOperators?.has(op)) return leaf => leaf;
 
     for (const alt of ConditionTreeEquivalent.getAlternatives(op) ?? []) {
       const { replacer, dependsOn } = alt;

--- a/packages/datasource-toolkit/test/__factories__/schema/column-schema.ts
+++ b/packages/datasource-toolkit/test/__factories__/schema/column-schema.ts
@@ -2,7 +2,6 @@ import { Factory } from 'fishery';
 
 import { ColumnSchema } from '../../../src/interfaces/schema';
 import { MAP_ALLOWED_OPERATORS_FOR_COLUMN_TYPE } from '../../../src/validation/rules';
-import { allOperators } from '../../../src/interfaces/query/condition-tree/nodes/operators';
 
 export class ColumnSchemaFactory extends Factory<ColumnSchema> {
   isPrimaryKey(): ColumnSchemaFactory {
@@ -18,5 +17,4 @@ export class ColumnSchemaFactory extends Factory<ColumnSchema> {
 export default ColumnSchemaFactory.define(() => ({
   type: 'Column' as const,
   columnType: 'String' as const,
-  filterOperators: new Set(allOperators),
 }));

--- a/packages/datasource-toolkit/test/decorators/relation/collection.test.ts
+++ b/packages/datasource-toolkit/test/decorators/relation/collection.test.ts
@@ -83,9 +83,13 @@ describe('RelationCollectionDecorator', () => {
             id: factories.columnSchema.build({
               isPrimaryKey: true,
               columnType: 'Number',
+              filterOperators: new Set(['In']),
             }),
             issueDate: factories.columnSchema.build({ columnType: 'Dateonly' }),
-            ownerId: factories.columnSchema.build({ columnType: 'Number' }),
+            ownerId: factories.columnSchema.build({
+              columnType: 'Number',
+              filterOperators: new Set(['In']),
+            }),
             pictureId: factories.columnSchema.build({ columnType: 'Number' }),
             picture: factories.manyToOneSchema.build({
               foreignCollection: 'pictures',
@@ -113,9 +117,16 @@ describe('RelationCollectionDecorator', () => {
             id: factories.columnSchema.build({
               isPrimaryKey: true,
               columnType: 'Number',
+              filterOperators: new Set(['In']),
             }),
-            otherId: factories.columnSchema.build({ columnType: 'Number' }),
-            name: factories.columnSchema.build(),
+            otherId: factories.columnSchema.build({
+              columnType: 'Number',
+              filterOperators: new Set(['In']),
+            }),
+            name: factories.columnSchema.build({
+              columnType: 'String',
+              filterOperators: new Set(['In']),
+            }),
           },
         }),
         list: jest.fn().mockImplementation((filter, projection) => {
@@ -161,7 +172,7 @@ describe('RelationCollectionDecorator', () => {
     describe('missing operators', () => {
       test('should throw when In is not supported by the fk in the target', () => {
         const schema = passports.schema.fields.ownerId as ColumnSchema;
-        schema.filterOperators.clear();
+        schema.filterOperators = new Set();
 
         expect(() =>
           newPersons.addRelation('passport', {

--- a/packages/datasource-toolkit/test/decorators/segment/collection.test.ts
+++ b/packages/datasource-toolkit/test/decorators/segment/collection.test.ts
@@ -39,7 +39,9 @@ describe('SegmentCollectionDecorator', () => {
           const collection = factories.collection.build({
             schema: factories.collectionSchema.build({
               fields: {
-                name: factories.columnSchema.build({}),
+                name: factories.columnSchema.build({
+                  filterOperators: new Set(['Equal', 'In']),
+                }),
               },
             }),
           });

--- a/packages/datasource-toolkit/test/utils/collection.test.ts
+++ b/packages/datasource-toolkit/test/utils/collection.test.ts
@@ -33,6 +33,7 @@ describe('CollectionUtils', () => {
           id: factories.columnSchema.build({
             isPrimaryKey: true,
             columnType: 'Number',
+            filterOperators: new Set(['In', 'Equal']),
           }),
           oneToManyRelationField: factories.oneToManySchema.build({
             foreignCollection: 'reviews',

--- a/packages/datasource-toolkit/test/validation/condition-tree.test.ts
+++ b/packages/datasource-toolkit/test/validation/condition-tree.test.ts
@@ -48,7 +48,9 @@ describe('ConditionTreeValidation', () => {
               name: 'persons',
               schema: factories.collectionSchema.build({
                 fields: {
-                  id: factories.columnSchema.isPrimaryKey().build(),
+                  id: factories.columnSchema.isPrimaryKey().build({
+                    filterOperators: new Set(['Equal']),
+                  }),
                 },
               }),
             }),
@@ -88,6 +90,7 @@ describe('ConditionTreeValidation', () => {
               fields: {
                 target: factories.columnSchema.build({
                   columnType: 'String',
+                  filterOperators: new Set(['Equal']),
                 }),
               },
             }),
@@ -112,6 +115,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               target: factories.columnSchema.build({
                 columnType: 'String',
+                filterOperators: new Set(['Equal']),
               }),
             },
           }),
@@ -142,6 +146,7 @@ describe('ConditionTreeValidation', () => {
               fields: {
                 target: factories.columnSchema.build({
                   columnType: 'String',
+                  filterOperators: new Set(['Equal']),
                 }),
               },
             }),
@@ -167,6 +172,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               target: factories.columnSchema.build({
                 columnType: 'Number',
+                filterOperators: new Set(['Contains']),
               }),
             },
           }),
@@ -193,6 +199,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               target: factories.columnSchema.build({
                 columnType: 'Number',
+                filterOperators: new Set(['GreaterThan']),
               }),
             },
           }),
@@ -218,6 +225,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               target: factories.columnSchema.build({
                 columnType: 'String',
+                filterOperators: new Set(['In']),
               }),
             },
           }),
@@ -241,6 +249,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               uuidField: factories.columnSchema.build({
                 columnType: 'Uuid',
+                filterOperators: new Set(['In']),
               }),
             },
           }),
@@ -285,6 +294,7 @@ describe('ConditionTreeValidation', () => {
               enumField: factories.columnSchema.build({
                 columnType: 'Enum',
                 enumValues: ['anAllowedValue'],
+                filterOperators: new Set(['Equal']),
               }),
             },
           }),
@@ -307,6 +317,7 @@ describe('ConditionTreeValidation', () => {
               enumField: factories.columnSchema.build({
                 columnType: 'Enum',
                 enumValues: ['allowedValue'],
+                filterOperators: new Set(['In']),
               }),
             },
           }),
@@ -329,6 +340,7 @@ describe('ConditionTreeValidation', () => {
               enumField: factories.columnSchema.build({
                 columnType: 'Enum',
                 enumValues: ['allowedValue', 'otherAllowedValue'],
+                filterOperators: new Set(['In']),
               }),
             },
           }),
@@ -350,6 +362,7 @@ describe('ConditionTreeValidation', () => {
             fields: {
               pointField: factories.columnSchema.build({
                 columnType: 'Point',
+                filterOperators: new Set(['Equal']),
               }),
             },
           }),
@@ -370,6 +383,7 @@ describe('ConditionTreeValidation', () => {
               fields: {
                 pointField: factories.columnSchema.build({
                   columnType: 'Point',
+                  filterOperators: new Set(['Equal']),
                 }),
               },
             }),


### PR DESCRIPTION
`ColumnSchema.filterOperators` is marked as optional in `packages/datasource-toolkit/src/interfaces/schema.ts`

When not provided, the field should just be assumed not to support any operator, however currently this cause the agent to crash.

To replicate the issue, comment out the filterOperator definition in any datasource and start the example project