### PR TITLE
feat(forestadmin-client): add schema hash to startup logs

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -249,11 +249,6 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
     }
 
     // Send schema to forest servers
-    const updated = await this.options.forestAdminClient.postSchema(schema);
-    const message = updated
-      ? 'Schema was updated, sending new version'
-      : 'Schema was not updated since last run';
-
-    this.options.logger('Info', message);
+    await this.options.forestAdminClient.postSchema(schema);
   }
 }

--- a/packages/forestadmin-client/src/schema/index.ts
+++ b/packages/forestadmin-client/src/schema/index.ts
@@ -18,6 +18,12 @@ export default class SchemaService {
       await ServerUtils.query(this.options, 'post', '/forest/apimaps', {}, apimap);
     }
 
+    const message = shouldSend
+      ? 'Schema was updated, sending new version'
+      : 'Schema was not updated since last run';
+
+    this.options.logger('Info', `${message} (hash: ${apimap.meta.schemaFileHash})`);
+
     return shouldSend;
   }
 

--- a/packages/forestadmin-client/test/schema/index.test.ts
+++ b/packages/forestadmin-client/test/schema/index.test.ts
@@ -62,6 +62,11 @@ describe('SchemaService', () => {
           },
         }),
       );
+      expect(options.logger).toHaveBeenCalledTimes(1);
+      expect(options.logger).toHaveBeenCalledWith(
+        'Info',
+        'Schema was updated, sending new version (hash: f61f747c5f1de29c3aa2a93da76a723ee3f50785)',
+      );
     });
   });
 
@@ -97,6 +102,11 @@ describe('SchemaService', () => {
         '/forest/apimaps/hashcheck',
         {},
         expect.objectContaining({}),
+      );
+      expect(options.logger).toHaveBeenCalledTimes(1);
+      expect(options.logger).toHaveBeenCalledWith(
+        'Info',
+        'Schema was not updated since last run (hash: f61f747c5f1de29c3aa2a93da76a723ee3f50785)',
       );
     });
   });


### PR DESCRIPTION
Copy of https://github.com/ForestAdmin/agent-nodejs/pull/866 so that the CI is not broken due to Fork