### PR TITLE
revert: remove unused canOneOf internal authorisation function

### DIFF
--- a/packages/agent/src/services/authorization/internal/action-permission.ts
+++ b/packages/agent/src/services/authorization/internal/action-permission.ts
@@ -85,10 +85,10 @@ export default class ActionPermissionService {
     actionName: string;
     userId: string;
   }): boolean {
-    return (
+    return Boolean(
       permissions.everythingAllowed ||
-      permissions.actionsGloballyAllowed.has(actionName) ||
-      permissions.actionsAllowedByUser.get(actionName)?.has(userId)
+        permissions.actionsGloballyAllowed.has(actionName) ||
+        permissions.actionsAllowedByUser.get(actionName)?.has(userId),
     );
   }
 

--- a/packages/agent/src/services/authorization/internal/action-permission.ts
+++ b/packages/agent/src/services/authorization/internal/action-permission.ts
@@ -15,25 +15,33 @@ export default class ActionPermissionService {
 
   constructor(private readonly options: ActionPermissionOptions) {}
 
+  public canOneOf(userId: string, actionNames: string[]): Promise<boolean> {
+    return this.hasPermissionOrRefetch({
+      userId,
+      actionNames,
+      allowRefetch: true,
+    });
+  }
+
   public can(userId: string, actionName: string): Promise<boolean> {
     return this.hasPermissionOrRefetch({
       userId,
-      actionName,
+      actionNames: [actionName],
       allowRefetch: true,
     });
   }
 
   private async hasPermissionOrRefetch({
     userId,
-    actionName,
+    actionNames,
     allowRefetch,
   }: {
     userId: string;
-    actionName: string;
+    actionNames: string[];
     allowRefetch: boolean;
   }): Promise<boolean> {
     const permissions = await this.getPermissions();
-    const isAllowed = this.isAllowed({ permissions, actionName, userId });
+    const isAllowed = this.isAllowedOneOf({ permissions, actionNames, userId });
 
     if (!isAllowed && allowRefetch) {
       this.permissionsPromise = undefined;
@@ -41,17 +49,31 @@ export default class ActionPermissionService {
 
       return this.hasPermissionOrRefetch({
         userId,
-        actionName,
+        actionNames,
         allowRefetch: false,
       });
     }
 
     this.options.logger(
       'Debug',
-      `User ${userId} is ${isAllowed ? '' : 'not '}allowed to perform ${actionName}`,
+      `User ${userId} is ${isAllowed ? '' : 'not '}allowed to perform ${
+        actionNames.length > 1 ? ' one of ' : ''
+      }${actionNames.join(', ')}`,
     );
 
     return isAllowed;
+  }
+
+  private isAllowedOneOf({
+    permissions,
+    actionNames,
+    userId,
+  }: {
+    permissions: ActionPermissions;
+    actionNames: string[];
+    userId: string;
+  }): boolean {
+    return actionNames.some(actionName => this.isAllowed({ permissions, actionName, userId }));
   }
 
   private isAllowed({
@@ -63,7 +85,7 @@ export default class ActionPermissionService {
     actionName: string;
     userId: string;
   }): boolean {
-    return !!(
+    return (
       permissions.everythingAllowed ||
       permissions.actionsGloballyAllowed.has(actionName) ||
       permissions.actionsAllowedByUser.get(actionName)?.has(userId)

--- a/packages/agent/test/__factories__/authorization/internal/action-permission.ts
+++ b/packages/agent/test/__factories__/authorization/internal/action-permission.ts
@@ -5,6 +5,7 @@ export class ActionPermissionsFactory extends Factory<ActionPermissionService> {
   mockAllMethods() {
     return this.afterBuild(permissions => {
       permissions.can = jest.fn();
+      permissions.canOneOf = jest.fn();
     });
   }
 }

--- a/packages/agent/test/services/authorization/authorization.test.ts
+++ b/packages/agent/test/services/authorization/authorization.test.ts
@@ -293,7 +293,7 @@ describe('AuthorizationService', () => {
       } as unknown as Context;
 
       (generateCustomActionIdentifier as jest.Mock).mockReturnValue('custom:books:approve');
-      (actionPermissionService.can as jest.Mock).mockResolvedValue(false);
+      (actionPermissionService.canOneOf as jest.Mock).mockResolvedValue(false);
 
       await authorizationService.assertCanExecuteCustomAction(context, 'custom-action', 'books');
 

--- a/packages/agent/test/services/authorization/authorization.test.ts
+++ b/packages/agent/test/services/authorization/authorization.test.ts
@@ -293,7 +293,7 @@ describe('AuthorizationService', () => {
       } as unknown as Context;
 
       (generateCustomActionIdentifier as jest.Mock).mockReturnValue('custom:books:approve');
-      (actionPermissionService.canOneOf as jest.Mock).mockResolvedValue(false);
+      (actionPermissionService.can as jest.Mock).mockResolvedValue(false);
 
       await authorizationService.assertCanExecuteCustomAction(context, 'custom-action', 'books');
 

--- a/packages/agent/test/services/authorization/internal/action-permission.test.ts
+++ b/packages/agent/test/services/authorization/internal/action-permission.test.ts
@@ -191,4 +191,105 @@ describe('ActionPermissionService', () => {
       expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('canOneOf', () => {
+    it('should return true if everything is allowed', async () => {
+      const { service, options, permissions, users } = setup({
+        everythingAllowed: true,
+        actionsAllowedByUser: new Map(),
+        actionsGloballyAllowed: new Set(),
+      });
+
+      const can = await service.canOneOf('1', ['action1', 'action2']);
+      expect(can).toBe(true);
+
+      expect(getUsersMock).toHaveBeenCalledTimes(1);
+      expect(getUsersMock).toHaveBeenCalledWith(options);
+
+      expect(getEnvironmentPermissionsMock).toHaveBeenCalledTimes(1);
+      expect(getEnvironmentPermissionsMock).toHaveBeenCalledWith(options);
+
+      expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(1);
+      expect(generateActionsFromPermissionsMock).toHaveBeenCalledWith(permissions, users);
+    });
+
+    it('should return true if one of the actions is globally allowed', async () => {
+      const { service } = setup({
+        everythingAllowed: false,
+        actionsAllowedByUser: new Map(),
+        actionsGloballyAllowed: new Set(['action2']),
+      });
+
+      const can = await service.canOneOf('1', ['action1', 'action2']);
+
+      expect(can).toBe(true);
+
+      expect(getUsersMock).toHaveBeenCalledTimes(1);
+      expect(getEnvironmentPermissionsMock).toHaveBeenCalledTimes(1);
+      expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return true if one of the actions is allowed for the user', async () => {
+      const { service } = setup({
+        everythingAllowed: false,
+        actionsAllowedByUser: new Map([['action2', new Set(['10'])]]),
+        actionsGloballyAllowed: new Set(),
+      });
+
+      const can = await service.canOneOf('10', ['action1', 'action2']);
+
+      expect(can).toBe(true);
+
+      expect(getUsersMock).toHaveBeenCalledTimes(1);
+      expect(getEnvironmentPermissionsMock).toHaveBeenCalledTimes(1);
+      expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(1);
+    });
+
+    describe('when the user is not allowed in the first place', () => {
+      it('should refresh the cache and return the second result', async () => {
+        const { service } = setup(
+          {
+            everythingAllowed: false,
+            actionsAllowedByUser: new Map(),
+            actionsGloballyAllowed: new Set(),
+          },
+          {
+            everythingAllowed: true,
+            actionsAllowedByUser: new Map([]),
+            actionsGloballyAllowed: new Set(),
+          },
+        );
+
+        const can = await service.canOneOf('10', ['action1', 'action2']);
+        expect(can).toBe(true);
+
+        expect(getUsersMock).toHaveBeenCalledTimes(2);
+        expect(getEnvironmentPermissionsMock).toHaveBeenCalledTimes(2);
+        expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(2);
+      });
+
+      it('should return false if the user is still not authorized', async () => {
+        const { service } = setup(
+          {
+            everythingAllowed: false,
+            actionsAllowedByUser: new Map(),
+            actionsGloballyAllowed: new Set(),
+          },
+          {
+            everythingAllowed: false,
+            actionsAllowedByUser: new Map([]),
+            actionsGloballyAllowed: new Set(),
+          },
+        );
+
+        const can = await service.canOneOf('10', ['action1', 'action2']);
+
+        expect(can).toBe(false);
+
+        expect(getUsersMock).toHaveBeenCalledTimes(2);
+        expect(getEnvironmentPermissionsMock).toHaveBeenCalledTimes(2);
+        expect(generateActionsFromPermissionsMock).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
 });


### PR DESCRIPTION
…(#474)"

This reverts commit 0e0f511730363e2761a1385c01d4ffcec14cfc5e.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
