### PR TITLE
refactor(ai-proxy): add ServerRemoteTool and ServerRemoteToolBuilder

### DIFF
--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -3,7 +3,7 @@ import type { Logger } from '@forestadmin/datasource-toolkit';
 import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 
 import { McpConnectionError } from './errors';
-import RemoteTool from './remote-tool';
+import McpServerRemoteTool from './mcp-server-remote-tool';
 
 export type McpConfiguration = {
   configs: MultiServerMCPClient['config']['mcpServers'];
@@ -13,7 +13,7 @@ export default class McpClient {
   private readonly mcpClients: Record<string, MultiServerMCPClient> = {};
   private readonly logger?: Logger;
 
-  readonly tools: RemoteTool[] = [];
+  readonly tools: McpServerRemoteTool[] = [];
 
   constructor(config: McpConfiguration, logger?: Logger) {
     this.logger = logger;
@@ -27,7 +27,7 @@ export default class McpClient {
     });
   }
 
-  async loadTools(): Promise<RemoteTool[]> {
+  async loadTools(): Promise<McpServerRemoteTool[]> {
     const errors: Array<{ server: string; error: Error }> = [];
 
     await Promise.all(
@@ -35,12 +35,7 @@ export default class McpClient {
         try {
           const tools = (await client.getTools()) ?? [];
           const extendedTools = tools.map(
-            tool =>
-              new RemoteTool({
-                tool,
-                sourceId: name,
-                sourceType: 'mcp-server',
-              }),
+            tool => new McpServerRemoteTool({ tool, sourceId: name }),
           );
           this.tools.push(...extendedTools);
         } catch (error) {

--- a/packages/ai-proxy/src/mcp-server-remote-tool.ts
+++ b/packages/ai-proxy/src/mcp-server-remote-tool.ts
@@ -1,0 +1,11 @@
+import type { StructuredToolInterface } from '@langchain/core/tools';
+
+import RemoteTool from './remote-tool';
+
+export default class McpServerRemoteTool<ToolType = unknown> extends RemoteTool {
+  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+    super({ ...options, sourceType: 'mcp-server' });
+    this.base = options.tool;
+    this.sourceId = options.sourceId;
+  }
+}

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -1,16 +1,14 @@
 import type { StructuredToolInterface } from '@langchain/core/tools';
 
-export type SourceType = 'server' | 'mcp-server';
-
-export default class RemoteTool<ToolType = unknown> {
+export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
-  sourceType: SourceType;
+  sourceType: string;
 
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
-    sourceType?: SourceType;
+    sourceType?: string;
   }) {
     this.base = options.tool;
     this.sourceId = options.sourceId;
@@ -18,12 +16,8 @@ export default class RemoteTool<ToolType = unknown> {
   }
 
   get sanitizedName() {
-    return this.sanitizeName(this.base.name);
-  }
-
-  private sanitizeName(name: string): string {
     // OpenAI function names must be alphanumeric and can contain underscores
     // This function replaces non-alphanumeric characters with underscores
-    return name.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return this.base.name.replace(/[^a-zA-Z0-9_-]/g, '_');
   }
 }

--- a/packages/ai-proxy/src/remote-tools.ts
+++ b/packages/ai-proxy/src/remote-tools.ts
@@ -1,35 +1,20 @@
+import type RemoteTool from './remote-tool';
+import type { ServerRemoteToolsApiKeys } from './server-remote-tool-builder';
 import type { ResponseFormat } from '@langchain/core/tools';
 import type { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions';
 
-import { BraveSearch } from '@langchain/community/tools/brave_search';
 import { toJsonSchema } from '@langchain/core/utils/json_schema';
 
 import { AIToolNotFoundError, AIToolUnprocessableError } from './errors';
-import RemoteTool from './remote-tool';
+import ServerRemoteToolBuilder from './server-remote-tool-builder';
 
 export type Messages = ChatCompletionCreateParamsNonStreaming['messages'];
 
-export type RemoteToolsApiKeys =
-  | { ['AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY']: string }
-  | Record<string, string>; // To avoid to cast the object because env is not always well typed from the caller
-
 export class RemoteTools {
-  private readonly apiKeys?: RemoteToolsApiKeys;
   readonly tools: RemoteTool[] = [];
 
-  constructor(apiKeys: RemoteToolsApiKeys, tools?: RemoteTool[]) {
-    this.apiKeys = apiKeys;
-    this.tools.push(...(tools ?? []));
-
-    if (this.apiKeys?.AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY) {
-      this.tools.push(
-        new RemoteTool({
-          sourceId: 'brave_search',
-          sourceType: 'server',
-          tool: new BraveSearch({ apiKey: this.apiKeys.AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY }),
-        }),
-      );
-    }
+  constructor(apiKeys: ServerRemoteToolsApiKeys, tools?: RemoteTool[]) {
+    this.tools.push(...ServerRemoteToolBuilder.buildTools(apiKeys), ...(tools ?? []));
   }
 
   get toolDefinitionsForFrontend() {

--- a/packages/ai-proxy/src/router.ts
+++ b/packages/ai-proxy/src/router.ts
@@ -1,6 +1,7 @@
 import type { McpConfiguration } from './mcp-client';
 import type { AiConfiguration, DispatchBody } from './provider-dispatcher';
-import type { Messages, RemoteToolsApiKeys } from './remote-tools';
+import type { Messages } from './remote-tools';
+import type { ServerRemoteToolsApiKeys } from './server-remote-tool-builder';
 import type { Logger } from '@forestadmin/datasource-toolkit';
 
 import { AIUnprocessableError, ProviderDispatcher } from './index';
@@ -13,7 +14,7 @@ export type Route = 'ai-query' | 'remote-tools' | 'invoke-remote-tool';
 export type Query = {
   'tool-name'?: string;
 };
-export type ApiKeys = RemoteToolsApiKeys;
+export type ApiKeys = ServerRemoteToolsApiKeys;
 
 export class Router {
   private readonly localToolsApiKeys?: ApiKeys;

--- a/packages/ai-proxy/src/server-remote-tool-builder.ts
+++ b/packages/ai-proxy/src/server-remote-tool-builder.ts
@@ -1,0 +1,28 @@
+import { BraveSearch } from '@langchain/community/tools/brave_search';
+
+import ServerRemoteTool from './server-remote-tool';
+
+export type BraveApiKey = { ['AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY']: string };
+
+export type ServerRemoteToolsApiKeys = BraveApiKey | Record<string, string>; // To avoid to cast the object because env is not always well typed from the caller
+
+export default class ServerRemoteToolBuilder {
+  static buildTools(apiKeys?: ServerRemoteToolsApiKeys) {
+    const tools: ServerRemoteTool[] = [];
+    this.addBrave(apiKeys, tools);
+    // TODO: slack, infogreffe etc. tools will be built here.
+
+    return tools;
+  }
+
+  private static addBrave(apiKeys: ServerRemoteToolsApiKeys, tools: ServerRemoteTool[]) {
+    if (apiKeys?.AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY) {
+      tools.push(
+        new ServerRemoteTool({
+          sourceId: 'brave_search',
+          tool: new BraveSearch({ apiKey: apiKeys.AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY }),
+        }),
+      );
+    }
+  }
+}

--- a/packages/ai-proxy/src/server-remote-tool.ts
+++ b/packages/ai-proxy/src/server-remote-tool.ts
@@ -1,0 +1,11 @@
+import type { StructuredToolInterface } from '@langchain/core/tools';
+
+import RemoteTool from './remote-tool';
+
+export default class ServerRemoteTool<ToolType = unknown> extends RemoteTool {
+  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+    super({ ...options, sourceType: 'server' });
+    this.base = options.tool;
+    this.sourceId = options.sourceId;
+  }
+}

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -4,7 +4,7 @@ import { tool } from '@langchain/core/tools';
 
 import { McpConnectionError } from '../src';
 import McpClient from '../src/mcp-client';
-import RemoteTool from '../src/remote-tool';
+import McpServerRemoteTool from '../src/mcp-server-remote-tool';
 
 const getToolsMock = jest.fn();
 const closeMock = jest.fn();
@@ -56,15 +56,13 @@ describe('McpClient', () => {
         await mcpClient.loadTools();
 
         expect(mcpClient.tools).toEqual([
-          new RemoteTool({
+          new McpServerRemoteTool({
             tool: tool1,
             sourceId: 'slack',
-            sourceType: 'mcp-server',
           }),
-          new RemoteTool({
+          new McpServerRemoteTool({
             tool: tool2,
             sourceId: 'slack',
-            sourceType: 'mcp-server',
           }),
         ]);
       });

--- a/packages/ai-proxy/test/remote-tools.test.ts
+++ b/packages/ai-proxy/test/remote-tools.test.ts
@@ -4,7 +4,7 @@ import type { JSONSchema } from '@langchain/core/utils/json_schema';
 import { toJsonSchema } from '@langchain/core/utils/json_schema';
 
 import { RemoteTools } from '../src';
-import RemoteTool from '../src/remote-tool';
+import McpServerRemoteTool from '../src/mcp-server-remote-tool';
 
 describe('RemoteTools', () => {
   const apiKeys = { AI_REMOTE_TOOL_BRAVE_SEARCH_API_KEY: 'api-key' };
@@ -31,7 +31,7 @@ describe('RemoteTools', () => {
     describe('when tools are passed in the constructor', () => {
       it('should return the tools', () => {
         const tools = [
-          new RemoteTool({
+          new McpServerRemoteTool({
             tool: {
               name: 'tool1',
               description: 'description1',
@@ -42,7 +42,8 @@ describe('RemoteTools', () => {
         ];
         const remoteTools = new RemoteTools(apiKeys, tools);
         expect(remoteTools.tools.length).toEqual(2);
-        expect(remoteTools.tools[0].base.name).toEqual('tool1');
+        // Server tools (brave-search) are added first, then passed tools
+        expect(remoteTools.tools[1].base.name).toEqual('tool1');
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add `ServerRemoteTool` for server-side tools (`sourceType: 'server'`)
- Extract tool building logic into `ServerRemoteToolBuilder`
- Update `RemoteTools` to use `ServerRemoteToolBuilder`
- Update router types

This prepares the codebase for adding more server-side tools (slack, infogreffe, etc.) by providing a cleaner, extensible architecture.

## Depends on
- #1417

## Test plan
- [x] All unit tests pass (`yarn workspace @forestadmin/ai-proxy test`)
- [x] Lint passes (`yarn workspace @forestadmin/ai-proxy lint`)
- [x] Build passes (`yarn workspace @forestadmin/ai-proxy build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)