### PR TITLE
feat(customizer): improve condition tree leaf typing

### DIFF
--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -178,7 +178,9 @@ export default class CollectionCustomizer<
    */
   addChart(name: string, definition: CollectionChartDefinition<S, N>): this {
     return this.pushCustomization(async () => {
-      this.stack.chart.getCollection(this.name).addChart(name, definition);
+      this.stack.chart
+        .getCollection(this.name)
+        .addChart(name, definition as unknown as CollectionChartDefinition);
     });
   }
 
@@ -228,7 +230,10 @@ export default class CollectionCustomizer<
         ? collectionBeforeRelations
         : collectionAfterRelations;
 
-      collection.registerComputed(name, mapDeprecated<S, N>(definition));
+      collection.registerComputed(
+        name,
+        mapDeprecated<S, N>(definition) as unknown as ComputedDefinition,
+      );
     });
   };
 
@@ -261,7 +266,7 @@ export default class CollectionCustomizer<
   addHook<P extends HookPosition, T extends HookType>(
     position: P,
     type: T,
-    handler: HookHandler<HooksContext<S, N>[P][T]>,
+    handler: HookHandler<HooksContext<S, N>[P][T], void, S, N>,
   ): this {
     return this.pushCustomization(async () => {
       this.stack.hook
@@ -554,7 +559,7 @@ export default class CollectionCustomizer<
         ? this.stack.earlyOpEmulate.getCollection(this.name)
         : this.stack.lateOpEmulate.getCollection(this.name);
 
-      collection.replaceFieldOperator(name, operator, replacer as OperatorDefinition);
+      collection.replaceFieldOperator(name, operator, replacer as unknown as OperatorDefinition);
     });
   }
 
@@ -574,7 +579,9 @@ export default class CollectionCustomizer<
     definition: WriteDefinition<S, N, C>,
   ): this {
     return this.pushCustomization(async () => {
-      this.stack.write.getCollection(this.name).replaceFieldWriting(name, definition);
+      this.stack.write
+        .getCollection(this.name)
+        .replaceFieldWriting(name, definition as unknown as WriteDefinition);
     });
   }
 
@@ -609,7 +616,9 @@ export default class CollectionCustomizer<
    */
   overrideCreate(handler: CreateOverrideHandler<S, N>): this {
     return this.pushCustomization(async () => {
-      this.stack.override.getCollection(this.name).addCreateHandler(handler);
+      this.stack.override
+        .getCollection(this.name)
+        .addCreateHandler(handler as unknown as CreateOverrideHandler);
     });
   }
 
@@ -625,7 +634,9 @@ export default class CollectionCustomizer<
    */
   overrideUpdate(handler: UpdateOverrideHandler<S, N>): this {
     return this.pushCustomization(async () => {
-      this.stack.override.getCollection(this.name).addUpdateHandler(handler);
+      this.stack.override
+        .getCollection(this.name)
+        .addUpdateHandler(handler as unknown as UpdateOverrideHandler);
     });
   }
 
@@ -641,7 +652,9 @@ export default class CollectionCustomizer<
    */
   overrideDelete(handler: DeleteOverrideHandler<S, N>): this {
     return this.pushCustomization(async () => {
-      this.stack.override.getCollection(this.name).addDeleteHandler(handler);
+      this.stack.override
+        .getCollection(this.name)
+        .addDeleteHandler(handler as unknown as DeleteOverrideHandler);
     });
   }
 

