### PR TITLE
feat(plugin-aws-s3): add force path style parameter to s3 client

### DIFF
--- a/packages/plugin-aws-s3/src/types.ts
+++ b/packages/plugin-aws-s3/src/types.ts
@@ -117,6 +117,9 @@ export type Options<
 
     /** AWS endpoint, defaults to process.env.AWS_S3_ENDPOINT */
     endpoint?: string;
+
+    /** AWS forcePathStyle, defauls to false */
+    forcePathStyle?: boolean;
   };
 };
 

--- a/packages/plugin-aws-s3/src/utils/s3.ts
+++ b/packages/plugin-aws-s3/src/utils/s3.ts
@@ -20,6 +20,7 @@ export default class Client {
     this.client = new S3Client({
       region: options?.region ?? process.env.AWS_DEFAULT_REGION,
       endpoint: options?.endpoint ?? process.env.AWS_S3_ENDPOINT,
+      forcePathStyle: options?.forcePathStyle ?? false,
       credentials: {
         accessKeyId: options?.accessKeyId ?? process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: options?.secretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY,


### PR DESCRIPTION
In plugin-aws-s3 for people using S3 based solution (but not AWS) like Localstack in a local environment we should allow the forcePathStyle option in order to support these solution.

Work perfectly without for getting PreSignedUrl but not with the PutObjectCommand
## Definition of Done

### General

- [X] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [X] Consider the security impact of the changes made
