### PR TITLE
feat: expose typing generator

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,10 +2,13 @@ import { TSchema } from '@forestadmin/datasource-toolkit';
 
 import { AgentOptions } from './types';
 import Agent from './builder/agent';
+import TypingGenerator from './builder/utils/typing-generator';
 
 export { default as Collection } from './builder/collection';
 export { Agent };
 export * from './types';
+
+export { TypingGenerator }
 
 export function createAgent<S extends TSchema = TSchema>(options: AgentOptions): Agent<S> {
   return new Agent<S>(options);


### PR DESCRIPTION
When I use the typing generator, it causes my NestJS app to enter in a restart loop because it always rewrites the type file (even if there are no changes), the NestJS file watcher catches this file change and restart the app.
It would be better if the typing generator would write the file only if there are changes but it would create a caching behaviour that has other drawbacks.

Instead, I would prefere to be able to use the TypingGenerator by myself (in a script triggered manually or at startup)

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made
