### PR TITLE
fix(mongoose): implement route to submit related data edition

### DIFF
--- a/packages/agent/src/agent/routes/index.ts
+++ b/packages/agent/src/agent/routes/index.ts
@@ -24,6 +24,7 @@ import ListRelated from './access/list-related';
 import Logger from './system/logger';
 import ScopeInvalidation from './security/scope-invalidation';
 import Update from './modification/update';
+import UpdateField from './modification/update-field';
 import UpdateRelation from './modification/update-relation';
 
 export const ROOT_ROUTES_CTOR = [
@@ -34,7 +35,17 @@ export const ROOT_ROUTES_CTOR = [
   Logger,
   ScopeInvalidation,
 ];
-export const COLLECTION_ROUTES_CTOR = [Chart, Count, Create, Csv, Delete, Get, List, Update];
+export const COLLECTION_ROUTES_CTOR = [
+  Chart,
+  Count,
+  Create,
+  Csv,
+  Delete,
+  Get,
+  List,
+  Update,
+  UpdateField,
+];
 export const RELATED_ROUTES_CTOR = [
   AssociateRelated,
   CountRelated,

--- a/packages/agent/src/agent/routes/modification/update-field.ts
+++ b/packages/agent/src/agent/routes/modification/update-field.ts
@@ -8,6 +8,7 @@ import {
 import { Context } from 'koa';
 import Router from '@koa/router';
 
+import { HttpCode } from '../../types';
 import CollectionRoute from '../collection-route';
 import IdUtils from '../../utils/id';
 import QueryStringParser from '../../utils/query-string';
@@ -15,7 +16,7 @@ import QueryStringParser from '../../utils/query-string';
 export default class UpdateField extends CollectionRoute {
   setupRoutes(router: Router): void {
     router.put(
-      `/${this.collection.name}/:id/relationships/:field/:index`,
+      `/${this.collection.name}/:id/relationships/:field/:index(\\d+)`,
       this.handleUpdate.bind(this),
     );
   }
@@ -52,6 +53,6 @@ export default class UpdateField extends CollectionRoute {
     // Update record
     await this.collection.update(caller, filter, { [field]: record[field] });
 
-    context.response.status = 204;
+    context.response.status = HttpCode.NoContent;
   }
 }

--- a/packages/agent/src/agent/routes/modification/update-field.ts
+++ b/packages/agent/src/agent/routes/modification/update-field.ts
@@ -1,0 +1,57 @@
+import {
+  ConditionTreeFactory,
+  FieldValidator,
+  Filter,
+  Projection,
+  ValidationError,
+} from '@forestadmin/datasource-toolkit';
+import { Context } from 'koa';
+import Router from '@koa/router';
+
+import CollectionRoute from '../collection-route';
+import IdUtils from '../../utils/id';
+import QueryStringParser from '../../utils/query-string';
+
+export default class UpdateField extends CollectionRoute {
+  setupRoutes(router: Router): void {
+    router.put(
+      `/${this.collection.name}/:id/relationships/:field/:index`,
+      this.handleUpdate.bind(this),
+    );
+  }
+
+  public async handleUpdate(context: Context): Promise<void> {
+    await this.services.permissions.can(context, `edit:${this.collection.name}`);
+
+    const { field, index, id } = context.params;
+    const subRecord = context.request.body?.data?.attributes;
+
+    // Validate parameters
+    // @fixme At the time of writing this route, the Validator does not support composite types
+    FieldValidator.validate(this.collection, field, [{ [field]: [subRecord] }]);
+
+    // Create caller & filter
+    const unpackedId = IdUtils.unpackId(this.collection.schema, id);
+    const conditionTree = ConditionTreeFactory.intersect(
+      ConditionTreeFactory.matchIds(this.collection.schema, [unpackedId]),
+      await this.services.permissions.getScope(this.collection, context),
+    );
+
+    const caller = QueryStringParser.parseCaller(context);
+    const filter = new Filter({ conditionTree });
+
+    // Load & check record
+    const [record] = await this.collection.list(caller, filter, new Projection(field));
+
+    if (index > record[field]?.length) {
+      throw new ValidationError(`Field '${field}' is too short`);
+    }
+
+    record[field][index] = subRecord;
+
+    // Update record
+    await this.collection.update(caller, filter, { [field]: record[field] });
+
+    context.response.status = 204;
+  }
+}

--- a/packages/agent/test/agent/routes/index.test.ts
+++ b/packages/agent/test/agent/routes/index.test.ts
@@ -26,6 +26,7 @@ import ListRelated from '../../../src/agent/routes/access/list-related';
 import Logger from '../../../src/agent/routes/system/logger';
 import ScopeInvalidation from '../../../src/agent/routes/security/scope-invalidation';
 import Update from '../../../src/agent/routes/modification/update';
+import UpdateField from '../../../src/agent/routes/modification/update-field';
 import UpdateRelation from '../../../src/agent/routes/modification/update-relation';
 
 describe('Route index', () => {
@@ -38,7 +39,17 @@ describe('Route index', () => {
       Logger,
       ScopeInvalidation,
     ]);
-    expect(COLLECTION_ROUTES_CTOR).toEqual([Chart, Count, Create, Csv, Delete, Get, List, Update]);
+    expect(COLLECTION_ROUTES_CTOR).toEqual([
+      Chart,
+      Count,
+      Create,
+      Csv,
+      Delete,
+      Get,
+      List,
+      Update,
+      UpdateField,
+    ]);
     expect(RELATED_ROUTES_CTOR).toEqual([
       AssociateRelated,
       CountRelated,

--- a/packages/agent/test/agent/routes/modification/update-field.test.ts
+++ b/packages/agent/test/agent/routes/modification/update-field.test.ts
@@ -17,7 +17,7 @@ describe('UpdateField', () => {
     updateRoute.setupRoutes(router);
 
     expect(router.put).toHaveBeenCalledWith(
-      '/books/:id/relationships/:field/:index',
+      '/books/:id/relationships/:field/:index(\\d+)',
       expect.any(Function),
     );
   });

--- a/packages/agent/test/agent/routes/modification/update-field.test.ts
+++ b/packages/agent/test/agent/routes/modification/update-field.test.ts
@@ -1,0 +1,123 @@
+import { DataSource, Projection, ValidationError } from '@forestadmin/datasource-toolkit';
+import { createMockContext } from '@shopify/jest-koa-mocks';
+
+import * as factories from '../../__factories__';
+import UpdateField from '../../../../src/agent/routes/modification/update-field';
+
+describe('UpdateField', () => {
+  const options = factories.forestAdminHttpDriverOptions.build();
+  const services = factories.forestAdminHttpDriverServices.build();
+  const router = factories.router.mockAllMethods().build();
+
+  test('should register PUT /books/:id/relationships/:field/:index route', () => {
+    const bookCollection = factories.collection.build({ name: 'books' });
+    const dataSource = factories.dataSource.buildWithCollections([bookCollection]);
+    const updateRoute = new UpdateField(services, options, dataSource, 'books');
+
+    updateRoute.setupRoutes(router);
+
+    expect(router.put).toHaveBeenCalledWith(
+      '/books/:id/relationships/:field/:index',
+      expect.any(Function),
+    );
+  });
+
+  describe('handleUpdate', () => {
+    let dataSource: DataSource;
+
+    beforeEach(() => {
+      dataSource = factories.dataSource.buildWithCollection(
+        factories.collection.build({
+          name: 'books',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.isPrimaryKey().build({
+                columnType: 'Number',
+              }),
+              itemList: factories.columnSchema.build({
+                columnType: [{ key: 'String', value: 'String' }],
+              }),
+            },
+          }),
+          list: jest.fn().mockResolvedValue([
+            {
+              id: '1523',
+              itemList: [
+                { key: 'key1', value: 'value1' },
+                { key: 'key2', value: 'value2' },
+              ],
+            },
+          ]),
+          update: jest.fn(),
+        }),
+      );
+    });
+
+    it('should throw if the field does not exists', async () => {
+      const updateRoute = new UpdateField(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: { attributes: { key: 'newKey', value: 'newValue' } } },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { id: '1523', field: 'otherField', index: '1' },
+        },
+      });
+
+      await expect(() => updateRoute.handleUpdate(context)).rejects.toThrow(ValidationError);
+    });
+
+    it('should throw if the array is too short', async () => {
+      const updateRoute = new UpdateField(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: { attributes: { key: 'newKey', value: 'newValue' } } },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { id: '1523', field: 'itemList', index: '456' },
+        },
+      });
+
+      await expect(() => updateRoute.handleUpdate(context)).rejects.toThrow(ValidationError);
+    });
+
+    it('should call the update action successfully when providing a valid request', async () => {
+      const updateRoute = new UpdateField(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: { attributes: { key: 'newKey', value: 'newValue' } } },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { id: '1523', field: 'itemList', index: '1' },
+        },
+      });
+
+      await updateRoute.handleUpdate(context);
+
+      const expectedFilter = factories.filter.build({
+        conditionTree: factories.conditionTreeLeaf.build({
+          operator: 'Equal',
+          value: 1523,
+          field: 'id',
+        }),
+      });
+
+      expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+        { email: 'john.doe@domain.com', timezone: 'Europe/Paris' },
+        expectedFilter,
+        new Projection('itemList'),
+      );
+      expect(dataSource.getCollection('books').update).toHaveBeenCalledWith(
+        { email: 'john.doe@domain.com', timezone: 'Europe/Paris' },
+        expectedFilter,
+        {
+          itemList: [
+            { key: 'key1', value: 'value1' },
+            { key: 'newKey', value: 'newValue' },
+          ],
+        },
+      );
+      expect(context.response.status).toEqual(204);
+    });
+  });
+});


### PR DESCRIPTION
# How to test

The example project does not have any writable embedded relation...
To have one:

- Edit _example/src/forest/agent.ts
- Replace `bills.items` by `bills` on line 45
- You should have an embedded relation on the "account bills" models 