### PR TITLE
feat(datasource-customizer): add helper to fetch values from selected record in single actions

### DIFF
--- a/packages/datasource-customizer/src/decorators/actions/context/single.ts
+++ b/packages/datasource-customizer/src/decorators/actions/context/single.ts
@@ -1,7 +1,7 @@
 import { CompositeId } from '@forestadmin/datasource-toolkit';
 
 import ActionContext from './base';
-import { TCollectionName, TFieldName, TRow, TSchema } from '../../../templates';
+import { TCollectionName, TFieldName, TFieldType, TRow, TSchema } from '../../../templates';
 
 export default class ActionContextSingle<
   S extends TSchema = TSchema,
@@ -23,5 +23,15 @@ export default class ActionContextSingle<
     const records = await this.getRecords(fields);
 
     return records[0];
+  }
+
+  async getField<T extends TFieldName<S, N>>(field: T): Promise<TFieldType<S, N, T>> {
+    let value = await this.getRecord([field]);
+
+    for (const path of field.split(':')) {
+      value = value?.[path];
+    }
+
+    return value as TFieldType<S, N, T>;
   }
 }

--- a/packages/datasource-customizer/test/decorators/actions/context.test.ts
+++ b/packages/datasource-customizer/test/decorators/actions/context.test.ts
@@ -8,17 +8,37 @@ describe('ActionContext', () => {
   let books: Collection;
 
   beforeEach(() => {
-    books = factories.collection.build({
-      dataSource: factories.dataSource.build(),
-      name: 'books',
-      schema: factories.collectionSchema.build({
-        fields: {
-          id: factories.columnSchema.build({ isPrimaryKey: true }),
-          title: factories.columnSchema.build(),
-        },
+    const dataSource = factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        dataSource: factories.dataSource.build(),
+        name: 'authors',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.build({ isPrimaryKey: true }),
+            firstname: factories.columnSchema.build(),
+            lastname: factories.columnSchema.build(),
+          },
+        }),
       }),
-      list: jest.fn().mockResolvedValue([{ id: 1, title: 'Foundation' }]),
-    });
+      factories.collection.build({
+        dataSource: factories.dataSource.build(),
+        name: 'books',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.build({ isPrimaryKey: true }),
+            title: factories.columnSchema.build(),
+            author: factories.manyToOneSchema.build({ foreignCollection: 'authors' }),
+          },
+        }),
+        list: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 1, title: 'Foundation', author: { firstname: 'Isaac', lastname: 'Asimov' } },
+          ]),
+      }),
+    ]);
+
+    books = dataSource.getCollection('books');
   });
 
   test('should factorize calls to list made at the same time', async () => {
@@ -98,11 +118,20 @@ describe('ActionContext', () => {
     const caller = factories.caller.build();
 
     const context = new ActionContextSingle(books, caller, {}, {});
-    const [id, title] = await Promise.all([context.getField('id'), context.getField('title')]);
+    const [id, title, authorFirstName] = await Promise.all([
+      context.getField('id'),
+      context.getField('title'),
+      context.getField('author:firstname'),
+    ]);
 
     expect(books.list).toHaveBeenCalledTimes(1);
-    expect(books.list).toHaveBeenCalledWith(caller, new Filter({}), ['id', 'title']);
+    expect(books.list).toHaveBeenCalledWith(caller, new Filter({}), [
+      'id',
+      'title',
+      'author:firstname',
+    ]);
     expect(id).toEqual(1);
     expect(title).toEqual('Foundation');
+    expect(authorFirstName).toEqual('Isaac');
   });
 });

--- a/packages/datasource-customizer/test/decorators/actions/context.test.ts
+++ b/packages/datasource-customizer/test/decorators/actions/context.test.ts
@@ -93,4 +93,16 @@ describe('ActionContext', () => {
     await expect(promise1).rejects.toThrow('bad request');
     await expect(promise2).rejects.toThrow('bad request');
   });
+
+  test('should get individual fields', async () => {
+    const caller = factories.caller.build();
+
+    const context = new ActionContextSingle(books, caller, {}, {});
+    const [id, title] = await Promise.all([context.getField('id'), context.getField('title')]);
+
+    expect(books.list).toHaveBeenCalledTimes(1);
+    expect(books.list).toHaveBeenCalledWith(caller, new Filter({}), ['id', 'title']);
+    expect(id).toEqual(1);
+    expect(title).toEqual('Foundation');
+  });
 });


### PR DESCRIPTION
This is not much, but it helps when declaring single actions which use data from the selected record.
It's a major eyesore in the codebase I'm currently working in, as the field names are quite long, and this pattern is everywhere!

The templating is so that the output of the function have the proper type

Go from this:
```
{
    label: 'Street',
    isRequired: true,
    type: 'String',
    defaultValue: async (context) =>
      (await context.getRecord(['company:street'])).company?.street,
}
```

to this

```
{
    label: 'Street',
    isRequired: true,
    type: 'String',
    defaultValue: (context) => context.getField('company:street')
}
```