### PR TITLE
fix(prefix): fix prefix validation regexp

### DIFF
--- a/packages/agent/src/builder/utils/options-validator.ts
+++ b/packages/agent/src/builder/utils/options-validator.ts
@@ -107,7 +107,7 @@ export default class OptionsValidator {
   }
 
   private static checkOtherOptions(options: AgentOptions): void {
-    if (typeof options.prefix !== 'string' || !/^[-/a-z]*$/i.test(options.prefix)) {
+    if (typeof options.prefix !== 'string' || !/^[-~/\w]*$/i.test(options.prefix)) {
       throw new Error(
         'options.prefix is invalid. It should contain the prefix on which ' +
           'forest admin routes should be mounted (i.e. "/api/v1")',

--- a/packages/agent/test/builder/utils/http-driver-options.test.ts
+++ b/packages/agent/test/builder/utils/http-driver-options.test.ts
@@ -141,5 +141,32 @@ describe('OptionsValidator', () => {
         );
       });
     });
+
+    test('should fail when prefix contains not allowed characters', () => {
+      expect(() =>
+        OptionsValidator.validate({
+          ...allOptions,
+          prefix: 'this-should#fail&as-a-prefix!',
+        }),
+      ).toThrow(
+        'options.prefix is invalid. It should contain the prefix on which ' +
+          'forest admin routes should be mounted (i.e. "/api/v1")',
+      );
+    });
+
+    test('should work when prefix is valid', () => {
+      const testPrefix = prefix =>
+        expect(() =>
+          OptionsValidator.validate({
+            ...allOptions,
+            prefix,
+          }),
+        ).not.toThrow();
+
+      testPrefix('api/~v1');
+      testPrefix('api/version-1');
+      testPrefix('foo/bar/baz');
+      testPrefix('foo_bar');
+    });
   });
 });


### PR DESCRIPTION
Close #399

Final decision is the one describe [here](https://developers.google.com/maps/url-encoding) without:
- reserved character 
- `.` that shouldn't be supported in prefix.

`\w` handle `[a-zA-Z0-0_]`, so this should be ok

<img width="725" alt="image" src="https://user-images.githubusercontent.com/22832687/187475136-0fa6c0b0-55f4-41a9-b499-07d80d0aaf95.png">


## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [ ] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made
