### PR TITLE
feat(config): configuration now allows to differenciate bucket path and database path

### DIFF
--- a/packages/datasource-customizer/src/decorators/write/write-replace/collection.ts
+++ b/packages/datasource-customizer/src/decorators/write/write-replace/collection.ts
@@ -48,7 +48,7 @@ export default class WriteReplacerCollectionDecorator extends CollectionDecorato
   }
 
   override async update(caller: Caller, filter: Filter, patch: RecordData): Promise<void> {
-    const newPatch = await this.rewritePatch(caller, 'update', patch);
+    const newPatch = await this.rewritePatch(caller, 'update', patch, [], filter);
 
     return this.childCollection.update(caller, filter, newPatch);
   }
@@ -61,9 +61,10 @@ export default class WriteReplacerCollectionDecorator extends CollectionDecorato
     action: 'create' | 'update',
     patch: RecordData,
     usedHandlers: string[] = [],
+    filter?: Filter,
   ): Promise<RecordData> {
     // We rewrite the patch by applying all handlers on each field.
-    const context = new WriteCustomizationContext(this, caller, action, patch);
+    const context = new WriteCustomizationContext(this, caller, action, patch, filter);
     const patches = await Promise.all(
       Object.keys(patch).map(key => this.rewriteKey(context, key, usedHandlers)),
     );

--- a/packages/datasource-customizer/src/decorators/write/write-replace/context.ts
+++ b/packages/datasource-customizer/src/decorators/write/write-replace/context.ts
@@ -1,7 +1,7 @@
-import { Caller, Collection } from '@forestadmin/datasource-toolkit';
+import { Caller, Collection, Filter } from '@forestadmin/datasource-toolkit';
 
 import CollectionCustomizationContext from '../../../context/collection-context';
-import { TCollectionName, TPartialSimpleRow, TSchema } from '../../../templates';
+import { TCollectionName, TFilter, TPartialSimpleRow, TSchema } from '../../../templates';
 
 export default class WriteCustomizationContext<
   S extends TSchema = TSchema,
@@ -9,16 +9,19 @@ export default class WriteCustomizationContext<
 > extends CollectionCustomizationContext<S, N> {
   readonly action: 'update' | 'create';
   readonly record: TPartialSimpleRow<S, N>;
+  readonly filter?: TFilter<S, N>;
 
   constructor(
     collection: Collection,
     caller: Caller,
     action: 'update' | 'create',
     record: TPartialSimpleRow<S, N>,
+    filter?: Filter,
   ) {
     super(collection, caller);
 
     this.action = action;
+    this.filter = filter as unknown as TFilter<S, N>;
     this.record = Object.freeze({ ...record });
   }
 }

--- a/packages/datasource-customizer/src/decorators/write/write-replace/types.ts
+++ b/packages/datasource-customizer/src/decorators/write/write-replace/types.ts
@@ -1,6 +1,8 @@
 import WriteCustomizationContext from './context';
 import { TCollectionName, TFieldName, TFieldType, TPartialRow, TSchema } from '../../../templates';
 
+export { WriteCustomizationContext };
+
 export type WriteDefinition<
   S extends TSchema = TSchema,
   N extends TCollectionName<S> = TCollectionName<S>,

--- a/packages/datasource-customizer/src/index.ts
+++ b/packages/datasource-customizer/src/index.ts
@@ -13,7 +13,7 @@ export { OperatorDefinition } from './decorators/operators-emulate/types';
 export { RelationDefinition } from './decorators/relation/types';
 export { SearchDefinition } from './decorators/search/types';
 export { SegmentDefinition } from './decorators/segment/types';
-export { WriteDefinition } from './decorators/write/write-replace/types';
+export * from './decorators/write/write-replace/types';
 export * from './decorators/hook/types';
 
 // Context

--- a/packages/plugin-aws-s3/src/field/create-field.ts
+++ b/packages/plugin-aws-s3/src/field/create-field.ts
@@ -4,10 +4,16 @@ import type { CollectionCustomizer } from '@forestadmin/datasource-customizer';
 import { encodeDataUri } from '../utils/data-uri';
 
 export default function createField(collection: CollectionCustomizer, config: Configuration): void {
-  const dependencies = [config.sourcename];
+  const dependencies = [];
 
-  if (config.buildFilePathFromDatabase?.dependencies) {
-    dependencies.push(...config.buildFilePathFromDatabase.dependencies);
+  if (config.bucketFilePathFromDatabaseKey?.dependencies) {
+    dependencies.push(...config.bucketFilePathFromDatabaseKey.dependencies);
+  } else {
+    dependencies.push(...Object.keys(collection.schema.fields));
+  }
+
+  if (dependencies.indexOf(config.sourcename) < 0) {
+    dependencies.push(config.sourcename);
   }
 
   collection.addField(config.filename, {
@@ -21,8 +27,8 @@ export default function createField(collection: CollectionCustomizer, config: Co
           return null;
         }
 
-        key = config.buildFilePathFromDatabase?.builder
-          ? await config.buildFilePathFromDatabase.builder(record, context)
+        key = config.bucketFilePathFromDatabaseKey?.mappingFunction
+          ? await config.bucketFilePathFromDatabaseKey.mappingFunction(record, context)
           : key;
 
         if (config.readMode === 'proxy') {

--- a/packages/plugin-aws-s3/src/field/create-field.ts
+++ b/packages/plugin-aws-s3/src/field/create-field.ts
@@ -4,15 +4,9 @@ import type { CollectionCustomizer } from '@forestadmin/datasource-customizer';
 import { encodeDataUri } from '../utils/data-uri';
 
 export default function createField(collection: CollectionCustomizer, config: Configuration): void {
-  const dependencies = [];
+  const dependencies = config.objectKeyFromRecord?.extraDependencies ?? [];
 
-  if (config.bucketFilePathFromDatabaseKey?.dependencies) {
-    dependencies.push(...config.bucketFilePathFromDatabaseKey.dependencies);
-  } else {
-    dependencies.push(...Object.keys(collection.schema.fields));
-  }
-
-  if (dependencies.indexOf(config.sourcename) < 0) {
+  if (!dependencies.includes(config.sourcename)) {
     dependencies.push(config.sourcename);
   }
 
@@ -27,8 +21,8 @@ export default function createField(collection: CollectionCustomizer, config: Co
           return null;
         }
 
-        key = config.bucketFilePathFromDatabaseKey?.mappingFunction
-          ? await config.bucketFilePathFromDatabaseKey.mappingFunction(record, context)
+        key = config.objectKeyFromRecord?.mappingFunction
+          ? await config.objectKeyFromRecord.mappingFunction(record, context)
           : key;
 
         if (config.readMode === 'proxy') {

--- a/packages/plugin-aws-s3/src/field/make-field-writable.ts
+++ b/packages/plugin-aws-s3/src/field/make-field-writable.ts
@@ -39,7 +39,7 @@ export default function makeFieldWritable(
         // On updates, we fetch the missing information from the database.
         const pks = getPks(collection);
         const projection = computeProjection(collection, config);
-        const records = await context.collection.list(context.filter, projection);
+        const records = await context.collection.list(context.filter || {}, projection);
 
         // context.record is the patch coming from the frontend.
         record = { ...(records?.[0] ?? {}), ...context.record };

--- a/packages/plugin-aws-s3/src/field/make-field-writable.ts
+++ b/packages/plugin-aws-s3/src/field/make-field-writable.ts
@@ -23,10 +23,20 @@ export default function makeFieldWritable(
     if (value) {
       const recordId = getRecordId(collection, context.record).join('|');
       const file = parseDataUri(value);
-      const key = config.storeAt(recordId, file.name);
+      const storeConfig = await config.storeAt(recordId, file.name, context);
+      let databasePath: string;
+      let awsPath: string;
 
-      await config.client.save(key, file, config.acl);
-      patch[config.sourcename] = key;
+      if (typeof storeConfig === 'string') {
+        databasePath = storeConfig;
+        awsPath = storeConfig;
+      } else {
+        databasePath = storeConfig.databasePath;
+        awsPath = storeConfig.AWSPath;
+      }
+
+      await config.client.save(awsPath, file, config.acl);
+      patch[config.sourcename] = databasePath;
     }
 
     return patch;

--- a/packages/plugin-aws-s3/src/index.ts
+++ b/packages/plugin-aws-s3/src/index.ts
@@ -34,7 +34,7 @@ export async function createFileField<
     readMode: options?.readMode ?? 'url',
     acl: options?.acl ?? 'private',
     storeAt: options?.storeAt ?? ((id, name) => `${collection.name}/${id}/${name}`),
-    bucketFilePathFromDatabaseKey: options?.bucketFilePathFromDatabaseKey || null,
+    objectKeyFromRecord: options?.objectKeyFromRecord || null,
   };
 
   createField(collection, config);

--- a/packages/plugin-aws-s3/src/index.ts
+++ b/packages/plugin-aws-s3/src/index.ts
@@ -37,7 +37,9 @@ export async function createFileField(
     deleteFiles: options?.deleteFiles ?? false,
     readMode: options?.readMode ?? 'url',
     acl: options?.acl ?? 'private',
-    storeAt: options?.storeAt ?? ((id, name) => `${collection.name}/${id}/${name}`),
+    storeAt:
+      options?.storeAt ?? ((id, name) => Promise.resolve(`${collection.name}/${id}/${name}`)),
+    buildFilePathFromDatabase: options?.buildFilePathFromDatabase,
   };
 
   createField(collection, config);

--- a/packages/plugin-aws-s3/src/index.ts
+++ b/packages/plugin-aws-s3/src/index.ts
@@ -33,8 +33,7 @@ export async function createFileField<
     deleteFiles: options?.deleteFiles ?? false,
     readMode: options?.readMode ?? 'url',
     acl: options?.acl ?? 'private',
-    storeAt:
-      options?.storeAt ?? ((id, name) => Promise.resolve(`${collection.name}/${id}/${name}`)),
+    storeAt: options?.storeAt ?? ((id, name) => `${collection.name}/${id}/${name}`),
     bucketFilePathFromDatabaseKey: options?.bucketFilePathFromDatabaseKey || null,
   };
 

--- a/packages/plugin-aws-s3/src/index.ts
+++ b/packages/plugin-aws-s3/src/index.ts
@@ -1,7 +1,4 @@
-import type {
-  CollectionCustomizer,
-  DataSourceCustomizer,
-} from '@forestadmin/datasource-customizer';
+import type { TCollectionName, TSchema } from '@forestadmin/datasource-customizer';
 
 import createField from './field/create-field';
 import makeFieldDeleteable from './field/make-field-deleteable';
@@ -15,11 +12,10 @@ import Client from './utils/s3';
 
 export { Options, File };
 
-export async function createFileField(
-  dataSource: DataSourceCustomizer,
-  collection: CollectionCustomizer,
-  options?: Options,
-): Promise<void> {
+export async function createFileField<
+  S extends TSchema = TSchema,
+  N extends TCollectionName<S> = TCollectionName<S>,
+>(dataSource, collection, options?: Options<S, N>): Promise<void> {
   if (!collection) throw new Error('createFileField can only be used on collections.');
   if (!options) throw new Error('Options must be provided.');
 
@@ -39,7 +35,7 @@ export async function createFileField(
     acl: options?.acl ?? 'private',
     storeAt:
       options?.storeAt ?? ((id, name) => Promise.resolve(`${collection.name}/${id}/${name}`)),
-    buildFilePathFromDatabase: options?.buildFilePathFromDatabase,
+    bucketFilePathFromDatabaseKey: options?.bucketFilePathFromDatabaseKey || null,
   };
 
   createField(collection, config);

--- a/packages/plugin-aws-s3/src/types.ts
+++ b/packages/plugin-aws-s3/src/types.ts
@@ -3,11 +3,11 @@ import type {
   TCollectionName,
   TColumnName,
   TFieldName,
+  TPartialSimpleRow,
   TSchema,
 } from '@forestadmin/datasource-customizer';
 import type CollectionCustomizationContext from '@forestadmin/datasource-customizer/dist/context/collection-context';
 import type WriteCustomizationContext from '@forestadmin/datasource-customizer/dist/decorators/write/write-replace/context';
-import type { RecordData } from '@forestadmin/datasource-toolkit';
 
 import { ObjectCannedACL } from '@aws-sdk/client-s3';
 
@@ -72,7 +72,7 @@ export type Options<
   objectKeyFromRecord?: {
     extraDependencies?: TFieldName<S, N>[];
     mappingFunction: (
-      record: RecordData,
+      record: TPartialSimpleRow<S, N>,
       context: CollectionCustomizationContext<S, N>,
     ) => string | Promise<string>;
   };

--- a/packages/plugin-aws-s3/src/types.ts
+++ b/packages/plugin-aws-s3/src/types.ts
@@ -47,7 +47,7 @@ export type Options<
     | Promise<string | { AWSPath: string; databasePath: string }>;
 
   /**
-   * If and how should the database key be computed to match the actual bucket file name
+   * If and how should the database key be computed to match the actual bucket file path
    */
   bucketFilePathFromDatabaseKey?: {
     dependencies?: TFieldName<S, N>[];

--- a/packages/plugin-aws-s3/test/index.test.ts
+++ b/packages/plugin-aws-s3/test/index.test.ts
@@ -189,6 +189,28 @@ describe('plugin-aws-s3', () => {
         { id: 1, file: 'books/1/myfile.txt' },
       );
     });
+
+    test('create should decode the url, and upload the new version', async () => {
+      await dataSource.getCollection('books').create(factories.caller.build(), [
+        {
+          file: 'data:text/plain;name=myfile.txt;charset=utf-8;base64,SGVsbG8gV29ybGQ=',
+        },
+      ]);
+
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ACL: 'private',
+          Body: Buffer.from('Hello World'),
+          Bucket: 'myBucket',
+          ContentType: 'text/plain',
+          Key: 'books/null/myfile.txt',
+        }),
+      );
+
+      expect(baseDataSource.getCollection('books').create).toHaveBeenCalledWith(expect.anything(), [
+        { file: 'books/null/myfile.txt' },
+      ]);
+    });
   });
 
   describe('when using a required field for the path', () => {


### PR DESCRIPTION
This PR has been done to allow customers to differentiate the path in their bucket, and the path stored in the database. 

The new storeAt attribute allows to configure two different logics to compute AWSPath and databasePath. 

Knowing the two paths can now be different, we also need a logic to reconcile the database stored value with the actual path  in the bucket. 

Customers also found really restrictive to be given only the record id in the storeAt conf, I've changed that so it is now asynchronous and provides the context as-well. 

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
