### PR TITLE
test(datasource-sql): do not restart db between each connection test

### DIFF
--- a/packages/datasource-sql/test/connection/handle-errors.test.ts
+++ b/packages/datasource-sql/test/connection/handle-errors.test.ts
@@ -18,7 +18,7 @@ describe('connect errors', () => {
     (dialect, username, password, host, containerPort, port, dockerServiceName) => {
       const db = `test_connection`;
 
-      beforeEach(async () => {
+      beforeAll(async () => {
         await setupDatabaseWithTypes(
           `${dialect}://${username}:${password}@${host}:${containerPort}`,
           dialect,


### PR DESCRIPTION
Before
`PASS test/connection/handle-errors.test.ts (31.468 s)`

After
`PASS packages/datasource-sql/test/connection/handle-errors.test.ts (16.964 s)`
