### PR TITLE
feat(plugin-aws-s3): add S3Client endpoint option

### DIFF
--- a/packages/plugin-aws-s3/src/types.ts
+++ b/packages/plugin-aws-s3/src/types.ts
@@ -64,6 +64,9 @@ export type Options = {
 
     /** AWS bucket, defaults to process.env.AWS_S3_BUCKET */
     bucket?: string;
+
+    /** AWS endpoint, defaults to process.env.AWS_S3_ENDPOINT */
+    endpoint?: string;
   };
 };
 

--- a/packages/plugin-aws-s3/src/utils/s3.ts
+++ b/packages/plugin-aws-s3/src/utils/s3.ts
@@ -16,8 +16,10 @@ export default class Client {
 
   constructor(options: Options['aws']) {
     this.bucket = options?.bucket ?? process.env.AWS_S3_BUCKET;
+
     this.client = new S3Client({
       region: options?.region ?? process.env.AWS_DEFAULT_REGION,
+      endpoint: options?.endpoint ?? process.env.AWS_S3_ENDPOINT,
       credentials: {
         accessKeyId: options?.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: options?.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY,


### PR DESCRIPTION
Add S3Client endpoint option, to use AWS S3 plugin with other S3-compatible object storage services.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
