### PR TITLE
fix: when customer passes 0 as port on standalone server it was considered as undefined instead of generating a random available port

### DIFF
--- a/packages/agent/test/framework-mounter.test.ts
+++ b/packages/agent/test/framework-mounter.test.ts
@@ -40,10 +40,10 @@ describe('Builder > Agent', () => {
         }
       });
 
-      describe('when a port is not provided or 0', () => {
-        it.each([undefined, 0])('should use a random PORT when %s', async port => {
+      describe('when a port is 0', () => {
+        it('should use a random available PORT', async () => {
           const mounter = new FrameworkMounter('my-api', logger);
-          mounter.mountOnStandaloneServer(port, 'localhost');
+          mounter.mountOnStandaloneServer(0, 'localhost');
 
           try {
             // @ts-expect-error: testing a protected method
@@ -53,6 +53,49 @@ describe('Builder > Agent', () => {
               `http://localhost:${mounter.standaloneServerPort}/my-api/forest`,
             );
             expect(response.body).toStrictEqual({ error: null, message: 'Agent is running' });
+            expect(mounter.standaloneServerPort).not.toEqual('3351');
+          } finally {
+            await mounter.stop();
+          }
+        });
+      });
+
+      describe('when the port is undefined', () => {
+        it('should use the PORT environment variable', async () => {
+          process.env.PORT = '9998';
+          const mounter = new FrameworkMounter('my-api', logger);
+          mounter.mountOnStandaloneServer(undefined, 'localhost');
+
+          try {
+            // @ts-expect-error: testing a protected method
+            await mounter.mount(router);
+
+            const response = await superagent.get(
+              `http://localhost:${mounter.standaloneServerPort}/my-api/forest`,
+            );
+            expect(response.body).toStrictEqual({ error: null, message: 'Agent is running' });
+            expect(mounter.standaloneServerPort).toEqual(9998);
+          } finally {
+            await mounter.stop();
+            process.env.PORT = undefined;
+          }
+        });
+      });
+
+      describe('when the port is undefined and no PORT environment variable', () => {
+        it('should use the default port 3351', async () => {
+          const mounter = new FrameworkMounter('my-api', logger);
+          mounter.mountOnStandaloneServer(undefined, 'localhost');
+
+          try {
+            // @ts-expect-error: testing a protected method
+            await mounter.mount(router);
+
+            const response = await superagent.get(
+              `http://localhost:${mounter.standaloneServerPort}/my-api/forest`,
+            );
+            expect(response.body).toStrictEqual({ error: null, message: 'Agent is running' });
+            expect(mounter.standaloneServerPort).toEqual(3351);
           } finally {
             await mounter.stop();
           }

--- a/packages/agent/test/framework-mounter.test.ts
+++ b/packages/agent/test/framework-mounter.test.ts
@@ -39,6 +39,25 @@ describe('Builder > Agent', () => {
           await mounter.stop();
         }
       });
+
+      describe('when a port is not provided or 0', () => {
+        it.each([undefined, 0])('should use a random PORT when %s', async port => {
+          const mounter = new FrameworkMounter('my-api', logger);
+          mounter.mountOnStandaloneServer(port, 'localhost');
+
+          try {
+            // @ts-expect-error: testing a protected method
+            await mounter.mount(router);
+
+            const response = await superagent.get(
+              `http://localhost:${mounter.standaloneServerPort}/my-api/forest`,
+            );
+            expect(response.body).toStrictEqual({ error: null, message: 'Agent is running' });
+          } finally {
+            await mounter.stop();
+          }
+        });
+      });
     });
 
     describe('when the agent is not started', () => {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
