### PR TITLE
feat(forestadmin-client): add MCP server configuration service

### DIFF
--- a/packages/agent/test/__factories__/forest-admin-client.ts
+++ b/packages/agent/test/__factories__/forest-admin-client.ts
@@ -43,6 +43,9 @@ const forestAdminClientFactory = ForestAdminClientFactory.define(() => ({
   modelCustomizationService: {
     getConfiguration: jest.fn(),
   },
+  mcpServerConfigService: {
+    getConfiguration: jest.fn(),
+  },
   subscribeToServerEvents: jest.fn(),
   close: jest.fn(),
   onRefreshCustomizations: jest.fn(),

--- a/packages/forestadmin-client/package.json
+++ b/packages/forestadmin-client/package.json
@@ -31,6 +31,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@forestadmin/ai-proxy": "0.1.0",
     "@forestadmin/datasource-toolkit": "1.50.0",
     "@types/json-api-serializer": "^2.6.3",
     "@types/jsonwebtoken": "^9.0.1",

--- a/packages/forestadmin-client/src/build-application-services.ts
+++ b/packages/forestadmin-client/src/build-application-services.ts
@@ -3,6 +3,7 @@ import EventsSubscriptionService from './events-subscription';
 import NativeRefreshEventsHandlerService from './events-subscription/native-refresh-events-handler-service';
 import { RefreshEventsHandlerService } from './events-subscription/types';
 import IpWhiteListService from './ip-whitelist';
+import McpServerConfigFromApiService, { McpServerConfigService } from './mcp-server-config';
 import ModelCustomizationFromApiService from './model-customizations/model-customization-from-api';
 import { ModelCustomizationService } from './model-customizations/types';
 import ActionPermissionService from './permissions/action-permission';
@@ -32,6 +33,7 @@ export default function buildApplicationServices(
   chartHandler: ChartHandler;
   auth: ForestAdminAuthServiceInterface;
   modelCustomizationService: ModelCustomizationService;
+  mcpServerConfigService: McpServerConfigService;
   eventsSubscription: EventsSubscriptionService;
   eventsHandler: RefreshEventsHandlerService;
 } {
@@ -84,6 +86,10 @@ export default function buildApplicationServices(
     schema: new SchemaService(optionsWithDefaults),
     auth: forestAdminServerInterface.makeAuthService(optionsWithDefaults),
     modelCustomizationService: new ModelCustomizationFromApiService(
+      forestAdminServerInterface,
+      optionsWithDefaults,
+    ),
+    mcpServerConfigService: new McpServerConfigFromApiService(
       forestAdminServerInterface,
       optionsWithDefaults,
     ),

--- a/packages/forestadmin-client/src/forest-admin-client-with-cache.ts
+++ b/packages/forestadmin-client/src/forest-admin-client-with-cache.ts
@@ -5,6 +5,7 @@ import {
 } from './events-subscription/types';
 import IpWhiteListService from './ip-whitelist';
 import { IpWhitelistConfiguration } from './ip-whitelist/types';
+import { McpServerConfigService } from './mcp-server-config';
 import { ModelCustomizationService } from './model-customizations/types';
 import RenderingPermissionService from './permissions/rendering-permission';
 import { RawTree } from './permissions/types';
@@ -30,6 +31,7 @@ export default class ForestAdminClientWithCache implements ForestAdminClient {
     protected readonly schemaService: SchemaService,
     public readonly authService: ForestAdminAuthServiceInterface,
     public readonly modelCustomizationService: ModelCustomizationService,
+    public readonly mcpServerConfigService: McpServerConfigService,
     protected readonly eventsSubscription: BaseEventsSubscriptionService,
     protected readonly eventsHandler: RefreshEventsHandlerService,
   ) {}

--- a/packages/forestadmin-client/src/index.ts
+++ b/packages/forestadmin-client/src/index.ts
@@ -43,6 +43,7 @@ export default function createForestAdminClient(
     schema,
     auth,
     modelCustomizationService,
+    mcpServerConfigService,
     eventsSubscription,
     eventsHandler,
   } = buildApplicationServices(new ForestHttpApi(), options);
@@ -57,6 +58,7 @@ export default function createForestAdminClient(
     schema,
     auth,
     modelCustomizationService,
+    mcpServerConfigService,
     eventsSubscription,
     eventsHandler,
   );

--- a/packages/forestadmin-client/src/mcp-server-config/index.ts
+++ b/packages/forestadmin-client/src/mcp-server-config/index.ts
@@ -1,0 +1,17 @@
+import type { McpConfiguration } from '@forestadmin/ai-proxy';
+
+import { McpServerConfigService } from './types';
+import { ForestAdminClientOptionsWithDefaults, ForestAdminServerInterface } from '../types';
+
+export default class McpServerConfigFromApiService implements McpServerConfigService {
+  constructor(
+    private readonly forestadminServerInterface: ForestAdminServerInterface,
+    private readonly options: ForestAdminClientOptionsWithDefaults,
+  ) {}
+
+  async getConfiguration(): Promise<McpConfiguration> {
+    return this.forestadminServerInterface.getMcpServerConfigs(this.options);
+  }
+}
+
+export { McpServerConfigService } from './types';

--- a/packages/forestadmin-client/src/mcp-server-config/types.ts
+++ b/packages/forestadmin-client/src/mcp-server-config/types.ts
@@ -1,0 +1,5 @@
+import type { McpConfiguration } from '@forestadmin/ai-proxy';
+
+export interface McpServerConfigService {
+  getConfiguration(): Promise<McpConfiguration>;
+}

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -1,3 +1,5 @@
+import type { McpConfiguration } from '@forestadmin/ai-proxy';
+
 import { EnvironmentPermissionsV4, RenderingPermissionV4, UserPermissionV4 } from './types';
 import AuthService from '../auth';
 import { ModelCustomization } from '../model-customizations/types';
@@ -32,6 +34,14 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
 
   async getModelCustomizations(options: HttpOptions): Promise<ModelCustomization[]> {
     return ServerUtils.query<ModelCustomization[]>(options, 'get', '/liana/model-customizations');
+  }
+
+  async getMcpServerConfigs(options: HttpOptions): Promise<McpConfiguration> {
+    return ServerUtils.query<McpConfiguration>(
+      options,
+      'get',
+      '/liana/mcp-server-configs-with-details',
+    );
   }
 
   makeAuthService(options: Required<ForestAdminClientOptions>): ForestAdminAuthServiceInterface {

--- a/packages/forestadmin-client/src/schema/types.ts
+++ b/packages/forestadmin-client/src/schema/types.ts
@@ -6,6 +6,7 @@ export type ForestSchema = {
     liana: string;
     liana_version: string;
     liana_features: Record<string, string> | null;
+    ai_llms?: Array<{ provider: string }> | null;
     stack: {
       engine: string;
       engine_version: string;

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -1,10 +1,12 @@
 import type { ChartRequest } from './charts/chart-handler';
 import type { Chart, QueryChart } from './charts/types';
+import type { McpConfiguration } from '@forestadmin/ai-proxy';
 
 import { ParsedUrlQuery } from 'querystring';
 
 import { Tokens, UserInfo } from './auth/types';
 import { IpWhitelistConfiguration } from './ip-whitelist/types';
+import { McpServerConfigService } from './mcp-server-config/types';
 import { ModelCustomization, ModelCustomizationService } from './model-customizations/types';
 import { HttpOptions } from './permissions/forest-http-api';
 import {
@@ -49,6 +51,7 @@ export interface ForestAdminClient {
   readonly contextVariablesInstantiator: ContextVariablesInstantiatorInterface;
   readonly chartHandler: ChartHandlerInterface;
   readonly modelCustomizationService: ModelCustomizationService;
+  readonly mcpServerConfigService: McpServerConfigService;
   readonly authService: ForestAdminAuthServiceInterface;
 
   verifySignedActionParameters<TSignedParameters>(signedParameters: string): TSignedParameters;
@@ -161,5 +164,6 @@ export interface ForestAdminServerInterface {
   getUsers: (...args) => Promise<UserPermissionV4[]>;
   getRenderingPermissions: (renderingId: number, ...args) => Promise<RenderingPermissionV4>;
   getModelCustomizations: (options: HttpOptions) => Promise<ModelCustomization[]>;
+  getMcpServerConfigs: (options: HttpOptions) => Promise<McpConfiguration>;
   makeAuthService(options: ForestAdminClientOptionsWithDefaults): ForestAdminAuthServiceInterface;
 }

--- a/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
+++ b/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
@@ -6,6 +6,7 @@ const forestAdminServerInterface = {
     getEnvironmentPermissions: jest.fn(),
     getUsers: jest.fn(),
     getModelCustomizations: jest.fn(),
+    getMcpServerConfigs: jest.fn(),
     makeAuthService: jest.fn(),
   }),
 };

--- a/packages/forestadmin-client/test/__factories__/index.ts
+++ b/packages/forestadmin-client/test/__factories__/index.ts
@@ -12,3 +12,4 @@ export { default as ipWhiteList } from './ip-whitelist';
 export { default as schema } from './schema';
 export { default as auth } from './auth';
 export { default as modelCustomization } from './model-customizations/model-customization-from-api';
+export { default as mcpServerConfig } from './mcp-server-config';

--- a/packages/forestadmin-client/test/__factories__/mcp-server-config.ts
+++ b/packages/forestadmin-client/test/__factories__/mcp-server-config.ts
@@ -1,0 +1,10 @@
+import { McpServerConfigService } from '../../src/mcp-server-config/types';
+
+const mcpServerConfig = {
+  build: (overrides?: Partial<McpServerConfigService>): McpServerConfigService => ({
+    getConfiguration: jest.fn().mockResolvedValue({ mcpServers: [] }),
+    ...overrides,
+  }),
+};
+
+export default mcpServerConfig;

--- a/packages/forestadmin-client/test/forest-admin-client-with-cache.test.ts
+++ b/packages/forestadmin-client/test/forest-admin-client-with-cache.test.ts
@@ -26,6 +26,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         factories.eventsSubscription.build(),
         factories.eventsHandler.build(),
       );
@@ -52,6 +53,7 @@ describe('ForestAdminClientWithCache', () => {
         schemaService,
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         factories.eventsSubscription.build(),
         factories.eventsHandler.build(),
       );
@@ -62,6 +64,7 @@ describe('ForestAdminClientWithCache', () => {
           liana: 'forest-nodejs-agent',
           liana_version: '1.0.0',
           liana_features: null,
+          ai_llms: null,
           stack: { engine: 'nodejs', engine_version: '16.0.0' },
         },
       });
@@ -84,6 +87,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         factories.eventsSubscription.build(),
         factories.eventsHandler.build(),
       );
@@ -111,6 +115,7 @@ describe('ForestAdminClientWithCache', () => {
           factories.schema.build(),
           factories.auth.build(),
           factories.modelCustomization.build(),
+          factories.mcpServerConfig.build(),
           factories.eventsSubscription.build(),
           factories.eventsHandler.build(),
         );
@@ -134,6 +139,7 @@ describe('ForestAdminClientWithCache', () => {
           factories.schema.build(),
           factories.auth.build(),
           factories.modelCustomization.build(),
+          factories.mcpServerConfig.build(),
           factories.eventsSubscription.build(),
           factories.eventsHandler.build(),
         );
@@ -158,6 +164,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         factories.eventsSubscription.build(),
         factories.eventsHandler.build(),
       );
@@ -192,6 +199,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         eventsSubscriptionService,
         factories.eventsHandler.build(),
       );
@@ -215,6 +223,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         eventsSubscriptionService,
         factories.eventsHandler.build(),
       );
@@ -238,6 +247,7 @@ describe('ForestAdminClientWithCache', () => {
         factories.schema.build(),
         factories.auth.build(),
         factories.modelCustomization.build(),
+        factories.mcpServerConfig.build(),
         factories.eventsSubscription.build(),
         eventsHandlerService,
       );
@@ -263,6 +273,7 @@ describe('ForestAdminClientWithCache', () => {
           factories.schema.build(),
           factories.auth.build(),
           factories.modelCustomization.build(),
+          factories.mcpServerConfig.build(),
           factories.eventsSubscription.build(),
           eventsHandlerService,
         );

--- a/packages/forestadmin-client/test/mcp-server-config/index.test.ts
+++ b/packages/forestadmin-client/test/mcp-server-config/index.test.ts
@@ -1,0 +1,106 @@
+import McpServerConfigFromApiService from '../../src/mcp-server-config';
+import * as factories from '../__factories__';
+
+describe('McpServerConfigFromApiService', () => {
+  describe('getConfiguration', () => {
+    it('should call getMcpServerConfigs on the server interface', async () => {
+      const mcpConfig = {
+        configs: { server1: { transport: 'sse', url: 'http://localhost:3000' } },
+      };
+      const serverInterface = factories.forestAdminServerInterface.build();
+      (serverInterface.getMcpServerConfigs as jest.Mock).mockResolvedValue(mcpConfig);
+
+      const options = factories.forestAdminClientOptions.build();
+      const service = new McpServerConfigFromApiService(serverInterface, options);
+
+      const result = await service.getConfiguration();
+
+      expect(serverInterface.getMcpServerConfigs).toHaveBeenCalledWith(options);
+      expect(result).toEqual(mcpConfig);
+    });
+
+    it('should return empty configs when server returns empty config', async () => {
+      const mcpConfig = { configs: {} };
+      const serverInterface = factories.forestAdminServerInterface.build();
+      (serverInterface.getMcpServerConfigs as jest.Mock).mockResolvedValue(mcpConfig);
+
+      const options = factories.forestAdminClientOptions.build();
+      const service = new McpServerConfigFromApiService(serverInterface, options);
+
+      const result = await service.getConfiguration();
+
+      expect(result).toEqual({ configs: {} });
+    });
+
+    it('should return config with multiple SSE servers', async () => {
+      const mcpConfig = {
+        configs: {
+          zendesk: { transport: 'sse', url: 'http://localhost:3001/sse' },
+          slack: { transport: 'sse', url: 'http://localhost:3002/sse' },
+          github: { transport: 'sse', url: 'http://localhost:3003/sse' },
+        },
+      };
+      const serverInterface = factories.forestAdminServerInterface.build();
+      (serverInterface.getMcpServerConfigs as jest.Mock).mockResolvedValue(mcpConfig);
+
+      const options = factories.forestAdminClientOptions.build();
+      const service = new McpServerConfigFromApiService(serverInterface, options);
+
+      const result = await service.getConfiguration();
+
+      expect(result).toEqual(mcpConfig);
+      expect(Object.keys(result.configs)).toHaveLength(3);
+    });
+
+    it('should return config with stdio transport server', async () => {
+      const mcpConfig = {
+        configs: {
+          localServer: {
+            transport: 'stdio',
+            command: 'node',
+            args: ['./server.js'],
+          },
+        },
+      };
+      const serverInterface = factories.forestAdminServerInterface.build();
+      (serverInterface.getMcpServerConfigs as jest.Mock).mockResolvedValue(mcpConfig);
+
+      const options = factories.forestAdminClientOptions.build();
+      const service = new McpServerConfigFromApiService(serverInterface, options);
+
+      const result = await service.getConfiguration();
+
+      expect(result).toEqual(mcpConfig);
+      expect(result.configs.localServer).toMatchObject({
+        transport: 'stdio',
+        command: 'node',
+        args: ['./server.js'],
+      });
+    });
+
+    it('should return config with mixed transport types', async () => {
+      const mcpConfig = {
+        configs: {
+          remoteServer: { transport: 'sse', url: 'http://remote.example.com/sse' },
+          localServer: {
+            transport: 'stdio',
+            command: 'python',
+            args: ['-m', 'mcp_server'],
+            env: { DEBUG: 'true' },
+          },
+        },
+      };
+      const serverInterface = factories.forestAdminServerInterface.build();
+      (serverInterface.getMcpServerConfigs as jest.Mock).mockResolvedValue(mcpConfig);
+
+      const options = factories.forestAdminClientOptions.build();
+      const service = new McpServerConfigFromApiService(serverInterface, options);
+
+      const result = await service.getConfiguration();
+
+      expect(result).toEqual(mcpConfig);
+      expect(result.configs.remoteServer.transport).toBe('sse');
+      expect(result.configs.localServer.transport).toBe('stdio');
+    });
+  });
+});

--- a/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
+++ b/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
@@ -42,4 +42,16 @@ describe('ForestHttpApi', () => {
       expect(ServerUtils.query).toHaveBeenCalledWith(options, 'get', '/liana/model-customizations');
     });
   });
+
+  describe('getMcpServerConfigs', () => {
+    it('should call the right endpoint', async () => {
+      await new ForestHttpApi().getMcpServerConfigs(options);
+
+      expect(ServerUtils.query).toHaveBeenCalledWith(
+        options,
+        'get',
+        '/liana/mcp-server-configs-with-details',
+      );
+    });
+  });
 });


### PR DESCRIPTION
linked to: CU-86c70j195
## Summary
- Add new `McpServerConfigService` for fetching MCP server configurations from Forest Admin API
- Add `getMcpServerConfigs` endpoint to ForestHttpApi (`/liana/mcp-server-configs-with-details`)
- Integrate service into ForestAdminClient

## Dependencies
This PR depends on #1355 (ai-proxy package) being merged first.

## Test plan
- [x] Unit tests for McpServerConfigService
- [x] Unit tests for getMcpServerConfigs in ForestHttpApi
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)