### PR TITLE
perf(customizer): improve CPU usage and response time

### DIFF
--- a/packages/agent/src/services/serializer.ts
+++ b/packages/agent/src/services/serializer.ts
@@ -136,17 +136,19 @@ export default class Serializer {
   }
 
   private stripUndefinedsInPlace(record: unknown): void {
-    if (record === null || typeof record !== 'object') {
-      return;
-    }
+    if (record !== null && typeof record === 'object') {
+      const keys = Object.keys(record);
+      let i = keys.length;
 
-    const indexable = record as Record<string, unknown>;
+      // eslint-disable-next-line no-plusplus
+      while (i--) {
+        const key = keys[i];
 
-    for (const key of Object.keys(indexable)) {
-      if (indexable[key] === undefined) {
-        delete indexable[key];
-      } else {
-        this.stripUndefinedsInPlace(indexable[key]);
+        if (record[key] === undefined) {
+          delete record[key];
+        } else {
+          this.stripUndefinedsInPlace(record[key]);
+        }
       }
     }
   }

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -437,7 +437,7 @@ describe('QueryStringParser', () => {
 
       test('should throw a HTTP 500 when the timezone cannot be validated', () => {
         const context = createMockContext({
-          customProperties: { query: { timezone: 'America/Los_Angeles' } },
+          customProperties: { query: { timezone: 'Europe/Paris' } },
         });
 
         const fn = () => QueryStringParser.parseCaller(context);

--- a/packages/datasource-customizer/src/decorators/collection-decorator.ts
+++ b/packages/datasource-customizer/src/decorators/collection-decorator.ts
@@ -23,9 +23,8 @@ export default class CollectionDecorator implements Collection {
   private lastSubSchema: CollectionSchema;
 
   get schema(): CollectionSchema {
-    const subSchema = this.childCollection.schema;
-
-    if (!this.lastSchema || this.lastSubSchema !== subSchema) {
+    if (!this.lastSchema) {
+      const subSchema = this.childCollection.schema;
       this.lastSchema = this.refineSchema(subSchema);
       this.lastSubSchema = subSchema;
     }
@@ -40,6 +39,15 @@ export default class CollectionDecorator implements Collection {
   constructor(childCollection: Collection, dataSource: DataSource) {
     this.childCollection = childCollection;
     this.dataSource = dataSource;
+
+    if (childCollection instanceof CollectionDecorator) {
+      const { markSchemaAsDirty } = childCollection;
+
+      childCollection.markSchemaAsDirty = () => {
+        this.markSchemaAsDirty();
+        markSchemaAsDirty.call(childCollection);
+      };
+    }
   }
 
   async execute(

--- a/packages/datasource-customizer/src/decorators/computed/collection.ts
+++ b/packages/datasource-customizer/src/decorators/computed/collection.ts
@@ -55,6 +55,8 @@ export default class ComputedCollection extends CollectionDecorator {
   ): Promise<RecordData[]> {
     const childProjection = projection.replace(path => rewriteField(this, path));
     const records = await this.childCollection.list(caller, filter, childProjection);
+    if (childProjection.equals(projection)) return records;
+
     const context = new CollectionCustomizationContext(this, caller);
 
     return computeFromRecords(context, this, childProjection, projection, records);

--- a/packages/datasource-customizer/src/decorators/relation/collection.ts
+++ b/packages/datasource-customizer/src/decorators/relation/collection.ts
@@ -41,6 +41,7 @@ export default class RelationCollectionDecorator extends CollectionDecorator {
     const newFilter = await this.refineFilter(caller, filter);
     const newProjection = projection.replace(this.rewriteField, this).withPks(this);
     const records = await this.childCollection.list(caller, newFilter, newProjection);
+    if (newProjection.equals(projection)) return records;
 
     await this.reprojectInPlace(caller, records, projection);
 

--- a/packages/datasource-customizer/src/decorators/rename-field/collection.ts
+++ b/packages/datasource-customizer/src/decorators/rename-field/collection.ts
@@ -106,6 +106,7 @@ export default class RenameFieldCollectionDecorator extends CollectionDecorator 
   ): Promise<RecordData[]> {
     const childProjection = projection.replace(field => this.pathToChildCollection(field));
     const records = await super.list(caller, filter, childProjection);
+    if (childProjection.equals(projection)) return records;
 
     return records.map(record => this.recordFromChildCollection(record));
   }

--- a/packages/datasource-customizer/test/decorators/collection-decorator.test.ts
+++ b/packages/datasource-customizer/test/decorators/collection-decorator.test.ts
@@ -139,20 +139,32 @@ describe('CollectionDecorator', () => {
     });
 
     it('when the child schema changes everytime, refine schema should be called', async () => {
+      const dataSource = factories.dataSource.buildWithCollection(
+        factories.collection.build({ name: 'books' }),
+      );
+      const collection = dataSource.getCollection('books');
+
       // "Identity decorator"
+      const ParentDecorator = class extends CollectionDecorator {
+        public override markSchemaAsDirty(): void {
+          super.markSchemaAsDirty();
+        }
+      };
+
       const refineSchema = jest.fn().mockImplementation(child => child);
-      const MyDecorator = class extends CollectionDecorator {
+      const ChildDecorator = class extends CollectionDecorator {
         override refineSchema = refineSchema;
       };
 
-      // Create collections
-      const child = factories.collection.build({ schema: factories.collectionSchema.build() });
-      Object.defineProperty(child, 'schema', { get: () => factories.collectionSchema.build() });
+      const parent = new ParentDecorator(collection, dataSource);
+      const child = new ChildDecorator(parent, dataSource);
+      parent.markSchemaAsDirty();
+      child.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
+      parent.markSchemaAsDirty();
+      child.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
+      parent.markSchemaAsDirty();
+      child.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
 
-      const parent = new MyDecorator(child, null);
-      parent.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
-      parent.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
-      parent.schema; // eslint-disable-line @typescript-eslint/no-unused-expressions
       expect(refineSchema).toHaveBeenCalledTimes(3);
     });
   });

--- a/packages/datasource-toolkit/src/interfaces/query/projection/index.ts
+++ b/packages/datasource-toolkit/src/interfaces/query/projection/index.ts
@@ -21,6 +21,10 @@ export default class Projection extends Array<string> {
     }, {});
   }
 
+  equals(other: Projection): boolean {
+    return this.length === other.length && this.every(field => other.includes(field));
+  }
+
   replace(handler: (path: string) => Projection | string | string[], bind?: unknown): Projection {
     return this.map(handler, bind).reduce<Projection>((memo, newPaths) => {
       if (typeof newPaths === 'string') return memo.union([newPaths]);

--- a/packages/datasource-toolkit/test/interfaces/projection.test.ts
+++ b/packages/datasource-toolkit/test/interfaces/projection.test.ts
@@ -2,6 +2,17 @@ import Projection from '../../src/interfaces/query/projection';
 import * as factories from '../__factories__';
 
 describe('Projection', () => {
+  describe('equals()', () => {
+    test('should remove duplicates', () => {
+      const projection1 = new Projection('id', 'name', 'address');
+      const projection2 = new Projection('id', 'name');
+      const projection3 = new Projection('id', 'name');
+
+      expect(projection1.equals(projection2)).toBe(false);
+      expect(projection2.equals(projection3)).toBe(true);
+    });
+  });
+
   describe('replace()', () => {
     test('should remove duplicates', () => {
       const projection = new Projection('id', 'name').replace(() => 'id');

--- a/packages/datasource-toolkit/test/interfaces/projection.test.ts
+++ b/packages/datasource-toolkit/test/interfaces/projection.test.ts
@@ -3,7 +3,7 @@ import * as factories from '../__factories__';
 
 describe('Projection', () => {
   describe('equals()', () => {
-    test('should remove duplicates', () => {
+    test('should work', () => {
       const projection1 = new Projection('id', 'name', 'address');
       const projection2 = new Projection('id', 'name');
       const projection3 = new Projection('id', 'name');


### PR DESCRIPTION
Took one hour to do that with `ab` + `vs code CPU profiler`

The request I'm testing in `ab` is the list of the `account` collection in the `_example` project.

Before:
```
Time taken for tests:   15.564 seconds
Complete requests:      5000
Failed requests:        0
Total transferred:      37740000 bytes
HTML transferred:       36400000 bytes
Requests per second:    321.26 [#/sec] (mean)
Time per request:       31.127 [ms] (mean)
Time per request:       3.113 [ms] (mean, across all concurrent requests)
Transfer rate:          2368.04 [Kbytes/sec] received
```

After:
```
Time taken for tests:   10.487 seconds
Complete requests:      5000
Failed requests:        0
Total transferred:      37515000 bytes
HTML transferred:       36175000 bytes
Requests per second:    476.78 [#/sec] (mean)
Time per request:       20.974 [ms] (mean)
Time per request:       2.097 [ms] (mean, across all concurrent requests)
Transfer rate:          3493.46 [Kbytes/sec] received
```