### PR TITLE
feat(ai-proxy): add infogreffe tools

### DIFF
--- a/packages/ai-proxy/package.json
+++ b/packages/ai-proxy/package.json
@@ -12,17 +12,18 @@
     "directory": "packages/ai-proxy"
   },
   "dependencies": {
-    "openai": "4.95.0",
     "@forestadmin/datasource-toolkit": "1.50.1",
     "@langchain/community": "0.3.57",
     "@langchain/core": "1.1.4",
     "@langchain/langgraph": "1.0.4",
-    "@langchain/mcp-adapters": "1.0.3"
+    "@langchain/mcp-adapters": "1.0.3",
+    "openai": "4.95.0",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "1.20.0",
-    "express": "5.1.0",
     "@types/express": "5.0.1",
+    "express": "5.1.0",
     "node-zendesk": "6.0.1"
   },
   "files": [

--- a/packages/ai-proxy/src/examples/run-mcp-gmail-server.ts
+++ b/packages/ai-proxy/src/examples/run-mcp-gmail-server.ts
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-extraneous-dependencies, import/extensions */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+/* eslint-enable import/no-extraneous-dependencies, import/extensions */
+
+import runMcpServer from './simple-mcp-server';
+
+const server = new McpServer({
+  name: 'gmail',
+  version: '1.0.0',
+});
+
+// Gmail API configuration
+// To use this, you'll need to:
+// 1. Enable Gmail API in Google Cloud Console
+// 2. Create OAuth 2.0 credentials
+// 3. Get an access token
+const GMAIL_ACCESS_TOKEN = 'YOUR_GMAIL_ACCESS_TOKEN';
+
+const headers = {
+  Authorization: `Bearer ${GMAIL_ACCESS_TOKEN}`,
+  'Content-Type': 'application/json',
+};
+
+server.tool('gmail_search', { query: 'string', maxResults: 'number' }, async params => {
+  const url = new URL('https://gmail.googleapis.com/gmail/v1/users/me/messages');
+  url.searchParams.set('q', params.query);
+  url.searchParams.set('maxResults', (params.maxResults || 10).toString());
+
+  const response = await fetch(url.toString(), { headers });
+  const data = await response.json();
+
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+});
+
+server.tool(
+  'gmail_send_message',
+  { to: 'array', subject: 'string', message: 'string' },
+  async params => {
+    const emailLines = [
+      `To: ${params.to.join(', ')}`,
+      `Subject: ${params.subject}`,
+      '',
+      params.message,
+    ];
+
+    const email = emailLines.join('\r\n');
+    const encodedEmail = Buffer.from(email)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ raw: encodedEmail }),
+    });
+
+    const data = await response.json();
+
+    return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+  },
+);
+
+server.tool('gmail_get_message', { messageId: 'string' }, async params => {
+  const response = await fetch(
+    `https://gmail.googleapis.com/gmail/v1/users/me/messages/${params.messageId}?format=full`,
+    { headers },
+  );
+
+  const data = await response.json();
+
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+});
+
+runMcpServer(server, 3125);

