### PR TITLE
chore(ci): increase test computation timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     name: Testing
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [build]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
(CI is failling on beta due to a timeout limit that have been reached multiple time in the past merge)
I'm still testing though, as this issue seems to only happen on the beta branch
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [ ] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made