--- a/packages/datasource-customizer/src/datasource-customizer.ts
+++ b/packages/datasource-customizer/src/datasource-customizer.ts
@@ -104,7 +104,7 @@ export default class DataSourceCustomizer<S extends TSchema = TSchema> {
    */
   addChart(name: string, definition: DataSourceChartDefinition<S>): this {
     this.stack.queueCustomization(async () => {
-      this.stack.chart.addChart(name, definition);
+      this.stack.chart.addChart(name, definition as unknown as DataSourceChartDefinition);
     });
 
     return this;

--- a/packages/datasource-customizer/src/decorators/actions/collection.ts
+++ b/packages/datasource-customizer/src/decorators/actions/collection.ts
@@ -8,7 +8,7 @@ import type {
   SearchOptionsHandler,
   ValueOrHandler,
 } from './types/fields';
-import type { TSchema } from '../../templates';
+import type { TFilter, TSchema } from '../../templates';
 import type {
   ActionFormElement,
   ActionResult,
@@ -18,7 +18,6 @@ import type {
   Filter,
   GetFormMetas,
   LayoutElementPageWithField,
-  PlainFilter,
   RecordData,
 } from '@forestadmin/datasource-toolkit';
 
@@ -177,7 +176,7 @@ export default class ActionCollectionDecorator extends CollectionDecorator {
       Global: ActionContext,
       Bulk: ActionContext,
       Single: ActionContextSingle,
-    }[action.scope](this, caller, formValues, filter as unknown as PlainFilter, used, changedField);
+    }[action.scope](this, caller, formValues, filter as unknown as TFilter, used, changedField);
   }
 
   private getSearchedField(element: DynamicFormElementOrPage, search: string): DynamicField | null {

--- a/packages/datasource-customizer/src/templates.ts
+++ b/packages/datasource-customizer/src/templates.ts
@@ -78,14 +78,52 @@ export type TPartialFlatRow<
   N extends TCollectionName<S> = TCollectionName<S>,
 > = RecursivePartial<S[N]['plain'] & S[N]['flat']>;
 
+/** Operators that require no value */
+type NoValueOperator =
+  | 'Blank'
+  | 'Present'
+  | 'Missing'
+  | 'Today'
+  | 'Yesterday'
+  | 'PreviousMonth'
+  | 'PreviousQuarter'
+  | 'PreviousWeek'
+  | 'PreviousYear'
+  | 'PreviousMonthToDate'
+  | 'PreviousQuarterToDate'
+  | 'PreviousWeekToDate'
+  | 'PreviousYearToDate'
+  | 'Past'
+  | 'Future';
+
+/** Operators that require an array of values */
+type ArrayValueOperator = 'In' | 'NotIn' | 'IncludesAll' | 'IncludesNone';
+
+/** Operators that always require a number value */
+type NumberValueOperator =
+  | 'PreviousXDaysToDate'
+  | 'PreviousXDays'
+  | 'BeforeXHoursAgo'
+  | 'AfterXHoursAgo'
+  | 'LongerThan'
+  | 'ShorterThan';
+
+/** Operators that require a single value matching the field type */
+type SingleValueOperator = Exclude<
+  Operator,
+  NoValueOperator | ArrayValueOperator | NumberValueOperator
+>;
+
 export type TConditionTreeLeaf<
   S extends TSchema = TSchema,
   N extends TCollectionName<S> = TCollectionName<S>,
 > = {
-  field: TFieldName<S, N>;
-  operator: Operator;
-  value?: unknown;
-};
+  [F in TFieldName<S, N>]:
+    | { field: F; operator: NoValueOperator }
+    | { field: F; operator: ArrayValueOperator; value: TFieldType<S, N, F>[] }
+    | { field: F; operator: NumberValueOperator; value: number }
+    | { field: F; operator: SingleValueOperator; value: TFieldType<S, N, F> };
+}[TFieldName<S, N>];
 
 export type TConditionTreeBranch<
   S extends TSchema = TSchema,

--- a/packages/datasource-customizer/test/collection-customizer.test.ts
+++ b/packages/datasource-customizer/test/collection-customizer.test.ts
@@ -9,7 +9,7 @@ import type { ActionDefinition } from '../src/decorators/actions/types/actions';
 import type { WriteDefinition } from '../src/decorators/write/write-replace/types';
 import type { ColumnSchema } from '@forestadmin/datasource-toolkit';
 
-import { ConditionTreeLeaf, MissingFieldError, Sort } from '@forestadmin/datasource-toolkit';
+import { MissingFieldError, Sort } from '@forestadmin/datasource-toolkit';
 import * as factories from '@forestadmin/datasource-toolkit/dist/test/__factories__';
 
 import { CollectionCustomizer, DataSourceCustomizer } from '../src';
@@ -639,7 +639,7 @@ describe('Builder > Collection', () => {
     it('should add a segment', async () => {
       const { dsc, customizer } = await setup();
 
-      const generator = async () => new ConditionTreeLeaf('fieldName', 'Present');
+      const generator = async () => ({ field: 'fieldName', operator: 'Present' } as const);
 
       const self = customizer.addSegment('new segment', generator);
       await dsc.getDataSource(logger);
@@ -773,7 +773,8 @@ describe('Builder > Collection', () => {
     it('should replace operator on field', async () => {
       const { dsc, customizer } = await setup();
 
-      const replacer = async () => new ConditionTreeLeaf('fieldName', 'NotEqual', null);
+      const replacer = async () =>
+        ({ field: 'fieldName', operator: 'NotEqual', value: null } as const);
 
       const self = customizer.replaceFieldOperator('firstName', 'Present', replacer);
       await dsc.getDataSource(logger);


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine `TConditionTreeLeaf` typing to enforce operator-specific value constraints
> - Introduces a discriminated union for `TConditionTreeLeaf` in [templates.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1509/files#diff-674fff71d416717b464f7fdd666734c8b506b1d84d02199f3e11561ce88e47db), splitting operators into `NoValueOperator`, `ArrayValueOperator`, `NumberValueOperator`, and `SingleValueOperator` categories so the value type is statically enforced per operator.
> - Updates `CollectionCustomizer` and `DataSourceCustomizer` methods to cast generic typed definitions through `unknown` before passing to internal decorators, resolving type mismatches introduced by the stricter leaf typing.
> - Replaces `ConditionTreeLeaf` constructor usage in tests with plain object literals that satisfy the new discriminated union shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16c414f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->