### PR TITLE
fix: upgrade ssh-tunnel dependency to avoid crash when "no response from server"

### DIFF
--- a/packages/datasource-mongo/package.json
+++ b/packages/datasource-mongo/package.json
@@ -16,7 +16,7 @@
     "@forestadmin/datasource-toolkit": "1.44.0",
     "json-stringify-pretty-compact": "^3.0.0",
     "mongoose": "^7.0.1",
-    "tunnel-ssh": "^5.1.2"
+    "tunnel-ssh": "^5.2.0"
   },
   "files": [
     "dist/**/*.js",

--- a/packages/datasource-mongo/src/connection/create-connection.ts
+++ b/packages/datasource-mongo/src/connection/create-connection.ts
@@ -23,6 +23,7 @@ async function createSSHTunnel(uri: string, sshConfig: SshOptions) {
 
   const tunnelOptions: TunnelOptions = {
     autoClose: false,
+    reconnectOnError: false,
   };
   const serverOptions: ServerOptions = {};
   const forwardOptions: ForwardOptions = {

--- a/packages/datasource-mongo/test/connection/create-connection.unit.test.ts
+++ b/packages/datasource-mongo/test/connection/create-connection.unit.test.ts
@@ -183,7 +183,7 @@ describe('createConnection', () => {
       const createdConnection = await createConnection(params);
 
       expect(createTunnel).toHaveBeenCalledWith(
-        { autoClose: false },
+        { autoClose: false, reconnectOnError: false },
         {},
         {
           host: 'localhost',

--- a/yarn.lock
+++ b/yarn.lock
@@ -14974,10 +14974,10 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel-ssh@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/tunnel-ssh/-/tunnel-ssh-5.1.2.tgz#da4b4e262633af26b0536a50963a827b9b9afef3"
-  integrity sha512-PNfxgg5aEV9ZWpx4oHvkyPoC7TvYGdbob9L35BrYGY/LM3mt5KUQ5uOO9PbT/gNQowGanOfli3JGwRZ+DTd2ZQ==
+tunnel-ssh@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tunnel-ssh/-/tunnel-ssh-5.2.0.tgz#199df96b07f1fa833d578e47a5801da4af065b2a"
+  integrity sha512-IGiyhE2RSt3NVvZ7aKH3ykziAxKNPe/z97Rab/lrIXslif/cq7J/m6EXfERlDITiFyGGYMqqi5SSrt/mk1VbEg==
   dependencies:
     ssh2 "^1.15.0"
 


### PR DESCRIPTION
I upgrade ssh-tunnel dependency because the maintainer merges our contribution to fix this issue: https://github.com/agebrock/tunnel-ssh/pull/121