### PR TITLE
ci: add NPM_TOKEN to release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
         run: '$(yarn bin)/multi-semantic-release --deps.bump=override'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}


### PR DESCRIPTION
## Summary
- Add NPM_TOKEN environment variable to the semantic-release step
- Required for publishing new packages (like agent-testing) when trusted publishing is not configured

## Context
The release of `@forestadmin/agent-testing` failed because NPM_TOKEN was missing. Other packages may have trusted publishing configured on npm, but new packages need the token.

## Test plan
- [x] CI passes
- [ ] agent-testing publishes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)