### PR TITLE
fix(mcp-server): make collection name validation non-strict in tool schemas

### DIFF
--- a/packages/mcp-server/src/schemas/collection-name.ts
+++ b/packages/mcp-server/src/schemas/collection-name.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Creates a collection name schema that accepts any string but provides
+ * available collection names as suggestions in the description.
+ *
+ * Unlike z.enum() which strictly validates against a list, this schema
+ * allows any collection name to pass validation. This is useful when:
+ * - The collection list might be incomplete
+ * - We want to delegate validation to the actual API call
+ * - We want to provide helpful suggestions without being restrictive
+ */
+export default function createCollectionNameSchema(collectionNames: string[]) {
+  if (collectionNames.length > 0) {
+    return z.string().describe(`Available collections: ${collectionNames.join(', ')}`);
+  }
+
+  return z.string();
+}

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -4,6 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
 
+import createCollectionNameSchema from '../schemas/collection-name';
 import buildClient from '../utils/agent-caller';
 import registerToolWithLogging from '../utils/tool-with-logging';
 import withActivityLog from '../utils/with-activity-log';
@@ -26,8 +27,7 @@ interface CreateArgument {
 
 function createArgumentShape(collectionNames: string[]) {
   return {
-    collectionName:
-      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    collectionName: createCollectionNameSchema(collectionNames),
     attributes: attributesWithPreprocess.describe(
       'The attributes of the record to create. Must be an object with field names as keys.',
     ),

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -4,6 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
 
+import createCollectionNameSchema from '../schemas/collection-name';
 import buildClient from '../utils/agent-caller';
 import registerToolWithLogging from '../utils/tool-with-logging';
 import withActivityLog from '../utils/with-activity-log';
@@ -15,8 +16,7 @@ interface DeleteArgument {
 
 function createArgumentShape(collectionNames: string[]) {
   return {
-    collectionName:
-      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    collectionName: createCollectionNameSchema(collectionNames),
     recordIds: z
       .array(z.union([z.string(), z.number()]))
       .describe('The IDs of the records to delete.'),

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -2,8 +2,7 @@ import type { ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { z } from 'zod';
-
+import createCollectionNameSchema from '../schemas/collection-name';
 import buildClient from '../utils/agent-caller';
 import {
   fetchForestSchema,
@@ -23,8 +22,7 @@ interface CollectionCapabilities {
 
 function createDescribeCollectionArgumentShape(collectionNames: string[]) {
   return {
-    collectionName:
-      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    collectionName: createCollectionNameSchema(collectionNames),
   };
 }
 

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -5,6 +5,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
 
+import createCollectionNameSchema from '../schemas/collection-name';
 import filterSchema from '../schemas/filter';
 import buildClient from '../utils/agent-caller';
 import { fetchForestSchema, getFieldsOfCollection } from '../utils/schema-fetcher';
@@ -66,8 +67,7 @@ export type ListArgument = z.infer<typeof listArgumentSchema>;
 export function createListArgumentShape(collectionNames: string[]) {
   return {
     ...listArgumentSchema.shape,
-    collectionName:
-      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    collectionName: createCollectionNameSchema(collectionNames),
   };
 }
 

--- a/packages/mcp-server/src/tools/update.ts
+++ b/packages/mcp-server/src/tools/update.ts
@@ -4,6 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
 
+import createCollectionNameSchema from '../schemas/collection-name';
 import buildClient from '../utils/agent-caller';
 import registerToolWithLogging from '../utils/tool-with-logging';
 import withActivityLog from '../utils/with-activity-log';
@@ -27,8 +28,7 @@ interface UpdateArgument {
 
 function createArgumentShape(collectionNames: string[]) {
   return {
-    collectionName:
-      collectionNames.length > 0 ? z.enum(collectionNames as [string, ...string[]]) : z.string(),
+    collectionName: createCollectionNameSchema(collectionNames),
     recordId: z.union([z.string(), z.number()]).describe('The ID of the record to update.'),
     attributes: attributesWithPreprocess.describe(
       'The attributes to update. Must be an object with field names as keys.',

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -77,16 +77,20 @@ describe('declareCreateTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareCreateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
   });
 

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -77,16 +77,20 @@ describe('declareDeleteTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareDeleteTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
     it('should accept array of strings or numbers for recordIds', () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -93,7 +93,7 @@ describe('declareDescribeCollectionTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger, [
         'users',
         'products',
@@ -102,15 +102,17 @@ describe('declareDescribeCollectionTool', () => {
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      // Enum type should have options property with the collection names
-      expect(schema.collectionName.options).toEqual(['users', 'products', 'orders']);
-      // Should accept valid collection names
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      expect(schema.collectionName.description).toContain('orders');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
       expect(() => schema.collectionName.parse('products')).not.toThrow();
-      // Should reject invalid collection names
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
   });
 

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -135,7 +135,7 @@ describe('declareListRelatedTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger, [
         'users',
         'products',
@@ -144,15 +144,17 @@ describe('declareListRelatedTool', () => {
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      // Enum type should have options property with the collection names
-      expect(schema.collectionName.options).toEqual(['users', 'products', 'orders']);
-      // Should accept valid collection names
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      expect(schema.collectionName.description).toContain('orders');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
       expect(() => schema.collectionName.parse('products')).not.toThrow();
-      // Should reject invalid collection names
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
     it('should accept string parentRecordId', () => {

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -147,7 +147,7 @@ describe('declareListTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareListTool(mcpServer, mockForestServerClient, mockLogger, [
         'users',
         'products',
@@ -156,15 +156,17 @@ describe('declareListTool', () => {
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      // Enum type should have options property with the collection names
-      expect(schema.collectionName.options).toEqual(['users', 'products', 'orders']);
-      // Should accept valid collection names
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      expect(schema.collectionName.description).toContain('orders');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
       expect(() => schema.collectionName.parse('products')).not.toThrow();
-      // Should reject invalid collection names
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
   });
 

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -78,16 +78,20 @@ describe('declareUpdateTool', () => {
       expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
-    it('should use enum type for collectionName when collection names provided', () => {
+    it('should provide collection names in description when collection names provided', () => {
       declareUpdateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
-        { options: string[]; parse: (value: unknown) => unknown }
+        { description?: string; parse: (value: unknown) => unknown }
       >;
-      expect(schema.collectionName.options).toEqual(['users', 'products']);
+      // Description should include available collection names
+      expect(schema.collectionName.description).toContain('Available collections:');
+      expect(schema.collectionName.description).toContain('users');
+      expect(schema.collectionName.description).toContain('products');
+      // Should accept any string (no strict validation)
       expect(() => schema.collectionName.parse('users')).not.toThrow();
-      expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
+      expect(() => schema.collectionName.parse('any-collection')).not.toThrow();
     });
 
     it('should accept both string and number for recordId', () => {


### PR DESCRIPTION
## Summary
- Replace `z.enum()` with `z.string()` for collectionName parameter in all MCP tools
- Collection names are now provided as suggestions in the schema description instead of strict validation
- Create reusable `createCollectionNameSchema` helper to avoid code duplication

This change ensures that:
- Tools accept any collection name without Zod validation errors
- Collection names are still provided as hints to the AI via schema description
- Validation is delegated to the actual API call which provides better error messages

## Test plan
- [x] All tool tests pass with updated expectations
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)