### PR TITLE
fix(mcp-server): handle filters sent as JSON string by LLM

### DIFF
--- a/packages/mcp-server/src/schemas/filter.ts
+++ b/packages/mcp-server/src/schemas/filter.ts
@@ -1,61 +1,74 @@
 import { z } from 'zod';
 
-const plainConditionTreeLeafSchema = z.object({
+const operatorEnum = z.enum([
+  'Equal',
+  'NotEqual',
+  'LessThan',
+  'GreaterThan',
+  'LessThanOrEqual',
+  'GreaterThanOrEqual',
+  'Match',
+  'NotContains',
+  'NotIContains',
+  'LongerThan',
+  'ShorterThan',
+  'IncludesAll',
+  'IncludesNone',
+  'Today',
+  'Yesterday',
+  'PreviousMonth',
+  'PreviousQuarter',
+  'PreviousWeek',
+  'PreviousYear',
+  'PreviousMonthToDate',
+  'PreviousQuarterToDate',
+  'PreviousWeekToDate',
+  'PreviousXDaysToDate',
+  'PreviousXDays',
+  'PreviousYearToDate',
+  'Present',
+  'Blank',
+  'Missing',
+  'In',
+  'NotIn',
+  'StartsWith',
+  'EndsWith',
+  'Contains',
+  'IStartsWith',
+  'IEndsWith',
+  'IContains',
+  'Like',
+  'ILike',
+  'Before',
+  'After',
+  'AfterXHoursAgo',
+  'BeforeXHoursAgo',
+  'Future',
+  'Past',
+]);
+
+const aggregatorEnum = z.enum(['And', 'Or']);
+
+// Leaf condition (e.g., { field: 'name', operator: 'Equal', value: 'John' })
+const leafSchema = z.object({
   field: z.string(),
-  operator: z.enum([
-    'Equal',
-    'NotEqual',
-    'LessThan',
-    'GreaterThan',
-    'LessThanOrEqual',
-    'GreaterThanOrEqual',
-    'Match',
-    'NotContains',
-    'NotIContains',
-    'LongerThan',
-    'ShorterThan',
-    'IncludesAll',
-    'IncludesNone',
-    'Today',
-    'Yesterday',
-    'PreviousMonth',
-    'PreviousQuarter',
-    'PreviousWeek',
-    'PreviousYear',
-    'PreviousMonthToDate',
-    'PreviousQuarterToDate',
-    'PreviousWeekToDate',
-    'PreviousXDaysToDate',
-    'PreviousXDays',
-    'PreviousYearToDate',
-    'Present',
-    'Blank',
-    'Missing',
-    'In',
-    'NotIn',
-    'StartsWith',
-    'EndsWith',
-    'Contains',
-    'IStartsWith',
-    'IEndsWith',
-    'IContains',
-    'Like',
-    'ILike',
-    'Before',
-    'After',
-    'AfterXHoursAgo',
-    'BeforeXHoursAgo',
-    'Future',
-    'Past',
-  ]),
+  operator: operatorEnum,
   value: z.unknown().optional(),
 });
 
-const plainConditionTreeBranchSchema: z.ZodType<unknown> = z.object({
-  aggregator: z.enum(['And', 'Or']),
-  conditions: z.array(
-    z.lazy(() => plainConditionTreeBranchSchema).or(plainConditionTreeLeafSchema),
-  ),
-});
+// Build nested branch schemas iteratively (avoids z.lazy() which causes $ref issues)
+const MAX_NESTING_DEPTH = 3;
 
-export default plainConditionTreeBranchSchema;
+let conditionSchema: z.ZodTypeAny = leafSchema;
+
+for (let i = 0; i < MAX_NESTING_DEPTH; i++) {
+  conditionSchema = z.union([
+    leafSchema,
+    z.object({
+      aggregator: aggregatorEnum,
+      conditions: z.array(conditionSchema),
+    }),
+  ]);
+}
+
+export default conditionSchema;

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -7,12 +7,18 @@ import buildClient from '../utils/agent-caller.js';
 import parseAgentError from '../utils/error-parser.js';
 import { fetchForestSchema, getFieldsOfCollection } from '../utils/schema-fetcher.js';
 
+// Preprocess to handle LLM sending filters as JSON string instead of object
+const filtersWithPreprocess = z.preprocess(
+  val => (typeof val === 'string' ? JSON.parse(val) : val),
+  filterSchema,
+);
+
 function createListArgumentShape(collectionNames: string[]) {
   return {
     collectionName:
       collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
     search: z.string().optional(),
-    filters: filterSchema.optional(),
+    filters: filtersWithPreprocess.optional(),
     sort: z
       .object({
         field: z.string(),


### PR DESCRIPTION
## Summary
- Fix filters parameter failing validation when LLM sends it as a JSON string instead of object
- The MCP SDK doesn't properly handle JSON Schemas with `$ref` (generated from recursive Zod schemas)
- Uses `z.preprocess()` to parse JSON strings before Zod validation
- Refactors filter schema to use iterative depth-limited approach instead of `z.lazy()` for cleaner JSON Schema generation

## Context
When using the `list` tool with filters, the LLM sends the filter object as a stringified JSON. This happens because:
1. `z.lazy()` generates `$ref` in JSON Schema
2. MCP SDK doesn't handle `$ref` properly and passes strings to the handler

## Test plan
- [x] Build passes
- [ ] Manual test with LLM sending filter queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)