### PR TITLE
feat: parse both cursors and offset pagination in routes

### DIFF
--- a/packages/agent/src/agent/utils/context-filter-factory.ts
+++ b/packages/agent/src/agent/utils/context-filter-factory.ts
@@ -17,7 +17,7 @@ export default class ContextFilterFactory {
   ): PaginatedFilter {
     return new PaginatedFilter({
       sort: QueryStringParser.parseSort(collection, context),
-      page: QueryStringParser.parsePagination(context),
+      page: QueryStringParser.parsePagination(collection, context),
       ...ContextFilterFactory.build(collection, context, scope),
       ...partialFilter,
     });

--- a/packages/agent/src/agent/utils/forest-schema/generator-collection.ts
+++ b/packages/agent/src/agent/utils/forest-schema/generator-collection.ts
@@ -29,7 +29,7 @@ export default class SchemaGeneratorCollection {
       isVirtual: false,
       name: collection.name,
       onlyForRelationships: false,
-      paginationType: 'page',
+      paginationType: 'cursor',
       segments: collection.schema.segments
         .sort()
         .map(name => SchemaGeneratorSegments.buildSchema(collection, name)),

--- a/packages/agent/src/agent/utils/forest-schema/types.ts
+++ b/packages/agent/src/agent/utils/forest-schema/types.ts
@@ -13,7 +13,7 @@ export type ForestServerCollection = {
   isSearchable: boolean;
   isVirtual: false;
   onlyForRelationships: boolean;
-  paginationType: 'page';
+  paginationType: 'cursor';
   actions: Array<ForestServerAction>;
   fields: Array<ForestServerField>;
   segments: Array<ForestServerSegment>;

--- a/packages/agent/test/agent/routes/access/list.test.ts
+++ b/packages/agent/test/agent/routes/access/list.test.ts
@@ -56,7 +56,7 @@ describe('ListRoute', () => {
           search: '2',
           searchExtended: false,
           segment: null,
-          page: { limit: 15, skip: 0 },
+          page: { limit: 15, skip: 0, cursor: null },
           sort: [{ ascending: true, field: 'id' }],
         },
         new Projection('id'),

--- a/packages/agent/test/agent/utils/csv-generator.test.ts
+++ b/packages/agent/test/agent/utils/csv-generator.test.ts
@@ -149,7 +149,7 @@ describe('CsvGenerator', () => {
           1,
           caller,
           {
-            page: { skip: 0, limit: CHUNK_SIZE },
+            page: { skip: 0, limit: CHUNK_SIZE, cursor: null },
             sort: [{ field: 'id', ascending: true }],
           },
           ['name', 'id'],
@@ -158,7 +158,7 @@ describe('CsvGenerator', () => {
           2,
           caller,
           {
-            page: { skip: CHUNK_SIZE, limit: CHUNK_SIZE },
+            page: { skip: CHUNK_SIZE, limit: CHUNK_SIZE, cursor: [CHUNK_SIZE - 1] },
             sort: [{ field: 'id', ascending: true }],
           },
           ['name', 'id'],
@@ -167,7 +167,7 @@ describe('CsvGenerator', () => {
           3,
           caller,
           {
-            page: { skip: CHUNK_SIZE * 2, limit: CHUNK_SIZE },
+            page: { skip: CHUNK_SIZE * 2, limit: CHUNK_SIZE, cursor: [CHUNK_SIZE * 2 - 1] },
             sort: [{ field: 'id', ascending: true }],
           },
           ['name', 'id'],

--- a/packages/agent/test/agent/utils/csv-generator.test.ts
+++ b/packages/agent/test/agent/utils/csv-generator.test.ts
@@ -54,7 +54,7 @@ describe('CsvGenerator', () => {
         caller,
         factories.filter.build({
           conditionTree: filter.conditionTree,
-          page: new Page(0, CHUNK_SIZE),
+          page: new Page(0, CHUNK_SIZE, null),
           sort: new Sort({ ascending: true, field: 'id' }),
         }),
         projection,

--- a/packages/agent/test/agent/utils/query-string.test.ts
+++ b/packages/agent/test/agent/utils/query-string.test.ts
@@ -450,13 +450,20 @@ describe('QueryStringParser', () => {
   describe('parsePagination', () => {
     test('should return the pagination parameters', () => {
       const context = createMockContext({
-        customProperties: { query: { 'page[size]': 10, 'page[number]': 3 } },
+        customProperties: {
+          query: {
+            'page[size]': 10,
+            'page[number]': 3,
+            starting_after: '123e4567-e89b-12d3-a456-426614174000',
+          },
+        },
       });
 
-      const pagination = QueryStringParser.parsePagination(context);
+      const pagination = QueryStringParser.parsePagination(collectionSimple, context);
 
       expect(pagination.limit).toEqual(10);
       expect(pagination.skip).toEqual(20);
+      expect(pagination.cursor).toEqual(['123e4567-e89b-12d3-a456-426614174000']);
     });
 
     describe('when context does not provide the pagination parameters', () => {
@@ -465,7 +472,7 @@ describe('QueryStringParser', () => {
           customProperties: { query: {} },
         });
 
-        const pagination = QueryStringParser.parsePagination(context);
+        const pagination = QueryStringParser.parsePagination(collectionSimple, context);
 
         expect(pagination.limit).toEqual(15);
         expect(pagination.skip).toEqual(0);
@@ -478,7 +485,7 @@ describe('QueryStringParser', () => {
           customProperties: { query: { 'page[size]': -5, 'page[number]': 'NaN' } },
         });
 
-        const fn = () => QueryStringParser.parsePagination(context);
+        const fn = () => QueryStringParser.parsePagination(collectionSimple, context);
 
         expect(fn).toThrow('Invalid pagination [limit: -5, skip: NaN]');
       });

--- a/packages/datasource-toolkit/src/context/relaxed-wrappers/collection.ts
+++ b/packages/datasource-toolkit/src/context/relaxed-wrappers/collection.ts
@@ -100,7 +100,9 @@ export default class RelaxedCollection<
         ? ConditionTreeFactory.fromPlainObject(filter.conditionTree)
         : undefined,
       sort: filter.sort ? new Sort(...filter.sort) : undefined,
-      page: filter.page ? new Page(filter.page.skip, filter.page.limit) : undefined,
+      page: filter.page
+        ? new Page(filter.page.skip, filter.page.limit, filter.page.cursor)
+        : undefined,
     });
   }
 

--- a/packages/datasource-toolkit/src/interfaces/query/filter/paginated.ts
+++ b/packages/datasource-toolkit/src/interfaces/query/filter/paginated.ts
@@ -20,6 +20,10 @@ export default class PaginatedFilter extends Filter {
   sort?: Sort;
   page?: Page;
 
+  override get isNestable(): boolean {
+    return super.isNestable && !this.page?.cursor;
+  }
+
   constructor(parts: PaginatedFilterComponents) {
     super(parts);
     this.sort = parts.sort;

--- a/packages/datasource-toolkit/src/interfaces/query/page.ts
+++ b/packages/datasource-toolkit/src/interfaces/query/page.ts
@@ -1,14 +1,20 @@
-import { RecordData } from '../record';
+import { CompositeId, RecordData } from '../record';
 
-export type PlainPage = { skip: number; limit: number };
+export type PlainPage = {
+  skip: number;
+  limit: number;
+  cursor: CompositeId;
+};
 
 export default class Page {
   skip: number;
   limit: number;
+  cursor: CompositeId;
 
-  constructor(skip?: number, limit?: number) {
+  constructor(skip?: number, limit?: number, cursor?: CompositeId) {
     this.skip = skip ?? 0;
     this.limit = limit ?? null;
+    this.cursor = cursor ?? null;
   }
 
   apply(records: RecordData[]): RecordData[] {

--- a/packages/datasource-toolkit/test/context/wrapper.test.ts
+++ b/packages/datasource-toolkit/test/context/wrapper.test.ts
@@ -60,7 +60,7 @@ describe('RelaxedWrappers', () => {
       await relaxed.list(
         {
           conditionTree: { field: 'id', operator: 'Equal', value: 123 },
-          page: { skip: 0, limit: 10 },
+          page: { skip: 0, limit: 10, cursor: ['someValue'] },
           sort: [{ field: 'id', ascending: true }],
         },
         ['id', 'truc'],
@@ -76,7 +76,7 @@ describe('RelaxedWrappers', () => {
         caller,
         new PaginatedFilter({
           conditionTree: new ConditionTreeLeaf('id', 'Equal', 123),
-          page: new Page(0, 10),
+          page: new Page(0, 10, ['someValue']),
           sort: new Sort({ field: 'id', ascending: true }),
         }),
         new Projection('id', 'truc'),

--- a/packages/datasource-toolkit/test/interfaces/filter-instances.test.ts
+++ b/packages/datasource-toolkit/test/interfaces/filter-instances.test.ts
@@ -23,7 +23,7 @@ describe('Filter', () => {
 
       expect(newFilter).toEqual({
         conditionTree: { field: 'column', operator: 'LessThan', value: 0 },
-        page: { limit: 10, skip: 0 },
+        page: { limit: 10, skip: 0, cursor: null },
         sort: [{ ascending: true, field: 'column2' }],
       });
     });
@@ -34,13 +34,20 @@ describe('Filter', () => {
       expect(paginatedFilter.isNestable).toBeTruthy();
       expect(nestedFilter).toEqual({
         conditionTree: { field: 'prefix:column', operator: 'GreaterThan', value: 0 },
-        page: { limit: null, skip: 0 },
+        page: { limit: null, skip: 0, cursor: null },
         sort: [{ ascending: true, field: 'prefix:column' }],
       });
     });
 
     test('nest should crash with a segment', () => {
       const filter = new PaginatedFilter({ segment: 'someSegment' });
+
+      expect(filter.isNestable).toBeFalsy();
+      expect(() => filter.nest('prefix')).toThrow();
+    });
+
+    test('nest should crash with a cursor', () => {
+      const filter = new PaginatedFilter({ page: new Page(0, 10, ['id']) });
 
       expect(filter.isNestable).toBeFalsy();
       expect(() => filter.nest('prefix')).toThrow();


### PR DESCRIPTION
Needs 
- https://github.com/ForestAdmin/agent-nodejs/pull/328

This PR allow to retrieve cursors from the frontend and pass them to the datasources