### PR TITLE
fix(datasource-mongoose): handle ObjectId with _bsontype in replaceMongoTypes

### DIFF
--- a/packages/datasource-mongoose/src/utils/helpers.ts
+++ b/packages/datasource-mongoose/src/utils/helpers.ts
@@ -142,6 +142,11 @@ export function replaceMongoTypes(data: any): any {
   if (data instanceof Types.ObjectId) return data.toHexString();
   if (data instanceof Types.Decimal128) return data.toString();
 
+  // Handle BSON types that may not pass instanceof checks due to different module versions
+  // eslint-disable-next-line no-underscore-dangle
+  if (data?._bsontype === 'ObjectId' && typeof data.toHexString === 'function') {
+    return data.toHexString();
+  }
   // eslint-disable-next-line no-underscore-dangle
   if (data?._bsontype === 'Binary') return data.buffer;
 

--- a/packages/datasource-mongoose/test/utils/helper.test.ts
+++ b/packages/datasource-mongoose/test/utils/helper.test.ts
@@ -64,4 +64,17 @@ describe('helpers', () => {
       nested: [{ _id: '5a934e000102030405000000', date: '1985-10-26T09:22:00.000Z', price: '42' }],
     });
   });
+
+  it('replaceMongoTypes should handle ObjectId with _bsontype property (BSON module mismatch)', () => {
+    // Simulate an ObjectId that doesn't pass instanceof check but has _bsontype
+    // This can happen when different versions of the BSON library are loaded
+    const fakeObjectId = {
+      _bsontype: 'ObjectId',
+      toHexString: () => '5a934e000102030405000000',
+    };
+
+    const record = helpers.replaceMongoTypes({ _id: fakeObjectId });
+
+    expect(record).toEqual({ _id: '5a934e000102030405000000' });
+  });
 });


### PR DESCRIPTION
…ngoTypes

Sometimes MongoDB driver returns ObjectId instances that don't pass `instanceof Types.ObjectId` checks due to different BSON module versions being loaded. These objects have a `_bsontype: 'ObjectId'` property.

This fix adds a fallback check for `_bsontype === 'ObjectId'` to ensure ObjectIds are always converted to hex strings, preventing flaky test failures where _id is returned as a raw buffer instead of a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
