### PR TITLE
fix(mcp-server): make ascending optional in sort schema

### DIFF
--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -34,7 +34,7 @@ const listArgumentSchema = z.object({
   sort: z
     .object({
       field: z.string(),
-      ascending: z.boolean(),
+      ascending: z.boolean().optional().default(true),
     })
     .optional(),
   shouldSearchInRelation: z

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -166,6 +166,18 @@ describe('declareListTool', () => {
       // Should reject invalid collection names
       expect(() => schema.collectionName.parse('invalid-collection')).toThrow();
     });
+
+    it('should make ascending optional in sort schema with default value true', () => {
+      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { parse: (value: unknown) => unknown }
+      >;
+      // Sort with only field should be accepted
+      const result = schema.sort.parse({ field: 'createdAt' });
+      expect(result).toEqual({ field: 'createdAt', ascending: true });
+    });
   });
 
   describe('tool execution', () => {


### PR DESCRIPTION
## Summary
- Make `ascending` field optional in the sort object schema
- Defaults to `true` (ascending order) when not provided

This allows the AI to specify just the field name: `{ field: "name" }` instead of requiring `{ field: "name", ascending: true }`.

## Test plan
- [x] All tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)