### PR TITLE
fix(mcp-server): reject unknown keys in tool inputs

### DIFF
--- a/packages/mcp-server/src/utils/tool-with-logging.ts
+++ b/packages/mcp-server/src/utils/tool-with-logging.ts
@@ -26,47 +26,18 @@ type RegisterToolConfig = Parameters<McpServer['registerTool']>[1];
 type ToolHandlerExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
 // -----------------------------------------------------------------------------
-// Validation Helpers
-// -----------------------------------------------------------------------------
-
-/**
- * Formats a Zod error into a human-readable string.
- * Example: "collectionName: Required, sort.field: Expected string"
- */
-function formatZodError(error: z.ZodError): string {
-  return error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`).join(', ');
-}
-
-/**
- * Validates arguments against a schema and logs errors if validation fails.
- * This is a pre-validation step for logging purposes only - the SDK handles actual validation.
- */
-function logValidationErrorsIfAny(
-  args: unknown,
-  schema: z.ZodSchema,
-  toolName: string,
-  logger: Logger,
-): void {
-  const result = schema.safeParse(args);
-
-  if (!result.success) {
-    const errorMessage = formatZodError(result.error);
-    logger('Error', `Tool "${toolName}" validation error: ${errorMessage}`);
-  }
-}
-
-// -----------------------------------------------------------------------------
 // Tool Registration
 // -----------------------------------------------------------------------------
 
 /**
- * Registers an MCP tool with automatic validation error logging.
+ * Registers an MCP tool with strict input validation.
  *
- * This wrapper logs validation errors with detailed field information,
- * which helps debug tool calls when clients send invalid arguments.
+ * Uses Zod's `.strict()` mode so the SDK rejects unknown keys instead of
+ * silently stripping them. This prevents hard-to-debug issues where a typo
+ * (e.g. "filter" instead of "filters") causes the tool to run without the
+ * intended parameter.
  *
- * Note: Execution errors are caught and converted to { isError: true } tool results.
- * The SSE response interceptor in server.ts additionally logs these errors from the stream.
+ * Execution errors are caught and converted to { isError: true } tool results.
  *
  * @example
  * registerToolWithLogging(
@@ -94,14 +65,12 @@ export default function registerToolWithLogging<
   handler: (args: TArgs, extra: ToolHandlerExtra) => Promise<CallToolResult>,
   logger: Logger,
 ): string {
-  const schema = z.object(config.inputSchema);
+  const strictSchema = z.object(config.inputSchema).strict();
 
   mcpServer.registerTool(
     toolName,
-    config as RegisterToolConfig,
+    { ...config, inputSchema: strictSchema } as RegisterToolConfig,
     async (args: Record<string, unknown>, extra: ToolHandlerExtra) => {
-      logValidationErrorsIfAny(args, schema, toolName, logger);
-
       // Return errors as tool results (isError: true) instead of throwing.
       // Per MCP spec, tool errors should be reported within the result object,
       // not as protocol-level errors, so the LLM can see and handle them.

--- a/packages/mcp-server/src/utils/tool-with-logging.ts
+++ b/packages/mcp-server/src/utils/tool-with-logging.ts
@@ -63,6 +63,7 @@ export default function registerToolWithLogging<
   toolName: string,
   config: ToolConfig<TSchema>,
   handler: (args: TArgs, extra: ToolHandlerExtra) => Promise<CallToolResult>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   logger: Logger,
 ): string {
   const strictSchema = z.object(config.inputSchema).strict();

--- a/packages/mcp-server/test/tools/associate.test.ts
+++ b/packages/mcp-server/test/tools/associate.test.ts
@@ -21,7 +21,11 @@ describe('declareAssociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/associate.test.ts
+++ b/packages/mcp-server/test/tools/associate.test.ts
@@ -21,7 +21,7 @@ describe('declareAssociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,16 +62,16 @@ describe('declareAssociateTool', () => {
     it('should define correct input schema', () => {
       declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('parentRecordId');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('targetRecordId');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('relationName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('parentRecordId');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('targetRecordId');
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
       declareAssociateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'posts']);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -21,7 +21,7 @@ describe('declareCreateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,14 +62,14 @@ describe('declareCreateTool', () => {
     it('should define correct input schema', () => {
       declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('attributes');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('attributes');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -80,7 +80,7 @@ describe('declareCreateTool', () => {
     it('should use enum type for collectionName when collection names provided', () => {
       declareCreateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -222,7 +222,7 @@ describe('declareCreateTool', () => {
         const attributes = { name: 'John', age: 30 };
         const attributesAsString = JSON.stringify(attributes);
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -21,7 +21,11 @@ describe('declareCreateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -21,7 +21,7 @@ describe('declareDeleteTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,14 +62,14 @@ describe('declareDeleteTool', () => {
     it('should define correct input schema', () => {
       declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('recordIds');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('recordIds');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -80,7 +80,7 @@ describe('declareDeleteTool', () => {
     it('should use enum type for collectionName when collection names provided', () => {
       declareDeleteTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -92,7 +92,7 @@ describe('declareDeleteTool', () => {
     it('should accept array of strings or numbers for recordIds', () => {
       declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -21,7 +21,11 @@ describe('declareDeleteTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -32,7 +32,11 @@ describe('declareDescribeCollectionTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -32,7 +32,7 @@ describe('declareDescribeCollectionTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -79,13 +79,13 @@ describe('declareDescribeCollectionTool', () => {
     it('should define correct input schema', () => {
       declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -102,7 +102,7 @@ describe('declareDescribeCollectionTool', () => {
         'orders',
       ]);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;

--- a/packages/mcp-server/test/tools/dissociate.test.ts
+++ b/packages/mcp-server/test/tools/dissociate.test.ts
@@ -21,7 +21,11 @@ describe('declareDissociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/dissociate.test.ts
+++ b/packages/mcp-server/test/tools/dissociate.test.ts
@@ -21,7 +21,7 @@ describe('declareDissociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,16 +62,16 @@ describe('declareDissociateTool', () => {
     it('should define correct input schema', () => {
       declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('parentRecordId');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('targetRecordIds');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('relationName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('parentRecordId');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('targetRecordIds');
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
       declareDissociateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'posts']);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -26,7 +26,7 @@ const mockWithActivityLog = withActivityLog as jest.MockedFunction<typeof withAc
 describe('declareExecuteActionTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,16 +66,16 @@ describe('declareExecuteActionTool', () => {
     it('should define correct input schema', () => {
       declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('actionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('recordIds');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('values');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('actionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('recordIds');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('values');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -89,7 +89,7 @@ describe('declareExecuteActionTool', () => {
         'products',
       ]);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -101,7 +101,7 @@ describe('declareExecuteActionTool', () => {
     it('should accept array of strings or numbers for recordIds', () => {
       declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -113,7 +113,7 @@ describe('declareExecuteActionTool', () => {
     it('should accept null for recordIds (global actions)', () => {
       declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -123,7 +123,7 @@ describe('declareExecuteActionTool', () => {
     it('should accept optional values parameter', () => {
       declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -365,7 +365,7 @@ describe('declareExecuteActionTool', () => {
         const values = { subject: 'Test', message: 'Hello' };
         const valuesAsString = JSON.stringify(values);
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -26,7 +26,11 @@ const mockWithActivityLog = withActivityLog as jest.MockedFunction<typeof withAc
 describe('declareExecuteActionTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -23,7 +23,7 @@ const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction
 describe('declareGetActionFormTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,16 +60,16 @@ describe('declareGetActionFormTool', () => {
     it('should define correct input schema', () => {
       declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('actionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('recordIds');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('values');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('actionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('recordIds');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('values');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -83,7 +83,7 @@ describe('declareGetActionFormTool', () => {
         'products',
       ]);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -95,7 +95,7 @@ describe('declareGetActionFormTool', () => {
     it('should accept array of strings or numbers for recordIds', () => {
       declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -107,7 +107,7 @@ describe('declareGetActionFormTool', () => {
     it('should accept null for recordIds (global actions)', () => {
       declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -117,7 +117,7 @@ describe('declareGetActionFormTool', () => {
     it('should accept optional values parameter', () => {
       declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -687,7 +687,7 @@ describe('declareGetActionFormTool', () => {
         const values = { subject: 'Test', message: 'Hello' };
         const valuesAsString = JSON.stringify(values);
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -23,7 +23,11 @@ const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction
 describe('declareGetActionFormTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -28,7 +28,7 @@ describe('declareListRelatedTool', () => {
   let mockLogger: Logger;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -101,18 +101,18 @@ describe('declareListRelatedTool', () => {
     it('should define correct input schema', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('parentRecordId');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('search');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('filters');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('sort');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('relationName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('parentRecordId');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('search');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('filters');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('sort');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -125,7 +125,7 @@ describe('declareListRelatedTool', () => {
     it('should use string type for collectionName when empty array provided', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger, []);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -142,7 +142,7 @@ describe('declareListRelatedTool', () => {
         'orders',
       ]);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -158,7 +158,7 @@ describe('declareListRelatedTool', () => {
     it('should accept string parentRecordId', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -168,7 +168,7 @@ describe('declareListRelatedTool', () => {
     it('should accept number parentRecordId', () => {
       declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -28,7 +28,11 @@ describe('declareListRelatedTool', () => {
   let mockLogger: Logger;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -29,7 +29,7 @@ describe('declareListTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -99,13 +99,13 @@ describe('declareListTool', () => {
     it('should define correct input schema', () => {
       declareListTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('search');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('filters');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('sort');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('shouldSearchInRelation');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('fields');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('enableCount');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('search');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('filters');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('sort');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('shouldSearchInRelation');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('fields');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('enableCount');
     });
 
     it('should have fields schema with description mentioning @@@ separator for relations', () => {
@@ -115,7 +115,7 @@ describe('declareListTool', () => {
       const schema = registeredToolConfig.inputSchema as any;
       // Zod schema: z.array().describe().optional()
       // The description is stored in metadata, accessible via meta() on the inner type
-      const fieldsZodDef = Reflect.get(schema.fields, '_def');
+      const fieldsZodDef = Reflect.get(schema.shape.fields, '_def');
       const fieldsDescription = fieldsZodDef.innerType.meta().description;
       expect(fieldsDescription).toContain('@@@');
       expect(fieldsDescription).toContain('relationName@@@fieldName');
@@ -124,7 +124,7 @@ describe('declareListTool', () => {
     it('should use string type for collectionName when no collection names provided', () => {
       declareListTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -137,7 +137,7 @@ describe('declareListTool', () => {
     it('should use string type for collectionName when empty array provided', () => {
       declareListTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -154,7 +154,7 @@ describe('declareListTool', () => {
         'orders',
       ]);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -170,7 +170,7 @@ describe('declareListTool', () => {
     it('should make ascending optional in sort schema with default value true', () => {
       declareListTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -828,7 +828,7 @@ describe('declareListTool', () => {
         const filtersAsString = JSON.stringify(filters);
 
         // Simulate MCP SDK behavior: parse input through schema before calling handler
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           {
             parse: (value: unknown) => unknown;
@@ -861,7 +861,7 @@ describe('declareListTool', () => {
       it('should throw validation error when filters is malformed JSON string', () => {
         const malformedJson = '{ invalid json }';
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;
@@ -872,7 +872,7 @@ describe('declareListTool', () => {
       it('should throw validation error when filters is a plain string', () => {
         const plainString = 'not a json object';
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -29,7 +29,11 @@ describe('declareListTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -21,7 +21,11 @@ describe('declareUpdateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: { shape: Record<string, unknown> };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -21,7 +21,7 @@ describe('declareUpdateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: { title: string; description: string; inputSchema: { shape: Record<string, unknown> } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,15 +62,15 @@ describe('declareUpdateTool', () => {
     it('should define correct input schema', () => {
       declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('recordId');
-      expect(registeredToolConfig.inputSchema).toHaveProperty('attributes');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('collectionName');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('recordId');
+      expect(registeredToolConfig.inputSchema.shape).toHaveProperty('attributes');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
       declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options?: string[]; parse: (value: unknown) => unknown }
       >;
@@ -81,7 +81,7 @@ describe('declareUpdateTool', () => {
     it('should use enum type for collectionName when collection names provided', () => {
       declareUpdateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { options: string[]; parse: (value: unknown) => unknown }
       >;
@@ -93,7 +93,7 @@ describe('declareUpdateTool', () => {
     it('should accept both string and number for recordId', () => {
       declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
 
-      const schema = registeredToolConfig.inputSchema as Record<
+      const schema = registeredToolConfig.inputSchema.shape as Record<
         string,
         { parse: (value: unknown) => unknown }
       >;
@@ -234,7 +234,7 @@ describe('declareUpdateTool', () => {
         const attributes = { name: 'Updated', age: 31 };
         const attributesAsString = JSON.stringify(attributes);
 
-        const inputSchema = registeredToolConfig.inputSchema as Record<
+        const inputSchema = registeredToolConfig.inputSchema.shape as Record<
           string,
           { parse: (value: unknown) => unknown }
         >;

--- a/packages/mcp-server/test/utils/tool-with-logging.test.ts
+++ b/packages/mcp-server/test/utils/tool-with-logging.test.ts
@@ -6,6 +6,7 @@ describe('registerToolWithLogging', () => {
   let mockMcpServer: { registerTool: jest.Mock };
   let mockLogger: jest.Mock;
   let registeredHandler: (args: unknown, extra: unknown) => Promise<unknown>;
+  let registeredConfig: { inputSchema: z.ZodTypeAny };
 
   const toolConfig = {
     title: 'Test Tool',
@@ -18,7 +19,8 @@ describe('registerToolWithLogging', () => {
 
   beforeEach(() => {
     mockMcpServer = {
-      registerTool: jest.fn((_, __, handler) => {
+      registerTool: jest.fn((_, config, handler) => {
+        registeredConfig = config;
         registeredHandler = handler;
       }),
     };
@@ -33,7 +35,7 @@ describe('registerToolWithLogging', () => {
 
       expect(mockMcpServer.registerTool).toHaveBeenCalledWith(
         'test-tool',
-        toolConfig,
+        expect.objectContaining({ title: 'Test Tool', description: 'A test tool' }),
         expect.any(Function),
       );
     });
@@ -51,49 +53,20 @@ describe('registerToolWithLogging', () => {
 
       expect(result).toBe('my-tool');
     });
-  });
 
-  describe('validation error logging', () => {
-    it('should log validation error when arguments are invalid', async () => {
+    it('should register with a strict schema that rejects unknown keys', () => {
       const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
 
       registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
 
-      const invalidArgs = { name: 123, count: 'not a number' };
-      await registeredHandler(invalidArgs, {});
+      const { inputSchema } = registeredConfig;
 
-      expect(mockLogger).toHaveBeenCalledWith(
-        'Error',
-        expect.stringContaining('Tool "test-tool" validation error:'),
-      );
-      expect(mockLogger).toHaveBeenCalledWith('Error', expect.stringContaining('name:'));
-      expect(mockLogger).toHaveBeenCalledWith('Error', expect.stringContaining('count:'));
-    });
+      // Valid args should pass
+      expect(inputSchema.safeParse({ name: 'test', count: 42 }).success).toBe(true);
 
-    it('should log validation error for missing required field', async () => {
-      const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-
-      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
-
-      const missingFieldArgs = { name: 'test' };
-      await registeredHandler(missingFieldArgs, {});
-
-      expect(mockLogger).toHaveBeenCalledWith(
-        'Error',
-        expect.stringContaining('Tool "test-tool" validation error:'),
-      );
-      expect(mockLogger).toHaveBeenCalledWith('Error', expect.stringContaining('count:'));
-    });
-
-    it('should not log when arguments are valid', async () => {
-      const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-
-      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
-
-      const validArgs = { name: 'test', count: 42 };
-      await registeredHandler(validArgs, {});
-
-      expect(mockLogger).not.toHaveBeenCalled();
+      // Unknown keys should be rejected
+      const resultWithUnknown = inputSchema.safeParse({ name: 'test', count: 42, filter: 'x' });
+      expect(resultWithUnknown.success).toBe(false);
     });
   });
 
@@ -121,7 +94,7 @@ describe('registerToolWithLogging', () => {
       expect(result).toBe(expectedResult);
     });
 
-    it('should catch handler errors and return isError result without logging', async () => {
+    it('should catch handler errors and return isError result', async () => {
       const error = new Error('Handler failed');
       const handler = jest.fn().mockRejectedValue(error);
 
@@ -132,7 +105,6 @@ describe('registerToolWithLogging', () => {
         content: [{ type: 'text', text: expect.stringContaining('Handler failed') }],
         isError: true,
       });
-      expect(mockLogger).not.toHaveBeenCalled();
     });
 
     it('should stringify non-Error throws in isError result', async () => {
@@ -172,17 +144,6 @@ describe('registerToolWithLogging', () => {
         isError: true,
       });
     });
-
-    it('should call handler even when validation fails', async () => {
-      const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-
-      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
-
-      const invalidArgs = { name: 123, count: 'bad' };
-      await registeredHandler(invalidArgs, {});
-
-      expect(handler).toHaveBeenCalledWith(invalidArgs, {});
-    });
   });
 
   describe('optional fields', () => {
@@ -208,7 +169,6 @@ describe('registerToolWithLogging', () => {
 
       await registeredHandler({ name: 'test' }, {});
 
-      expect(mockLogger).not.toHaveBeenCalled();
       expect(handler).toHaveBeenCalledWith({ name: 'test' }, {});
     });
   });


### PR DESCRIPTION
## Summary

- Use Zod `.strict()` mode on tool input schemas so the MCP SDK rejects unknown keys instead of silently stripping them
- Prevents hard-to-debug issues where a typo (e.g. `filter` instead of `filters`) causes the tool to run without the intended parameter and return incorrect data
- Removes the now-unnecessary `logValidationErrorsIfAny` pre-validation (SDK handles it natively with strict mode)

**Context:** A customer (Sapheer) was sending `filter` (singular) instead of `filters` (plural) in their MCP tool calls. Zod's default `.strip()` behavior silently removed the unknown key, so the tool ran with no filter and returned the first 10 records — with no error. With `.strict()`, the SDK now returns a clear validation error: `Unrecognized key(s) in object: 'filter'`.

## Test plan

- [x] All 517 existing MCP server tests pass
- [x] New test verifies unknown keys are rejected by the strict schema
- [ ] Manual verification: call a tool with an unknown key via curl and confirm error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unknown keys in MCP server tool inputs using strict Zod schema validation
> - Replaces the pre-validation logging approach in [`registerToolWithLogging`](https://github.com/ForestAdmin/agent-nodejs/pull/1536/files#diff-1989bb6374348e66de98a0d536b15201ebde9a1430c7f5ded16df0addd68fba6) with a strict Zod schema (`z.object(...).strict()`) passed directly to `mcpServer.registerTool`.
> - Removes `logValidationErrorsIfAny` and `formatZodError` helpers, which previously logged validation errors but still passed invalid inputs to the handler.
> - Updates all tool tests to access schema fields via `inputSchema.shape` to reflect the new Zod object structure.
> - Behavioral Change: Tool calls with unknown keys are now rejected outright rather than silently accepted or stripped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccca5ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->