### PR TITLE
fix(agent-client): handle missing layout in hook responses

### DIFF
--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -81,7 +81,7 @@ export default class FieldFormStates {
     });
 
     this.clearFieldsAndLayout();
-    this.layout.push(...queryResults.layout);
+    this.layout.push(...(queryResults.layout ?? []));
     this.addFields(queryResults.fields);
   }
 
@@ -115,6 +115,6 @@ export default class FieldFormStates {
 
     this.clearFieldsAndLayout();
     this.addFields(queryResults.fields);
-    this.layout.push(...queryResults.layout);
+    this.layout.push(...(queryResults.layout ?? []));
   }
 }

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -83,6 +83,19 @@ describe('FieldFormStates', () => {
       expect(fieldFormStates.getLayout()).toEqual(mockLayout);
     });
 
+    it('should handle missing layout in response', async () => {
+      httpRequester.query.mockResolvedValue({
+        fields: [
+          { field: 'name', type: 'String', isRequired: false, isReadOnly: false, value: '' },
+        ],
+      });
+
+      await fieldFormStates.loadInitialState();
+
+      expect(fieldFormStates.getFields()).toHaveLength(1);
+      expect(fieldFormStates.getLayout()).toEqual([]);
+    });
+
     it('should clear previous fields and layout on reload', async () => {
       // First load
       httpRequester.query.mockResolvedValue({


### PR DESCRIPTION
## Summary
- When a backend returns a response without a `layout` field (e.g. domain service actions returning only `{ fields: [...] }`), `loadInitialState` and `loadChanges` crash with `queryResults.layout is not iterable`
- Default `layout` to `[]` when missing in both `loadInitialState` and `loadChanges`

## Test plan
- [x] All agent-client tests pass
- [x] New test verifies missing layout is handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix crash in `FieldFormStates` when hook responses omit the layout property
> In [`field-form-states.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1540/files#diff-7ab5307c436664b3183f218254bb7e09882031d99c6b49a865e1280f22b2531d), spreading `undefined` on the internal layout array caused a runtime error when load or change hook responses did not include a `layout` property. Both `loadInitialState` and `setFieldValue` now fall back to an empty array when `layout` is absent, leaving the internal layout empty rather than throwing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53f9e58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->