--- a/packages/ai-proxy/src/integrations/brave/tools.ts
+++ b/packages/ai-proxy/src/integrations/brave/tools.ts
@@ -1,0 +1,17 @@
+import { BraveSearch } from '@langchain/community/tools/brave_search';
+
+import RemoteTool from '../../remote-tool';
+
+export interface BraveConfig {
+  apiKey: string;
+}
+
+export default function getBraveTools(config: BraveConfig): RemoteTool[] {
+  return [
+    new RemoteTool({
+      sourceId: 'brave_search',
+      sourceType: 'server',
+      tool: new BraveSearch({ apiKey: config.apiKey }),
+    }),
+  ];
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools.ts
@@ -1,0 +1,32 @@
+import RemoteTool from '../../remote-tool';
+import createDraftTool from './tools/create-draft';
+import createGetMessageTool from './tools/get-message';
+import createGetThreadTool from './tools/get-thread';
+import createSearchTool from './tools/search';
+import createSendMessageTool from './tools/send-message';
+
+export interface GmailConfig {
+  accessToken: string;
+}
+
+export default function getGmailTools(config: GmailConfig): RemoteTool[] {
+  const headers = {
+    Authorization: `Bearer ${config.accessToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  return [
+    createSendMessageTool(headers),
+    createGetMessageTool(headers),
+    createSearchTool(headers),
+    createDraftTool(headers),
+    createGetThreadTool(headers),
+  ].map(
+    tool =>
+      new RemoteTool({
+        sourceId: 'gmail',
+        sourceType: 'server',
+        tool,
+      }),
+  );
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools/create-draft.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools/create-draft.ts
@@ -1,0 +1,50 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createDraftTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'gmail_create_draft',
+    description: 'Create a draft email in Gmail',
+    schema: z.object({
+      to: z.array(z.string()).describe('Array of recipient email addresses'),
+      subject: z.string().describe('Email subject line'),
+      message: z.string().describe('Email body content'),
+      cc: z.array(z.string()).optional().describe('Array of CC email addresses'),
+      bcc: z.array(z.string()).optional().describe('Array of BCC email addresses'),
+    }),
+    func: async ({ to, subject, message, cc, bcc }) => {
+      const emailLines = [
+        `To: ${to.join(', ')}`,
+        ...(cc ? [`Cc: ${cc.join(', ')}`] : []),
+        ...(bcc ? [`Bcc: ${bcc.join(', ')}`] : []),
+        `Subject: ${subject}`,
+        '',
+        message,
+      ];
+
+      const email = emailLines.join('\r\n');
+      const encodedEmail = Buffer.from(email)
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      const response = await fetch(
+        'https://gmail.googleapis.com/gmail/v1/users/me/drafts',
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            message: {
+              raw: encodedEmail,
+            },
+          }),
+        },
+      );
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools/get-message.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools/get-message.ts
@@ -1,0 +1,69 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetMessageTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'gmail_get_message',
+    description: 'Get a specific email message by ID from Gmail',
+    schema: z.object({
+      message_id: z.string().describe('The ID of the message to retrieve'),
+    }),
+    func: async ({ message_id }) => {
+      const response = await fetch(
+        `https://gmail.googleapis.com/gmail/v1/users/me/messages/${message_id}?format=full`,
+        {
+          method: 'GET',
+          headers,
+        },
+      );
+
+      const data = await response.json();
+
+      if (!data.payload) {
+        return JSON.stringify({ error: 'Message not found or invalid payload' });
+      }
+
+      const getHeader = (name: string) =>
+        data.payload.headers?.find(
+          (h: { name: string; value: string }) => h.name.toLowerCase() === name.toLowerCase(),
+        )?.value || '';
+
+      const decodeBody = (body: string) => {
+        if (!body) return '';
+        try {
+          const sanitized = body.replace(/-/g, '+').replace(/_/g, '/');
+          return Buffer.from(sanitized, 'base64').toString('utf-8');
+        } catch {
+          return '';
+        }
+      };
+
+      const getBody = (payload: any): string => {
+        if (payload.body?.data) {
+          return decodeBody(payload.body.data);
+        }
+        if (payload.parts) {
+          for (const part of payload.parts) {
+            const body = getBody(part);
+            if (body) return body;
+          }
+        }
+        return '';
+      };
+
+      const result = {
+        id: data.id,
+        threadId: data.threadId,
+        subject: getHeader('Subject'),
+        from: getHeader('From'),
+        to: getHeader('To'),
+        date: getHeader('Date'),
+        body: getBody(data.payload),
+      };
+
+      return JSON.stringify(result);
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools/get-thread.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools/get-thread.ts
@@ -1,0 +1,75 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetThreadTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'gmail_get_thread',
+    description: 'Get a complete email thread (conversation) by thread ID from Gmail',
+    schema: z.object({
+      thread_id: z.string().describe('The ID of the thread to retrieve'),
+    }),
+    func: async ({ thread_id }) => {
+      const response = await fetch(
+        `https://gmail.googleapis.com/gmail/v1/users/me/threads/${thread_id}?format=full`,
+        {
+          method: 'GET',
+          headers,
+        },
+      );
+
+      const data = await response.json();
+
+      if (!data.messages) {
+        return JSON.stringify({ error: 'Thread not found or no messages' });
+      }
+
+      const decodeBody = (body: string) => {
+        if (!body) return '';
+        try {
+          const sanitized = body.replace(/-/g, '+').replace(/_/g, '/');
+          return Buffer.from(sanitized, 'base64').toString('utf-8');
+        } catch {
+          return '';
+        }
+      };
+
+      const getBody = (payload: any): string => {
+        if (payload.body?.data) {
+          return decodeBody(payload.body.data);
+        }
+        if (payload.parts) {
+          for (const part of payload.parts) {
+            const body = getBody(part);
+            if (body) return body;
+          }
+        }
+        return '';
+      };
+
+      const messages = data.messages.map((msg: any) => {
+        const getHeader = (name: string) =>
+          msg.payload?.headers?.find(
+            (h: { name: string; value: string }) =>
+              h.name.toLowerCase() === name.toLowerCase(),
+          )?.value || '';
+
+        return {
+          id: msg.id,
+          subject: getHeader('Subject'),
+          from: getHeader('From'),
+          to: getHeader('To'),
+          date: getHeader('Date'),
+          body: getBody(msg.payload),
+        };
+      });
+
+      return JSON.stringify({
+        threadId: data.id,
+        messageCount: messages.length,
+        messages,
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools/search.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools/search.ts
@@ -1,0 +1,102 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createSearchTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'gmail_search',
+    description:
+      'Search for Gmail messages or threads using Gmail search query syntax. Returns message/thread IDs that can be used with other tools.',
+    schema: z.object({
+      query: z
+        .string()
+        .describe(
+          'Gmail search query (e.g., "from:user@example.com", "subject:meeting", "is:unread")',
+        ),
+      max_results: z.number().optional().default(10).describe('Maximum number of results (default: 10)'),
+      resource: z
+        .enum(['messages', 'threads'])
+        .optional()
+        .default('messages')
+        .describe('Type of resource to search for (messages or threads)'),
+    }),
+    func: async ({ query, max_results = 10, resource = 'messages' }) => {
+      const url = new URL(`https://gmail.googleapis.com/gmail/v1/users/me/${resource}`);
+      url.searchParams.set('q', query);
+      url.searchParams.set('maxResults', max_results.toString());
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      if (resource === 'messages') {
+        const messages = data.messages || [];
+        if (messages.length === 0) {
+          return JSON.stringify({ results: [], count: 0 });
+        }
+
+        const detailedMessages = await Promise.all(
+          messages.map(async (msg: { id: string }) => {
+            const msgResponse = await fetch(
+              `https://gmail.googleapis.com/gmail/v1/users/me/messages/${msg.id}?format=full`,
+              {
+                method: 'GET',
+                headers,
+              },
+            );
+            const msgData = await msgResponse.json();
+
+            const getHeader = (name: string) =>
+              msgData.payload?.headers?.find(
+                (h: { name: string; value: string }) =>
+                  h.name.toLowerCase() === name.toLowerCase(),
+              )?.value || '';
+
+            const decodeBody = (body: string) => {
+              if (!body) return '';
+              try {
+                const sanitized = body.replace(/-/g, '+').replace(/_/g, '/');
+                return Buffer.from(sanitized, 'base64').toString('utf-8');
+              } catch {
+                return '';
+              }
+            };
+
+            const getBody = (payload: any): string => {
+              if (payload.body?.data) {
+                return decodeBody(payload.body.data);
+              }
+              if (payload.parts) {
+                for (const part of payload.parts) {
+                  const body = getBody(part);
+                  if (body) return body;
+                }
+              }
+              return '';
+            };
+
+            return {
+              id: msgData.id,
+              threadId: msgData.threadId,
+              subject: getHeader('Subject'),
+              from: getHeader('From'),
+              to: getHeader('To'),
+              date: getHeader('Date'),
+              snippet: msgData.snippet,
+              body: getBody(msgData.payload)?.substring(0, 500),
+            };
+          }),
+        );
+
+        return JSON.stringify({ results: detailedMessages, count: detailedMessages.length });
+      }
+
+      const threads = data.threads || [];
+      return JSON.stringify({ results: threads, count: threads.length });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/gmail/tools/send-message.ts
+++ b/packages/ai-proxy/src/integrations/gmail/tools/send-message.ts
@@ -1,0 +1,48 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createSendMessageTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'gmail_send_message',
+    description: 'Send an email message via Gmail',
+    schema: z.object({
+      to: z.array(z.string()).describe('Array of recipient email addresses'),
+      subject: z.string().describe('Email subject line'),
+      message: z.string().describe('Email body content'),
+      cc: z.array(z.string()).optional().describe('Array of CC email addresses'),
+      bcc: z.array(z.string()).optional().describe('Array of BCC email addresses'),
+    }),
+    func: async ({ to, subject, message, cc, bcc }) => {
+      const emailLines = [
+        `To: ${to.join(', ')}`,
+        ...(cc ? [`Cc: ${cc.join(', ')}`] : []),
+        ...(bcc ? [`Bcc: ${bcc.join(', ')}`] : []),
+        `Subject: ${subject}`,
+        '',
+        message,
+      ];
+
+      const email = emailLines.join('\r\n');
+      const encodedEmail = Buffer.from(email)
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      const response = await fetch(
+        'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            raw: encodedEmail,
+          }),
+        },
+      );
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools.ts
@@ -1,0 +1,37 @@
+import RemoteTool from '../../remote-tool';
+import createAdvancedCompanySearchTool from './tools/advanced-company-search';
+import createAssessCompanyRiskTool from './tools/assess-company-risk';
+import createCheckCompanyRadiationTool from './tools/check-company-radiation';
+import createFindRelatedCompaniesTool from './tools/find-related-companies';
+import createGetCompanyDetailsTool from './tools/get-company-details';
+import createGetFinancialIndicatorsTool from './tools/get-financial-indicators';
+import createSearchNewCompaniesTool from './tools/search-new-companies';
+import createSearchRadiatedCompaniesTool from './tools/search-radiated-companies';
+
+export interface InfogreffeConfig {
+  apiKey: string;
+}
+
+export default function getInfogreffeTools(config: InfogreffeConfig): RemoteTool[] {
+  const headers: Record<string, string> = {
+    Authorization: `Apikey ${config.apiKey}`,
+  };
+
+  return [
+    createCheckCompanyRadiationTool(headers),
+    createSearchRadiatedCompaniesTool(headers),
+    createSearchNewCompaniesTool(headers),
+    createGetCompanyDetailsTool(headers),
+    createAssessCompanyRiskTool(headers),
+    createGetFinancialIndicatorsTool(headers),
+    createFindRelatedCompaniesTool(headers),
+    createAdvancedCompanySearchTool(headers),
+  ].map(
+    tool =>
+      new RemoteTool({
+        sourceId: 'infogreffe',
+        sourceType: 'server',
+        tool,
+      }),
+  );
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/advanced-company-search.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/advanced-company-search.ts
@@ -1,0 +1,82 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { buildQuery, searchV1Api } from '../utils';
+
+export default function createAdvancedCompanySearchTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_advanced_company_search',
+    description:
+      'Advanced multi-criteria search for French companies with combined filters (year, city, sector, legal form, etc.)',
+    schema: z.object({
+      ville: z.string().optional().describe('City (e.g., PARIS)'),
+      code_postal: z.string().optional().describe('Postal code (e.g., 75001)'),
+      secteur_d_activite: z.string().optional().describe('Business sector'),
+      code_ape: z.string().optional().describe('APE/NAF code (e.g., 6420Z)'),
+      forme_juridique: z.string().optional().describe('Legal form'),
+      status: z
+        .enum(['active', 'closed'])
+        .default('active')
+        .describe('Status: active (registered) or closed (struck-off)'),
+      year: z.enum(['2022', '2023', '2024', '2025']).default('2024').describe('Year'),
+      limit: z.number().int().positive().default(20).describe('Maximum results (default: 20)'),
+    }),
+    func: async ({
+      ville,
+      code_postal,
+      secteur_d_activite,
+      code_ape,
+      forme_juridique,
+      status,
+      year,
+      limit,
+    }) => {
+      const dataset =
+        status === 'closed'
+          ? `entreprises-radiees-en-${year}`
+          : `entreprises-immatriculees-en-${year}`;
+
+      const query = buildQuery([
+        ville && `ville:${ville}`,
+        code_postal && `code_postal:${code_postal}`,
+        secteur_d_activite && `secteur_d_activite:"${secteur_d_activite}"`,
+        code_ape && `code_ape:${code_ape}`,
+        forme_juridique && `forme_juridique:"${forme_juridique}"`,
+      ]);
+
+      const result = await searchV1Api(headers, dataset, query, limit);
+
+      return JSON.stringify({
+        criteres: {
+          ville,
+          code_postal,
+          secteur_d_activite,
+          code_ape,
+          forme_juridique,
+          status,
+          year,
+        },
+        total_resultats: result.nhits,
+        resultats_affiches: result.records.length,
+        entreprises: result.records.map(r => {
+          const fields = r.fields as Record<string, unknown>;
+
+          return {
+            siren: fields.siren,
+            denomination: fields.denomination,
+            adresse: fields.adresse,
+            code_postal: fields.code_postal,
+            ville: fields.ville,
+            forme_juridique: fields.forme_juridique,
+            secteur_d_activite: fields.secteur_d_activite,
+            code_ape: fields.code_ape,
+            date_immatriculation: fields.date_immatriculation,
+            date_radiation: fields.date_radiation,
+          };
+        }),
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/assess-company-risk.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/assess-company-risk.ts
@@ -1,0 +1,123 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { searchV1Api } from '../utils';
+
+type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+interface RiskFactor {
+  type: string;
+  severity: RiskLevel;
+  description: string;
+  date?: string;
+  date_immatriculation?: string;
+}
+
+const RECOMMENDATIONS: Record<RiskLevel, string> = {
+  CRITICAL: 'DO NOT ONBOARD - Company struck off or major risk',
+  HIGH: 'CAUTION - Manual verification required',
+  MEDIUM: 'VIGILANCE - Monitor closely',
+  LOW: 'Acceptable - Low risk',
+};
+
+function calculateRiskLevel(score: number): RiskLevel {
+  if (score >= 80) return 'CRITICAL';
+  if (score >= 50) return 'HIGH';
+  if (score >= 25) return 'MEDIUM';
+
+  return 'LOW';
+}
+
+export default function createAssessCompanyRiskTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_assess_company_risk',
+    description:
+      'Assess risk for a French company for KYC/KYB. Checks radiations, company age, etc. Returns a risk score',
+    schema: z
+      .object({
+        siren: z.string().length(9).optional().describe('SIREN number (9 digits)'),
+        denomination: z.string().optional().describe('Company name'),
+      })
+      .refine(data => data.siren || data.denomination, {
+        message: 'Either siren or denomination is required',
+      }),
+    func: async ({ siren, denomination }) => {
+      const riskFactors: RiskFactor[] = [];
+      let riskScore = 0;
+
+      const query = siren ? `siren:${siren}` : `denomination:${denomination}`;
+
+      const radiationResults = await Promise.all(
+        [2025, 2024].map(async year => {
+          const result = await searchV1Api(headers, `entreprises-radiees-en-${year}`, query, 1);
+
+          return { year, result };
+        }),
+      );
+
+      for (const { year, result } of radiationResults) {
+        if (result.nhits > 0) {
+          const fields = result.records[0].fields as Record<string, unknown>;
+          riskScore += 100;
+          riskFactors.push({
+            type: 'RADIATION',
+            severity: 'CRITICAL',
+            description: `Company struck off in ${year}`,
+            date: fields.date_radiation as string,
+          });
+          break;
+        }
+      }
+
+      if (siren) {
+        const result = await searchV1Api(
+          headers,
+          'entreprises-immatriculees-en-2024',
+          `siren:${siren}`,
+          1,
+        );
+
+        if (result.nhits > 0) {
+          const fields = result.records[0].fields as Record<string, unknown>;
+          const dateImmat = fields.date_immatriculation as string;
+
+          if (dateImmat) {
+            const immatDate = new Date(dateImmat);
+            const ageDays = Math.floor((Date.now() - immatDate.getTime()) / (1000 * 60 * 60 * 24));
+
+            if (ageDays < 90) {
+              riskScore += 30;
+              riskFactors.push({
+                type: 'YOUNG_COMPANY',
+                severity: 'HIGH',
+                description: `Very recent company (${ageDays} days)`,
+                date_immatriculation: dateImmat,
+              });
+            } else if (ageDays < 180) {
+              riskScore += 15;
+              riskFactors.push({
+                type: 'YOUNG_COMPANY',
+                severity: 'MEDIUM',
+                description: `Recent company (${ageDays} days)`,
+                date_immatriculation: dateImmat,
+              });
+            }
+          }
+        }
+      }
+
+      const riskLevel = calculateRiskLevel(riskScore);
+
+      return JSON.stringify({
+        siren,
+        denomination,
+        risk_score: riskScore,
+        risk_level: riskLevel,
+        risk_factors: riskFactors,
+        recommendation: RECOMMENDATIONS[riskLevel],
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/check-company-radiation.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/check-company-radiation.ts
@@ -1,0 +1,80 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { searchV1Api } from '../utils';
+
+const AVAILABLE_YEARS = [2025, 2024, 2023, 2022] as const;
+
+export default function createCheckCompanyRadiationTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_check_company_radiation',
+    description:
+      'Check if a French company (by SIREN or name) is struck off from RCS. If no year is specified, checks all available years (2022-2025)',
+    schema: z
+      .object({
+        siren: z.string().length(9).optional().describe('SIREN number (9 digits)'),
+        denomination: z.string().optional().describe('Company name'),
+        year: z
+          .enum(['2022', '2023', '2024', '2025'])
+          .optional()
+          .describe('Specific year to check (optional, checks all years if not provided)'),
+      })
+      .refine(data => data.siren || data.denomination, {
+        message: 'Either siren or denomination is required',
+      }),
+    func: async ({ siren, denomination, year }) => {
+      const query = siren ? `siren:${siren}` : `denomination:${denomination}`;
+      const yearsToCheck = year ? [parseInt(year, 10)] : [...AVAILABLE_YEARS];
+
+      const results = await Promise.all(
+        yearsToCheck.map(async checkYear => {
+          const dataset = `entreprises-radiees-en-${checkYear}`;
+          const result = await searchV1Api(headers, dataset, query, 10);
+
+          return { checkYear, result };
+        }),
+      );
+
+      const allResults: Array<Record<string, unknown>> = [];
+
+      for (const { checkYear, result } of results) {
+        if (result.nhits > 0) {
+          for (const r of result.records) {
+            const fields = r.fields as Record<string, unknown>;
+            allResults.push({
+              annee: checkYear,
+              siren: fields.siren,
+              denomination: fields.denomination,
+              date_radiation: fields.date_radiation,
+              date_immatriculation: fields.date_immatriculation,
+              forme_juridique: fields.forme_juridique,
+              ville: fields.ville,
+              code_postal: fields.code_postal,
+              adresse: fields.adresse,
+              secteur_d_activite: fields.secteur_d_activite,
+              greffe: fields.greffe,
+            });
+          }
+        }
+      }
+
+      if (allResults.length === 0) {
+        return JSON.stringify({
+          est_radiee: false,
+          annees_verifiees: yearsToCheck,
+          critere: { siren, denomination },
+          message: 'No radiation found for this company',
+        });
+      }
+
+      return JSON.stringify({
+        est_radiee: true,
+        annees_verifiees: yearsToCheck,
+        nb_resultats: allResults.length,
+        entreprises: allResults,
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/find-related-companies.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/find-related-companies.ts
@@ -1,0 +1,92 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { searchV1Api } from '../utils';
+
+export default function createFindRelatedCompaniesTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_find_related_companies',
+    description: 'Find related French companies (same address, same sector in same area, etc.)',
+    schema: z.object({
+      siren: z.string().length(9).optional().describe('Reference company SIREN'),
+      adresse: z.string().optional().describe('Address to search'),
+      search_type: z
+        .enum(['same_address', 'same_sector'])
+        .default('same_address')
+        .describe('Search type: same_address or same_sector (same sector + city)'),
+      limit: z.number().int().positive().default(20).describe('Maximum results (default: 20)'),
+    }),
+    func: async ({ siren, adresse, search_type, limit }) => {
+      let searchAddress = adresse;
+      let ville: unknown;
+      let secteur: unknown;
+
+      if (siren && !adresse) {
+        const result = await searchV1Api(
+          headers,
+          'entreprises-immatriculees-en-2024',
+          `siren:${siren}`,
+          1,
+        );
+
+        if (result.nhits > 0) {
+          const fields = result.records[0].fields as Record<string, unknown>;
+          searchAddress = fields.adresse as string;
+          ville = fields.ville;
+          secteur = fields.secteur_d_activite;
+        }
+      }
+
+      if (!searchAddress && search_type === 'same_address') {
+        return JSON.stringify({
+          error: 'Address required or valid SIREN to lookup address',
+        });
+      }
+
+      let query: string;
+
+      if (search_type === 'same_address') {
+        query = `adresse:"${searchAddress}"`;
+      } else {
+        if (!ville || !secteur) {
+          return JSON.stringify({
+            error: 'Cannot determine city and sector for same_sector search',
+          });
+        }
+
+        query = `ville:${ville} AND secteur_d_activite:"${secteur}"`;
+      }
+
+      const result = await searchV1Api(headers, 'entreprises-immatriculees-en-2024', query, limit);
+
+      return JSON.stringify({
+        critere_recherche: {
+          siren_reference: siren,
+          adresse: searchAddress,
+          type: search_type,
+        },
+        total_resultats: result.nhits,
+        entreprises_liees: result.records
+          .filter(r => {
+            const fields = r.fields as Record<string, unknown>;
+
+            return fields.siren !== siren;
+          })
+          .map(r => {
+            const fields = r.fields as Record<string, unknown>;
+
+            return {
+              siren: fields.siren,
+              denomination: fields.denomination,
+              adresse: fields.adresse,
+              ville: fields.ville,
+              forme_juridique: fields.forme_juridique,
+              date_immatriculation: fields.date_immatriculation,
+            };
+          }),
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/get-company-details.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/get-company-details.ts
@@ -1,0 +1,46 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { searchV1Api } from '../utils';
+
+export default function createGetCompanyDetailsTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_get_company_details',
+    description: 'Get full details of a French company (struck-off or registered) by SIREN or name',
+    schema: z
+      .object({
+        siren: z.string().length(9).optional().describe('SIREN number (9 digits)'),
+        denomination: z.string().optional().describe('Company name'),
+        year: z
+          .enum(['2022', '2023', '2024', '2025'])
+          .default('2024')
+          .describe('Year to search (default: 2024)'),
+      })
+      .refine(data => data.siren || data.denomination, {
+        message: 'Either siren or denomination is required',
+      }),
+    func: async ({ siren, denomination, year }) => {
+      const query = siren ? `siren:${siren}` : `denomination:${denomination}`;
+
+      const [resultRad, resultImmat] = await Promise.all([
+        searchV1Api(headers, `entreprises-radiees-en-${year}`, query, 5),
+        searchV1Api(headers, `entreprises-immatriculees-en-${year}`, query, 5),
+      ]);
+
+      return JSON.stringify({
+        critere: { siren, denomination },
+        annee_recherchee: year,
+        radiations: {
+          total: resultRad.nhits,
+          entreprises: resultRad.records.map(r => r.fields),
+        },
+        immatriculations: {
+          total: resultImmat.nhits,
+          entreprises: resultImmat.records.map(r => r.fields),
+        },
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/get-financial-indicators.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/get-financial-indicators.ts
@@ -1,0 +1,68 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { searchV1Api } from '../utils';
+
+export default function createGetFinancialIndicatorsTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_get_financial_indicators',
+    description:
+      'Get financial indicators for a French company (revenue, operating result, headcount) for the last 3 fiscal years',
+    schema: z.object({
+      siren: z.string().length(9).describe('SIREN number (9 digits)'),
+    }),
+    func: async ({ siren }) => {
+      const result = await searchV1Api(headers, 'chiffres-cles-2024', `siren:${siren}`, 1);
+
+      if (result.nhits === 0) {
+        return JSON.stringify({
+          siren,
+          found: false,
+          message: 'No financial data available for this company',
+        });
+      }
+
+      const fields = result.records[0].fields as Record<string, unknown>;
+
+      return JSON.stringify({
+        siren,
+        found: true,
+        denomination: fields.denomination,
+        forme_juridique: fields.forme_juridique,
+        secteur: fields.libelle_ape,
+        ville: fields.ville,
+        exercices: {
+          millesime_1: {
+            annee: fields.millesime_1,
+            ca: fields.ca_1 ?? 'Confidential',
+            tranche_ca: fields.tranche_ca_millesime_1,
+            resultat: fields.resultat_1 ?? 'Confidential',
+            effectif: fields.effectif_1 ?? 'Confidential',
+            duree: fields.duree_1,
+            date_cloture: fields.date_de_cloture_exercice_1,
+          },
+          millesime_2: {
+            annee: fields.millesime_2,
+            ca: fields.ca_2 ?? 'Confidential',
+            tranche_ca: fields.tranche_ca_millesime_2,
+            resultat: fields.resultat_2 ?? 'Confidential',
+            effectif: fields.effectif_2 ?? 'Confidential',
+            duree: fields.duree_2,
+            date_cloture: fields.date_de_cloture_exercice_2,
+          },
+          millesime_3: {
+            annee: fields.millesime_3,
+            ca: fields.ca_3 ?? 'Confidential',
+            tranche_ca: fields.tranche_ca_millesime_3,
+            resultat: fields.resultat_3 ?? 'Confidential',
+            effectif: fields.effectif_3 ?? 'Confidential',
+            duree: fields.duree_3,
+            date_cloture: fields.date_de_cloture_exercice_3,
+          },
+        },
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/search-new-companies.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/search-new-companies.ts
@@ -1,0 +1,55 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { buildQuery, searchV1Api } from '../utils';
+
+export default function createSearchNewCompaniesTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_search_new_companies',
+    description: 'Search for newly registered French companies by various criteria',
+    schema: z.object({
+      year: z.enum(['2022', '2023', '2024', '2025']).default('2024').describe('Registration year'),
+      siren: z.string().length(9).optional().describe('SIREN number'),
+      denomination: z.string().optional().describe('Company name'),
+      ville: z.string().optional().describe('City'),
+      region: z.string().optional().describe('Region'),
+      secteur_d_activite: z.string().optional().describe('Business sector'),
+      limit: z.number().int().positive().default(10).describe('Maximum results (default: 10)'),
+    }),
+    func: async ({ year, siren, denomination, ville, region, secteur_d_activite, limit }) => {
+      const dataset = `entreprises-immatriculees-en-${year}`;
+
+      const query = buildQuery([
+        siren && `siren:${siren}`,
+        denomination && `denomination:${denomination}`,
+        ville && `ville:${ville}`,
+        region && `region:${region}`,
+        secteur_d_activite && `secteur_d_activite:${secteur_d_activite}`,
+      ]);
+
+      const result = await searchV1Api(headers, dataset, query, limit);
+
+      return JSON.stringify({
+        annee: year,
+        total_resultats: result.nhits,
+        resultats_affiches: result.records.length,
+        entreprises: result.records.map(r => {
+          const fields = r.fields as Record<string, unknown>;
+
+          return {
+            siren: fields.siren,
+            denomination: fields.denomination,
+            date_immatriculation: fields.date_immatriculation,
+            ville: fields.ville,
+            forme_juridique: fields.forme_juridique,
+            secteur_d_activite: fields.secteur_d_activite,
+            adresse: fields.adresse,
+            code_postal: fields.code_postal,
+          };
+        }),
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/tools/search-radiated-companies.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/tools/search-radiated-companies.ts
@@ -1,0 +1,53 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { buildQuery, searchV1Api } from '../utils';
+
+export default function createSearchRadiatedCompaniesTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'infogreffe_search_radiated_companies',
+    description:
+      'Search for struck-off French companies by various criteria (city, sector, region, etc.)',
+    schema: z.object({
+      year: z.enum(['2022', '2023', '2024', '2025']).default('2024').describe('Radiation year'),
+      ville: z.string().optional().describe('City (e.g., PARIS, LYON)'),
+      region: z.string().optional().describe('Region (e.g., Ile-de-France)'),
+      secteur_d_activite: z.string().optional().describe('Business sector'),
+      forme_juridique: z.string().optional().describe('Legal form (e.g., SARL, SAS)'),
+      limit: z.number().int().positive().default(10).describe('Maximum results (default: 10)'),
+    }),
+    func: async ({ year, ville, region, secteur_d_activite, forme_juridique, limit }) => {
+      const dataset = `entreprises-radiees-en-${year}`;
+
+      const query = buildQuery([
+        ville && `ville:${ville}`,
+        region && `region:${region}`,
+        secteur_d_activite && `secteur_d_activite:${secteur_d_activite}`,
+        forme_juridique && `forme_juridique:${forme_juridique}`,
+      ]);
+
+      const result = await searchV1Api(headers, dataset, query, limit);
+
+      return JSON.stringify({
+        annee: year,
+        criteres: { ville, region, secteur_d_activite, forme_juridique },
+        total_resultats: result.nhits,
+        resultats_affiches: result.records.length,
+        entreprises: result.records.map(r => {
+          const fields = r.fields as Record<string, unknown>;
+
+          return {
+            siren: fields.siren,
+            denomination: fields.denomination,
+            date_radiation: fields.date_radiation,
+            ville: fields.ville,
+            forme_juridique: fields.forme_juridique,
+            secteur_d_activite: fields.secteur_d_activite,
+          };
+        }),
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/infogreffe/utils.ts
+++ b/packages/ai-proxy/src/integrations/infogreffe/utils.ts
@@ -1,0 +1,39 @@
+const API_BASE_V1 = 'https://opendata.datainfogreffe.fr/api/records/1.0/search';
+
+export interface DatainfogreffeRecord {
+  fields: Record<string, unknown>;
+  recordid: string;
+}
+
+export interface DatainfogreffeResponse {
+  nhits: number;
+  records: DatainfogreffeRecord[];
+}
+
+export async function searchV1Api(
+  headers: Record<string, string>,
+  dataset: string,
+  query?: string,
+  rows = 10,
+): Promise<DatainfogreffeResponse> {
+  const params = new URLSearchParams({ dataset, rows: rows.toString() });
+  if (query) params.set('q', query);
+
+  const response = await fetch(`${API_BASE_V1}?${params}`, { headers });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return { nhits: 0, records: [] };
+    }
+
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export function buildQuery(parts: Array<string | undefined>): string | undefined {
+  const filtered = parts.filter(Boolean);
+
+  return filtered.length > 0 ? filtered.join(' AND ') : undefined;
+}

--- a/packages/ai-proxy/src/integrations/slack/tools.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools.ts
@@ -1,0 +1,40 @@
+import RemoteTool from '../../remote-tool';
+import createAddReactionTool from './tools/add-reaction';
+import createGetChannelHistoryTool from './tools/get-channel-history';
+import createGetThreadRepliesTool from './tools/get-thread-replies';
+import createGetUserProfileTool from './tools/get-user-profile';
+import createGetUsersTool from './tools/get-users';
+import createListChannelsTool from './tools/list-channels';
+import createPostMessageTool from './tools/post-message';
+import createReplyToThreadTool from './tools/reply-to-thread';
+
+export interface SlackConfig {
+  authToken: string;
+  teamId: string;
+  channelIds?: string;
+}
+
+export default function getSlackTools(config: SlackConfig): RemoteTool[] {
+  const headers = {
+    Authorization: `Bearer ${config.authToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  return [
+    createListChannelsTool(headers, config),
+    createPostMessageTool(headers),
+    createReplyToThreadTool(headers),
+    createAddReactionTool(headers),
+    createGetChannelHistoryTool(headers),
+    createGetThreadRepliesTool(headers),
+    createGetUsersTool(headers, config.teamId),
+    createGetUserProfileTool(headers),
+  ].map(
+    tool =>
+      new RemoteTool({
+        sourceId: 'slack',
+        sourceType: 'server',
+        tool,
+      }),
+  );
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/add-reaction.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/add-reaction.ts
@@ -1,0 +1,29 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createAddReactionTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_add_reaction',
+    description: 'Add a reaction emoji to a message',
+    schema: z.object({
+      channel_id: z.string().describe('The ID of the channel containing the message'),
+      timestamp: z.string().describe('The timestamp of the message to react to'),
+      reaction: z.string().describe('The name of the emoji reaction (without ::)'),
+    }),
+    func: async ({ channel_id, timestamp, reaction }) => {
+      const response = await fetch('https://slack.com/api/reactions.add', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          channel: channel_id,
+          timestamp,
+          name: reaction,
+        }),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/get-channel-history.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/get-channel-history.ts
@@ -1,0 +1,30 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetChannelHistoryTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_get_channel_history',
+    description: 'Get recent messages from a channel',
+    schema: z.object({
+      channel_id: z.string().describe('The ID of the channel'),
+      limit: z
+        .number()
+        .optional()
+        .default(10)
+        .describe('Number of messages to retrieve (default 10)'),
+    }),
+    func: async ({ channel_id, limit }) => {
+      const params = new URLSearchParams({
+        channel: channel_id,
+        limit: limit.toString(),
+      });
+      const response = await fetch(`https://slack.com/api/conversations.history?${params}`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/get-thread-replies.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/get-thread-replies.ts
@@ -1,0 +1,32 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetThreadRepliesTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_get_thread_replies',
+    description: 'Get all replies in a message thread',
+    schema: z.object({
+      channel_id: z.string().describe('The ID of the channel containing the thread'),
+      thread_ts: z
+        .string()
+        .describe(
+          "The timestamp of the parent message in the format '1234567890.123456'. " +
+            'Timestamps in the format without the period can be converted by adding the period ' +
+            'such that 6 numbers come after it.',
+        ),
+    }),
+    func: async ({ channel_id, thread_ts }) => {
+      const params = new URLSearchParams({
+        channel: channel_id,
+        ts: thread_ts,
+      });
+      const response = await fetch(`https://slack.com/api/conversations.replies?${params}`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/get-user-profile.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/get-user-profile.ts
@@ -1,0 +1,25 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetUserProfileTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_get_user_profile',
+    description: 'Get detailed profile information for a specific user',
+    schema: z.object({
+      user_id: z.string().describe('The ID of the user'),
+    }),
+    func: async ({ user_id }) => {
+      const params = new URLSearchParams({
+        user: user_id,
+        include_labels: 'true',
+      });
+      const response = await fetch(`https://slack.com/api/users.profile.get?${params}`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/get-users.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/get-users.ts
@@ -1,0 +1,36 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetUsersTool(
+  headers: Record<string, string>,
+  teamId: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_get_users',
+    description: 'Get a list of all users in the workspace with their basic profile information',
+    schema: z.object({
+      cursor: z.string().optional().describe('Pagination cursor for next page of results'),
+      limit: z
+        .number()
+        .optional()
+        .default(100)
+        .describe('Maximum number of users to return (default 100, max 200)'),
+    }),
+    func: async ({ cursor, limit }) => {
+      const params = new URLSearchParams({
+        limit: Math.min(limit, 200).toString(),
+        team_id: teamId,
+      });
+
+      if (cursor) {
+        params.append('cursor', cursor);
+      }
+
+      const response = await fetch(`https://slack.com/api/users.list?${params}`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/list-channels.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/list-channels.ts
@@ -1,0 +1,68 @@
+import type { SlackConfig } from '../tools';
+
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createListChannelsTool(
+  headers: Record<string, string>,
+  config: SlackConfig,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_list_channels',
+    description: 'List public or pre-defined channels in the workspace with pagination',
+    schema: z.object({
+      limit: z
+        .number()
+        .optional()
+        .default(100)
+        .describe('Maximum number of channels to return (default 100, max 200)'),
+      cursor: z.string().optional().describe('Pagination cursor for next page of results'),
+    }),
+    func: async ({ limit, cursor }) => {
+      const { channelIds } = config;
+
+      if (!channelIds) {
+        const params = new URLSearchParams({
+          types: 'public_channel',
+          exclude_archived: 'true',
+          limit: Math.min(limit, 200).toString(),
+          team_id: config.teamId,
+        });
+
+        if (cursor) {
+          params.append('cursor', cursor);
+        }
+
+        const response = await fetch(`https://slack.com/api/conversations.list?${params}`, {
+          headers,
+        });
+
+        return JSON.stringify(await response.json());
+      }
+
+      const predefinedChannelIdsArray = channelIds.split(',').map(id => id.trim());
+
+      const channelPromises = predefinedChannelIdsArray.map(async channelId => {
+        const params = new URLSearchParams({
+          channel: channelId,
+        });
+        const response = await fetch(`https://slack.com/api/conversations.info?${params}`, {
+          headers,
+        });
+
+        return response.json();
+      });
+
+      const results = await Promise.all(channelPromises);
+      const channels = results
+        .filter(data => data.ok && data.channel && !data.channel.is_archived)
+        .map(data => data.channel);
+
+      return JSON.stringify({
+        ok: true,
+        channels,
+        response_metadata: { next_cursor: '' },
+      });
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/post-message.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/post-message.ts
@@ -1,0 +1,27 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createPostMessageTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_post_message',
+    description: 'Post a new message to a Slack channel',
+    schema: z.object({
+      channel_id: z.string().describe('The ID of the channel to post to'),
+      text: z.string().describe('The message text to post'),
+    }),
+    func: async ({ channel_id, text }) => {
+      const response = await fetch('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          channel: channel_id,
+          text,
+        }),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/slack/tools/reply-to-thread.ts
+++ b/packages/ai-proxy/src/integrations/slack/tools/reply-to-thread.ts
@@ -1,0 +1,35 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createReplyToThreadTool(
+  headers: Record<string, string>,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'slack_reply_to_thread',
+    description: 'Reply to a specific message thread in Slack',
+    schema: z.object({
+      channel_id: z.string().describe('The ID of the channel containing the thread'),
+      thread_ts: z
+        .string()
+        .describe(
+          "The timestamp of the parent message in the format '1234567890.123456'. " +
+            'Timestamps in the format without the period can be converted by adding the period ' +
+            'such that 6 numbers come after it.',
+        ),
+      text: z.string().describe('The reply text'),
+    }),
+    func: async ({ channel_id, thread_ts, text }) => {
+      const response = await fetch('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          channel: channel_id,
+          thread_ts,
+          text,
+        }),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/tools.ts
+++ b/packages/ai-proxy/src/integrations/tools.ts
@@ -1,17 +1,20 @@
 import type RemoteTool from '../remote-tool';
 import type { BraveConfig } from './brave/tools';
 import type { GmailConfig } from './gmail/tools';
+import type { InfogreffeConfig } from './infogreffe/tools';
 import type { SlackConfig } from './slack/tools';
 import type { ZendeskConfig } from './zendesk/tools';
 
 import getBraveTools from './brave/tools';
 import getGmailTools from './gmail/tools';
+import getInfogreffeTools from './infogreffe/tools';
 import getSlackTools from './slack/tools';
 import getZendeskTools from './zendesk/tools';
 
 export interface IntegrationConfigs {
   brave?: BraveConfig;
   gmail?: GmailConfig;
+  infogreffe?: InfogreffeConfig;
   slack?: SlackConfig;
   zendesk?: ZendeskConfig;
 }
@@ -33,6 +36,10 @@ export default function getIntegratedTools(configs: IntegrationConfigs): RemoteT
 
   if (configs.zendesk) {
     integratedTools.push(...getZendeskTools(configs.zendesk));
+  }
+
+  if (configs.infogreffe) {
+    integratedTools.push(...getInfogreffeTools(configs.infogreffe));
   }
 
   return integratedTools;

--- a/packages/ai-proxy/src/integrations/tools.ts
+++ b/packages/ai-proxy/src/integrations/tools.ts
@@ -1,10 +1,19 @@
 import type RemoteTool from '../remote-tool';
 import type { BraveConfig } from './brave/tools';
+import type { GmailConfig } from './gmail/tools';
+import type { SlackConfig } from './slack/tools';
+import type { ZendeskConfig } from './zendesk/tools';
 
 import getBraveTools from './brave/tools';
+import getGmailTools from './gmail/tools';
+import getSlackTools from './slack/tools';
+import getZendeskTools from './zendesk/tools';
 
 export interface IntegrationConfigs {
   brave?: BraveConfig;
+  gmail?: GmailConfig;
+  slack?: SlackConfig;
+  zendesk?: ZendeskConfig;
 }
 
 export default function getIntegratedTools(configs: IntegrationConfigs): RemoteTool[] {
@@ -12,6 +21,18 @@ export default function getIntegratedTools(configs: IntegrationConfigs): RemoteT
 
   if (configs.brave) {
     integratedTools.push(...getBraveTools(configs.brave));
+  }
+
+  if (configs.gmail) {
+    integratedTools.push(...getGmailTools(configs.gmail));
+  }
+
+  if (configs.slack) {
+    integratedTools.push(...getSlackTools(configs.slack));
+  }
+
+  if (configs.zendesk) {
+    integratedTools.push(...getZendeskTools(configs.zendesk));
   }
 
   return integratedTools;

--- a/packages/ai-proxy/src/integrations/tools.ts
+++ b/packages/ai-proxy/src/integrations/tools.ts
@@ -1,0 +1,18 @@
+import type RemoteTool from '../remote-tool';
+import type { BraveConfig } from './brave/tools';
+
+import getBraveTools from './brave/tools';
+
+export interface IntegrationConfigs {
+  brave?: BraveConfig;
+}
+
+export default function getIntegratedTools(configs: IntegrationConfigs): RemoteTool[] {
+  const integratedTools: RemoteTool[] = [];
+
+  if (configs.brave) {
+    integratedTools.push(...getBraveTools(configs.brave));
+  }
+
+  return integratedTools;
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools.ts
@@ -1,0 +1,38 @@
+import RemoteTool from '../../remote-tool';
+import createCreateTicketCommentTool from './tools/create-ticket-comment';
+import createCreateTicketTool from './tools/create-ticket';
+import createGetTicketCommentsTool from './tools/get-ticket-comments';
+import createGetTicketTool from './tools/get-ticket';
+import createGetTicketsTool from './tools/get-tickets';
+import createUpdateTicketTool from './tools/update-ticket';
+
+export interface ZendeskConfig {
+  subdomain: string;
+  email: string;
+  apiToken: string;
+}
+
+export default function getZendeskTools(config: ZendeskConfig): RemoteTool[] {
+  const baseUrl = `https://${config.subdomain}.zendesk.com/api/v2`;
+  const auth = Buffer.from(`${config.email}/token:${config.apiToken}`).toString('base64');
+  const headers = {
+    Authorization: `Basic ${auth}`,
+    'Content-Type': 'application/json',
+  };
+
+  return [
+    createGetTicketsTool(headers, baseUrl),
+    createGetTicketTool(headers, baseUrl),
+    createGetTicketCommentsTool(headers, baseUrl),
+    createCreateTicketTool(headers, baseUrl),
+    createCreateTicketCommentTool(headers, baseUrl),
+    createUpdateTicketTool(headers, baseUrl),
+  ].map(
+    tool =>
+      new RemoteTool({
+        sourceId: 'zendesk',
+        sourceType: 'server',
+        tool,
+      }),
+  );
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket-comment.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket-comment.ts
@@ -1,0 +1,39 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createCreateTicketCommentTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_create_ticket_comment',
+    description: 'Add a new comment to an existing Zendesk ticket',
+    schema: z.object({
+      ticket_id: z.number().int().positive().describe('The ID of the ticket to add a comment to'),
+      comment: z.string().min(1).describe('The comment text to add'),
+      public: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('Whether the comment is visible to the requester (true) or internal only (false)'),
+    }),
+    func: async ({ ticket_id, comment, public: isPublic }) => {
+      const updateData = {
+        ticket: {
+          comment: {
+            body: comment,
+            public: isPublic,
+          },
+        },
+      };
+
+      const response = await fetch(`${baseUrl}/tickets/${ticket_id}.json`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(updateData),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket.ts
@@ -1,0 +1,58 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createCreateTicketTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_create_ticket',
+    description: 'Create a new Zendesk ticket',
+    schema: z.object({
+      subject: z.string().min(1).describe('The subject/title of the ticket'),
+      description: z.string().min(1).describe('The description/body of the ticket'),
+      requester_id: z.number().int().positive().optional().describe('The ID of the requester'),
+      assignee_id: z.number().int().positive().optional().describe('The ID of the assignee'),
+      priority: z
+        .enum(['low', 'normal', 'high', 'urgent'])
+        .optional()
+        .describe('The priority level of the ticket'),
+      type: z
+        .enum(['problem', 'incident', 'question', 'task'])
+        .optional()
+        .describe('The type of the ticket'),
+      tags: z.array(z.string()).optional().describe('Tags to apply to the ticket'),
+      custom_fields: z
+        .array(
+          z.object({
+            id: z.number().describe('The custom field ID'),
+            value: z.unknown().describe('The custom field value'),
+          }),
+        )
+        .optional()
+        .describe('Custom fields to set on the ticket'),
+    }),
+    func: async ({ subject, description, requester_id, assignee_id, priority, type, tags, custom_fields }) => {
+      const ticketData: Record<string, unknown> = {
+        ticket: {
+          subject,
+          comment: { body: description },
+          ...(requester_id && { requester_id }),
+          ...(assignee_id && { assignee_id }),
+          ...(priority && { priority }),
+          ...(type && { type }),
+          ...(tags && { tags }),
+          ...(custom_fields && { custom_fields }),
+        },
+      };
+
+      const response = await fetch(`${baseUrl}/tickets.json`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(ticketData),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/get-ticket-comments.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/get-ticket-comments.ts
@@ -1,0 +1,22 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetTicketCommentsTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_get_ticket_comments',
+    description: 'Get all comments for a specific Zendesk ticket',
+    schema: z.object({
+      ticket_id: z.number().int().positive().describe('The ID of the ticket to get comments for'),
+    }),
+    func: async ({ ticket_id }) => {
+      const response = await fetch(`${baseUrl}/tickets/${ticket_id}/comments.json`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/get-ticket.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/get-ticket.ts
@@ -1,0 +1,22 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetTicketTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_get_ticket',
+    description: 'Retrieve a single Zendesk ticket by its ID',
+    schema: z.object({
+      ticket_id: z.number().int().positive().describe('The ID of the ticket to retrieve'),
+    }),
+    func: async ({ ticket_id }) => {
+      const response = await fetch(`${baseUrl}/tickets/${ticket_id}.json`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/get-tickets.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/get-tickets.ts
@@ -1,0 +1,43 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createGetTicketsTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_get_tickets',
+    description: 'Fetch a paginated list of Zendesk tickets with sorting options',
+    schema: z.object({
+      page: z.number().int().positive().optional().default(1).describe('Page number for pagination'),
+      per_page: z
+        .number()
+        .int()
+        .positive()
+        .max(100)
+        .optional()
+        .default(25)
+        .describe('Number of tickets per page (max 100)'),
+      sort_by: z
+        .enum(['created_at', 'updated_at', 'priority', 'status'])
+        .optional()
+        .default('created_at')
+        .describe('Field to sort tickets by'),
+      sort_order: z.enum(['asc', 'desc']).optional().default('desc').describe('Sort order'),
+    }),
+    func: async ({ page, per_page, sort_by, sort_order }) => {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        per_page: per_page.toString(),
+        sort_by,
+        sort_order,
+      });
+
+      const response = await fetch(`${baseUrl}/tickets.json?${params}`, {
+        headers,
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/zendesk/tools/update-ticket.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/update-ticket.ts
@@ -1,0 +1,73 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export default function createUpdateTicketTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'zendesk_update_ticket',
+    description: 'Update fields on an existing Zendesk ticket',
+    schema: z.object({
+      ticket_id: z.number().int().positive().describe('The ID of the ticket to update'),
+      subject: z.string().min(1).optional().describe('New subject for the ticket'),
+      status: z
+        .enum(['new', 'open', 'pending', 'hold', 'solved', 'closed'])
+        .optional()
+        .describe('New status for the ticket'),
+      priority: z
+        .enum(['low', 'normal', 'high', 'urgent'])
+        .optional()
+        .describe('New priority for the ticket'),
+      type: z
+        .enum(['problem', 'incident', 'question', 'task'])
+        .optional()
+        .describe('New type for the ticket'),
+      assignee_id: z.number().int().positive().optional().describe('New assignee ID for the ticket'),
+      requester_id: z.number().int().positive().optional().describe('New requester ID for the ticket'),
+      tags: z.array(z.string()).optional().describe('New tags for the ticket (replaces existing tags)'),
+      custom_fields: z
+        .array(
+          z.object({
+            id: z.number().describe('The custom field ID'),
+            value: z.unknown().describe('The custom field value'),
+          }),
+        )
+        .optional()
+        .describe('Custom fields to update'),
+      due_at: z.string().optional().describe('Due date in ISO8601 format (for task tickets)'),
+    }),
+    func: async ({
+      ticket_id,
+      subject,
+      status,
+      priority,
+      type,
+      assignee_id,
+      requester_id,
+      tags,
+      custom_fields,
+      due_at,
+    }) => {
+      const ticketUpdate: Record<string, unknown> = {};
+
+      if (subject !== undefined) ticketUpdate.subject = subject;
+      if (status !== undefined) ticketUpdate.status = status;
+      if (priority !== undefined) ticketUpdate.priority = priority;
+      if (type !== undefined) ticketUpdate.type = type;
+      if (assignee_id !== undefined) ticketUpdate.assignee_id = assignee_id;
+      if (requester_id !== undefined) ticketUpdate.requester_id = requester_id;
+      if (tags !== undefined) ticketUpdate.tags = tags;
+      if (custom_fields !== undefined) ticketUpdate.custom_fields = custom_fields;
+      if (due_at !== undefined) ticketUpdate.due_at = due_at;
+
+      const response = await fetch(`${baseUrl}/tickets/${ticket_id}.json`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ ticket: ticketUpdate }),
+      });
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,6 +1794,42 @@
     path-to-regexp "^6.3.0"
     reusify "^1.0.4"
 
+"@forestadmin/agent-client@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@forestadmin/agent-client/-/agent-client-1.2.3.tgz#9f48ab0a74c7fb38cd42573a0770a2b7f9cd4b05"
+  integrity sha512-R6HVdNhgmjv4BVLe9jROL3G9Ta2+rufUEE2IC0M90C4/ZXN546HiHFe8O5092EplQMDyr0XEsRlzoEAdi12fyg==
+  dependencies:
+    "@forestadmin/datasource-toolkit" "1.50.1"
+    "@forestadmin/forestadmin-client" "1.37.3"
+    jsonapi-serializer "^3.6.9"
+    superagent "^10.2.3"
+
+"@forestadmin/agent@1.70.6":
+  version "1.70.6"
+  resolved "https://registry.yarnpkg.com/@forestadmin/agent/-/agent-1.70.6.tgz#31d891793b64b23c9a9f027e18e8f5c15a9186ce"
+  integrity sha512-24sJ7dmXvsTIzq44Z5YzGAQfJVzpsLAqc4yFehbLkGeR+RQSCMb3e329ctoBQNkKws26QNLyef+IeaEcTzw7HQ==
+  dependencies:
+    "@fast-csv/format" "^4.3.5"
+    "@forestadmin/datasource-customizer" "1.67.2"
+    "@forestadmin/datasource-toolkit" "1.50.1"
+    "@forestadmin/forestadmin-client" "1.37.3"
+    "@forestadmin/mcp-server" "1.5.5"
+    "@koa/bodyparser" "^6.0.0"
+    "@koa/cors" "^5.0.0"
+    "@koa/router" "^13.1.0"
+    "@paralleldrive/cuid2" "2.2.2"
+    "@types/koa__router" "^12.0.4"
+    forest-ip-utils "^1.0.1"
+    json-api-serializer "^2.6.6"
+    json-stringify-pretty-compact "^3.0.0"
+    jsonwebtoken "^9.0.0"
+    koa "^3.0.1"
+    koa-jwt "^4.0.4"
+    luxon "^3.2.1"
+    object-hash "^3.0.0"
+    superagent "^10.2.3"
+    uuid "11.0.2"
+
 "@forestadmin/context@1.37.1":
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/@forestadmin/context/-/context-1.37.1.tgz#301486c456061d43cb653b3e8be60644edb3f71a"
@@ -1827,6 +1863,32 @@
     luxon "^3.2.1"
     object-hash "^3.0.0"
     uuid "^9.0.0"
+
+"@forestadmin/forestadmin-client@1.37.3":
+  version "1.37.3"
+  resolved "https://registry.yarnpkg.com/@forestadmin/forestadmin-client/-/forestadmin-client-1.37.3.tgz#5d9c94ed31cbb5ace99f46c62810ebc4fceae291"
+  integrity sha512-NIsuUZOv8UuC/8sOCwxO9X+slvkouRO56ot7CXeICBc47SZ9+iFXcC64guxFU/pCFyGvxkFpvjBUlvlEgwYBrw==
+  dependencies:
+    eventsource "2.0.2"
+    json-api-serializer "^2.6.6"
+    jsonwebtoken "^9.0.0"
+    object-hash "^3.0.0"
+    openid-client "^5.7.1"
+    superagent "^10.2.3"
+
+"@forestadmin/mcp-server@1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@forestadmin/mcp-server/-/mcp-server-1.5.5.tgz#f1d60154fae130b4d0454739b03a86cdbccc5bf5"
+  integrity sha512-yNGpVoh1g9z7qPgBV+Z5bIeg4RlhkQejEZNrOzLrpP3nseOroG7abozfGAL3R5sgvOwikOzMHOaqdw9B/wrMqw==
+  dependencies:
+    "@forestadmin/agent-client" "1.2.3"
+    "@forestadmin/forestadmin-client" "1.37.3"
+    "@modelcontextprotocol/sdk" "^1.25.1"
+    cors "^2.8.5"
+    express "^5.2.1"
+    jsonapi-serializer "^3.6.9"
+    jsonwebtoken "^9.0.3"
+    zod "^4.2.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -18660,6 +18722,11 @@ zod@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.2.1.tgz#07f0388c7edbfd5f5a2466181cb4adf5b5dbd57b"
   integrity sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==
+
+zod@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
+  integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Infogreffe, Gmail, Slack, and Zendesk tool integrations to ai-proxy
> - Adds eight Infogreffe tools (company search, radiation check, risk assessment, financial indicators, related companies, etc.) via [tools.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1416/files#diff-db3a34e26346bb5e7028b64def737eaeb8931d19ea2f77d2261ac513ea37646f) and supporting factories under `src/integrations/infogreffe/tools/`
> - Adds Gmail tools (send, search, get message, get thread, create draft) and Slack tools (post message, list channels, channel history, reactions, user profile, etc.) as `DynamicStructuredTool` instances wrapped in `RemoteTool`
> - Adds Zendesk tools (list, get, create, update tickets and comments) with Basic auth configured per subdomain
> - Introduces [getIntegratedTools](https://github.com/ForestAdmin/agent-nodejs/pull/1416/files#diff-efa148941da8e6d70fbe43aa7798e419ac8ab2f4f5aa4b70b1d23c49a33c647a) as a single aggregator that conditionally loads tools based on provided integration configs
> - Refactors [remote-tools.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1416/files#diff-b83326c57598ba6c156f8daeae3f3352bc3b93564d8541278cf18721311a6484) to use `getIntegratedTools` and `IntegrationConfigs` instead of directly instantiating `BraveSearch`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 75956b8. 36 files reviewed, 13 issues evaluated, 5 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/ai-proxy/src/examples/run-mcp-gmail-server.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 40](https://github.com/ForestAdmin/agent-nodejs/blob/75956b87774e0f531f39364ef286701a9d8b754e/packages/ai-proxy/src/examples/run-mcp-gmail-server.ts#L40): Email header injection vulnerability: If `params.subject` or elements in `params.to` contain CRLF sequences (`\r\n`), an attacker could inject arbitrary email headers. For example, a subject like `"Test\r\nBcc: attacker@evil.com"` would add an unauthorized Bcc recipient to the email. The values should be sanitized to remove or reject newline characters before being included in the email header construction. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>packages/ai-proxy/src/integrations/gmail/tools/search.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 70](https://github.com/ForestAdmin/agent-nodejs/blob/75956b87774e0f531f39364ef286701a9d8b754e/packages/ai-proxy/src/integrations/gmail/tools/search.ts#L70): The `getBody` function at line 69 will throw a `TypeError` when `msgData.payload` is `undefined`. If the individual message fetch at line 44-50 returns an error response (e.g., 401, 404, or rate limit), the response JSON won't have a `payload` property. When `getBody(msgData.payload)` is called at line 90 with `undefined`, the expression `payload.body?.data` at line 70 throws "Cannot read properties of undefined (reading 'body')" because optional chaining only guards against `body` being undefined, not `payload` itself. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/ai-proxy/src/integrations/gmail/tools/send-message.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 11](https://github.com/ForestAdmin/agent-nodejs/blob/75956b87774e0f531f39364ef286701a9d8b754e/packages/ai-proxy/src/integrations/gmail/tools/send-message.ts#L11): The schema allows `to` to be an empty array (`z.array(z.string())`), which would produce an invalid `To: ` header with no recipients when sending an email. Consider using `z.array(z.string()).nonempty()` or `z.array(z.string()).min(1)` to require at least one recipient. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/ai-proxy/src/integrations/slack/tools/add-reaction.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 18](https://github.com/ForestAdmin/agent-nodejs/blob/75956b87774e0f531f39364ef286701a9d8b754e/packages/ai-proxy/src/integrations/slack/tools/add-reaction.ts#L18): The Slack API POST request sends a `JSON.stringify()` body but doesn't ensure the `Content-Type: application/json` header is set. The `headers` parameter is passed directly from the caller, and if it doesn't include `Content-Type`, Slack's API will not correctly parse the JSON body, causing the request to fail or behave unexpectedly. The code should explicitly set or merge `Content-Type: application/json; charset=utf-8` into the headers. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/ai-proxy/src/integrations/slack/tools/post-message.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 17](https://github.com/ForestAdmin/agent-nodejs/blob/75956b87774e0f531f39364ef286701a9d8b754e/packages/ai-proxy/src/integrations/slack/tools/post-message.ts#L17): POST request with JSON body missing `Content-Type: application/json` header. The `headers` parameter is passed through directly (line 17), but when sending `JSON.stringify()` as the body (lines 18-21), Slack's API requires the `Content-Type: application/json` header to parse the body correctly. If the caller only provides authorization headers, the request body won't be parsed and the message won't post correctly. The fix is to explicitly set or merge the Content-Type header: `headers: { ...headers, 'Content-Type': 'application/json' }` <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->