### PR TITLE
chore(release-config): use a different place for the force-release tag

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -22,11 +22,10 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
+        preset: 'angular',
         releaseRules: [
-          {
-            scope: 'force-release',
-            release: 'patch',
-          },
+          // Example: `type(scope): subject [force release]`
+          { subject: '*[force release]*', release: 'patch' },
         ],
       },
     ],


### PR DESCRIPTION
Instead of losing the scope of the commit with a CI-related instruction, move this instruction to the end of the commit, surrounded by squared brackets (like the `skip ci` GH Action instruction)

Example of usage : `type(scope): subject [force release]`

Sources:
- https://github.com/semantic-release/commit-analyzer#configuration
- https://github.com/semantic-release/commit-analyzer#release-rules
- https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
- https://github.com/micromatch/micromatch#matching-features