### PR TITLE
fix(user-permission): don't cache rejected promises

### DIFF
--- a/packages/forestadmin-client/src/permissions/user-permission.ts
+++ b/packages/forestadmin-client/src/permissions/user-permission.ts
@@ -31,7 +31,12 @@ export default class UserPermissionService {
       // the response is not yet available.
       this.userInfoById = this.forestAdminServerInterface
         .getUsers(this.options)
-        .then(users => new Map(users.map(user => [`${user.id}`, user])));
+        .then(users => new Map(users.map(user => [`${user.id}`, user])))
+        .catch(err => {
+          // Don't cache rejected promises
+          this.invalidateCache();
+          throw err;
+        });
     }
 
     return (await this.userInfoById).get(`${userId}`);

--- a/packages/forestadmin-client/test/permissions/user-permission.test.ts
+++ b/packages/forestadmin-client/test/permissions/user-permission.test.ts
@@ -143,6 +143,24 @@ describe('UserPermission', () => {
       expect(serverInterface.getUsers).toHaveBeenCalledTimes(2);
       expect(userInfo).toEqual({ id: 43, email: 'bob2@world.com' });
     });
+
+    it('should not cache a rejected promise', async () => {
+      const { userPermissions, serverInterface } = setup();
+      serverInterface.getUsers = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('first'))
+        .mockResolvedValueOnce([
+          { id: 42, email: 'alice@world.com' },
+          { id: 43, email: 'bob2@world.com' },
+        ]);
+
+      await expect(() => userPermissions.getUserInfo(43)).rejects.toThrow('first');
+
+      const userInfo = await userPermissions.getUserInfo(43);
+
+      expect(serverInterface.getUsers).toHaveBeenCalledTimes(2);
+      expect(userInfo).toEqual({ id: 43, email: 'bob2@world.com' });
+    });
   });
 
   describe('invalidateCache', () => {


### PR DESCRIPTION
(Follows the same issue on action-permission: https://github.com/ForestAdmin/agent-nodejs/pull/1238)

### Current issue:
Sometimes our app would be stuck due to the following error in our logs: "Error: The request to Forest Admin server has timed out while trying to reach https://api.forestadmin.com/liana/v4/permissions/users".
This would make our app unusable (since it can't reach Forest) and we had to restart the pod to make it work again.

### Root cause:
The code responsible for calling the "https://api.forestadmin.com/liana/v4/permissions/users" URL, in [UserPermissionService](https://github.com/ForestAdmin/agent-nodejs/blob/main/packages/forestadmin-client/src/permissions/user-permission.ts), uses a cache which keeps returning the same timed out promise.

### Suggested solution:
Don't cache rejected promises, so that the following calls will retry until one succeeds.