### PR TITLE
feat(workflow-executor): add UpdateRecordStepExecutor with confirmation flow

### DIFF
--- a/packages/workflow-executor/CLAUDE.md
+++ b/packages/workflow-executor/CLAUDE.md
@@ -42,7 +42,7 @@ Front  ◀──▶  Orchestrator  ◀──pull/push──▶  Executor  ──
 
 ```
 src/
-├── errors.ts               # WorkflowExecutorError, MissingToolCallError, MalformedToolCallError, NoRecordsError, NoReadableFieldsError
+├── errors.ts               # WorkflowExecutorError, MissingToolCallError, MalformedToolCallError, NoRecordsError, NoReadableFieldsError, NoWritableFieldsError
 ├── runner.ts               # Runner class — main entry point (start/stop/triggerPoll, HTTP server wiring)
 ├── types/                  # Core type definitions (@draft)
 │   ├── step-definition.ts  # StepType enum + step definition interfaces
@@ -60,7 +60,8 @@ src/
 ├── executors/              # Step executor implementations
 │   ├── base-step-executor.ts       # Abstract base class (context injection + shared helpers)
 │   ├── condition-step-executor.ts  # AI-powered condition step (chooses among options)
-│   └── read-record-step-executor.ts # AI-powered record field reading step
+│   ├── read-record-step-executor.ts  # AI-powered record field reading step
+│   └── update-record-step-executor.ts # AI-powered record field update step (with confirmation flow)
 ├── http/                   # HTTP server (optional, for frontend data access)
 │   └── executor-http-server.ts  # Koa server: GET /runs/:runId, POST /runs/:runId/trigger
 └── index.ts                # Barrel exports

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -45,3 +45,9 @@ export class NoResolvedFieldsError extends WorkflowExecutorError {
     super(`None of the requested fields could be resolved: ${fieldNames.join(', ')}`);
   }
 }
+
+export class NoWritableFieldsError extends WorkflowExecutorError {
+  constructor(collectionName: string) {
+    super(`No writable fields on record from collection "${collectionName}"`);
+  }
+}

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -148,7 +148,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   /** Returns baseRecordRef + any related records loaded by previous steps. */
   protected async getAvailableRecordRefs(): Promise<RecordRef[]> {
-    const stepExecutions = await this.context.runStore.getStepExecutions();
+    const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
     const relatedRecords = stepExecutions
       .filter((e): e is LoadRelatedRecordStepExecutionData => e.type === 'load-related-record')
       .map(e => e.record);

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -1,5 +1,5 @@
 import type { ExecutionContext, StepExecutionResult } from '../types/execution';
-import type { CollectionSchema, RecordRef } from '../types/record';
+import type { CollectionSchema, FieldSchema, RecordRef } from '../types/record';
 import type { StepDefinition } from '../types/step-definition';
 import type {
   LoadRelatedRecordStepExecutionData,
@@ -30,6 +30,30 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   }
 
   abstract execute(): Promise<StepExecutionResult>;
+
+  /** Find a field by displayName first, then fallback to fieldName. */
+  protected findField(schema: CollectionSchema, name: string): FieldSchema | undefined {
+    return (
+      schema.fields.find(f => f.displayName === name) ??
+      schema.fields.find(f => f.fieldName === name)
+    );
+  }
+
+  /** Builds a StepExecutionResult with the given status and optional error. */
+  protected buildOutcomeResult(
+    status: 'success' | 'error' | 'awaiting-input',
+    error?: string,
+  ): StepExecutionResult {
+    return {
+      stepOutcome: {
+        type: 'ai-task',
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        status,
+        ...(error !== undefined && { error }),
+      },
+    };
+  }
 
   /**
    * Returns a SystemMessage array summarizing previously executed steps.
@@ -73,6 +97,8 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     if (isExecutedStepOnExecutor(execution)) {
       if (execution.executionParams !== undefined) {
         lines.push(`  Input: ${JSON.stringify(execution.executionParams)}`);
+      } else if (execution.type === 'update-record' && execution.pendingUpdate) {
+        lines.push(`  Pending: ${JSON.stringify(execution.pendingUpdate)}`);
       }
 
       if (execution.executionResult) {

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -36,7 +36,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
    * Empty array when there is no history. Ready to spread into a messages array.
    */
   protected async buildPreviousStepsMessages(): Promise<SystemMessage[]> {
-    if (!this.context.history.length) return [];
+    if (!this.context.previousSteps.length) return [];
 
     const summary = await this.summarizePreviousSteps();
 
@@ -52,7 +52,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   private async summarizePreviousSteps(): Promise<string> {
     const allStepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
 
-    return this.context.history
+    return this.context.previousSteps
       .map(({ stepDefinition, stepOutcome }) => {
         const execution = allStepExecutions.find(e => e.stepIndex === stepOutcome.stepIndex);
 

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -46,7 +46,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   ): StepExecutionResult {
     return {
       stepOutcome: {
-        type: 'ai-task',
+        type: 'record-task',
         stepId: this.context.stepId,
         stepIndex: this.context.stepIndex,
         status,

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -1,17 +1,29 @@
 import type { ExecutionContext, StepExecutionResult } from '../types/execution';
+import type { CollectionSchema, RecordRef } from '../types/record';
 import type { StepDefinition } from '../types/step-definition';
-import type { StepExecutionData } from '../types/step-execution-data';
+import type {
+  LoadRelatedRecordStepExecutionData,
+  StepExecutionData,
+} from '../types/step-execution-data';
 import type { StepOutcome } from '../types/step-outcome';
 import type { AIMessage, BaseMessage } from '@langchain/core/messages';
-import type { DynamicStructuredTool } from '@langchain/core/tools';
 
-import { SystemMessage } from '@langchain/core/messages';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
 
-import { MalformedToolCallError, MissingToolCallError } from '../errors';
+import {
+  MalformedToolCallError,
+  MissingToolCallError,
+  NoRecordsError,
+  WorkflowExecutorError,
+} from '../errors';
 import { isExecutedStepOnExecutor } from '../types/step-execution-data';
 
 export default abstract class BaseStepExecutor<TStep extends StepDefinition = StepDefinition> {
   protected readonly context: ExecutionContext<TStep>;
+
+  protected readonly schemaCache = new Map<string, CollectionSchema>();
 
   constructor(context: ExecutionContext<TStep>) {
     this.context = context;
@@ -106,5 +118,79 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     }
 
     throw new MissingToolCallError();
+  }
+
+  /** Returns baseRecordRef + any related records loaded by previous steps. */
+  protected async getAvailableRecordRefs(): Promise<RecordRef[]> {
+    const stepExecutions = await this.context.runStore.getStepExecutions();
+    const relatedRecords = stepExecutions
+      .filter((e): e is LoadRelatedRecordStepExecutionData => e.type === 'load-related-record')
+      .map(e => e.record);
+
+    return [this.context.baseRecordRef, ...relatedRecords];
+  }
+
+  /** Selects a record ref via AI when multiple are available, returns directly when only one. */
+  protected async selectRecordRef(
+    records: RecordRef[],
+    prompt: string | undefined,
+  ): Promise<RecordRef> {
+    if (records.length === 0) throw new NoRecordsError();
+    if (records.length === 1) return records[0];
+
+    const identifiers = await Promise.all(records.map(r => this.toRecordIdentifier(r)));
+    const identifierTuple = identifiers as [string, ...string[]];
+
+    const tool = new DynamicStructuredTool({
+      name: 'select-record',
+      description: 'Select the most relevant record for this workflow step.',
+      schema: z.object({
+        recordIdentifier: z.enum(identifierTuple),
+      }),
+      func: undefined,
+    });
+
+    const messages = [
+      ...(await this.buildPreviousStepsMessages()),
+      new SystemMessage(
+        'You are an AI agent selecting the most relevant record for a workflow step.\n' +
+          'Choose the record whose collection best matches the user request.\n' +
+          'Pay attention to the collection name of each record.',
+      ),
+      new HumanMessage(prompt ?? 'Select the most relevant record.'),
+    ];
+
+    const { recordIdentifier } = await this.invokeWithTool<{ recordIdentifier: string }>(
+      messages,
+      tool,
+    );
+
+    const selectedIndex = identifiers.indexOf(recordIdentifier);
+
+    if (selectedIndex === -1) {
+      throw new WorkflowExecutorError(
+        `AI selected record "${recordIdentifier}" which does not match any available record`,
+      );
+    }
+
+    return records[selectedIndex];
+  }
+
+  /** Fetches a collection schema from WorkflowPort, with caching. */
+  protected async getCollectionSchema(collectionName: string): Promise<CollectionSchema> {
+    const cached = this.schemaCache.get(collectionName);
+    if (cached) return cached;
+
+    const schema = await this.context.workflowPort.getCollectionSchema(collectionName);
+    this.schemaCache.set(collectionName, schema);
+
+    return schema;
+  }
+
+  /** Formats a record ref as "Step X - CollectionDisplayName #id". */
+  protected async toRecordIdentifier(record: RecordRef): Promise<string> {
+    const schema = await this.getCollectionSchema(record.collectionName);
+
+    return `Step ${record.stepIndex} - ${schema.collectionDisplayName} #${record.recordId}`;
   }
 }

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -39,7 +39,11 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     );
   }
 
