### PR TITLE
fix(datasource-customizer): correct confusing type when using addExternalRelation

### DIFF
--- a/packages/datasource-customizer/src/types.ts
+++ b/packages/datasource-customizer/src/types.ts
@@ -12,7 +12,7 @@ export type OneToManyEmbeddedDefinition<
   schema: Record<string, PrimitiveTypes>;
   dependencies?: TFieldName<S, N>[];
   listRecords(
-    records: TRow<S, N>,
+    record: TRow<S, N>,
     context: CollectionCustomizationContext<S, N>,
   ): Promise<unknown[]> | unknown[];
 };


### PR DESCRIPTION
Hello!

I noticed this small issue while working.
Did not want to bother you guys on the community forums for such a small patch

and besides, it's my name on the git blame (yes, I checked)