### PR TITLE
fix(datasource-sequelize): returns all records when NotIn is given with empty array

### DIFF
--- a/packages/datasource-sequelize/src/utils/query-converter.ts
+++ b/packages/datasource-sequelize/src/utils/query-converter.ts
@@ -152,6 +152,8 @@ export default class QueryConverter {
       };
     }
 
+    if (valueAsArray.length === 0) return { [colName]: { [Op.notIn]: [] } };
+
     return {
       [Op.or]: [{ [colName]: { [Op.notIn]: valueAsArray } }, { [colName]: { [Op.is]: null } }],
     };

--- a/packages/datasource-sequelize/test/integration/list/filter.integration.test.ts
+++ b/packages/datasource-sequelize/test/integration/list/filter.integration.test.ts
@@ -315,6 +315,18 @@ describe('Filter tests on collection', () => {
             ]),
           );
         });
+
+        it('should return all lines when empty array is passed', async () => {
+          const result = await collection.list(
+            caller,
+            new PaginatedFilter({
+              conditionTree: new ConditionTreeLeaf('name', 'NotIn', []),
+            }),
+            new Projection('name'),
+          );
+
+          expect(result.length).toBe(4);
+        });
       });
     });
 


### PR DESCRIPTION
linked to: CU-86bzhg9kj
…en, it should return all the records

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
