### PR TITLE
feat: ignore frontend pagination and sort for csv exports

### DIFF
--- a/packages/agent/src/agent/routes/access/csv-related.ts
+++ b/packages/agent/src/agent/routes/access/csv-related.ts
@@ -33,7 +33,7 @@ export default class CsvRelatedRoute extends RelationRoute {
     const projection = QueryStringParser.parseProjection(this.foreignCollection, context);
     const scope = await this.services.permissions.getScope(this.foreignCollection, context);
     const caller = QueryStringParser.parseCaller(context);
-    const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);
+    const filter = ContextFilterFactory.build(this.foreignCollection, context, scope);
     const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
 
     const gen = CsvGenerator.generate(

--- a/packages/agent/src/agent/routes/access/csv.ts
+++ b/packages/agent/src/agent/routes/access/csv.ts
@@ -23,7 +23,7 @@ export default class CsvRoute extends CollectionRoute {
     const projection = QueryStringParser.parseProjection(this.collection, context);
     const scope = await this.services.permissions.getScope(this.collection, context);
     const caller = QueryStringParser.parseCaller(context);
-    const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);
+    const filter = ContextFilterFactory.build(this.collection, context, scope);
 
     const list = this.collection.list.bind(this.collection);
     const gen = CsvGenerator.generate(caller, projection, header, filter, this.collection, list);

--- a/packages/agent/test/agent/routes/access/csv-related.test.ts
+++ b/packages/agent/test/agent/routes/access/csv-related.test.ts
@@ -106,16 +106,14 @@ describe('CsvRelatedRoute', () => {
       const listRelation = jest.spyOn(CollectionUtils, 'listRelation').mockResolvedValue([]);
       const csvGenerator = jest.spyOn(CsvGenerator, 'generate');
 
-      const paginatedFilter = factories.filter.build();
-      const buildPaginated = jest
-        .spyOn(ContextFilterFactory, 'buildPaginated')
-        .mockReturnValue(paginatedFilter);
+      const filter = factories.filter.build();
+      const build = jest.spyOn(ContextFilterFactory, 'build').mockReturnValue(filter);
 
       // when
       await csvRoute.handleRelatedCsv(context);
 
       // then
-      expect(buildPaginated).toHaveBeenCalledWith(personsCollection, context, scopeCondition);
+      expect(build).toHaveBeenCalledWith(personsCollection, context, scopeCondition);
 
       expect(services.permissions.can).toHaveBeenCalledWith(context, 'browse:books');
       expect(services.permissions.can).toHaveBeenCalledWith(context, 'export:books');
@@ -125,7 +123,7 @@ describe('CsvRelatedRoute', () => {
         { email: 'john.doe@domain.com', timezone: 'Europe/Paris' },
         new Projection('id', 'name'),
         'id,name',
-        paginatedFilter,
+        filter,
         personsCollection,
         expect.any(Function),
       );

--- a/packages/agent/test/agent/routes/access/csv.test.ts
+++ b/packages/agent/test/agent/routes/access/csv.test.ts
@@ -76,10 +76,8 @@ describe('CsvRoute', () => {
       booksCollection.list = jest.fn().mockReturnValue([]);
       const csvGenerator = jest.spyOn(CsvGenerator, 'generate');
 
-      const paginatedFilter = factories.filter.build();
-      const buildPaginated = jest
-        .spyOn(ContextFilterFactory, 'buildPaginated')
-        .mockReturnValue(paginatedFilter);
+      const filter = factories.filter.build();
+      const build = jest.spyOn(ContextFilterFactory, 'build').mockReturnValue(filter);
       // when
       await csvRoute.handleCsv(context);
 
@@ -87,14 +85,14 @@ describe('CsvRoute', () => {
       expect(services.permissions.can).toHaveBeenCalledWith(context, 'browse:books');
       expect(services.permissions.can).toHaveBeenCalledWith(context, 'export:books');
 
-      expect(buildPaginated).toHaveBeenCalledWith(booksCollection, context, scopeCondition);
+      expect(build).toHaveBeenCalledWith(booksCollection, context, scopeCondition);
 
       await readCsv(context.response.body as AsyncGenerator<string>);
       expect(csvGenerator).toHaveBeenCalledWith(
         { email: 'john.doe@domain.com', timezone: 'Europe/Paris' },
         ['id', 'name'],
         'id,name',
-        paginatedFilter,
+        filter,
         booksCollection,
         expect.any(Function),
       );

--- a/packages/agent/test/agent/utils/csv-generator.test.ts
+++ b/packages/agent/test/agent/utils/csv-generator.test.ts
@@ -54,7 +54,7 @@ describe('CsvGenerator', () => {
         caller,
         factories.filter.build({
           conditionTree: filter.conditionTree,
-          page: new Page(0, CHUNK_SIZE, null),
+          page: new Page(0, CHUNK_SIZE),
           sort: new Sort({ ascending: true, field: 'id' }),
         }),
         projection,


### PR DESCRIPTION
Current CSV implementation only exports the current page and the following ones, which is an unexpected behavior from user point of view => Switch to exporting the whole collection (we're still keeping filters, segments, etc...).

We're dropping the custom sorting as well, as it allows the export to work with forest admin's cursor implementation
