### PR TITLE
fix: don't cache rejected promises

### DIFF
--- a/packages/forestadmin-client/test/utils/ttl-cache.test.ts
+++ b/packages/forestadmin-client/test/utils/ttl-cache.test.ts
@@ -60,6 +60,22 @@ describe('TTL Cache', () => {
 
       expect(fetchMethod).toHaveBeenCalledTimes(2);
     });
+
+    it('should not cache a rejected promise', async () => {
+      const fetchMethod = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('first'))
+        .mockResolvedValueOnce('second');
+
+      const cache = new TTLCache<string>(fetchMethod);
+
+      await expect(() => cache.fetch('key')).rejects.toThrow('first');
+
+      const fetch2 = await cache.fetch('key');
+      expect(fetch2).toEqual('second');
+
+      expect(fetchMethod).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('clear', () => {


### PR DESCRIPTION
**Current issue:**
Sometimes our app would be stuck due to the following error in our logs: `"Error: The request to Forest Admin server has timed out while trying to reach https://api.forestadmin.com/liana/v4/permissions/environment"`.
This would make our app unusable (since it can't reach Forest) and we had to restart the pod to make it work again.

**Root cause:**
The code responsible for calling the "https://api.forestadmin.com/liana/v4/permissions/environment" URL, in [ActionPermissionService](https://github.com/ForestAdmin/agent-nodejs/blob/main/packages/forestadmin-client/src/permissions/action-permission.ts#L87), uses a [TTLCache](https://github.com/ForestAdmin/agent-nodejs/blob/main/packages/forestadmin-client/src/utils/ttl-cache.ts), which keeps returning the **same** timed out promise.

**Suggested solution:**
Don't cache rejected promises, so that the following calls will retry until one succeeds.