-  /** Builds a StepExecutionResult with the given status and optional error. */
+  /**
+   * Builds a StepExecutionResult with the given status and optional error.
+   * Only for record-task executors — hardcodes type: 'record-task'.
+   * ConditionStepExecutor and future non-record-task executors must NOT call this method.
+   */
   protected buildOutcomeResult(
     status: 'success' | 'error' | 'awaiting-input',
     error?: string,

--- a/packages/workflow-executor/src/executors/condition-step-executor.ts
+++ b/packages/workflow-executor/src/executors/condition-step-executor.ts
@@ -5,6 +5,7 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 
+import { WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
 
 interface GatewayToolArgs {
@@ -66,16 +67,20 @@ export default class ConditionStepExecutor extends BaseStepExecutor<ConditionSte
 
     try {
       args = await this.invokeWithTool<GatewayToolArgs>(messages, tool);
-    } catch (error: unknown) {
-      return {
-        stepOutcome: {
-          type: 'condition',
-          stepId: this.context.stepId,
-          stepIndex: this.context.stepIndex,
-          status: 'error',
-          error: (error as Error).message,
-        },
-      };
+    } catch (error) {
+      if (error instanceof WorkflowExecutorError) {
+        return {
+          stepOutcome: {
+            type: 'condition',
+            stepId: this.context.stepId,
+            stepIndex: this.context.stepIndex,
+            status: 'error',
+            error: error.message,
+          },
+        };
+      }
+
+      throw error;
     }
 
     const { option: selectedOption, reasoning } = args;

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -1,6 +1,6 @@
 import type { StepExecutionResult } from '../types/execution';
 import type { CollectionSchema, RecordRef } from '../types/record';
-import type { AiTaskStepDefinition } from '../types/step-definition';
+import type { RecordTaskStepDefinition } from '../types/step-definition';
 import type { FieldReadResult } from '../types/step-execution-data';
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
@@ -18,7 +18,7 @@ Important rules:
 - Final answer is definitive, you won't receive any other input from the user.
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
 
-export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepDefinition> {
+export default class ReadRecordStepExecutor extends BaseStepExecutor<RecordTaskStepDefinition> {
   async execute(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const records = await this.getAvailableRecordRefs();

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -1,21 +1,13 @@
 import type { StepExecutionResult } from '../types/execution';
 import type { CollectionSchema, RecordRef } from '../types/record';
 import type { AiTaskStepDefinition } from '../types/step-definition';
-import type {
-  FieldReadResult,
-  LoadRelatedRecordStepExecutionData,
-} from '../types/step-execution-data';
+import type { FieldReadResult } from '../types/step-execution-data';
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 
-import {
-  NoReadableFieldsError,
-  NoRecordsError,
-  NoResolvedFieldsError,
-  WorkflowExecutorError,
-} from '../errors';
+import { NoReadableFieldsError, NoResolvedFieldsError, WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
 
 const READ_RECORD_SYSTEM_PROMPT = `You are an AI agent reading fields from a record to answer a user request.
@@ -27,8 +19,6 @@ Important rules:
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
 
 export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepDefinition> {
-  private readonly schemaCache = new Map<string, CollectionSchema>();
-
   async execute(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const records = await this.getAvailableRecordRefs();
@@ -111,51 +101,6 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
     return args.fieldNames;
   }
 
-  private async selectRecordRef(
-    records: RecordRef[],
-    prompt: string | undefined,
-  ): Promise<RecordRef> {
-    if (records.length === 0) throw new NoRecordsError();
-    if (records.length === 1) return records[0];
-
-    const identifiers = await Promise.all(records.map(r => this.toRecordIdentifier(r)));
-    const identifierTuple = identifiers as [string, ...string[]];
-
-    const tool = new DynamicStructuredTool({
-      name: 'select-record',
-      description: 'Select the most relevant record for this workflow step.',
-      schema: z.object({
-        recordIdentifier: z.enum(identifierTuple),
-      }),
-      func: undefined,
-    });
-
-    const messages = [
-      ...(await this.buildPreviousStepsMessages()),
-      new SystemMessage(
-        'You are an AI agent selecting the most relevant record for a workflow step.\n' +
-          'Choose the record whose collection best matches the user request.\n' +
-          'Pay attention to the collection name of each record.',
-      ),
-      new HumanMessage(prompt ?? 'Select the most relevant record.'),
-    ];
-
-    const { recordIdentifier } = await this.invokeWithTool<{ recordIdentifier: string }>(
-      messages,
-      tool,
-    );
-
-    const selectedIndex = identifiers.indexOf(recordIdentifier);
-
-    if (selectedIndex === -1) {
-      throw new WorkflowExecutorError(
-        `AI selected record "${recordIdentifier}" which does not match any available record`,
-      );
-    }
-
-    return records[selectedIndex];
-  }
-
   private buildReadFieldTool(schema: CollectionSchema): DynamicStructuredTool {
     const nonRelationFields = schema.fields.filter(f => !f.isRelationship);
 
@@ -200,30 +145,5 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
         displayName: field.displayName,
       };
     });
-  }
-
-  private async getAvailableRecordRefs(): Promise<RecordRef[]> {
-    const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
-    const relatedRecords = stepExecutions
-      .filter((e): e is LoadRelatedRecordStepExecutionData => e.type === 'load-related-record')
-      .map(e => e.record);
-
-    return [this.context.baseRecordRef, ...relatedRecords];
-  }
-
-  private async getCollectionSchema(collectionName: string): Promise<CollectionSchema> {
-    const cached = this.schemaCache.get(collectionName);
-    if (cached) return cached;
-
-    const schema = await this.context.workflowPort.getCollectionSchema(collectionName);
-    this.schemaCache.set(collectionName, schema);
-
-    return schema;
-  }
-
-  private async toRecordIdentifier(record: RecordRef): Promise<string> {
-    const schema = await this.getCollectionSchema(record.collectionName);
-
-    return `Step ${record.stepIndex} - ${schema.collectionDisplayName} #${record.recordId}`;
   }
 }

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -9,7 +9,6 @@ import { z } from 'zod';
 
 import { NoReadableFieldsError, NoResolvedFieldsError, WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
-import { findField } from '../types/record';
 
 const READ_RECORD_SYSTEM_PROMPT = `You are an AI agent reading fields from a record to answer a user request.
 Select the field(s) that best answer the request. You can read one field or multiple fields at once.
@@ -33,7 +32,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
       schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const selectedDisplayNames = await this.selectFields(schema, step.prompt);
       const resolvedFieldNames = selectedDisplayNames
-        .map(name => findField(schema, name)?.fieldName)
+        .map(name => this.findField(schema, name)?.fieldName)
         .filter((name): name is string => name !== undefined);
 
       if (resolvedFieldNames.length === 0) {
@@ -48,15 +47,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
       fieldResults = this.formatFieldResults(recordData.values, schema, selectedDisplayNames);
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
-        return {
-          stepOutcome: {
-            type: 'ai-task',
-            stepId: this.context.stepId,
-            stepIndex: this.context.stepIndex,
-            status: 'error',
-            error: error.message,
-          },
-        };
+        return this.buildOutcomeResult('error', error.message);
       }
 
       throw error;
@@ -70,14 +61,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
       selectedRecordRef,
     });
 
-    return {
-      stepOutcome: {
-        type: 'ai-task',
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
-        status: 'success',
-      },
-    };
+    return this.buildOutcomeResult('success');
   }
 
   private async selectFields(
@@ -133,7 +117,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
     fieldNames: string[],
   ): FieldReadResult[] {
     return fieldNames.map(name => {
-      const field = findField(schema, name);
+      const field = this.findField(schema, name);
 
       if (!field) return { error: `Field not found: ${name}`, fieldName: name, displayName: name };
 

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { NoReadableFieldsError, NoResolvedFieldsError, WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
+import { findField } from '../types/record';
 
 const READ_RECORD_SYSTEM_PROMPT = `You are an AI agent reading fields from a record to answer a user request.
 Select the field(s) that best answer the request. You can read one field or multiple fields at once.
@@ -32,10 +33,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
       schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const selectedDisplayNames = await this.selectFields(schema, step.prompt);
       const resolvedFieldNames = selectedDisplayNames
-        .map(
-          name =>
-            schema.fields.find(f => f.fieldName === name || f.displayName === name)?.fieldName,
-        )
+        .map(name => findField(schema, name)?.fieldName)
         .filter((name): name is string => name !== undefined);
 
       if (resolvedFieldNames.length === 0) {
@@ -135,7 +133,7 @@ export default class ReadRecordStepExecutor extends BaseStepExecutor<AiTaskStepD
     fieldNames: string[],
   ): FieldReadResult[] {
     return fieldNames.map(name => {
-      const field = schema.fields.find(f => f.fieldName === name || f.displayName === name);
+      const field = findField(schema, name);
 
       if (!field) return { error: `Field not found: ${name}`, fieldName: name, displayName: name };
 

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { NoWritableFieldsError, WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
+import { findField } from '../types/record';
 
 const UPDATE_RECORD_SYSTEM_PROMPT = `You are an AI agent updating a field on a record based on a user request.
 Select the field to update and provide the new value.
@@ -195,9 +196,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
   }
 
   private resolveFieldName(schema: CollectionSchema, displayName: string): string {
-    const field = schema.fields.find(
-      f => f.displayName === displayName || f.fieldName === displayName,
-    );
+    const field = findField(schema, displayName);
 
     if (!field) {
       throw new WorkflowExecutorError(

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -9,7 +9,6 @@ import { z } from 'zod';
 
 import { NoWritableFieldsError, WorkflowExecutorError } from '../errors';
 import BaseStepExecutor from './base-step-executor';
-import { findField } from '../types/record';
 
 const UPDATE_RECORD_SYSTEM_PROMPT = `You are an AI agent updating a field on a record based on a user request.
 Select the field to update and provide the new value.
@@ -109,23 +108,16 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     value: string,
     existingExecution?: UpdateRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
+    let updated: { values: Record<string, unknown> };
+
     try {
       const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const fieldName = this.resolveFieldName(schema, fieldDisplayName);
-      const updated = await this.context.agentPort.updateRecord(
+      updated = await this.context.agentPort.updateRecord(
         selectedRecordRef.collectionName,
         selectedRecordRef.recordId,
         { [fieldName]: value },
       );
-
-      await this.context.runStore.saveStepExecution({
-        ...existingExecution,
-        type: 'update-record',
-        stepIndex: this.context.stepIndex,
-        executionParams: { fieldDisplayName, value },
-        executionResult: { updatedValues: updated.values },
-        selectedRecordRef,
-      });
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
         return this.buildOutcomeResult('error', error.message);
@@ -134,22 +126,16 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       throw error;
     }
 
-    return this.buildOutcomeResult('success');
-  }
+    await this.context.runStore.saveStepExecution({
+      ...existingExecution,
+      type: 'update-record',
+      stepIndex: this.context.stepIndex,
+      executionParams: { fieldDisplayName, value },
+      executionResult: { updatedValues: updated.values },
+      selectedRecordRef,
+    });
 
-  private buildOutcomeResult(
-    status: 'success' | 'error' | 'awaiting-input',
-    error?: string,
-  ): StepExecutionResult {
-    return {
-      stepOutcome: {
-        type: 'ai-task',
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
-        status,
-        ...(error && { error }),
-      },
-    };
+    return this.buildOutcomeResult('success');
   }
 
   private async selectFieldAndValue(
@@ -196,7 +182,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
   }
 
   private resolveFieldName(schema: CollectionSchema, displayName: string): string {
-    const field = findField(schema, displayName);
+    const field = this.findField(schema, displayName);
 
     if (!field) {
       throw new WorkflowExecutorError(

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -33,12 +33,10 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     const stepExecutions = await this.context.runStore.getStepExecutions();
     const interruption = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>
-        e.type === 'update-record' &&
-        e.stepIndex === this.context.stepIndex &&
-        !!e.toolConfirmationInterruption,
+        e.type === 'update-record' && e.stepIndex === this.context.stepIndex,
     );
 
-    if (!interruption) {
+    if (!interruption?.toolConfirmationInterruption) {
       return {
         stepOutcome: {
           type: 'ai-task',
@@ -74,10 +72,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     // User confirmed — resolve and update
     const { selectedRecordRef, toolConfirmationInterruption } = interruption;
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
-    const { fieldDisplayName, value } = toolConfirmationInterruption as {
-      fieldDisplayName: string;
-      value: string;
-    };
+    const { fieldDisplayName, value } = toolConfirmationInterruption;
 
     const fieldName = this.resolveFieldName(schema, fieldDisplayName);
 

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -18,6 +18,12 @@ Important rules:
 - Final answer is definitive, you won't receive any other input from the user.
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
 
+interface UpdateTarget {
+  selectedRecordRef: RecordRef;
+  fieldDisplayName: string;
+  value: string;
+}
+
 export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTaskStepDefinition> {
   async execute(): Promise<StepExecutionResult> {
     // Branch A -- Re-entry with user confirmation
@@ -30,7 +36,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
   }
 
   private async handleConfirmation(userInput: UserInput): Promise<StepExecutionResult> {
-    const stepExecutions = await this.context.runStore.getStepExecutions();
+    const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
     const execution = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>
         e.type === 'update-record' && e.stepIndex === this.context.stepIndex,
@@ -41,7 +47,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
     }
 
     if (!userInput.confirmed) {
-      await this.context.runStore.saveStepExecution({
+      await this.context.runStore.saveStepExecution(this.context.runId, {
         ...execution,
         executionResult: { skipped: true },
       });
@@ -50,29 +56,26 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
     }
 
     const { selectedRecordRef, pendingUpdate } = execution;
-
-    return this.resolveAndUpdate(
+    const target: UpdateTarget = {
       selectedRecordRef,
-      pendingUpdate.fieldDisplayName,
-      pendingUpdate.value,
-      execution,
-    );
+      fieldDisplayName: pendingUpdate.fieldDisplayName,
+      value: pendingUpdate.value,
+    };
+
+    return this.resolveAndUpdate(target, execution);
   }
 
   private async handleFirstCall(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const records = await this.getAvailableRecordRefs();
 
-    let selectedRecordRef: RecordRef;
-    let fieldDisplayName: string;
-    let value: string;
+    let target: UpdateTarget;
 
     try {
-      selectedRecordRef = await this.selectRecordRef(records, step.prompt);
+      const selectedRecordRef = await this.selectRecordRef(records, step.prompt);
       const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const args = await this.selectFieldAndValue(schema, step.prompt);
-      fieldDisplayName = args.fieldName;
-      value = args.value;
+      target = { selectedRecordRef, fieldDisplayName: args.fieldName, value: args.value };
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
         return this.buildOutcomeResult('error', error.message);
@@ -83,15 +86,15 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
 
     // Branch B -- automaticCompletion
     if (step.automaticCompletion) {
-      return this.resolveAndUpdate(selectedRecordRef, fieldDisplayName, value);
+      return this.resolveAndUpdate(target);
     }
 
     // Branch C -- Awaiting confirmation
-    await this.context.runStore.saveStepExecution({
+    await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'update-record',
       stepIndex: this.context.stepIndex,
-      pendingUpdate: { fieldDisplayName, value },
-      selectedRecordRef,
+      pendingUpdate: { fieldDisplayName: target.fieldDisplayName, value: target.value },
+      selectedRecordRef: target.selectedRecordRef,
     });
 
     return this.buildOutcomeResult('awaiting-input');
@@ -99,15 +102,14 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
 
   /**
    * Resolves the field name, calls updateRecord, and persists execution data.
-   * When `existingExecution` is provided (confirmation flow), it spreads its
-   * properties into the saved execution to preserve pendingUpdate for traceability.
+   * When `existingExecution` is provided (confirmation flow), it is spread into the
+   * saved execution to preserve pendingUpdate for traceability.
    */
   private async resolveAndUpdate(
-    selectedRecordRef: RecordRef,
-    fieldDisplayName: string,
-    value: string,
+    target: UpdateTarget,
     existingExecution?: UpdateRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
+    const { selectedRecordRef, fieldDisplayName, value } = target;
     let updated: { values: Record<string, unknown> };
 
     try {
@@ -126,7 +128,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
       throw error;
     }
 
-    await this.context.runStore.saveStepExecution({
+    await this.context.runStore.saveStepExecution(this.context.runId, {
       ...existingExecution,
       type: 'update-record',
       stepIndex: this.context.stepIndex,

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -46,9 +46,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       await this.context.runStore.saveStepExecution({
         ...execution,
         pendingUpdate: undefined,
-        executionResult: {
-          skipped: true,
-        } as unknown as UpdateRecordStepExecutionData['executionResult'],
+        executionResult: { skipped: true },
       });
 
       return {

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -38,7 +38,9 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
   private async handleConfirmation(userInput: UserInput): Promise<StepExecutionResult> {
     if (userInput.type !== 'confirmation') {
       throw new WorkflowExecutorError(
-        `UpdateRecordStepExecutor received unexpected userInput type: "${(userInput as { type: string }).type}"`,
+        `UpdateRecordStepExecutor received unexpected userInput type: "${
+          (userInput as { type: string }).type
+        }"`,
       );
     }
 
@@ -90,8 +92,8 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
       throw error;
     }
 
-    // Branch B -- automaticCompletion
-    if (step.automaticCompletion) {
+    // Branch B -- automaticExecution
+    if (step.automaticExecution) {
       return this.resolveAndUpdate(target);
     }
 

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -20,12 +20,12 @@ Important rules:
 
 export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskStepDefinition> {
   async execute(): Promise<StepExecutionResult> {
-    // Branch A — Re-entry with user confirmation
+    // Branch A -- Re-entry with user confirmation
     if (this.context.userInput) {
       return this.handleConfirmation(this.context.userInput);
     }
 
-    // Branches B & C — First call
+    // Branches B & C -- First call
     return this.handleFirstCall();
   }
 
@@ -40,66 +40,23 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       throw new WorkflowExecutorError('No pending update found for this step');
     }
 
-    const { confirmed } = userInput;
-
-    if (!confirmed) {
+    if (!userInput.confirmed) {
       await this.context.runStore.saveStepExecution({
         ...execution,
         executionResult: { skipped: true },
       });
 
-      return {
-        stepOutcome: {
-          type: 'ai-task',
-          stepId: this.context.stepId,
-          stepIndex: this.context.stepIndex,
-          status: 'success',
-        },
-      };
+      return this.buildSuccessResult();
     }
 
-    // User confirmed — resolve and update
     const { selectedRecordRef, pendingUpdate } = execution;
-    const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
-    const { fieldDisplayName, value } = pendingUpdate;
 
-    try {
-      const fieldName = this.resolveFieldName(schema, fieldDisplayName);
-      const updated = await this.context.agentPort.updateRecord(
-        selectedRecordRef.collectionName,
-        selectedRecordRef.recordId,
-        { [fieldName]: value },
-      );
-
-      await this.context.runStore.saveStepExecution({
-        ...execution,
-        executionParams: { fieldName: fieldDisplayName, value },
-        executionResult: { updatedValues: updated.values },
-      });
-    } catch (error) {
-      if (error instanceof WorkflowExecutorError) {
-        return {
-          stepOutcome: {
-            type: 'ai-task',
-            stepId: this.context.stepId,
-            stepIndex: this.context.stepIndex,
-            status: 'error',
-            error: error.message,
-          },
-        };
-      }
-
-      throw error;
-    }
-
-    return {
-      stepOutcome: {
-        type: 'ai-task',
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
-        status: 'success',
-      },
-    };
+    return this.resolveAndUpdate(
+      selectedRecordRef,
+      pendingUpdate.fieldDisplayName,
+      pendingUpdate.value,
+      execution,
+    );
   }
 
   private async handleFirstCall(): Promise<StepExecutionResult> {
@@ -107,38 +64,29 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     const records = await this.getAvailableRecordRefs();
 
     let selectedRecordRef: RecordRef;
-    let schema: CollectionSchema;
     let fieldDisplayName: string;
     let value: string;
 
     try {
       selectedRecordRef = await this.selectRecordRef(records, step.prompt);
-      schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
+      const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const args = await this.selectFieldAndValue(schema, step.prompt);
       fieldDisplayName = args.fieldName;
       value = args.value;
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
-        return {
-          stepOutcome: {
-            type: 'ai-task',
-            stepId: this.context.stepId,
-            stepIndex: this.context.stepIndex,
-            status: 'error',
-            error: error.message,
-          },
-        };
+        return this.buildErrorResult(error.message);
       }
 
       throw error;
     }
 
-    // Branch B — automaticCompletion
+    // Branch B -- automaticCompletion
     if (step.automaticCompletion) {
-      return this.executeUpdate(selectedRecordRef, schema, fieldDisplayName, value);
+      return this.resolveAndUpdate(selectedRecordRef, fieldDisplayName, value);
     }
 
-    // Branch C — Awaiting confirmation
+    // Branch C -- Awaiting confirmation
     await this.context.runStore.saveStepExecution({
       type: 'update-record',
       stepIndex: this.context.stepIndex,
@@ -146,23 +94,22 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       selectedRecordRef,
     });
 
-    return {
-      stepOutcome: {
-        type: 'ai-task',
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
-        status: 'awaiting-input',
-      },
-    };
+    return this.buildOutcomeResult('awaiting-input');
   }
 
-  private async executeUpdate(
+  /**
+   * Resolves the field name, calls updateRecord, and persists execution data.
+   * When `existingExecution` is provided (confirmation flow), it spreads its
+   * properties into the saved execution to preserve pendingUpdate for traceability.
+   */
+  private async resolveAndUpdate(
     selectedRecordRef: RecordRef,
-    schema: CollectionSchema,
     fieldDisplayName: string,
     value: string,
+    existingExecution?: UpdateRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
     try {
+      const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
       const fieldName = this.resolveFieldName(schema, fieldDisplayName);
       const updated = await this.context.agentPort.updateRecord(
         selectedRecordRef.collectionName,
@@ -171,36 +118,45 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       );
 
       await this.context.runStore.saveStepExecution({
+        ...existingExecution,
         type: 'update-record',
         stepIndex: this.context.stepIndex,
-        executionParams: { fieldName: fieldDisplayName, value },
+        executionParams: { fieldDisplayName, value },
         executionResult: { updatedValues: updated.values },
         selectedRecordRef,
       });
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
-        return {
-          stepOutcome: {
-            type: 'ai-task',
-            stepId: this.context.stepId,
-            stepIndex: this.context.stepIndex,
-            status: 'error',
-            error: error.message,
-          },
-        };
+        return this.buildErrorResult(error.message);
       }
 
       throw error;
     }
 
+    return this.buildSuccessResult();
+  }
+
+  private buildOutcomeResult(
+    status: 'success' | 'error' | 'awaiting-input',
+    error?: string,
+  ): StepExecutionResult {
     return {
       stepOutcome: {
         type: 'ai-task',
         stepId: this.context.stepId,
         stepIndex: this.context.stepIndex,
-        status: 'success',
+        status,
+        ...(error && { error }),
       },
     };
+  }
+
+  private buildSuccessResult(): StepExecutionResult {
+    return this.buildOutcomeResult('success');
+  }
+
+  private buildErrorResult(error: string): StepExecutionResult {
+    return this.buildOutcomeResult('error', error);
   }
 
   private async selectFieldAndValue(

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -36,6 +36,12 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
   }
 
   private async handleConfirmation(userInput: UserInput): Promise<StepExecutionResult> {
+    if (userInput.type !== 'confirmation') {
+      throw new WorkflowExecutorError(
+        `UpdateRecordStepExecutor received unexpected userInput type: "${(userInput as { type: string }).type}"`,
+      );
+    }
+
     const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
     const execution = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -31,28 +31,20 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
 
   private async handleConfirmation(): Promise<StepExecutionResult> {
     const stepExecutions = await this.context.runStore.getStepExecutions();
-    const interruption = stepExecutions.find(
+    const execution = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>
         e.type === 'update-record' && e.stepIndex === this.context.stepIndex,
     );
 
-    if (!interruption?.pendingUpdate) {
-      return {
-        stepOutcome: {
-          type: 'ai-task',
-          stepId: this.context.stepId,
-          stepIndex: this.context.stepIndex,
-          status: 'error',
-          error: 'No pending confirmation found for this step',
-        },
-      };
+    if (!execution?.pendingUpdate) {
+      throw new WorkflowExecutorError('No pending update found for this step');
     }
 
     const { confirmed } = this.context.userInput as { confirmed: boolean };
 
     if (!confirmed) {
       await this.context.runStore.saveStepExecution({
-        ...interruption,
+        ...execution,
         pendingUpdate: undefined,
         executionResult: {
           skipped: true,
@@ -70,7 +62,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     }
 
     // User confirmed — resolve and update
-    const { selectedRecordRef, pendingUpdate } = interruption;
+    const { selectedRecordRef, pendingUpdate } = execution;
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const { fieldDisplayName, value } = pendingUpdate;
 
@@ -84,7 +76,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       );
 
       await this.context.runStore.saveStepExecution({
-        ...interruption,
+        ...execution,
         pendingUpdate: undefined,
         executionParams: { fieldName: fieldDisplayName, value },
         executionResult: { updatedValues: updated.values },

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,6 +1,6 @@
 import type { StepExecutionResult, UserInput } from '../types/execution';
 import type { CollectionSchema, RecordRef } from '../types/record';
-import type { AiTaskStepDefinition } from '../types/step-definition';
+import type { RecordTaskStepDefinition } from '../types/step-definition';
 import type { UpdateRecordStepExecutionData } from '../types/step-execution-data';
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
@@ -18,7 +18,7 @@ Important rules:
 - Final answer is definitive, you won't receive any other input from the user.
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
 
-export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskStepDefinition> {
+export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTaskStepDefinition> {
   async execute(): Promise<StepExecutionResult> {
     // Branch A -- Re-entry with user confirmation
     if (this.context.userInput) {

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,4 +1,4 @@
-import type { StepExecutionResult } from '../types/execution';
+import type { StepExecutionResult, UserInput } from '../types/execution';
 import type { CollectionSchema, RecordRef } from '../types/record';
 import type { AiTaskStepDefinition } from '../types/step-definition';
 import type { UpdateRecordStepExecutionData } from '../types/step-execution-data';
@@ -22,14 +22,14 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
   async execute(): Promise<StepExecutionResult> {
     // Branch A — Re-entry with user confirmation
     if (this.context.userInput) {
-      return this.handleConfirmation();
+      return this.handleConfirmation(this.context.userInput);
     }
 
     // Branches B & C — First call
     return this.handleFirstCall();
   }
 
-  private async handleConfirmation(): Promise<StepExecutionResult> {
+  private async handleConfirmation(userInput: UserInput): Promise<StepExecutionResult> {
     const stepExecutions = await this.context.runStore.getStepExecutions();
     const execution = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>
@@ -40,7 +40,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       throw new WorkflowExecutorError('No pending update found for this step');
     }
 
-    const { confirmed } = this.context.userInput as { confirmed: boolean };
+    const { confirmed } = userInput;
 
     if (!confirmed) {
       await this.context.runStore.saveStepExecution({
@@ -63,9 +63,8 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const { fieldDisplayName, value } = pendingUpdate;
 
-    const fieldName = this.resolveFieldName(schema, fieldDisplayName);
-
     try {
+      const fieldName = this.resolveFieldName(schema, fieldDisplayName);
       const updated = await this.context.agentPort.updateRecord(
         selectedRecordRef.collectionName,
         selectedRecordRef.recordId,
@@ -163,9 +162,8 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     fieldDisplayName: string,
     value: string,
   ): Promise<StepExecutionResult> {
-    const fieldName = this.resolveFieldName(schema, fieldDisplayName);
-
     try {
+      const fieldName = this.resolveFieldName(schema, fieldDisplayName);
       const updated = await this.context.agentPort.updateRecord(
         selectedRecordRef.collectionName,
         selectedRecordRef.recordId,

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,4 +1,4 @@
-import type { StepExecutionResult, UserInput } from '../types/execution';
+import type { StepExecutionResult } from '../types/execution';
 import type { CollectionSchema, RecordRef } from '../types/record';
 import type { RecordTaskStepDefinition } from '../types/step-definition';
 import type { UpdateRecordStepExecutionData } from '../types/step-execution-data';
@@ -27,23 +27,15 @@ interface UpdateTarget {
 export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTaskStepDefinition> {
   async execute(): Promise<StepExecutionResult> {
     // Branch A -- Re-entry with user confirmation
-    if (this.context.userInput) {
-      return this.handleConfirmation(this.context.userInput);
+    if (this.context.userConfirmed !== undefined) {
+      return this.handleConfirmation();
     }
 
     // Branches B & C -- First call
     return this.handleFirstCall();
   }
 
-  private async handleConfirmation(userInput: UserInput): Promise<StepExecutionResult> {
-    if (userInput.type !== 'confirmation') {
-      throw new WorkflowExecutorError(
-        `UpdateRecordStepExecutor received unexpected userInput type: "${
-          (userInput as { type: string }).type
-        }"`,
-      );
-    }
-
+  private async handleConfirmation(): Promise<StepExecutionResult> {
     const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
     const execution = stepExecutions.find(
       (e): e is UpdateRecordStepExecutionData =>
@@ -54,7 +46,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<RecordTas
       throw new WorkflowExecutorError('No pending update found for this step');
     }
 
-    if (!userInput.confirmed) {
+    if (!this.context.userConfirmed) {
       await this.context.runStore.saveStepExecution(this.context.runId, {
         ...execution,
         executionResult: { skipped: true },

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -46,7 +46,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
         executionResult: { skipped: true },
       });
 
-      return this.buildSuccessResult();
+      return this.buildOutcomeResult('success');
     }
 
     const { selectedRecordRef, pendingUpdate } = execution;
@@ -75,7 +75,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       value = args.value;
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
-        return this.buildErrorResult(error.message);
+        return this.buildOutcomeResult('error', error.message);
       }
 
       throw error;
@@ -127,13 +127,13 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
       });
     } catch (error) {
       if (error instanceof WorkflowExecutorError) {
-        return this.buildErrorResult(error.message);
+        return this.buildOutcomeResult('error', error.message);
       }
 
       throw error;
     }
 
-    return this.buildSuccessResult();
+    return this.buildOutcomeResult('success');
   }
 
   private buildOutcomeResult(
@@ -149,14 +149,6 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
         ...(error && { error }),
       },
     };
-  }
-
-  private buildSuccessResult(): StepExecutionResult {
-    return this.buildOutcomeResult('success');
-  }
-
-  private buildErrorResult(error: string): StepExecutionResult {
-    return this.buildOutcomeResult('error', error);
   }
 
   private async selectFieldAndValue(

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -45,7 +45,6 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     if (!confirmed) {
       await this.context.runStore.saveStepExecution({
         ...execution,
-        pendingUpdate: undefined,
         executionResult: { skipped: true },
       });
 
@@ -75,7 +74,6 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
 
       await this.context.runStore.saveStepExecution({
         ...execution,
-        pendingUpdate: undefined,
         executionParams: { fieldName: fieldDisplayName, value },
         executionResult: { updatedValues: updated.values },
       });

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -36,7 +36,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
         e.type === 'update-record' && e.stepIndex === this.context.stepIndex,
     );
 
-    if (!interruption?.toolConfirmationInterruption) {
+    if (!interruption?.pendingUpdate) {
       return {
         stepOutcome: {
           type: 'ai-task',
@@ -53,7 +53,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     if (!confirmed) {
       await this.context.runStore.saveStepExecution({
         ...interruption,
-        toolConfirmationInterruption: undefined,
+        pendingUpdate: undefined,
         executionResult: {
           skipped: true,
         } as unknown as UpdateRecordStepExecutionData['executionResult'],
@@ -70,9 +70,9 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     }
 
     // User confirmed — resolve and update
-    const { selectedRecordRef, toolConfirmationInterruption } = interruption;
+    const { selectedRecordRef, pendingUpdate } = interruption;
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
-    const { fieldDisplayName, value } = toolConfirmationInterruption;
+    const { fieldDisplayName, value } = pendingUpdate;
 
     const fieldName = this.resolveFieldName(schema, fieldDisplayName);
 
@@ -85,7 +85,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
 
       await this.context.runStore.saveStepExecution({
         ...interruption,
-        toolConfirmationInterruption: undefined,
+        pendingUpdate: undefined,
         executionParams: { fieldName: fieldDisplayName, value },
         executionResult: { updatedValues: updated.values },
       });
@@ -155,7 +155,7 @@ export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskSte
     await this.context.runStore.saveStepExecution({
       type: 'update-record',
       stepIndex: this.context.stepIndex,
-      toolConfirmationInterruption: { fieldDisplayName, value },
+      pendingUpdate: { fieldDisplayName, value },
       selectedRecordRef,
     });
 

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,0 +1,281 @@
+import type { StepExecutionResult } from '../types/execution';
+import type { CollectionSchema, RecordRef } from '../types/record';
+import type { AiTaskStepDefinition } from '../types/step-definition';
+import type { UpdateRecordStepExecutionData } from '../types/step-execution-data';
+
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { NoWritableFieldsError, WorkflowExecutorError } from '../errors';
+import BaseStepExecutor from './base-step-executor';
+
+const UPDATE_RECORD_SYSTEM_PROMPT = `You are an AI agent updating a field on a record based on a user request.
+Select the field to update and provide the new value.
+
+Important rules:
+- Be precise: only update the field that is directly relevant to the request.
+- Final answer is definitive, you won't receive any other input from the user.
+- Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
+
+export default class UpdateRecordStepExecutor extends BaseStepExecutor<AiTaskStepDefinition> {
+  async execute(): Promise<StepExecutionResult> {
+    // Branch A — Re-entry with user confirmation
+    if (this.context.userInput) {
+      return this.handleConfirmation();
+    }
+
+    // Branches B & C — First call
+    return this.handleFirstCall();
+  }
+
+  private async handleConfirmation(): Promise<StepExecutionResult> {
+    const stepExecutions = await this.context.runStore.getStepExecutions();
+    const interruption = stepExecutions.find(
+      (e): e is UpdateRecordStepExecutionData =>
+        e.type === 'update-record' &&
+        e.stepIndex === this.context.stepIndex &&
+        !!e.toolConfirmationInterruption,
+    );
+
+    if (!interruption) {
+      return {
+        stepOutcome: {
+          type: 'ai-task',
+          stepId: this.context.stepId,
+          stepIndex: this.context.stepIndex,
+          status: 'error',
+          error: 'No pending confirmation found for this step',
+        },
+      };
+    }
+
+    const { confirmed } = this.context.userInput as { confirmed: boolean };
+
+    if (!confirmed) {
+      await this.context.runStore.saveStepExecution({
+        ...interruption,
+        toolConfirmationInterruption: undefined,
+        executionResult: {
+          skipped: true,
+        } as unknown as UpdateRecordStepExecutionData['executionResult'],
+      });
+
+      return {
+        stepOutcome: {
+          type: 'ai-task',
+          stepId: this.context.stepId,
+          stepIndex: this.context.stepIndex,
+          status: 'success',
+        },
+      };
+    }
+
+    // User confirmed — resolve and update
+    const { selectedRecordRef, toolConfirmationInterruption } = interruption;
+    const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
+    const { fieldDisplayName, value } = toolConfirmationInterruption as {
+      fieldDisplayName: string;
+      value: string;
+    };
+
+    const fieldName = this.resolveFieldName(schema, fieldDisplayName);
+
+    try {
+      const updated = await this.context.agentPort.updateRecord(
+        selectedRecordRef.collectionName,
+        selectedRecordRef.recordId,
+        { [fieldName]: value },
+      );
+
+      await this.context.runStore.saveStepExecution({
+        ...interruption,
+        toolConfirmationInterruption: undefined,
+        executionParams: { fieldName: fieldDisplayName, value },
+        executionResult: { updatedValues: updated.values },
+      });
+    } catch (error) {
+      if (error instanceof WorkflowExecutorError) {
+        return {
+          stepOutcome: {
+            type: 'ai-task',
+            stepId: this.context.stepId,
+            stepIndex: this.context.stepIndex,
+            status: 'error',
+            error: error.message,
+          },
+        };
+      }
+
+      throw error;
+    }
+
+    return {
+      stepOutcome: {
+        type: 'ai-task',
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        status: 'success',
+      },
+    };
+  }
+
+  private async handleFirstCall(): Promise<StepExecutionResult> {
+    const { stepDefinition: step } = this.context;
+    const records = await this.getAvailableRecordRefs();
+
+    let selectedRecordRef: RecordRef;
+    let schema: CollectionSchema;
+    let fieldDisplayName: string;
+    let value: string;
+
+    try {
+      selectedRecordRef = await this.selectRecordRef(records, step.prompt);
+      schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
+      const args = await this.selectFieldAndValue(schema, step.prompt);
+      fieldDisplayName = args.fieldName;
+      value = args.value;
+    } catch (error) {
+      if (error instanceof WorkflowExecutorError) {
+        return {
+          stepOutcome: {
+            type: 'ai-task',
+            stepId: this.context.stepId,
+            stepIndex: this.context.stepIndex,
+            status: 'error',
+            error: error.message,
+          },
+        };
+      }
+
+      throw error;
+    }
+
+    // Branch B — automaticCompletion
+    if (step.automaticCompletion) {
+      return this.executeUpdate(selectedRecordRef, schema, fieldDisplayName, value);
+    }
+
+    // Branch C — Awaiting confirmation
+    await this.context.runStore.saveStepExecution({
+      type: 'update-record',
+      stepIndex: this.context.stepIndex,
+      toolConfirmationInterruption: { fieldDisplayName, value },
+      selectedRecordRef,
+    });
+
+    return {
+      stepOutcome: {
+        type: 'ai-task',
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        status: 'awaiting-input',
+      },
+    };
+  }
+
+  private async executeUpdate(
+    selectedRecordRef: RecordRef,
+    schema: CollectionSchema,
+    fieldDisplayName: string,
+    value: string,
+  ): Promise<StepExecutionResult> {
+    const fieldName = this.resolveFieldName(schema, fieldDisplayName);
+
+    try {
+      const updated = await this.context.agentPort.updateRecord(
+        selectedRecordRef.collectionName,
+        selectedRecordRef.recordId,
+        { [fieldName]: value },
+      );
+
+      await this.context.runStore.saveStepExecution({
+        type: 'update-record',
+        stepIndex: this.context.stepIndex,
+        executionParams: { fieldName: fieldDisplayName, value },
+        executionResult: { updatedValues: updated.values },
+        selectedRecordRef,
+      });
+    } catch (error) {
+      if (error instanceof WorkflowExecutorError) {
+        return {
+          stepOutcome: {
+            type: 'ai-task',
+            stepId: this.context.stepId,
+            stepIndex: this.context.stepIndex,
+            status: 'error',
+            error: error.message,
+          },
+        };
+      }
+
+      throw error;
+    }
+
+    return {
+      stepOutcome: {
+        type: 'ai-task',
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        status: 'success',
+      },
+    };
+  }
+
+  private async selectFieldAndValue(
+    schema: CollectionSchema,
+    prompt: string | undefined,
+  ): Promise<{ fieldName: string; value: string; reasoning: string }> {
+    const tool = this.buildUpdateFieldTool(schema);
+    const messages = [
+      ...(await this.buildPreviousStepsMessages()),
+      new SystemMessage(UPDATE_RECORD_SYSTEM_PROMPT),
+      new SystemMessage(
+        `The selected record belongs to the "${schema.collectionDisplayName}" collection.`,
+      ),
+      new HumanMessage(`**Request**: ${prompt ?? 'Update the relevant field.'}`),
+    ];
+
+    return this.invokeWithTool<{ fieldName: string; value: string; reasoning: string }>(
+      messages,
+      tool,
+    );
+  }
+
+  private buildUpdateFieldTool(schema: CollectionSchema): DynamicStructuredTool {
+    const nonRelationFields = schema.fields.filter(f => !f.isRelationship);
+
+    if (nonRelationFields.length === 0) {
+      throw new NoWritableFieldsError(schema.collectionName);
+    }
+
+    const displayNames = nonRelationFields.map(f => f.displayName) as [string, ...string[]];
+
+    return new DynamicStructuredTool({
+      name: 'update-record-field',
+      description: 'Update a field on the selected record.',
+      schema: z.object({
+        fieldName: z.enum(displayNames),
+        // z.string() intentionally: the value is always transmitted as string
+        // to updateRecord; data typing is handled by the agent/datasource layer.
+        value: z.string().describe('The new value for the field'),
+        reasoning: z.string().describe('Why this field and value were chosen'),
+      }),
+      func: undefined,
+    });
+  }
+
+  private resolveFieldName(schema: CollectionSchema, displayName: string): string {
+    const field = schema.fields.find(
+      f => f.displayName === displayName || f.fieldName === displayName,
+    );
+
+    if (!field) {
+      throw new WorkflowExecutorError(
+        `Field "${displayName}" not found in collection "${schema.collectionName}"`,
+      );
+    }
+
+    return field.fieldName;
+  }
+}

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -2,7 +2,6 @@ export { StepType } from './types/step-definition';
 export type {
   ConditionStepDefinition,
   RecordTaskStepDefinition,
-  ToolTaskStepDefinition,
   StepDefinition,
 } from './types/step-definition';
 

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -1,14 +1,14 @@
 export { StepType } from './types/step-definition';
 export type {
   ConditionStepDefinition,
-  AiTaskStepDefinition,
+  RecordTaskStepDefinition,
   StepDefinition,
 } from './types/step-definition';
 
 export type {
   StepStatus,
   ConditionStepOutcome,
-  AiTaskStepOutcome,
+  RecordTaskStepOutcome,
   StepOutcome,
 } from './types/step-outcome';
 
@@ -19,7 +19,7 @@ export type {
   ConditionStepExecutionData,
   ReadRecordStepExecutionData,
   UpdateRecordStepExecutionData,
-  AiTaskStepExecutionData,
+  RecordTaskStepExecutionData,
   LoadRelatedRecordStepExecutionData,
   ExecutedStepExecutionData,
   StepExecutionData,

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -18,6 +18,7 @@ export type {
   FieldReadResult,
   ConditionStepExecutionData,
   ReadRecordStepExecutionData,
+  UpdateRecordStepExecutionData,
   AiTaskStepExecutionData,
   LoadRelatedRecordStepExecutionData,
   ExecutedStepExecutionData,
@@ -54,10 +55,12 @@ export {
   NoRecordsError,
   NoReadableFieldsError,
   NoResolvedFieldsError,
+  NoWritableFieldsError,
 } from './errors';
 export { default as BaseStepExecutor } from './executors/base-step-executor';
 export { default as ConditionStepExecutor } from './executors/condition-step-executor';
 export { default as ReadRecordStepExecutor } from './executors/read-record-step-executor';
+export { default as UpdateRecordStepExecutor } from './executors/update-record-step-executor';
 export { default as AgentClientAgentPort } from './adapters/agent-client-agent-port';
 export { default as ForestServerWorkflowPort } from './adapters/forest-server-workflow-port';
 export { default as ExecutorHttpServer } from './http/executor-http-server';

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -2,6 +2,7 @@ export { StepType } from './types/step-definition';
 export type {
   ConditionStepDefinition,
   RecordTaskStepDefinition,
+  ToolTaskStepDefinition,
   StepDefinition,
 } from './types/step-definition';
 

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -37,7 +37,6 @@ export type {
 
 export type {
   Step,
-  UserInput,
   PendingStepExecution,
   StepExecutionResult,
   ExecutionContext,

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -34,7 +34,6 @@ export type {
   RecordRef,
   RecordData,
 } from './types/record';
-export { findField } from './types/record';
 
 export type {
   Step,

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -34,6 +34,7 @@ export type {
   RecordRef,
   RecordData,
 } from './types/record';
+export { findField } from './types/record';
 
 export type {
   Step,

--- a/packages/workflow-executor/src/types/execution.ts
+++ b/packages/workflow-executor/src/types/execution.ts
@@ -13,8 +13,6 @@ export interface Step {
   stepOutcome: StepOutcome;
 }
 
-export type UserInput = { type: 'confirmation'; confirmed: boolean };
-
 export interface PendingStepExecution {
   readonly runId: string;
   readonly stepId: string;
@@ -22,7 +20,7 @@ export interface PendingStepExecution {
   readonly baseRecordRef: RecordRef;
   readonly stepDefinition: StepDefinition;
   readonly previousSteps: ReadonlyArray<Step>;
-  readonly userInput?: UserInput;
+  readonly userConfirmed?: boolean;
 }
 
 export interface StepExecutionResult {
@@ -41,5 +39,5 @@ export interface ExecutionContext<TStep extends StepDefinition = StepDefinition>
   readonly runStore: RunStore;
   readonly previousSteps: ReadonlyArray<Readonly<Step>>;
   readonly remoteTools: readonly unknown[];
-  readonly userInput?: UserInput;
+  readonly userConfirmed?: boolean;
 }

--- a/packages/workflow-executor/src/types/execution.ts
+++ b/packages/workflow-executor/src/types/execution.ts
@@ -39,7 +39,7 @@ export interface ExecutionContext<TStep extends StepDefinition = StepDefinition>
   readonly agentPort: AgentPort;
   readonly workflowPort: WorkflowPort;
   readonly runStore: RunStore;
-  readonly history: ReadonlyArray<Readonly<Step>>;
+  readonly previousSteps: ReadonlyArray<Readonly<Step>>;
   readonly remoteTools: readonly unknown[];
   readonly userInput?: UserInput;
 }

--- a/packages/workflow-executor/src/types/execution.ts
+++ b/packages/workflow-executor/src/types/execution.ts
@@ -41,4 +41,5 @@ export interface ExecutionContext<TStep extends StepDefinition = StepDefinition>
   readonly runStore: RunStore;
   readonly history: ReadonlyArray<Readonly<Step>>;
   readonly remoteTools: readonly unknown[];
+  readonly userInput?: UserInput;
 }

--- a/packages/workflow-executor/src/types/record.ts
+++ b/packages/workflow-executor/src/types/record.ts
@@ -21,11 +21,6 @@ export interface CollectionSchema {
   actions: ActionSchema[];
 }
 
-/** Find a field by fieldName or displayName. */
-export function findField(schema: CollectionSchema, name: string): FieldSchema | undefined {
-  return schema.fields.find(f => f.fieldName === name || f.displayName === name);
-}
-
 // -- Record types (data — source: AgentPort/RunStore) --
 
 /** Lightweight pointer to a specific record. */

--- a/packages/workflow-executor/src/types/record.ts
+++ b/packages/workflow-executor/src/types/record.ts
@@ -21,6 +21,11 @@ export interface CollectionSchema {
   actions: ActionSchema[];
 }
 
+/** Find a field by fieldName or displayName. */
+export function findField(schema: CollectionSchema, name: string): FieldSchema | undefined {
+  return schema.fields.find(f => f.fieldName === name || f.displayName === name);
+}
+
 // -- Record types (data — source: AgentPort/RunStore) --
 
 /** Lightweight pointer to a specific record. */

--- a/packages/workflow-executor/src/types/step-definition.ts
+++ b/packages/workflow-executor/src/types/step-definition.ts
@@ -21,10 +21,8 @@ export interface ConditionStepDefinition extends BaseStepDefinition {
 
 export interface RecordTaskStepDefinition extends BaseStepDefinition {
   type: Exclude<StepType, StepType.Condition>;
-  recordSourceStepId?: string;
   automaticCompletion?: boolean;
   allowedTools?: string[];
-  remoteToolsSourceId?: string;
 }
 
 export type StepDefinition = ConditionStepDefinition | RecordTaskStepDefinition;

--- a/packages/workflow-executor/src/types/step-definition.ts
+++ b/packages/workflow-executor/src/types/step-definition.ts
@@ -6,7 +6,7 @@ export enum StepType {
   UpdateRecord = 'update-record',
   TriggerAction = 'trigger-action',
   LoadRelatedRecord = 'load-related-record',
-  ToolTask = 'tool-task',
+  McpTask = 'mcp-task',
 }
 
 interface BaseStepDefinition {
@@ -21,17 +21,17 @@ export interface ConditionStepDefinition extends BaseStepDefinition {
 }
 
 export interface RecordTaskStepDefinition extends BaseStepDefinition {
-  type: Exclude<StepType, StepType.Condition | StepType.ToolTask>;
-  automaticCompletion?: boolean;
+  type: Exclude<StepType, StepType.Condition | StepType.McpTask>;
+  automaticExecution?: boolean;
 }
 
-export interface ToolTaskStepDefinition extends BaseStepDefinition {
-  type: StepType.ToolTask;
-  allowedTools?: string[];
-  automaticCompletion?: boolean;
+export interface McpTaskStepDefinition extends BaseStepDefinition {
+  type: StepType.McpTask;
+  mcpServerId?: string;
+  automaticExecution?: boolean;
 }
 
 export type StepDefinition =
   | ConditionStepDefinition
   | RecordTaskStepDefinition
-  | ToolTaskStepDefinition;
+  | McpTaskStepDefinition;

--- a/packages/workflow-executor/src/types/step-definition.ts
+++ b/packages/workflow-executor/src/types/step-definition.ts
@@ -6,6 +6,7 @@ export enum StepType {
   UpdateRecord = 'update-record',
   TriggerAction = 'trigger-action',
   LoadRelatedRecord = 'load-related-record',
+  ToolTask = 'tool-task',
 }
 
 interface BaseStepDefinition {
@@ -20,9 +21,14 @@ export interface ConditionStepDefinition extends BaseStepDefinition {
 }
 
 export interface RecordTaskStepDefinition extends BaseStepDefinition {
-  type: Exclude<StepType, StepType.Condition>;
+  type: Exclude<StepType, StepType.Condition | StepType.ToolTask>;
   automaticCompletion?: boolean;
-  allowedTools?: string[];
 }
 
-export type StepDefinition = ConditionStepDefinition | RecordTaskStepDefinition;
+export interface ToolTaskStepDefinition extends BaseStepDefinition {
+  type: StepType.ToolTask;
+  allowedTools?: string[];
+  automaticCompletion?: boolean;
+}
+
+export type StepDefinition = ConditionStepDefinition | RecordTaskStepDefinition | ToolTaskStepDefinition;

--- a/packages/workflow-executor/src/types/step-definition.ts
+++ b/packages/workflow-executor/src/types/step-definition.ts
@@ -31,4 +31,7 @@ export interface ToolTaskStepDefinition extends BaseStepDefinition {
   automaticCompletion?: boolean;
 }
 
-export type StepDefinition = ConditionStepDefinition | RecordTaskStepDefinition | ToolTaskStepDefinition;
+export type StepDefinition =
+  | ConditionStepDefinition
+  | RecordTaskStepDefinition
+  | ToolTaskStepDefinition;

--- a/packages/workflow-executor/src/types/step-definition.ts
+++ b/packages/workflow-executor/src/types/step-definition.ts
@@ -19,7 +19,7 @@ export interface ConditionStepDefinition extends BaseStepDefinition {
   options: [string, ...string[]];
 }
 
-export interface AiTaskStepDefinition extends BaseStepDefinition {
+export interface RecordTaskStepDefinition extends BaseStepDefinition {
   type: Exclude<StepType, StepType.Condition>;
   recordSourceStepId?: string;
   automaticCompletion?: boolean;
@@ -27,4 +27,4 @@ export interface AiTaskStepDefinition extends BaseStepDefinition {
   remoteToolsSourceId?: string;
 }
 
-export type StepDefinition = ConditionStepDefinition | AiTaskStepDefinition;
+export type StepDefinition = ConditionStepDefinition | RecordTaskStepDefinition;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -47,6 +47,7 @@ export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
   executionParams?: { fieldDisplayName: string; value: string };
   /** User confirmed → values returned by updateRecord. User rejected → skipped. */
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
+  /** AI-selected field and value awaiting user confirmation. Used in the confirmation flow only. */
   pendingUpdate?: {
     fieldDisplayName: string;
     value: string;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -40,6 +40,19 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
   selectedRecordRef: RecordRef;
 }
 
+// -- Update Record --
+
+export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
+  type: 'update-record';
+  executionParams?: { fieldName: string; value: string };
+  executionResult?: { updatedValues: Record<string, unknown> };
+  toolConfirmationInterruption?: {
+    fieldDisplayName: string;
+    value: string;
+  };
+  selectedRecordRef: RecordRef;
+}
+
 // -- Generic AI Task (fallback for untyped steps) --
 
 export interface AiTaskStepExecutionData extends BaseStepExecutionData {
@@ -61,12 +74,14 @@ export interface LoadRelatedRecordStepExecutionData extends BaseStepExecutionDat
 export type StepExecutionData =
   | ConditionStepExecutionData
   | ReadRecordStepExecutionData
+  | UpdateRecordStepExecutionData
   | AiTaskStepExecutionData
   | LoadRelatedRecordStepExecutionData;
 
 export type ExecutedStepExecutionData =
   | ConditionStepExecutionData
   | ReadRecordStepExecutionData
+  | UpdateRecordStepExecutionData
   | AiTaskStepExecutionData;
 
 // TODO: this condition should change when load-related-record gets its own executor

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -45,7 +45,7 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
   type: 'update-record';
   executionParams?: { fieldName: string; value: string };
-  executionResult?: { updatedValues: Record<string, unknown> };
+  executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
   pendingUpdate?: {
     fieldDisplayName: string;
     value: string;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -44,7 +44,7 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 
 export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
   type: 'update-record';
-  executionParams?: { fieldName: string; value: string };
+  executionParams?: { fieldDisplayName: string; value: string };
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
   pendingUpdate?: {
     fieldDisplayName: string;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -45,6 +45,7 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
   type: 'update-record';
   executionParams?: { fieldDisplayName: string; value: string };
+  /** User confirmed → values returned by updateRecord. User rejected → skipped. */
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
   pendingUpdate?: {
     fieldDisplayName: string;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -57,8 +57,8 @@ export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
 
 // -- Generic AI Task (fallback for untyped steps) --
 
-export interface AiTaskStepExecutionData extends BaseStepExecutionData {
-  type: 'ai-task';
+export interface RecordTaskStepExecutionData extends BaseStepExecutionData {
+  type: 'record-task';
   executionParams?: Record<string, unknown>;
   executionResult?: Record<string, unknown>;
   toolConfirmationInterruption?: Record<string, unknown>;
@@ -77,14 +77,14 @@ export type StepExecutionData =
   | ConditionStepExecutionData
   | ReadRecordStepExecutionData
   | UpdateRecordStepExecutionData
-  | AiTaskStepExecutionData
+  | RecordTaskStepExecutionData
   | LoadRelatedRecordStepExecutionData;
 
 export type ExecutedStepExecutionData =
   | ConditionStepExecutionData
   | ReadRecordStepExecutionData
   | UpdateRecordStepExecutionData
-  | AiTaskStepExecutionData;
+  | RecordTaskStepExecutionData;
 
 // TODO: this condition should change when load-related-record gets its own executor
 // and produces executionParams/executionResult like other steps.

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -46,7 +46,7 @@ export interface UpdateRecordStepExecutionData extends BaseStepExecutionData {
   type: 'update-record';
   executionParams?: { fieldName: string; value: string };
   executionResult?: { updatedValues: Record<string, unknown> };
-  toolConfirmationInterruption?: {
+  pendingUpdate?: {
     fieldDisplayName: string;
     value: string;
   };

--- a/packages/workflow-executor/src/types/step-outcome.ts
+++ b/packages/workflow-executor/src/types/step-outcome.ts
@@ -6,10 +6,10 @@ type BaseStepStatus = 'success' | 'error';
 export type ConditionStepStatus = BaseStepStatus | 'manual-decision';
 
 /** AI task steps can pause mid-execution to await user input (e.g. tool confirmation). */
-export type AiTaskStepStatus = BaseStepStatus | 'awaiting-input';
+export type RecordTaskStepStatus = BaseStepStatus | 'awaiting-input';
 
 /** Union of all step statuses. */
-export type StepStatus = ConditionStepStatus | AiTaskStepStatus;
+export type StepStatus = ConditionStepStatus | RecordTaskStepStatus;
 
 /**
  * StepOutcome is sent to the orchestrator — it must NEVER contain client data.
@@ -30,9 +30,9 @@ export interface ConditionStepOutcome extends BaseStepOutcome {
   selectedOption?: string;
 }
 
-export interface AiTaskStepOutcome extends BaseStepOutcome {
-  type: 'ai-task';
-  status: AiTaskStepStatus;
+export interface RecordTaskStepOutcome extends BaseStepOutcome {
+  type: 'record-task';
+  status: RecordTaskStepStatus;
 }
 
-export type StepOutcome = ConditionStepOutcome | AiTaskStepOutcome;
+export type StepOutcome = ConditionStepOutcome | RecordTaskStepOutcome;

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -73,7 +73,7 @@ function makeContext(overrides: Partial<ExecutionContext> = {}): ExecutionContex
     agentPort: {} as ExecutionContext['agentPort'],
     workflowPort: {} as ExecutionContext['workflowPort'],
     runStore: makeMockRunStore(),
-    history: [],
+    previousSteps: [],
     remoteTools: [],
     ...overrides,
   };
@@ -98,7 +98,7 @@ describe('BaseStepExecutor', () => {
       ]);
       const executor = new TestableExecutor(
         makeContext({
-          history: [makeHistoryEntry({ stepId: 'cond-1', stepIndex: 0, prompt: 'Approve?' })],
+          previousSteps: [makeHistoryEntry({ stepId: 'cond-1', stepIndex: 0, prompt: 'Approve?' })],
           runStore,
         }),
       );
@@ -117,7 +117,7 @@ describe('BaseStepExecutor', () => {
     it('uses Input for matched steps and History for unmatched steps', async () => {
       const executor = new TestableExecutor(
         makeContext({
-          history: [
+          previousSteps: [
             makeHistoryEntry({ stepId: 'cond-1', stepIndex: 0 }),
             makeHistoryEntry({ stepId: 'cond-2', stepIndex: 1, prompt: 'Second?' }),
           ],
@@ -147,7 +147,7 @@ describe('BaseStepExecutor', () => {
     it('falls back to History when no matching step execution in RunStore', async () => {
       const executor = new TestableExecutor(
         makeContext({
-          history: [
+          previousSteps: [
             makeHistoryEntry({ stepId: 'orphan', stepIndex: 5, prompt: 'Orphan step' }),
             makeHistoryEntry({ stepId: 'matched', stepIndex: 1, prompt: 'Matched step' }),
           ],
@@ -183,7 +183,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([]),
         }),
       );
@@ -207,7 +207,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([]),
         }),
       );
@@ -236,7 +236,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([]),
         }),
       );
@@ -272,7 +272,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [condEntry, aiEntry],
+          previousSteps: [condEntry, aiEntry],
           runStore: makeMockRunStore([
             {
               type: 'ai-task',
@@ -299,7 +299,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([
             {
               type: 'condition',
@@ -336,7 +336,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([
             {
               type: 'ai-task',
@@ -361,7 +361,7 @@ describe('BaseStepExecutor', () => {
 
       const executor = new TestableExecutor(
         makeContext({
-          history: [entry],
+          previousSteps: [entry],
           runStore: makeMockRunStore([
             {
               type: 'condition',

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -220,14 +220,14 @@ describe('BaseStepExecutor', () => {
       expect(result).toContain('"error":"AI could not match an option"');
     });
 
-    it('includes status in History for ai-task steps without RunStore data', async () => {
+    it('includes status in History for record-task steps without RunStore data', async () => {
       const entry: { stepDefinition: StepDefinition; stepOutcome: StepOutcome } = {
         stepDefinition: {
           type: StepType.ReadRecord,
           prompt: 'Run task',
         },
         stepOutcome: {
-          type: 'ai-task',
+          type: 'record-task',
           stepId: 'ai-step',
           stepIndex: 0,
           status: 'awaiting-input',
@@ -263,7 +263,7 @@ describe('BaseStepExecutor', () => {
           prompt: 'Read name',
         },
         stepOutcome: {
-          type: 'ai-task',
+          type: 'record-task',
           stepId: 'read-customer',
           stepIndex: 1,
           status: 'success',
@@ -275,7 +275,7 @@ describe('BaseStepExecutor', () => {
           previousSteps: [condEntry, aiEntry],
           runStore: makeMockRunStore([
             {
-              type: 'ai-task',
+              type: 'record-task',
               stepIndex: 1,
               executionParams: { answer: 'John Doe' },
             },
@@ -327,7 +327,7 @@ describe('BaseStepExecutor', () => {
           prompt: 'Do something',
         },
         stepOutcome: {
-          type: 'ai-task',
+          type: 'record-task',
           stepId: 'ai-step',
           stepIndex: 0,
           status: 'success',
@@ -339,7 +339,7 @@ describe('BaseStepExecutor', () => {
           previousSteps: [entry],
           runStore: makeMockRunStore([
             {
-              type: 'ai-task',
+              type: 'record-task',
               stepIndex: 0,
             },
           ]),

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -355,6 +355,41 @@ describe('BaseStepExecutor', () => {
       expect(result).not.toContain('Input:');
     });
 
+    it('uses Pending when update-record step has pendingUpdate but no executionParams', async () => {
+      const executor = new TestableExecutor(
+        makeContext({
+          previousSteps: [
+            {
+              stepDefinition: { type: StepType.UpdateRecord, prompt: 'Set status to active' },
+              stepOutcome: {
+                type: 'record-task',
+                stepId: 'update-1',
+                stepIndex: 0,
+                status: 'awaiting-input',
+              },
+            },
+          ],
+          runStore: makeMockRunStore([
+            {
+              type: 'update-record',
+              stepIndex: 0,
+              pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
+              selectedRecordRef: { collectionName: 'customers', recordId: [1], stepIndex: 0 },
+            },
+          ]),
+        }),
+      );
+
+      const result = await executor
+        .buildPreviousStepsMessages()
+        .then(msgs => msgs[0]?.content ?? '');
+
+      expect(result).toContain('Pending:');
+      expect(result).toContain('"fieldDisplayName":"Status"');
+      expect(result).toContain('"value":"active"');
+      expect(result).not.toContain('Input:');
+    });
+
     it('shows "(no prompt)" when step has no prompt', async () => {
       const entry = makeHistoryEntry({ stepIndex: 0 });
       entry.stepDefinition.prompt = undefined;

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -228,7 +228,7 @@ describe('BaseStepExecutor', () => {
         },
         stepOutcome: {
           type: 'record-task',
-          stepId: 'ai-step',
+          stepId: 'read-record-1',
           stepIndex: 0,
           status: 'awaiting-input',
         },
@@ -245,7 +245,7 @@ describe('BaseStepExecutor', () => {
         .buildPreviousStepsMessages()
         .then(msgs => msgs[0]?.content ?? '');
 
-      expect(result).toContain('Step "ai-step"');
+      expect(result).toContain('Step "read-record-1"');
       expect(result).toContain('History: {"status":"awaiting-input"}');
     });
 
@@ -328,7 +328,7 @@ describe('BaseStepExecutor', () => {
         },
         stepOutcome: {
           type: 'record-task',
-          stepId: 'ai-step',
+          stepId: 'read-record-1',
           stepIndex: 0,
           status: 'success',
         },
@@ -350,7 +350,7 @@ describe('BaseStepExecutor', () => {
         .buildPreviousStepsMessages()
         .then(msgs => msgs[0]?.content ?? '');
 
-      expect(result).toContain('Step "ai-step"');
+      expect(result).toContain('Step "read-record-1"');
       expect(result).toContain('Prompt: Do something');
       expect(result).not.toContain('Input:');
     });

--- a/packages/workflow-executor/test/executors/condition-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/condition-step-executor.test.ts
@@ -261,7 +261,7 @@ describe('ConditionStepExecutor', () => {
   });
 
   describe('error propagation', () => {
-    it('returns error status when model invocation fails', async () => {
+    it('lets infrastructure errors propagate', async () => {
       const invoke = jest.fn().mockRejectedValue(new Error('API timeout'));
       const bindTools = jest.fn().mockReturnValue({ invoke });
       const context = makeContext({
@@ -269,10 +269,7 @@ describe('ConditionStepExecutor', () => {
       });
       const executor = new ConditionStepExecutor(context);
 
-      const result = await executor.execute();
-
-      expect(result.stepOutcome.status).toBe('error');
-      expect(result.stepOutcome.error).toBe('API timeout');
+      await expect(executor.execute()).rejects.toThrow('API timeout');
     });
 
     it('lets run store errors propagate', async () => {

--- a/packages/workflow-executor/test/executors/condition-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/condition-step-executor.test.ts
@@ -53,7 +53,7 @@ function makeContext(
     agentPort: {} as ExecutionContext['agentPort'],
     workflowPort: {} as ExecutionContext['workflowPort'],
     runStore: makeMockRunStore(),
-    history: [],
+    previousSteps: [],
     remoteTools: [],
     ...overrides,
   };
@@ -175,7 +175,7 @@ describe('ConditionStepExecutor', () => {
       const context = makeContext({
         model: mockModel.model,
         runStore,
-        history: [
+        previousSteps: [
           {
             stepDefinition: {
               type: StepType.Condition,

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -111,7 +111,7 @@ function makeContext(
     agentPort: makeMockAgentPort(),
     workflowPort: makeMockWorkflowPort(),
     runStore: makeMockRunStore(),
-    history: [],
+    previousSteps: [],
     remoteTools: [],
     ...overrides,
   };
@@ -700,7 +700,7 @@ describe('ReadRecordStepExecutor', () => {
       const context = makeContext({
         model: mockModel.model,
         runStore,
-        history: [
+        previousSteps: [
           {
             stepDefinition: {
               type: StepType.Condition,

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -3,13 +3,13 @@ import type { RunStore } from '../../src/ports/run-store';
 import type { WorkflowPort } from '../../src/ports/workflow-port';
 import type { ExecutionContext } from '../../src/types/execution';
 import type { CollectionSchema, RecordRef } from '../../src/types/record';
-import type { AiTaskStepDefinition } from '../../src/types/step-definition';
+import type { RecordTaskStepDefinition } from '../../src/types/step-definition';
 
 import { NoRecordsError, RecordNotFoundError } from '../../src/errors';
 import ReadRecordStepExecutor from '../../src/executors/read-record-step-executor';
 import { StepType } from '../../src/types/step-definition';
 
-function makeStep(overrides: Partial<AiTaskStepDefinition> = {}): AiTaskStepDefinition {
+function makeStep(overrides: Partial<RecordTaskStepDefinition> = {}): RecordTaskStepDefinition {
   return {
     type: StepType.ReadRecord,
     prompt: 'Read the customer email',
@@ -99,8 +99,8 @@ function makeMockModel(
 }
 
 function makeContext(
-  overrides: Partial<ExecutionContext<AiTaskStepDefinition>> = {},
-): ExecutionContext<AiTaskStepDefinition> {
+  overrides: Partial<ExecutionContext<RecordTaskStepDefinition>> = {},
+): ExecutionContext<RecordTaskStepDefinition> {
   return {
     runId: 'run-1',
     stepId: 'read-1',

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -213,7 +213,7 @@ describe('UpdateRecordStepExecutor', () => {
           type: 'update-record',
           executionParams: { fieldName: 'Status', value: 'active' },
           executionResult: { updatedValues },
-          pendingUpdate: undefined,
+          pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         }),
       );
     });
@@ -242,7 +242,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         expect.objectContaining({
           executionResult: { skipped: true },
-          pendingUpdate: undefined,
+          pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         }),
       );
     });

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -142,6 +142,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.updateRecord).toHaveBeenCalledWith('customers', [42], { status: 'active' });
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
@@ -174,6 +175,7 @@ describe('UpdateRecordStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('awaiting-input');
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
@@ -209,6 +211,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.updateRecord).toHaveBeenCalledWith('customers', [42], { status: 'active' });
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
         expect.objectContaining({
           type: 'update-record',
           executionParams: { fieldDisplayName: 'Status', value: 'active' },
@@ -240,6 +243,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.updateRecord).not.toHaveBeenCalled();
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
         expect.objectContaining({
           executionResult: { skipped: true },
           pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
@@ -329,6 +333,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(updateTool.name).toBe('update-record-field');
 
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
         expect.objectContaining({
           pendingUpdate: { fieldDisplayName: 'Order Status', value: 'shipped' },
           selectedRecordRef: expect.objectContaining({

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -145,7 +145,7 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
-          executionParams: { fieldName: 'Status', value: 'active' },
+          executionParams: { fieldDisplayName: 'Status', value: 'active' },
           executionResult: { updatedValues },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
@@ -211,7 +211,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'update-record',
-          executionParams: { fieldName: 'Status', value: 'active' },
+          executionParams: { fieldDisplayName: 'Status', value: 'active' },
           executionResult: { updatedValues },
           pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         }),
@@ -362,6 +362,86 @@ describe('UpdateRecordStepExecutor', () => {
         'No writable fields on record from collection "customers"',
       );
       expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveFieldName failure', () => {
+    it('returns error when field is not found during confirmation (Branch A)', async () => {
+      const schema = makeCollectionSchema({
+        fields: [{ fieldName: 'email', displayName: 'Email', isRelationship: false }],
+      });
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingUpdate: { fieldDisplayName: 'NonExistentField', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      const workflowPort = makeMockWorkflowPort({ customers: schema });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ runStore, workflowPort, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'Field "NonExistentField" not found in collection "customers"',
+      );
+    });
+
+    it('returns error when field is not found during automaticCompletion (Branch B)', async () => {
+      // AI returns a display name that doesn't match any field in the schema
+      const mockModel = makeMockModel({
+        fieldName: 'NonExistentField',
+        value: 'test',
+        reasoning: 'test',
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'Field "NonExistentField" not found in collection "customers"',
+      );
+    });
+  });
+
+  describe('relationship fields excluded from update tool', () => {
+    it('excludes relationship fields from the tool schema', async () => {
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const context = makeContext({ model: mockModel.model });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      // Second bindTools call is for update-record-field (first may be select-record)
+      const lastCall = mockModel.bindTools.mock.calls[mockModel.bindTools.mock.calls.length - 1];
+      const tool = lastCall[0][0];
+      expect(tool.name).toBe('update-record-field');
+
+      // Non-relationship display names should be accepted
+      expect(tool.schema.parse({ fieldName: 'Email', value: 'x', reasoning: 'r' })).toBeTruthy();
+      expect(tool.schema.parse({ fieldName: 'Status', value: 'x', reasoning: 'r' })).toBeTruthy();
+      expect(
+        tool.schema.parse({ fieldName: 'Full Name', value: 'x', reasoning: 'r' }),
+      ).toBeTruthy();
+
+      // Relationship display name should be rejected
+      expect(() =>
+        tool.schema.parse({ fieldName: 'Orders', value: 'x', reasoning: 'r' }),
+      ).toThrow();
     });
   });
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -119,7 +119,7 @@ function makeContext(
 }
 
 describe('UpdateRecordStepExecutor', () => {
-  describe('automaticCompletion: update direct (Branch B)', () => {
+  describe('automaticExecution: update direct (Branch B)', () => {
     it('updates the record and returns success', async () => {
       const updatedValues = { status: 'active', name: 'John Doe' };
       const agentPort = makeMockAgentPort(updatedValues);
@@ -133,7 +133,7 @@ describe('UpdateRecordStepExecutor', () => {
         model: mockModel.model,
         agentPort,
         runStore,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -157,7 +157,7 @@ describe('UpdateRecordStepExecutor', () => {
     });
   });
 
-  describe('without automaticCompletion: awaiting-input (Branch C)', () => {
+  describe('without automaticExecution: awaiting-input (Branch C)', () => {
     it('saves execution and returns awaiting-input', async () => {
       const mockModel = makeMockModel({
         fieldName: 'Status',
@@ -432,7 +432,7 @@ describe('UpdateRecordStepExecutor', () => {
       );
     });
 
-    it('returns error when field is not found during automaticCompletion (Branch B)', async () => {
+    it('returns error when field is not found during automaticExecution (Branch B)', async () => {
       // AI returns a display name that doesn't match any field in the schema
       const mockModel = makeMockModel({
         fieldName: 'NonExistentField',
@@ -441,7 +441,7 @@ describe('UpdateRecordStepExecutor', () => {
       });
       const context = makeContext({
         model: mockModel.model,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -544,7 +544,7 @@ describe('UpdateRecordStepExecutor', () => {
         model: mockModel.model,
         agentPort,
         runStore,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -593,7 +593,7 @@ describe('UpdateRecordStepExecutor', () => {
       const context = makeContext({
         model: mockModel.model,
         agentPort,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -622,7 +622,7 @@ describe('UpdateRecordStepExecutor', () => {
 
   describe('stepOutcome shape', () => {
     it('emits correct type, stepId and stepIndex in the outcome', async () => {
-      const context = makeContext({ stepDefinition: makeStep({ automaticCompletion: true }) });
+      const context = makeContext({ stepDefinition: makeStep({ automaticExecution: true }) });
       const executor = new UpdateRecordStepExecutor(context);
 
       const result = await executor.execute();
@@ -656,7 +656,7 @@ describe('UpdateRecordStepExecutor', () => {
       const context = makeContext({
         model: mockModel.model,
         agentPort,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -672,7 +672,7 @@ describe('UpdateRecordStepExecutor', () => {
       const workflowPort = makeMockWorkflowPort();
       const context = makeContext({
         workflowPort,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 
@@ -730,7 +730,7 @@ describe('UpdateRecordStepExecutor', () => {
       });
       const context = makeContext({
         runStore,
-        stepDefinition: makeStep({ automaticCompletion: true }),
+        stepDefinition: makeStep({ automaticExecution: true }),
       });
       const executor = new UpdateRecordStepExecutor(context);
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -263,6 +263,41 @@ describe('UpdateRecordStepExecutor', () => {
 
       await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
     });
+
+    it('throws when execution exists but stepIndex does not match', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'update-record',
+            stepIndex: 5,
+            pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
+    });
+
+    it('throws when execution exists but pendingUpdate is absent', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'update-record',
+            stepIndex: 0,
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
+    });
   });
 
   describe('multi-record AI selection', () => {
@@ -582,6 +617,124 @@ describe('UpdateRecordStepExecutor', () => {
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('Connection refused');
+    });
+  });
+
+  describe('stepOutcome shape', () => {
+    it('emits correct type, stepId and stepIndex in the outcome', async () => {
+      const context = makeContext({ stepDefinition: makeStep({ automaticCompletion: true }) });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome).toMatchObject({
+        type: 'record-task',
+        stepId: 'update-1',
+        stepIndex: 0,
+        status: 'success',
+      });
+    });
+  });
+
+  describe('unexpected userInput type', () => {
+    it('throws when userInput has an unknown type', async () => {
+      const userInput = { type: 'text-input', value: 'hello' } as unknown as UserInput;
+      const context = makeContext({ userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow(
+        'UpdateRecordStepExecutor received unexpected userInput type: "text-input"',
+      );
+    });
+  });
+
+  describe('findField fieldName fallback', () => {
+    it('resolves update when AI returns raw fieldName instead of displayName', async () => {
+      const agentPort = makeMockAgentPort();
+      // AI returns 'status' (fieldName) instead of 'Status' (displayName)
+      const mockModel = makeMockModel({ fieldName: 'status', value: 'active', reasoning: 'test' });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith('customers', [42], { status: 'active' });
+    });
+  });
+
+  describe('schema caching', () => {
+    it('fetches getCollectionSchema once per collection even when called twice (Branch B)', async () => {
+      const workflowPort = makeMockWorkflowPort();
+      const context = makeContext({
+        workflowPort,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      // Branch B calls getCollectionSchema in handleFirstCall and again in resolveAndUpdate
+      // but the cache should prevent the second network call
+      expect(workflowPort.getCollectionSchema).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('RunStore error propagation', () => {
+    it('lets getStepExecutions errors propagate (Branch A)', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockRejectedValue(new Error('DB timeout')),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('DB timeout');
+    });
+
+    it('lets saveStepExecution errors propagate when user rejects (Branch A)', async () => {
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+        saveStepExecution: jest.fn().mockRejectedValue(new Error('Disk full')),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: false };
+      const context = makeContext({ runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('Disk full');
+    });
+
+    it('lets saveStepExecution errors propagate when saving awaiting-input (Branch C)', async () => {
+      const runStore = makeMockRunStore({
+        saveStepExecution: jest.fn().mockRejectedValue(new Error('Disk full')),
+      });
+      const context = makeContext({ runStore });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('Disk full');
+    });
+
+    it('lets saveStepExecution errors propagate after successful updateRecord (Branch B)', async () => {
+      const runStore = makeMockRunStore({
+        saveStepExecution: jest.fn().mockRejectedValue(new Error('Disk full')),
+      });
+      const context = makeContext({
+        runStore,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('Disk full');
     });
   });
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -112,7 +112,7 @@ function makeContext(
     agentPort: makeMockAgentPort(),
     workflowPort: makeMockWorkflowPort(),
     runStore: makeMockRunStore(),
-    history: [],
+    previousSteps: [],
     remoteTools: [],
     ...overrides,
   };
@@ -620,7 +620,7 @@ describe('UpdateRecordStepExecutor', () => {
       const context = makeContext({
         model: mockModel.model,
         runStore,
-        history: [
+        previousSteps: [
           {
             stepDefinition: {
               type: StepType.Condition,

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1,0 +1,578 @@
+import type { AgentPort } from '../../src/ports/agent-port';
+import type { RunStore } from '../../src/ports/run-store';
+import type { WorkflowPort } from '../../src/ports/workflow-port';
+import type { ExecutionContext, UserInput } from '../../src/types/execution';
+import type { CollectionSchema, RecordRef } from '../../src/types/record';
+import type { AiTaskStepDefinition } from '../../src/types/step-definition';
+import type { UpdateRecordStepExecutionData } from '../../src/types/step-execution-data';
+
+import { WorkflowExecutorError } from '../../src/errors';
+import UpdateRecordStepExecutor from '../../src/executors/update-record-step-executor';
+import { StepType } from '../../src/types/step-definition';
+
+function makeStep(overrides: Partial<AiTaskStepDefinition> = {}): AiTaskStepDefinition {
+  return {
+    type: StepType.UpdateRecord,
+    prompt: 'Set the customer status to active',
+    ...overrides,
+  };
+}
+
+function makeRecordRef(overrides: Partial<RecordRef> = {}): RecordRef {
+  return {
+    collectionName: 'customers',
+    recordId: [42],
+    stepIndex: 0,
+    ...overrides,
+  };
+}
+
+function makeMockAgentPort(
+  updatedValues: Record<string, unknown> = { status: 'active', name: 'John Doe' },
+): AgentPort {
+  return {
+    getRecord: jest.fn().mockResolvedValue({ values: updatedValues }),
+    updateRecord: jest.fn().mockResolvedValue({
+      collectionName: 'customers',
+      recordId: [42],
+      values: updatedValues,
+    }),
+    getRelatedData: jest.fn(),
+    executeAction: jest.fn(),
+  } as unknown as AgentPort;
+}
+
+function makeCollectionSchema(overrides: Partial<CollectionSchema> = {}): CollectionSchema {
+  return {
+    collectionName: 'customers',
+    collectionDisplayName: 'Customers',
+    primaryKeyFields: ['id'],
+    fields: [
+      { fieldName: 'email', displayName: 'Email', isRelationship: false },
+      { fieldName: 'status', displayName: 'Status', isRelationship: false },
+      { fieldName: 'name', displayName: 'Full Name', isRelationship: false },
+      { fieldName: 'orders', displayName: 'Orders', isRelationship: true },
+    ],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
+  return {
+    getStepExecutions: jest.fn().mockResolvedValue([]),
+    saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeMockWorkflowPort(
+  schemasByCollection: Record<string, CollectionSchema> = {
+    customers: makeCollectionSchema(),
+  },
+): WorkflowPort {
+  return {
+    getPendingStepExecutions: jest.fn().mockResolvedValue([]),
+    updateStepExecution: jest.fn().mockResolvedValue(undefined),
+    getCollectionSchema: jest
+      .fn()
+      .mockImplementation((name: string) =>
+        Promise.resolve(
+          schemasByCollection[name] ?? makeCollectionSchema({ collectionName: name }),
+        ),
+      ),
+    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function makeMockModel(toolCallArgs?: Record<string, unknown>, toolName = 'update-record-field') {
+  const invoke = jest.fn().mockResolvedValue({
+    tool_calls: toolCallArgs ? [{ name: toolName, args: toolCallArgs, id: 'call_1' }] : undefined,
+  });
+  const bindTools = jest.fn().mockReturnValue({ invoke });
+  const model = { bindTools } as unknown as ExecutionContext['model'];
+
+  return { model, bindTools, invoke };
+}
+
+function makeContext(
+  overrides: Partial<ExecutionContext<AiTaskStepDefinition>> = {},
+): ExecutionContext<AiTaskStepDefinition> {
+  return {
+    runId: 'run-1',
+    stepId: 'update-1',
+    stepIndex: 0,
+    baseRecordRef: makeRecordRef(),
+    stepDefinition: makeStep(),
+    model: makeMockModel({
+      fieldName: 'Status',
+      value: 'active',
+      reasoning: 'User requested status change',
+    }).model,
+    agentPort: makeMockAgentPort(),
+    workflowPort: makeMockWorkflowPort(),
+    runStore: makeMockRunStore(),
+    history: [],
+    remoteTools: [],
+    ...overrides,
+  };
+}
+
+describe('UpdateRecordStepExecutor', () => {
+  describe('automaticCompletion: update direct (Branch B)', () => {
+    it('updates the record and returns success', async () => {
+      const updatedValues = { status: 'active', name: 'John Doe' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'User requested status change',
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith('customers', [42], { status: 'active' });
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'update-record',
+          stepIndex: 0,
+          executionParams: { fieldName: 'Status', value: 'active' },
+          executionResult: { updatedValues },
+          selectedRecordRef: expect.objectContaining({
+            collectionName: 'customers',
+            recordId: [42],
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('without automaticCompletion: awaiting-input (Branch C)', () => {
+    it('saves interruption and returns awaiting-input', async () => {
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'User requested status change',
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        runStore,
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'update-record',
+          stepIndex: 0,
+          toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+          selectedRecordRef: expect.objectContaining({
+            collectionName: 'customers',
+            recordId: [42],
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('confirmation accepted (Branch A)', () => {
+    it('updates the record when user confirms', async () => {
+      const updatedValues = { status: 'active', name: 'John Doe' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      const interruption: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ agentPort, runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith('customers', [42], { status: 'active' });
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'update-record',
+          executionParams: { fieldName: 'Status', value: 'active' },
+          executionResult: { updatedValues },
+          toolConfirmationInterruption: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('confirmation rejected (Branch A)', () => {
+    it('skips the update when user rejects', async () => {
+      const agentPort = makeMockAgentPort();
+      const interruption: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: false };
+      const context = makeContext({ agentPort, runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).not.toHaveBeenCalled();
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionResult: { skipped: true },
+          toolConfirmationInterruption: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('no interruption in phase 2 (Branch A)', () => {
+    it('returns error when no pending confirmation is found', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('No pending confirmation found for this step');
+    });
+  });
+
+  describe('multi-record AI selection', () => {
+    it('uses AI to select among multiple records then selects field', async () => {
+      const baseRecordRef = makeRecordRef({ stepIndex: 1 });
+      const relatedRecord = makeRecordRef({
+        stepIndex: 2,
+        recordId: [99],
+        collectionName: 'orders',
+      });
+
+      const ordersSchema = makeCollectionSchema({
+        collectionName: 'orders',
+        collectionDisplayName: 'Orders',
+        fields: [
+          { fieldName: 'total', displayName: 'Total', isRelationship: false },
+          { fieldName: 'status', displayName: 'Order Status', isRelationship: false },
+        ],
+      });
+
+      // First call: select-record, second call: update-record-field
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record',
+              args: { recordIdentifier: 'Step 2 - Orders #99' },
+              id: 'call_1',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'update-record-field',
+              args: { fieldName: 'Order Status', value: 'shipped', reasoning: 'Mark as shipped' },
+              id: 'call_2',
+            },
+          ],
+        });
+      const bindTools = jest.fn().mockReturnValue({ invoke });
+      const model = { bindTools } as unknown as ExecutionContext['model'];
+
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest
+          .fn()
+          .mockResolvedValue([
+            { type: 'load-related-record', stepIndex: 2, record: relatedRecord },
+          ]),
+      });
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema(),
+        orders: ordersSchema,
+      });
+      const context = makeContext({ baseRecordRef, model, runStore, workflowPort });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(bindTools).toHaveBeenCalledTimes(2);
+
+      const selectTool = bindTools.mock.calls[0][0][0];
+      expect(selectTool.name).toBe('select-record');
+
+      const updateTool = bindTools.mock.calls[1][0][0];
+      expect(updateTool.name).toBe('update-record-field');
+
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolConfirmationInterruption: { fieldDisplayName: 'Order Status', value: 'shipped' },
+          selectedRecordRef: expect.objectContaining({
+            recordId: [99],
+            collectionName: 'orders',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('NoWritableFieldsError', () => {
+    it('returns error when all fields are relationships', async () => {
+      const schema = makeCollectionSchema({
+        fields: [{ fieldName: 'orders', displayName: 'Orders', isRelationship: true }],
+      });
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const runStore = makeMockRunStore();
+      const workflowPort = makeMockWorkflowPort({ customers: schema });
+      const context = makeContext({ model: mockModel.model, runStore, workflowPort });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'No writable fields on record from collection "customers"',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AI malformed/missing tool call', () => {
+    it('returns error on malformed tool call', async () => {
+      const invoke = jest.fn().mockResolvedValue({
+        tool_calls: [],
+        invalid_tool_calls: [
+          { name: 'update-record-field', args: '{bad json', error: 'JSON parse error' },
+        ],
+      });
+      const bindTools = jest.fn().mockReturnValue({ invoke });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: { bindTools } as unknown as ExecutionContext['model'],
+        runStore,
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'AI returned a malformed tool call for "update-record-field": JSON parse error',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+
+    it('returns error when AI returns no tool call', async () => {
+      const invoke = jest.fn().mockResolvedValue({ tool_calls: [] });
+      const bindTools = jest.fn().mockReturnValue({ invoke });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: { bindTools } as unknown as ExecutionContext['model'],
+        runStore,
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('AI did not return a tool call');
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('agentPort.updateRecord WorkflowExecutorError (Branch B)', () => {
+    it('returns error when updateRecord throws WorkflowExecutorError', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.updateRecord as jest.Mock).mockRejectedValue(
+        new WorkflowExecutorError('Record locked'),
+      );
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('Record locked');
+    });
+  });
+
+  describe('agentPort.updateRecord WorkflowExecutorError (Branch A)', () => {
+    it('returns error when updateRecord throws WorkflowExecutorError during confirmation', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.updateRecord as jest.Mock).mockRejectedValue(
+        new WorkflowExecutorError('Record locked'),
+      );
+      const interruption: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ agentPort, runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('Record locked');
+    });
+  });
+
+  describe('agentPort.updateRecord infra error', () => {
+    it('lets infrastructure errors propagate (Branch B)', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.updateRecord as jest.Mock).mockRejectedValue(new Error('Connection refused'));
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({ automaticCompletion: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('Connection refused');
+    });
+
+    it('lets infrastructure errors propagate (Branch A)', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.updateRecord as jest.Mock).mockRejectedValue(new Error('Connection refused'));
+      const interruption: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+      });
+      const userInput: UserInput = { type: 'confirmation', confirmed: true };
+      const context = makeContext({ agentPort, runStore, userInput });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await expect(executor.execute()).rejects.toThrow('Connection refused');
+    });
+  });
+
+  describe('default prompt', () => {
+    it('uses default prompt when step.prompt is undefined', async () => {
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        stepDefinition: makeStep({ prompt: undefined }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      const messages = mockModel.invoke.mock.calls[0][0];
+      const humanMessage = messages[messages.length - 1];
+      expect(humanMessage.content).toBe('**Request**: Update the relevant field.');
+    });
+  });
+
+  describe('previous steps context', () => {
+    it('includes previous steps summary in update-field messages', async () => {
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'test',
+      });
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'condition',
+            stepIndex: 0,
+            executionParams: { answer: 'Yes', reasoning: 'Approved' },
+          },
+        ]),
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        runStore,
+        history: [
+          {
+            stepDefinition: {
+              type: StepType.Condition,
+              options: ['Yes', 'No'],
+              prompt: 'Should we proceed?',
+            },
+            stepOutcome: {
+              type: 'condition',
+              stepId: 'prev-step',
+              stepIndex: 0,
+              status: 'success',
+            },
+          },
+        ],
+      });
+      const executor = new UpdateRecordStepExecutor({
+        ...context,
+        stepId: 'update-2',
+        stepIndex: 1,
+      });
+
+      await executor.execute();
+
+      const messages = mockModel.invoke.mock.calls[0][0];
+      // previous steps summary + system prompt + collection info + human message = 4
+      expect(messages).toHaveLength(4);
+      expect(messages[0].content).toContain('Should we proceed?');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[1].content).toContain('updating a field on a record');
+    });
+  });
+});

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -3,14 +3,14 @@ import type { RunStore } from '../../src/ports/run-store';
 import type { WorkflowPort } from '../../src/ports/workflow-port';
 import type { ExecutionContext, UserInput } from '../../src/types/execution';
 import type { CollectionSchema, RecordRef } from '../../src/types/record';
-import type { AiTaskStepDefinition } from '../../src/types/step-definition';
+import type { RecordTaskStepDefinition } from '../../src/types/step-definition';
 import type { UpdateRecordStepExecutionData } from '../../src/types/step-execution-data';
 
 import { WorkflowExecutorError } from '../../src/errors';
 import UpdateRecordStepExecutor from '../../src/executors/update-record-step-executor';
 import { StepType } from '../../src/types/step-definition';
 
-function makeStep(overrides: Partial<AiTaskStepDefinition> = {}): AiTaskStepDefinition {
+function makeStep(overrides: Partial<RecordTaskStepDefinition> = {}): RecordTaskStepDefinition {
   return {
     type: StepType.UpdateRecord,
     prompt: 'Set the customer status to active',
@@ -96,8 +96,8 @@ function makeMockModel(toolCallArgs?: Record<string, unknown>, toolName = 'updat
 }
 
 function makeContext(
-  overrides: Partial<ExecutionContext<AiTaskStepDefinition>> = {},
-): ExecutionContext<AiTaskStepDefinition> {
+  overrides: Partial<ExecutionContext<RecordTaskStepDefinition>> = {},
+): ExecutionContext<RecordTaskStepDefinition> {
   return {
     runId: 'run-1',
     stepId: 'update-1',

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -157,7 +157,7 @@ describe('UpdateRecordStepExecutor', () => {
   });
 
   describe('without automaticCompletion: awaiting-input (Branch C)', () => {
-    it('saves interruption and returns awaiting-input', async () => {
+    it('saves execution and returns awaiting-input', async () => {
       const mockModel = makeMockModel({
         fieldName: 'Status',
         value: 'active',
@@ -191,14 +191,14 @@ describe('UpdateRecordStepExecutor', () => {
     it('updates the record when user confirms', async () => {
       const updatedValues = { status: 'active', name: 'John Doe' };
       const agentPort = makeMockAgentPort(updatedValues);
-      const interruption: UpdateRecordStepExecutionData = {
+      const execution: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
         pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
-        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
       const userInput: UserInput = { type: 'confirmation', confirmed: true };
       const context = makeContext({ agentPort, runStore, userInput });
@@ -222,14 +222,14 @@ describe('UpdateRecordStepExecutor', () => {
   describe('confirmation rejected (Branch A)', () => {
     it('skips the update when user rejects', async () => {
       const agentPort = makeMockAgentPort();
-      const interruption: UpdateRecordStepExecutionData = {
+      const execution: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
         pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
-        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
       const userInput: UserInput = { type: 'confirmation', confirmed: false };
       const context = makeContext({ agentPort, runStore, userInput });
@@ -248,8 +248,8 @@ describe('UpdateRecordStepExecutor', () => {
     });
   });
 
-  describe('no interruption in phase 2 (Branch A)', () => {
-    it('returns error when no pending confirmation is found', async () => {
+  describe('no pending update in phase 2 (Branch A)', () => {
+    it('throws when no pending update is found', async () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([]),
       });
@@ -257,10 +257,7 @@ describe('UpdateRecordStepExecutor', () => {
       const context = makeContext({ runStore, userInput });
       const executor = new UpdateRecordStepExecutor(context);
 
-      const result = await executor.execute();
-
-      expect(result.stepOutcome.status).toBe('error');
-      expect(result.stepOutcome.error).toBe('No pending confirmation found for this step');
+      await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
     });
   });
 
@@ -444,14 +441,14 @@ describe('UpdateRecordStepExecutor', () => {
       (agentPort.updateRecord as jest.Mock).mockRejectedValue(
         new WorkflowExecutorError('Record locked'),
       );
-      const interruption: UpdateRecordStepExecutionData = {
+      const execution: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
         pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
-        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
       const userInput: UserInput = { type: 'confirmation', confirmed: true };
       const context = makeContext({ agentPort, runStore, userInput });
@@ -486,14 +483,14 @@ describe('UpdateRecordStepExecutor', () => {
     it('lets infrastructure errors propagate (Branch A)', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.updateRecord as jest.Mock).mockRejectedValue(new Error('Connection refused'));
-      const interruption: UpdateRecordStepExecutionData = {
+      const execution: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
         pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
-        getStepExecutions: jest.fn().mockResolvedValue([interruption]),
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
       const userInput: UserInput = { type: 'confirmation', confirmed: true };
       const context = makeContext({ agentPort, runStore, userInput });

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -177,7 +177,7 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
-          toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+          pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
             recordId: [42],
@@ -194,7 +194,7 @@ describe('UpdateRecordStepExecutor', () => {
       const interruption: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
-        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -213,7 +213,7 @@ describe('UpdateRecordStepExecutor', () => {
           type: 'update-record',
           executionParams: { fieldName: 'Status', value: 'active' },
           executionResult: { updatedValues },
-          toolConfirmationInterruption: undefined,
+          pendingUpdate: undefined,
         }),
       );
     });
@@ -225,7 +225,7 @@ describe('UpdateRecordStepExecutor', () => {
       const interruption: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
-        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -242,7 +242,7 @@ describe('UpdateRecordStepExecutor', () => {
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         expect.objectContaining({
           executionResult: { skipped: true },
-          toolConfirmationInterruption: undefined,
+          pendingUpdate: undefined,
         }),
       );
     });
@@ -333,7 +333,7 @@ describe('UpdateRecordStepExecutor', () => {
 
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         expect.objectContaining({
-          toolConfirmationInterruption: { fieldDisplayName: 'Order Status', value: 'shipped' },
+          pendingUpdate: { fieldDisplayName: 'Order Status', value: 'shipped' },
           selectedRecordRef: expect.objectContaining({
             recordId: [99],
             collectionName: 'orders',
@@ -447,7 +447,7 @@ describe('UpdateRecordStepExecutor', () => {
       const interruption: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
-        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -489,7 +489,7 @@ describe('UpdateRecordStepExecutor', () => {
       const interruption: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
-        toolConfirmationInterruption: { fieldDisplayName: 'Status', value: 'active' },
+        pendingUpdate: { fieldDisplayName: 'Status', value: 'active' },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1,7 +1,7 @@
 import type { AgentPort } from '../../src/ports/agent-port';
 import type { RunStore } from '../../src/ports/run-store';
 import type { WorkflowPort } from '../../src/ports/workflow-port';
-import type { ExecutionContext, UserInput } from '../../src/types/execution';
+import type { ExecutionContext } from '../../src/types/execution';
 import type { CollectionSchema, RecordRef } from '../../src/types/record';
 import type { RecordTaskStepDefinition } from '../../src/types/step-definition';
 import type { UpdateRecordStepExecutionData } from '../../src/types/step-execution-data';
@@ -202,8 +202,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ agentPort, runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ agentPort, runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       const result = await executor.execute();
@@ -234,8 +234,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: false };
-      const context = makeContext({ agentPort, runStore, userInput });
+      const userConfirmed = false;
+      const context = makeContext({ agentPort, runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       const result = await executor.execute();
@@ -257,8 +257,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
@@ -275,8 +275,8 @@ describe('UpdateRecordStepExecutor', () => {
           },
         ]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
@@ -292,8 +292,8 @@ describe('UpdateRecordStepExecutor', () => {
           },
         ]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('No pending update found for this step');
@@ -420,8 +420,8 @@ describe('UpdateRecordStepExecutor', () => {
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
       const workflowPort = makeMockWorkflowPort({ customers: schema });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ runStore, workflowPort, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ runStore, workflowPort, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       const result = await executor.execute();
@@ -570,8 +570,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ agentPort, runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ agentPort, runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       const result = await executor.execute();
@@ -612,8 +612,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ agentPort, runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ agentPort, runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('Connection refused');
@@ -633,18 +633,6 @@ describe('UpdateRecordStepExecutor', () => {
         stepIndex: 0,
         status: 'success',
       });
-    });
-  });
-
-  describe('unexpected userInput type', () => {
-    it('throws when userInput has an unknown type', async () => {
-      const userInput = { type: 'text-input', value: 'hello' } as unknown as UserInput;
-      const context = makeContext({ userInput });
-      const executor = new UpdateRecordStepExecutor(context);
-
-      await expect(executor.execute()).rejects.toThrow(
-        'UpdateRecordStepExecutor received unexpected userInput type: "text-input"',
-      );
     });
   });
 
@@ -689,8 +677,8 @@ describe('UpdateRecordStepExecutor', () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockRejectedValue(new Error('DB timeout')),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: true };
-      const context = makeContext({ runStore, userInput });
+      const userConfirmed = true;
+      const context = makeContext({ runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('DB timeout');
@@ -707,8 +695,8 @@ describe('UpdateRecordStepExecutor', () => {
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
         saveStepExecution: jest.fn().mockRejectedValue(new Error('Disk full')),
       });
-      const userInput: UserInput = { type: 'confirmation', confirmed: false };
-      const context = makeContext({ runStore, userInput });
+      const userConfirmed = false;
+      const context = makeContext({ runStore, userConfirmed });
       const executor = new UpdateRecordStepExecutor(context);
 
       await expect(executor.execute()).rejects.toThrow('Disk full');

--- a/packages/workflow-executor/test/index.test.ts
+++ b/packages/workflow-executor/test/index.test.ts
@@ -12,7 +12,7 @@ describe('StepType', () => {
     ['UpdateRecord', 'update-record'],
     ['TriggerAction', 'trigger-action'],
     ['LoadRelatedRecord', 'load-related-record'],
-    ['ToolTask', 'tool-task'],
+    ['McpTask', 'mcp-task'],
   ] as const)('should have %s = "%s"', (key, value) => {
     expect(StepType[key]).toBe(value);
   });

--- a/packages/workflow-executor/test/index.test.ts
+++ b/packages/workflow-executor/test/index.test.ts
@@ -1,9 +1,9 @@
 import { StepType } from '../src/index';
 
 describe('StepType', () => {
-  it('should expose exactly 5 step types', () => {
+  it('should expose exactly 6 step types', () => {
     const values = Object.values(StepType);
-    expect(values).toHaveLength(5);
+    expect(values).toHaveLength(6);
   });
 
   it.each([
@@ -12,6 +12,7 @@ describe('StepType', () => {
     ['UpdateRecord', 'update-record'],
     ['TriggerAction', 'trigger-action'],
     ['LoadRelatedRecord', 'load-related-record'],
+    ['ToolTask', 'tool-task'],
   ] as const)('should have %s = "%s"', (key, value) => {
     expect(StepType[key]).toBe(value);
   });


### PR DESCRIPTION
## Summary
- Implements PRD-219: `UpdateRecordStepExecutor` with 3 execution branches — automatic completion (Branch B), awaiting user confirmation (Branch C), and re-entry after confirmation accept/reject (Branch A)
- Extracts shared helpers (`selectRecordRef`, `getAvailableRecordRefs`, `getCollectionSchema`, `toRecordIdentifier`, `schemaCache`) from `ReadRecordStepExecutor` into `BaseStepExecutor` for DRY reuse
- Adds `UpdateRecordStepExecutionData` type, `NoWritableFieldsError`, and `userInput` on `ExecutionContext`

## Test plan
- [x] All 84 existing + new tests pass
- [x] ReadRecordStepExecutor tests still pass after refactor (no behavior change)
- [x] 11 new test cases cover: automatic completion, awaiting-input, confirmation accepted/rejected, missing interruption, multi-record AI selection, NoWritableFieldsError, malformed/missing tool calls, WorkflowExecutorError propagation, infra error propagation, default prompt fallback, previous steps context

fixes PRD-219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `UpdateRecordStepExecutor` with user confirmation flow to workflow-executor
> - Adds [`UpdateRecordStepExecutor`](https://github.com/ForestAdmin/agent-nodejs/pull/1499/files#diff-48a8a7d25858f11102893bd18198bf47ade9e1b93799f636fab3cbd200039d30) that uses an AI tool to select a writable field and value, then either updates immediately (`automaticExecution: true`) or returns `awaiting-input` for user confirmation.
> - On re-entry with `context.userConfirmed`, the executor fetches the prior execution and either applies the update or marks the step skipped.
> - Shared logic (record selection, schema caching, outcome building) is extracted into [`BaseStepExecutor`](https://github.com/ForestAdmin/agent-nodejs/pull/1499/files#diff-f2629617b13363027748d444be5374dd404d26c2f031b0b1a967cceb01d6c6d9) helpers and reused by `ReadRecordStepExecutor`.
> - Renames `AiTask*` types to `RecordTask*` throughout (outcomes, execution data, step definitions) and replaces `history` with `previousSteps` in `ExecutionContext`.
> - Adds `NoWritableFieldsError` and `McpTask` step type to the public API.
> - Behavioral Change: `ConditionStepExecutor` and `ReadRecordStepExecutor` now rethrow non-`WorkflowExecutorError` failures instead of converting them to error outcomes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d99fe27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->