### PR TITLE
feat(datasource-customizer): sort enum values in typings file

### DIFF
--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -151,10 +151,11 @@ export default class TypingGenerator {
 
     while (queue.length > 0 && result.length < this.options.maxFieldsCount) {
       const { collection, depth, prefix, traversed } = queue.shift();
+      const sortedFields = TypingGenerator.sortedEntries(collection.schema.fields);
 
       if (prefix) {
         result.push(
-          ...TypingGenerator.sortedEntries(collection.schema.fields)
+          ...sortedFields
             .filter(([, schema]) => schema.type === 'Column')
             .map(
               ([name, schema]) => `'${prefix}:${name}': ${this.getType(schema as ColumnSchema)};`,
@@ -164,7 +165,7 @@ export default class TypingGenerator {
 
       if (depth < maxDepth) {
         queue.push(
-          ...TypingGenerator.sortedEntries(collection.schema.fields)
+          ...sortedFields
             .filter(([, schema]) => schema.type === 'ManyToOne' || schema.type === 'OneToOne')
             .map(([name, schema]: [name: string, schema: OneToOneSchema | ManyToOneSchema]) => {
               return {

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -210,9 +210,11 @@ export default class TypingGenerator {
     }
 
     if (field.columnType === 'Enum') {
+      if (field.enumValues === undefined) return 'string';
+
       return (
-        field.enumValues
-          ?.sort((v1, v2) => v1.localeCompare(v2))
+        [...field.enumValues]
+          .sort((v1, v2) => v1.localeCompare(v2))
           .map(v => `'${v.replace(/'/g, "\\'")}'`)
           .join(' | ') ?? 'string'
       );

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -158,6 +158,7 @@ export default class TypingGenerator {
       if (depth < maxDepth) {
         queue.push(
           ...Object.entries(collection.schema.fields)
+            .sort(([f1Name], [f2Name]) => f1Name.localeCompare(f2Name))
             .filter(([, schema]) => schema.type === 'ManyToOne' || schema.type === 'OneToOne')
             .map(([name, schema]: [name: string, schema: OneToOneSchema | ManyToOneSchema]) => {
               return {

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -203,7 +203,12 @@ export default class TypingGenerator {
     }
 
     if (field.columnType === 'Enum') {
-      return field.enumValues?.map(v => `'${v.replace(/'/g, "\\'")}'`).join(' | ') ?? 'string';
+      return (
+        field.enumValues
+          ?.sort((v1, v2) => v1.localeCompare(v2))
+          .map(v => `'${v.replace(/'/g, "\\'")}'`)
+          .join(' | ') ?? 'string'
+      );
     }
 
     if (typeof field.columnType === 'string') {

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -18,7 +18,7 @@ export default class TypingGenerator {
     this.options.maxFieldsCount = options.maxFieldsCount ?? this.options.maxFieldsCount;
   }
 
-  private getSortedEntries<T>(
+  private static sortedEntries<T>(
     ...args: Parameters<typeof Object.entries<T>>
   ): ReturnType<typeof Object.entries<T>> {
     return Object.entries(...args).sort(([name1], [name2]) => name1.localeCompare(name2));
@@ -104,7 +104,7 @@ export default class TypingGenerator {
   }
 
   private getRow(collection: Collection): string {
-    const content = this.getSortedEntries(collection.schema.fields).reduce(
+    const content = TypingGenerator.sortedEntries(collection.schema.fields).reduce(
       (memo, [name, field]) => {
         return field.type === 'Column'
           ? [...memo, `      '${name}': ${this.getType(field)};`]
@@ -117,7 +117,7 @@ export default class TypingGenerator {
   }
 
   private getRelations(collection: Collection): string {
-    const content = this.getSortedEntries(collection.schema.fields).reduce(
+    const content = TypingGenerator.sortedEntries(collection.schema.fields).reduce(
       (memo, [name, field]) => {
         if (field.type === 'ManyToOne' || field.type === 'OneToOne') {
           const relation = field.foreignCollection;
@@ -154,7 +154,7 @@ export default class TypingGenerator {
 
       if (prefix) {
         result.push(
-          ...this.getSortedEntries(collection.schema.fields)
+          ...TypingGenerator.sortedEntries(collection.schema.fields)
             .filter(([, schema]) => schema.type === 'Column')
             .map(
               ([name, schema]) => `'${prefix}:${name}': ${this.getType(schema as ColumnSchema)};`,
@@ -164,7 +164,7 @@ export default class TypingGenerator {
 
       if (depth < maxDepth) {
         queue.push(
-          ...this.getSortedEntries(collection.schema.fields)
+          ...TypingGenerator.sortedEntries(collection.schema.fields)
             .filter(([, schema]) => schema.type === 'ManyToOne' || schema.type === 'OneToOne')
             .map(([name, schema]: [name: string, schema: OneToOneSchema | ManyToOneSchema]) => {
               return {
@@ -233,7 +233,7 @@ export default class TypingGenerator {
       }[field.columnType];
     }
 
-    return `{${this.getSortedEntries(field.columnType)
+    return `{${TypingGenerator.sortedEntries(field.columnType)
       .map(([key, subType]) => `${key}: ${this.getType({ columnType: subType })}`)
       .join('; ')}}`;
   }

--- a/packages/datasource-customizer/test/typing-generator.test.ts
+++ b/packages/datasource-customizer/test/typing-generator.test.ts
@@ -78,6 +78,41 @@ describe('TypingGenerator', () => {
     expectEqual(generated, expected);
   });
 
+  test('should sort field names', () => {
+    const datasource = factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        name: 'aCollectionName',
+        schema: {
+          fields: {
+            b: factories.columnSchema.build({ columnType: 'String' }),
+            A: factories.columnSchema.build({ columnType: 'String' }),
+            z: factories.columnSchema.build({ columnType: 'String' }),
+            a: factories.columnSchema.build({ columnType: 'String' }),
+            0: factories.columnSchema.build({ columnType: 'String' }),
+          },
+        },
+      }),
+    ]);
+
+    const generated = new TypingGenerator(jest.fn()).generateTypes(datasource, 5);
+    const expected = `
+      export type Schema = {
+        'aCollectionName': {
+          plain: {
+            '0': string;
+            'a': string;
+            'A': string;
+            'b': string;
+            'z': string;
+          };
+          nested: {};
+          flat: {};
+        };
+      };`;
+
+    expectContains(generated, expected);
+  });
+
   it.each(['_underscores', '-dashes'])('aliases should work with a collection with %s', char => {
     const datasource = factories.dataSource.buildWithCollections([
       factories.collection.build({ name: `aCollectionNameWith${char}` }),

--- a/packages/datasource-customizer/test/typing-generator.test.ts
+++ b/packages/datasource-customizer/test/typing-generator.test.ts
@@ -169,8 +169,8 @@ describe('TypingGenerator', () => {
             'b': Schema['b']['plain'] & Schema['b']['nested'];
           };
           flat: {
-            'b:id': number;
             'a:id': number;
+            'b:id': number;
           };
         };
       };`;

--- a/packages/datasource-customizer/test/typing-generator.test.ts
+++ b/packages/datasource-customizer/test/typing-generator.test.ts
@@ -113,6 +113,36 @@ describe('TypingGenerator', () => {
     expectContains(generated, expected);
   });
 
+  test('should sort enum values', () => {
+    const datasource = factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        name: 'aCollectionName',
+        schema: {
+          fields: {
+            enum: factories.columnSchema.build({
+              columnType: 'Enum',
+              enumValues: ['b', '0', 'z', 'a', 'A'],
+            }),
+          },
+        },
+      }),
+    ]);
+
+    const generated = new TypingGenerator(jest.fn()).generateTypes(datasource, 5);
+    const expected = `
+      export type Schema = {
+        'aCollectionName': {
+          plain: {
+            'enum': '0' | 'a' | 'A' | 'b' | 'z';
+          };
+          nested: {};
+          flat: {};
+        };
+      };`;
+
+    expectContains(generated, expected);
+  });
+
   it.each(['_underscores', '-dashes'])('aliases should work with a collection with %s', char => {
     const datasource = factories.dataSource.buildWithCollections([
       factories.collection.build({ name: `aCollectionNameWith${char}` }),

--- a/packages/datasource-customizer/test/typing-generator.test.ts
+++ b/packages/datasource-customizer/test/typing-generator.test.ts
@@ -113,6 +113,71 @@ describe('TypingGenerator', () => {
     expectContains(generated, expected);
   });
 
+  test('should sort nested field names', () => {
+    const datasource = factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        name: 'z',
+        schema: {
+          fields: {
+            id: factories.columnSchema.build({ columnType: 'Number' }),
+            b: factories.manyToOneSchema.build({ foreignCollection: 'b', foreignKey: 'id' }),
+            a: factories.manyToOneSchema.build({ foreignCollection: 'a', foreignKey: 'id' }),
+          },
+        },
+      }),
+      factories.collection.build({
+        name: 'b',
+        schema: {
+          fields: {
+            id: factories.columnSchema.build({ columnType: 'Number' }),
+          },
+        },
+      }),
+      factories.collection.build({
+        name: 'a',
+        schema: {
+          fields: {
+            id: factories.columnSchema.build({ columnType: 'Number' }),
+          },
+        },
+      }),
+    ]);
+
+    const generated = new TypingGenerator(jest.fn()).generateTypes(datasource, 5);
+    const expected = `
+      export type Schema = {
+        'a': {
+          plain: {
+            'id': number;
+          };
+          nested: {};
+          flat: {};
+        };
+        'b': {
+          plain: {
+            'id': number;
+          };
+          nested: {};
+          flat: {};
+        };
+        'z': {
+          plain: {
+            'id': number;
+          };
+          nested: {
+            'a': Schema['a']['plain'] & Schema['a']['nested'];
+            'b': Schema['b']['plain'] & Schema['b']['nested'];
+          };
+          flat: {
+            'b:id': number;
+            'a:id': number;
+          };
+        };
+      };`;
+
+    expectContains(generated, expected);
+  });
+
   test('should sort enum values', () => {
     const datasource = factories.dataSource.buildWithCollections([
       factories.collection.build({


### PR DESCRIPTION
## Definition of Done

Initially I had implemented sorting for enum values but also plain, nested and flat field names; when rebasing on main I realized someone else had done it in the meantine. Thus there are only additional tests for these, but enum values are still now sorted. This prevents the kind of problem I've had on my project when generating the typings file:

<img width="1102" alt="image" src="https://github.com/ForestAdmin/agent-nodejs/assets/6844183/e50597b1-c40b-4a8e-b466-aa5c0323f17a">

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
