### PR TITLE
fix(forest-cloud): display an error when the command does not exist

### DIFF
--- a/packages/forest-cloud/src/commands/logs.ts
+++ b/packages/forest-cloud/src/commands/logs.ts
@@ -81,7 +81,7 @@ export default (program: Command, context: MakeCommands) => {
     )
     .option(
       '-n, --tail <integer>',
-      'Number of lines to show from the end of the logs in the last hour.' +
+      'Number of lines to show from the end of the logs in the last month.' +
         ' Default is 30, Max is 1000. Use from option to get older logs.',
     )
     .option(

--- a/packages/forest-cloud/src/commands/version.ts
+++ b/packages/forest-cloud/src/commands/version.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import actionRunner from '../dialogs/action-runner';
 import checkLatestVersion from '../dialogs/check-latest-version';
+import { BusinessError } from '../errors';
 import HttpServer from '../services/http-server';
 import { MakeCommands } from '../types';
 
@@ -9,7 +10,14 @@ export default (program: Command, context: MakeCommands) => {
   const { logger, getCurrentVersion } = context;
 
   program.option('-v, --version', 'Output the version number').action(
-    actionRunner(logger.spinner, async () => {
+    actionRunner(logger.spinner, async (_, command) => {
+      // it is a bug from commander action is always called when the command
+      // does not match the implemented commands. To avoid this we check if
+      // there are any arguments and throw an error if it is the case.
+      if (command.args.length > 0) {
+        throw new BusinessError(`unknown command ${command.args.join(' ')}`);
+      }
+
       // we want to display before to display the warning
       const version = getCurrentVersion();
       logger.log(version);

--- a/packages/forest-cloud/test/commands/version.test.ts
+++ b/packages/forest-cloud/test/commands/version.test.ts
@@ -81,4 +81,19 @@ describe('version command', () => {
       expect(cmd.outputs).toEqual([cmd.logger.log('1.0.0'), cmd.spinner.stop()]);
     });
   });
+
+  describe('when a command does not exist', () => {
+    it('should return the version', async () => {
+      const setup = setupCommandArguments({
+        getCurrentVersion: jest.fn().mockReturnValue('1.0.0'),
+      });
+      const cmd = new CommandTester(setup, ['unknown-command']);
+      await cmd.run();
+
+      expect(cmd.outputs).toEqual([
+        cmd.spinner.fail('unknown command unknown-command'),
+        cmd.spinner.stop(),
+      ]);
+    });
+  });
 });


### PR DESCRIPTION

linked to: CU-86bxvf48e
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
