### PR TITLE
fix(agent-client): normalize path joining in HttpRequester

### DIFF
--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -35,7 +35,7 @@ export default class HttpRequester {
     contentType?: 'application/json' | 'text/csv';
   }): Promise<Data> {
     try {
-      const url = new URL(`${this.baseUrl}${HttpRequester.escapeUrlSlug(path)}`).toString();
+      const url = this.buildUrl(path);
 
       const req = superagent[method](url)
         .timeout(maxTimeAllowed ?? 10_000)
@@ -73,7 +73,7 @@ export default class HttpRequester {
     maxTimeAllowed?: number;
     stream: WriteStream;
   }): Promise<void> {
-    const url = new URL(`${this.baseUrl}${HttpRequester.escapeUrlSlug(reqPath)}`).toString();
+    const url = this.buildUrl(reqPath);
 
     return new Promise<void>((resolve, reject) => {
       superagent
@@ -96,5 +96,11 @@ export default class HttpRequester {
 
   static escapeUrlSlug(name: string): string {
     return encodeURI(name).replace(/([+?*])/g, '\\$1');
+  }
+
+  private buildUrl(path: string): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+    return new URL(`${this.baseUrl}${HttpRequester.escapeUrlSlug(normalizedPath)}`).toString();
   }
 }

--- a/packages/agent-client/test/http-requester.test.ts
+++ b/packages/agent-client/test/http-requester.test.ts
@@ -160,6 +160,18 @@ describe('HttpRequester', () => {
       });
     });
 
+    it('should normalize path without leading slash', async () => {
+      mockRequest.then = jest.fn((onFulfilled: any) => {
+        return Promise.resolve(onFulfilled({ body: {} }));
+      });
+
+      await requester.query({ method: 'get', path: 'forest/actions/my-action' });
+
+      expect(mockSuperagent.get).toHaveBeenCalledWith(
+        'https://api.example.com/forest/actions/my-action',
+      );
+    });
+
     it('should handle URL with prefix', async () => {
       const requesterWithPrefix = new HttpRequester('test-token', {
         url: 'https://api.example.com',


### PR DESCRIPTION
## Summary
- When `api_endpoint` has no trailing slash (e.g. `https://example.com/backoffice/v1`) and action endpoints have no leading slash (e.g. `forest/actions/my-action`), `HttpRequester` produces broken URLs like `/backoffice/v1forest/actions/...`
- Extract a `buildUrl()` method that ensures the path always starts with `/` before concatenation
- Applied to both `query()` and `stream()` methods

## Test plan
- [x] All 282 agent-client tests pass
- [x] New test verifies path without leading slash is normalized
- [ ] Verify action execution works with Ruby backend endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize path joining in `HttpRequester` to prevent malformed URLs
> Extracts URL construction into a private `buildUrl(path)` method in [http-requester.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1539/files#diff-5851a9c492435935d26984496c6accf0bba5379165224aa6a692406946b0c170) that ensures paths always have a leading `/` before joining with `baseUrl`. Both `query` and `stream` now use this helper instead of inline concatenation. A test covering paths without a leading slash is added in [http-requester.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1539/files#diff-e4181610f4192e2e36f62442aea49bd147a5d87b7eac8f9fa5b19d59379dd17d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 125d71d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->