### PR TITLE
feat(mcp-server): add create, update and delete tools

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -20,7 +20,10 @@ import * as http from 'http';
 
 import ForestOAuthProvider from './forest-oauth-provider';
 import { isMcpRoute } from './mcp-paths';
+import declareCreateTool from './tools/create';
+import declareDeleteTool from './tools/delete';
 import declareListTool from './tools/list';
+import declareUpdateTool from './tools/update';
 import { fetchForestSchema, getCollectionNames } from './utils/schema-fetcher';
 import interceptResponseForErrorLogging from './utils/sse-error-logger';
 import { NAME, VERSION } from './version';
@@ -48,6 +51,9 @@ const defaultLogger: Logger = (level, message) => {
 /** Fields that are safe to log for each tool (non-sensitive data) */
 const SAFE_ARGUMENTS_FOR_LOGGING: Record<string, string[]> = {
   list: ['collectionName'],
+  create: ['collectionName'],
+  update: ['collectionName', 'recordId'],
+  delete: ['collectionName', 'recordIds'],
 };
 
 /**
@@ -125,6 +131,9 @@ export default class ForestMCPServer {
     }
 
     declareListTool(this.mcpServer, this.forestServerUrl, this.logger, collectionNames);
+    declareCreateTool(this.mcpServer, this.forestServerUrl, this.logger, collectionNames);
+    declareUpdateTool(this.mcpServer, this.forestServerUrl, this.logger, collectionNames);
+    declareDeleteTool(this.mcpServer, this.forestServerUrl, this.logger, collectionNames);
   }
 
   private ensureSecretsAreSet(): { envSecret: string; authSecret: string } {

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -1,0 +1,73 @@
+import type { Logger } from '../server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { z } from 'zod';
+
+import createActivityLog from '../utils/activity-logs-creator.js';
+import buildClient from '../utils/agent-caller.js';
+import parseAgentError from '../utils/error-parser.js';
+import registerToolWithLogging from '../utils/tool-with-logging.js';
+
+// Preprocess to handle LLM sending attributes as JSON string instead of object
+const attributesWithPreprocess = z.preprocess(val => {
+  if (typeof val !== 'string') return val;
+
+  try {
+    return JSON.parse(val);
+  } catch {
+    return val;
+  }
+}, z.record(z.string(), z.unknown()));
+
+interface CreateArgument {
+  collectionName: string;
+  attributes: Record<string, unknown>;
+}
+
+function createArgumentShape(collectionNames: string[]) {
+  return {
+    collectionName:
+      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    attributes: attributesWithPreprocess.describe(
+      'The attributes of the record to create. Must be an object with field names as keys.',
+    ),
+  };
+}
+
+export default function declareCreateTool(
+  mcpServer: McpServer,
+  forestServerUrl: string,
+  logger: Logger,
+  collectionNames: string[] = [],
+): void {
+  const argumentShape = createArgumentShape(collectionNames);
+
+  registerToolWithLogging(
+    mcpServer,
+    'create',
+    {
+      title: 'Create a record',
+      description: 'Create a new record in the specified collection.',
+      inputSchema: argumentShape,
+    },
+    async (options: CreateArgument, extra) => {
+      const { rpcClient } = await buildClient(extra);
+
+      await createActivityLog(forestServerUrl, extra, 'create', {
+        collectionName: options.collectionName,
+      });
+
+      try {
+        const record = await rpcClient
+          .collection(options.collectionName)
+          .create(options.attributes);
+
+        return { content: [{ type: 'text', text: JSON.stringify({ record }) }] };
+      } catch (error) {
+        const errorDetail = parseAgentError(error);
+        throw errorDetail ? new Error(errorDetail) : error;
+      }
+    },
+    logger,
+  );
+}

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -1,0 +1,74 @@
+import type { Logger } from '../server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { z } from 'zod';
+
+import createActivityLog from '../utils/activity-logs-creator.js';
+import buildClient from '../utils/agent-caller.js';
+import parseAgentError from '../utils/error-parser.js';
+import registerToolWithLogging from '../utils/tool-with-logging.js';
+
+interface DeleteArgument {
+  collectionName: string;
+  recordIds: (string | number)[];
+}
+
+function createArgumentShape(collectionNames: string[]) {
+  return {
+    collectionName:
+      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    recordIds: z
+      .array(z.union([z.string(), z.number()]))
+      .describe('The IDs of the records to delete.'),
+  };
+}
+
+export default function declareDeleteTool(
+  mcpServer: McpServer,
+  forestServerUrl: string,
+  logger: Logger,
+  collectionNames: string[] = [],
+): void {
+  const argumentShape = createArgumentShape(collectionNames);
+
+  registerToolWithLogging(
+    mcpServer,
+    'delete',
+    {
+      title: 'Delete records',
+      description: 'Delete one or more records from the specified collection.',
+      inputSchema: argumentShape,
+    },
+    async (options: DeleteArgument, extra) => {
+      const { rpcClient } = await buildClient(extra);
+
+      // Cast to satisfy the type system - the API accepts both string[] and number[]
+      const recordIds = options.recordIds as string[] | number[];
+
+      await createActivityLog(forestServerUrl, extra, 'delete', {
+        collectionName: options.collectionName,
+        recordIds,
+      });
+
+      try {
+        await rpcClient.collection(options.collectionName).delete(recordIds);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: `Successfully deleted ${options.recordIds.length} record(s) from ${options.collectionName}`,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        const errorDetail = parseAgentError(error);
+        throw errorDetail ? new Error(errorDetail) : error;
+      }
+    },
+    logger,
+  );
+}

--- a/packages/mcp-server/src/tools/update.ts
+++ b/packages/mcp-server/src/tools/update.ts
@@ -1,0 +1,76 @@
+import type { Logger } from '../server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { z } from 'zod';
+
+import createActivityLog from '../utils/activity-logs-creator.js';
+import buildClient from '../utils/agent-caller.js';
+import parseAgentError from '../utils/error-parser.js';
+import registerToolWithLogging from '../utils/tool-with-logging.js';
+
+// Preprocess to handle LLM sending attributes as JSON string instead of object
+const attributesWithPreprocess = z.preprocess(val => {
+  if (typeof val !== 'string') return val;
+
+  try {
+    return JSON.parse(val);
+  } catch {
+    return val;
+  }
+}, z.record(z.string(), z.unknown()));
+
+interface UpdateArgument {
+  collectionName: string;
+  recordId: string | number;
+  attributes: Record<string, unknown>;
+}
+
+function createArgumentShape(collectionNames: string[]) {
+  return {
+    collectionName:
+      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    recordId: z.union([z.string(), z.number()]).describe('The ID of the record to update.'),
+    attributes: attributesWithPreprocess.describe(
+      'The attributes to update. Must be an object with field names as keys.',
+    ),
+  };
+}
+
+export default function declareUpdateTool(
+  mcpServer: McpServer,
+  forestServerUrl: string,
+  logger: Logger,
+  collectionNames: string[] = [],
+): void {
+  const argumentShape = createArgumentShape(collectionNames);
+
+  registerToolWithLogging(
+    mcpServer,
+    'update',
+    {
+      title: 'Update a record',
+      description: 'Update an existing record in the specified collection.',
+      inputSchema: argumentShape,
+    },
+    async (options: UpdateArgument, extra) => {
+      const { rpcClient } = await buildClient(extra);
+
+      await createActivityLog(forestServerUrl, extra, 'update', {
+        collectionName: options.collectionName,
+        recordId: options.recordId,
+      });
+
+      try {
+        const record = await rpcClient
+          .collection(options.collectionName)
+          .update(options.recordId, options.attributes);
+
+        return { content: [{ type: 'text', text: JSON.stringify({ record }) }] };
+      } catch (error) {
+        const errorDetail = parseAgentError(error);
+        throw errorDetail ? new Error(errorDetail) : error;
+      }
+    },
+    logger,
+  );
+}

--- a/packages/mcp-server/test/forest-oauth-provider.test.ts
+++ b/packages/mcp-server/test/forest-oauth-provider.test.ts
@@ -4,8 +4,8 @@ import type { Response } from 'express';
 import createForestAdminClient from '@forestadmin/forestadmin-client';
 import jsonwebtoken from 'jsonwebtoken';
 
-import ForestOAuthProvider from '../src/forest-oauth-provider';
 import MockServer from './test-utils/mock-server';
+import ForestOAuthProvider from '../src/forest-oauth-provider';
 
 jest.mock('jsonwebtoken');
 jest.mock('@forestadmin/forestadmin-client');

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -5,6 +5,7 @@ import request from 'supertest';
 
 import MockServer from './test-utils/mock-server';
 import ForestMCPServer from '../src/server';
+import { clearSchemaCache } from '../src/utils/schema-fetcher.js';
 
 function shutDownHttpServer(server: http.Server | undefined): Promise<void> {
   if (!server) return Promise.resolve();

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -1,0 +1,264 @@
+import type { Logger } from '../../src/server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
+
+import declareCreateTool from '../../src/tools/create';
+import createActivityLog from '../../src/utils/activity-logs-creator';
+import buildClient from '../../src/utils/agent-caller';
+
+jest.mock('../../src/utils/agent-caller');
+jest.mock('../../src/utils/activity-logs-creator');
+
+const mockLogger: Logger = jest.fn();
+
+const mockBuildClient = buildClient as jest.MockedFunction<typeof buildClient>;
+const mockCreateActivityLog = createActivityLog as jest.MockedFunction<typeof createActivityLog>;
+
+describe('declareCreateTool', () => {
+  let mcpServer: McpServer;
+  let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
+  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mcpServer = {
+      registerTool: jest.fn((name, config, handler) => {
+        registeredToolConfig = config;
+        registeredToolHandler = handler;
+      }),
+    } as unknown as McpServer;
+
+    mockCreateActivityLog.mockResolvedValue(undefined);
+  });
+
+  describe('tool registration', () => {
+    it('should register a tool named "create"', () => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(mcpServer.registerTool).toHaveBeenCalledWith(
+        'create',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should register tool with correct title and description', () => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.title).toBe('Create a record');
+      expect(registeredToolConfig.description).toBe(
+        'Create a new record in the specified collection.',
+      );
+    });
+
+    it('should define correct input schema', () => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema).toHaveProperty('attributes');
+    });
+
+    it('should use string type for collectionName when no collection names provided', () => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options?: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toBeUndefined();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
+    });
+
+    it('should use enum type for collectionName when collection names provided', () => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger, [
+        'users',
+        'products',
+      ]);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      expect(() => schema.collectionName.parse('users')).not.toThrow();
+      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+    });
+  });
+
+  describe('tool execution', () => {
+    const mockExtra = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          forestServerToken: 'forest-token',
+          renderingId: '123',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    beforeEach(() => {
+      declareCreateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+    });
+
+    it('should call buildClient with the extra parameter', async () => {
+      const mockCreate = jest.fn().mockResolvedValue({ id: 1, name: 'New Record' });
+      const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler(
+        { collectionName: 'users', attributes: { name: 'John' } },
+        mockExtra,
+      );
+
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+    });
+
+    it('should call rpcClient.collection with the collection name', async () => {
+      const mockCreate = jest.fn().mockResolvedValue({ id: 1, name: 'New Record' });
+      const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler(
+        { collectionName: 'products', attributes: { name: 'Product' } },
+        mockExtra,
+      );
+
+      expect(mockCollection).toHaveBeenCalledWith('products');
+    });
+
+    it('should call create with the attributes', async () => {
+      const mockCreate = jest
+        .fn()
+        .mockResolvedValue({ id: 1, name: 'John', email: 'john@test.com' });
+      const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const attributes = { name: 'John', email: 'john@test.com' };
+      await registeredToolHandler({ collectionName: 'users', attributes }, mockExtra);
+
+      expect(mockCreate).toHaveBeenCalledWith(attributes);
+    });
+
+    it('should return the created record as JSON text content', async () => {
+      const createdRecord = { id: 1, name: 'John', email: 'john@test.com' };
+      const mockCreate = jest.fn().mockResolvedValue(createdRecord);
+      const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', attributes: { name: 'John', email: 'john@test.com' } },
+        mockExtra,
+      );
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ record: createdRecord }) }],
+      });
+    });
+
+    describe('activity logging', () => {
+      beforeEach(() => {
+        const mockCreate = jest.fn().mockResolvedValue({ id: 1 });
+        const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+      });
+
+      it('should create activity log with "create" action type', async () => {
+        await registeredToolHandler(
+          { collectionName: 'users', attributes: { name: 'John' } },
+          mockExtra,
+        );
+
+        expect(mockCreateActivityLog).toHaveBeenCalledWith(
+          'https://api.forestadmin.com',
+          mockExtra,
+          'create',
+          { collectionName: 'users' },
+        );
+      });
+    });
+
+    describe('attributes parsing', () => {
+      it('should parse attributes sent as JSON string (LLM workaround)', () => {
+        const attributes = { name: 'John', age: 30 };
+        const attributesAsString = JSON.stringify(attributes);
+
+        const inputSchema = registeredToolConfig.inputSchema as Record<
+          string,
+          { parse: (value: unknown) => unknown }
+        >;
+        const parsedAttributes = inputSchema.attributes.parse(attributesAsString);
+
+        expect(parsedAttributes).toEqual(attributes);
+      });
+
+      it('should handle attributes as object when not sent as string', async () => {
+        const mockCreate = jest.fn().mockResolvedValue({ id: 1 });
+        const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        const attributes = { name: 'John', age: 30 };
+        await registeredToolHandler({ collectionName: 'users', attributes }, mockExtra);
+
+        expect(mockCreate).toHaveBeenCalledWith(attributes);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should parse error with nested error.text structure in message', async () => {
+        const errorPayload = {
+          error: {
+            status: 400,
+            text: JSON.stringify({
+              errors: [{ name: 'ValidationError', detail: 'Name is required' }],
+            }),
+          },
+        };
+        const agentError = new Error(JSON.stringify(errorPayload));
+        const mockCreate = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler({ collectionName: 'users', attributes: {} }, mockExtra),
+        ).rejects.toThrow('Name is required');
+      });
+
+      it('should rethrow original error when no parsable error found', async () => {
+        const agentError = { unknownProperty: 'some value' };
+        const mockCreate = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ create: mockCreate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler({ collectionName: 'users', attributes: {} }, mockExtra),
+        ).rejects.toEqual(agentError);
+      });
+    });
+  });
+});

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -1,0 +1,270 @@
+import type { Logger } from '../../src/server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
+
+import declareDeleteTool from '../../src/tools/delete';
+import createActivityLog from '../../src/utils/activity-logs-creator';
+import buildClient from '../../src/utils/agent-caller';
+
+jest.mock('../../src/utils/agent-caller');
+jest.mock('../../src/utils/activity-logs-creator');
+
+const mockLogger: Logger = jest.fn();
+
+const mockBuildClient = buildClient as jest.MockedFunction<typeof buildClient>;
+const mockCreateActivityLog = createActivityLog as jest.MockedFunction<typeof createActivityLog>;
+
+describe('declareDeleteTool', () => {
+  let mcpServer: McpServer;
+  let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
+  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mcpServer = {
+      registerTool: jest.fn((name, config, handler) => {
+        registeredToolConfig = config;
+        registeredToolHandler = handler;
+      }),
+    } as unknown as McpServer;
+
+    mockCreateActivityLog.mockResolvedValue(undefined);
+  });
+
+  describe('tool registration', () => {
+    it('should register a tool named "delete"', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(mcpServer.registerTool).toHaveBeenCalledWith(
+        'delete',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should register tool with correct title and description', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.title).toBe('Delete records');
+      expect(registeredToolConfig.description).toBe(
+        'Delete one or more records from the specified collection.',
+      );
+    });
+
+    it('should define correct input schema', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema).toHaveProperty('recordIds');
+    });
+
+    it('should use string type for collectionName when no collection names provided', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options?: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toBeUndefined();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
+    });
+
+    it('should use enum type for collectionName when collection names provided', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger, [
+        'users',
+        'products',
+      ]);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      expect(() => schema.collectionName.parse('users')).not.toThrow();
+      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+    });
+
+    it('should accept array of strings or numbers for recordIds', () => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { parse: (value: unknown) => unknown }
+      >;
+      expect(() => schema.recordIds.parse(['1', '2', '3'])).not.toThrow();
+      expect(() => schema.recordIds.parse([1, 2, 3])).not.toThrow();
+      expect(() => schema.recordIds.parse(['1', 2, '3'])).not.toThrow();
+    });
+  });
+
+  describe('tool execution', () => {
+    const mockExtra = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          forestServerToken: 'forest-token',
+          renderingId: '123',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    beforeEach(() => {
+      declareDeleteTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+    });
+
+    it('should call buildClient with the extra parameter', async () => {
+      const mockDelete = jest.fn().mockResolvedValue(undefined);
+      const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler({ collectionName: 'users', recordIds: [1, 2] }, mockExtra);
+
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+    });
+
+    it('should call rpcClient.collection with the collection name', async () => {
+      const mockDelete = jest.fn().mockResolvedValue(undefined);
+      const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler({ collectionName: 'products', recordIds: [1] }, mockExtra);
+
+      expect(mockCollection).toHaveBeenCalledWith('products');
+    });
+
+    it('should call delete with the recordIds', async () => {
+      const mockDelete = jest.fn().mockResolvedValue(undefined);
+      const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const recordIds = [1, 2, 3];
+      await registeredToolHandler({ collectionName: 'users', recordIds }, mockExtra);
+
+      expect(mockDelete).toHaveBeenCalledWith(recordIds);
+    });
+
+    it('should return success message with count', async () => {
+      const mockDelete = jest.fn().mockResolvedValue(undefined);
+      const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', recordIds: [1, 2, 3] },
+        mockExtra,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Successfully deleted 3 record(s) from users',
+            }),
+          },
+        ],
+      });
+    });
+
+    it('should handle single record deletion', async () => {
+      const mockDelete = jest.fn().mockResolvedValue(undefined);
+      const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', recordIds: [42] },
+        mockExtra,
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Successfully deleted 1 record(s) from users',
+            }),
+          },
+        ],
+      });
+    });
+
+    describe('activity logging', () => {
+      beforeEach(() => {
+        const mockDelete = jest.fn().mockResolvedValue(undefined);
+        const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+      });
+
+      it('should create activity log with "delete" action type and recordIds', async () => {
+        const recordIds = [1, 2, 3];
+        await registeredToolHandler({ collectionName: 'users', recordIds }, mockExtra);
+
+        expect(mockCreateActivityLog).toHaveBeenCalledWith(
+          'https://api.forestadmin.com',
+          mockExtra,
+          'delete',
+          { collectionName: 'users', recordIds },
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should parse error with nested error.text structure in message', async () => {
+        const errorPayload = {
+          error: {
+            status: 403,
+            text: JSON.stringify({
+              errors: [{ name: 'ForbiddenError', detail: 'Cannot delete protected records' }],
+            }),
+          },
+        };
+        const agentError = new Error(JSON.stringify(errorPayload));
+        const mockDelete = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler({ collectionName: 'users', recordIds: [1] }, mockExtra),
+        ).rejects.toThrow('Cannot delete protected records');
+      });
+
+      it('should rethrow original error when no parsable error found', async () => {
+        const agentError = { unknownProperty: 'some value' };
+        const mockDelete = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ delete: mockDelete });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler({ collectionName: 'users', recordIds: [1] }, mockExtra),
+        ).rejects.toEqual(agentError);
+      });
+    });
+  });
+});

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -680,9 +680,9 @@ describe('declareListTool', () => {
           expect(callOrder.indexOf('list-start')).toBeLessThan(callOrder.indexOf('list-end'));
           expect(callOrder.indexOf('count-start')).toBeLessThan(callOrder.indexOf('count-end'));
           // Both starts should happen before both ends
-          expect(
-            callOrder.indexOf('list-start') < 2 && callOrder.indexOf('count-start') < 2,
-          ).toBe(true);
+          expect(callOrder.indexOf('list-start') < 2 && callOrder.indexOf('count-start') < 2).toBe(
+            true,
+          );
         });
       });
 

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -1,0 +1,285 @@
+import type { Logger } from '../../src/server';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
+
+import declareUpdateTool from '../../src/tools/update';
+import createActivityLog from '../../src/utils/activity-logs-creator';
+import buildClient from '../../src/utils/agent-caller';
+
+jest.mock('../../src/utils/agent-caller');
+jest.mock('../../src/utils/activity-logs-creator');
+
+const mockLogger: Logger = jest.fn();
+
+const mockBuildClient = buildClient as jest.MockedFunction<typeof buildClient>;
+const mockCreateActivityLog = createActivityLog as jest.MockedFunction<typeof createActivityLog>;
+
+describe('declareUpdateTool', () => {
+  let mcpServer: McpServer;
+  let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
+  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mcpServer = {
+      registerTool: jest.fn((name, config, handler) => {
+        registeredToolConfig = config;
+        registeredToolHandler = handler;
+      }),
+    } as unknown as McpServer;
+
+    mockCreateActivityLog.mockResolvedValue(undefined);
+  });
+
+  describe('tool registration', () => {
+    it('should register a tool named "update"', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(mcpServer.registerTool).toHaveBeenCalledWith(
+        'update',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should register tool with correct title and description', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.title).toBe('Update a record');
+      expect(registeredToolConfig.description).toBe(
+        'Update an existing record in the specified collection.',
+      );
+    });
+
+    it('should define correct input schema', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema).toHaveProperty('recordId');
+      expect(registeredToolConfig.inputSchema).toHaveProperty('attributes');
+    });
+
+    it('should use string type for collectionName when no collection names provided', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options?: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toBeUndefined();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
+    });
+
+    it('should use enum type for collectionName when collection names provided', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger, [
+        'users',
+        'products',
+      ]);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { options: string[]; parse: (value: unknown) => unknown }
+      >;
+      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      expect(() => schema.collectionName.parse('users')).not.toThrow();
+      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+    });
+
+    it('should accept both string and number for recordId', () => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { parse: (value: unknown) => unknown }
+      >;
+      expect(() => schema.recordId.parse('123')).not.toThrow();
+      expect(() => schema.recordId.parse(123)).not.toThrow();
+    });
+  });
+
+  describe('tool execution', () => {
+    const mockExtra = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          forestServerToken: 'forest-token',
+          renderingId: '123',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    beforeEach(() => {
+      declareUpdateTool(mcpServer, 'https://api.forestadmin.com', mockLogger);
+    });
+
+    it('should call buildClient with the extra parameter', async () => {
+      const mockUpdate = jest.fn().mockResolvedValue({ id: 1, name: 'Updated' });
+      const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler(
+        { collectionName: 'users', recordId: 1, attributes: { name: 'Updated' } },
+        mockExtra,
+      );
+
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+    });
+
+    it('should call rpcClient.collection with the collection name', async () => {
+      const mockUpdate = jest.fn().mockResolvedValue({ id: 1, name: 'Updated' });
+      const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      await registeredToolHandler(
+        { collectionName: 'products', recordId: 1, attributes: { name: 'Updated' } },
+        mockExtra,
+      );
+
+      expect(mockCollection).toHaveBeenCalledWith('products');
+    });
+
+    it('should call update with the recordId and attributes', async () => {
+      const mockUpdate = jest
+        .fn()
+        .mockResolvedValue({ id: 1, name: 'Updated', email: 'new@test.com' });
+      const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const attributes = { name: 'Updated', email: 'new@test.com' };
+      await registeredToolHandler({ collectionName: 'users', recordId: 42, attributes }, mockExtra);
+
+      expect(mockUpdate).toHaveBeenCalledWith(42, attributes);
+    });
+
+    it('should return the updated record as JSON text content', async () => {
+      const updatedRecord = { id: 1, name: 'Updated', email: 'new@test.com' };
+      const mockUpdate = jest.fn().mockResolvedValue(updatedRecord);
+      const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+      mockBuildClient.mockReturnValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClient>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', recordId: 1, attributes: { name: 'Updated' } },
+        mockExtra,
+      );
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ record: updatedRecord }) }],
+      });
+    });
+
+    describe('activity logging', () => {
+      beforeEach(() => {
+        const mockUpdate = jest.fn().mockResolvedValue({ id: 1 });
+        const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+      });
+
+      it('should create activity log with "update" action type and recordId', async () => {
+        await registeredToolHandler(
+          { collectionName: 'users', recordId: 42, attributes: { name: 'Updated' } },
+          mockExtra,
+        );
+
+        expect(mockCreateActivityLog).toHaveBeenCalledWith(
+          'https://api.forestadmin.com',
+          mockExtra,
+          'update',
+          { collectionName: 'users', recordId: 42 },
+        );
+      });
+    });
+
+    describe('attributes parsing', () => {
+      it('should parse attributes sent as JSON string (LLM workaround)', () => {
+        const attributes = { name: 'Updated', age: 31 };
+        const attributesAsString = JSON.stringify(attributes);
+
+        const inputSchema = registeredToolConfig.inputSchema as Record<
+          string,
+          { parse: (value: unknown) => unknown }
+        >;
+        const parsedAttributes = inputSchema.attributes.parse(attributesAsString);
+
+        expect(parsedAttributes).toEqual(attributes);
+      });
+
+      it('should handle attributes as object when not sent as string', async () => {
+        const mockUpdate = jest.fn().mockResolvedValue({ id: 1 });
+        const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        const attributes = { name: 'Updated', age: 31 };
+        await registeredToolHandler(
+          { collectionName: 'users', recordId: 1, attributes },
+          mockExtra,
+        );
+
+        expect(mockUpdate).toHaveBeenCalledWith(1, attributes);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should parse error with nested error.text structure in message', async () => {
+        const errorPayload = {
+          error: {
+            status: 404,
+            text: JSON.stringify({
+              errors: [{ name: 'NotFoundError', detail: 'Record not found' }],
+            }),
+          },
+        };
+        const agentError = new Error(JSON.stringify(errorPayload));
+        const mockUpdate = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler(
+            { collectionName: 'users', recordId: 999, attributes: {} },
+            mockExtra,
+          ),
+        ).rejects.toThrow('Record not found');
+      });
+
+      it('should rethrow original error when no parsable error found', async () => {
+        const agentError = { unknownProperty: 'some value' };
+        const mockUpdate = jest.fn().mockRejectedValue(agentError);
+        const mockCollection = jest.fn().mockReturnValue({ update: mockUpdate });
+        mockBuildClient.mockReturnValue({
+          rpcClient: { collection: mockCollection },
+          authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+        } as unknown as ReturnType<typeof buildClient>);
+
+        await expect(
+          registeredToolHandler(
+            { collectionName: 'users', recordId: 1, attributes: {} },
+            mockExtra,
+          ),
+        ).rejects.toEqual(agentError);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `create` tool to create records in a collection
- Add `update` tool to update existing records by ID
- Add `delete` tool to delete one or more records by IDs

## New Tools

### create
Create a new record in a collection.
```json
{
  "collectionName": "users",
  "attributes": { "name": "John", "email": "john@example.com" }
}
```

### update
Update an existing record.
```json
{
  "collectionName": "users",
  "recordId": 42,
  "attributes": { "name": "John Updated" }
}
```

### delete
Delete one or more records.
```json
{
  "collectionName": "users",
  "recordIds": [1, 2, 3]
}
```

## Test plan
- [x] 43 new integration tests added
- [x] All 313 tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)