### PR TITLE
feat(mcp-server): add disabledTools option to ForestMCPServerOptions

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -47,6 +47,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
   /** Whether MCP server should be mounted */
   private mcpEnabled = false;
+  private mcpDisabledTools?: string[];
 
   /**
    * Create a new Agent Builder.
@@ -206,9 +207,12 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/ai/mcp-server}
    * @example
    * agent.mountAiMcpServer();
+   * // Or with options:
+   * agent.mountAiMcpServer({ disabledTools: ['create', 'update', 'delete'] });
    */
-  mountAiMcpServer(): this {
+  mountAiMcpServer(options?: { disabledTools?: string[] }): this {
     this.mcpEnabled = true;
+    this.mcpDisabledTools = options?.disabledTools;
 
     return this;
   }
@@ -326,6 +330,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         authSecret: this.options.authSecret,
         logger: mcpLogger,
         forestServerClient,
+        disabledTools: this.mcpDisabledTools,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -12,6 +12,7 @@ import type {
 } from '@forestadmin/datasource-customizer';
 import type { DataSource, DataSourceFactory } from '@forestadmin/datasource-toolkit';
 import type { ForestSchema } from '@forestadmin/forestadmin-client';
+import type { ToolName } from '@forestadmin/mcp-server';
 
 import { DataSourceCustomizer } from '@forestadmin/datasource-customizer';
 import bodyParser from '@koa/bodyparser';
@@ -47,7 +48,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
   /** Whether MCP server should be mounted */
   private mcpEnabled = false;
-  private mcpDisabledTools?: string[];
+  private mcpDisabledTools?: ToolName[];
 
   /**
    * Create a new Agent Builder.
@@ -210,7 +211,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * // Or with options:
    * agent.mountAiMcpServer({ disabledTools: ['create', 'update', 'delete'] });
    */
-  mountAiMcpServer(options?: { disabledTools?: string[] }): this {
+  mountAiMcpServer(options?: { disabledTools?: ToolName[] }): this {
     this.mcpEnabled = true;
     this.mcpDisabledTools = options?.disabledTools;
 

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -392,6 +392,18 @@ describe('Agent', () => {
       expect(mockLogger).toHaveBeenCalledWith('Info', '[MCP] Server initialized successfully');
     });
 
+    test('should pass disabledTools to ForestMCPServer', async () => {
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const agent = new Agent(options);
+
+      agent.mountAiMcpServer({ disabledTools: ['create', 'update', 'delete'] });
+      await agent.start();
+
+      expect(mcpServerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ disabledTools: ['create', 'update', 'delete'] }),
+      );
+    });
+
     test('should log error when MCP initialization fails', async () => {
       const mockLogger = jest.fn();
       const options = factories.forestAdminHttpDriverOptions.build({ logger: mockLogger });

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -61,6 +61,7 @@ yarn start:dev       # Development (loads .env file automatically)
 | `FOREST_ENV_SECRET` | **Yes** | - | Your Forest Admin environment secret |
 | `FOREST_AUTH_SECRET` | **Yes** | - | Your Forest Admin authentication secret (must match your agent) |
 | `MCP_SERVER_PORT` | No | `3931` | Port for the HTTP server |
+| `FOREST_MCP_DISABLED_TOOLS` | No | - | Comma-separated list of tools to disable (e.g. `create,update,delete`) |
 
 #### Example Configuration
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -72,21 +72,31 @@ FOREST_ENV_SECRET="your-env-secret" FOREST_AUTH_SECRET="your-auth-secret" npx fo
 
 ## Disabling Tools
 
-You can restrict which tools are exposed by the MCP server. This is useful to prevent AI assistants from performing write operations, for example.
+You can restrict which tools are exposed by the MCP server.
 
-**With Forest Admin Agent:**
+**Read-only mode** — disable all write operations:
 
 ```typescript
+// With Forest Admin Agent
 agent.mountAiMcpServer({
-  disabledTools: ['create', 'update', 'delete'],
+  disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate', 'executeAction'],
 });
 ```
 
-**Standalone (via environment variable):**
-
 ```bash
-export FOREST_MCP_DISABLED_TOOLS="create,update,delete"
+# Standalone
+export FOREST_MCP_DISABLED_TOOLS="create,update,delete,associate,dissociate,executeAction"
 npx forest-mcp-server
+```
+
+This keeps only `list`, `listRelated`, `describeCollection` and `getActionForm` available.
+
+**Custom selection** — disable specific tools:
+
+```typescript
+agent.mountAiMcpServer({
+  disabledTools: ['create', 'delete'],
+});
 ```
 
 Available tool names: `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -27,20 +27,21 @@ The MCP server will be automatically initialized and mounted on your application
 
 ### Standalone Server
 
-You can run the MCP server standalone using the CLI:
+You can also run the MCP server standalone using the CLI:
 
 ```bash
 npx forest-mcp-server
 ```
 
-Or from the package directory:
+Or programmatically:
 
 ```bash
-yarn start           # Production
-yarn start:dev       # Development (loads .env file automatically)
+node dist/index.js
 ```
 
 #### Environment Variables
+
+The following environment variables are required to run the server as a standalone:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -51,17 +52,12 @@ yarn start:dev       # Development (loads .env file automatically)
 
 #### Example Configuration
 
-Create a `.env` file in the package directory:
-
 ```bash
-FOREST_ENV_SECRET="your-env-secret"
-FOREST_AUTH_SECRET="your-auth-secret"
-```
+export FOREST_ENV_SECRET="your-env-secret"
+export FOREST_AUTH_SECRET="your-auth-secret"
+export MCP_SERVER_PORT=3931
 
-Then run:
-
-```bash
-yarn start:dev
+npx forest-mcp-server
 ```
 
 Or set the variables inline:
@@ -128,41 +124,32 @@ The `/mcp` endpoint expects MCP protocol messages (JSON-RPC 2.0) and requires a 
 ### Building
 
 ```bash
-yarn build
+npm run build
 ```
 
 ### Watch Mode
 
 ```bash
-yarn build:watch
+npm run build:watch
 ```
 
 ### Linting
 
 ```bash
-yarn lint
+npm run lint
 ```
 
 ### Testing
 
 ```bash
-yarn test
+npm test
 ```
 
 ### Cleaning
 
 ```bash
-yarn clean
+npm run clean
 ```
-
-### Internal Environment Variables
-
-These are only needed by Forest Admin developers (e.g. to point to a local or staging server):
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `FOREST_SERVER_URL` | `https://api.forestadmin.com` | Forest Admin API URL |
-| `FOREST_APP_URL` | `https://app.forestadmin.com` | Forest Admin application URL |
 
 ## Architecture
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -79,17 +79,17 @@ You can restrict which tools are exposed by the MCP server.
 ```typescript
 // With Forest Admin Agent
 agent.mountAiMcpServer({
-  disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate', 'executeAction'],
+  disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate', 'getActionForm', 'executeAction'],
 });
 ```
 
 ```bash
 # Standalone
-export FOREST_MCP_DISABLED_TOOLS="create,update,delete,associate,dissociate,executeAction"
+export FOREST_MCP_DISABLED_TOOLS="create,update,delete,associate,dissociate,getActionForm,executeAction"
 npx forest-mcp-server
 ```
 
-This keeps only `list`, `listRelated`, `describeCollection` and `getActionForm` available.
+This keeps only `list`, `listRelated` and `describeCollection` available.
 
 **Custom selection** — disable specific tools:
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -27,21 +27,20 @@ The MCP server will be automatically initialized and mounted on your application
 
 ### Standalone Server
 
-You can also run the MCP server standalone using the CLI:
+You can run the MCP server standalone using the CLI:
 
 ```bash
 npx forest-mcp-server
 ```
 
-Or programmatically:
+Or from the package directory:
 
 ```bash
-node dist/index.js
+yarn start           # Production
+yarn start:dev       # Development (loads .env file automatically)
 ```
 
 #### Environment Variables
-
-The following environment variables are required to run the server as a standalone:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -52,12 +51,17 @@ The following environment variables are required to run the server as a standalo
 
 #### Example Configuration
 
-```bash
-export FOREST_ENV_SECRET="your-env-secret"
-export FOREST_AUTH_SECRET="your-auth-secret"
-export MCP_SERVER_PORT=3931
+Create a `.env` file in the package directory:
 
-npx forest-mcp-server
+```bash
+FOREST_ENV_SECRET="your-env-secret"
+FOREST_AUTH_SECRET="your-auth-secret"
+```
+
+Then run:
+
+```bash
+yarn start:dev
 ```
 
 Or set the variables inline:
@@ -124,32 +128,41 @@ The `/mcp` endpoint expects MCP protocol messages (JSON-RPC 2.0) and requires a 
 ### Building
 
 ```bash
-npm run build
+yarn build
 ```
 
 ### Watch Mode
 
 ```bash
-npm run build:watch
+yarn build:watch
 ```
 
 ### Linting
 
 ```bash
-npm run lint
+yarn lint
 ```
 
 ### Testing
 
 ```bash
-npm test
+yarn test
 ```
 
 ### Cleaning
 
 ```bash
-npm run clean
+yarn clean
 ```
+
+### Internal Environment Variables
+
+These are only needed by Forest Admin developers (e.g. to point to a local or staging server):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FOREST_SERVER_URL` | `https://api.forestadmin.com` | Forest Admin API URL |
+| `FOREST_APP_URL` | `https://app.forestadmin.com` | Forest Admin application URL |
 
 ## Architecture
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -25,20 +25,6 @@ agent.start();
 
 The MCP server will be automatically initialized and mounted on your application.
 
-#### Disabling Tools
-
-You can restrict which tools are exposed by the MCP server using the `disabledTools` option:
-
-```typescript
-agent.mountAiMcpServer({
-  disabledTools: ['create', 'update', 'delete'],
-});
-```
-
-Available tool names: `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
-
-Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
-
 ### Standalone Server
 
 You can run the MCP server standalone using the CLI:
@@ -83,6 +69,29 @@ Or set the variables inline:
 ```bash
 FOREST_ENV_SECRET="your-env-secret" FOREST_AUTH_SECRET="your-auth-secret" npx forest-mcp-server
 ```
+
+## Disabling Tools
+
+You can restrict which tools are exposed by the MCP server. This is useful to prevent AI assistants from performing write operations, for example.
+
+**With Forest Admin Agent:**
+
+```typescript
+agent.mountAiMcpServer({
+  disabledTools: ['create', 'update', 'delete'],
+});
+```
+
+**Standalone (via environment variable):**
+
+```bash
+export FOREST_MCP_DISABLED_TOOLS="create,update,delete"
+npx forest-mcp-server
+```
+
+Available tool names: `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
+
+Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
 
 ## API Endpoints
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -25,6 +25,18 @@ agent.start();
 
 The MCP server will be automatically initialized and mounted on your application.
 
+#### Disabling Tools
+
+You can restrict which tools are exposed by the MCP server using the `disabledTools` option:
+
+```typescript
+agent.mountAiMcpServer({
+  disabledTools: ['create', 'update', 'delete'],
+});
+```
+
+Available tool names: `describeCollection`, `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
+
 ### Standalone Server
 
 You can run the MCP server standalone using the CLI:

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -6,6 +6,21 @@ Model Context Protocol (MCP) server for Forest Admin with OAuth authentication s
 
 This MCP server provides HTTP REST API access to Forest Admin operations, enabling AI assistants and other MCP clients to interact with your Forest Admin data through a standardized protocol.
 
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `describeCollection` | Get the schema of a collection (fields, types, relations) |
+| `list` | Retrieve records from a collection |
+| `listRelated` | Retrieve related records |
+| `create` | Create a new record |
+| `update` | Update an existing record |
+| `delete` | Delete records |
+| `associate` | Associate records in a relation |
+| `dissociate` | Dissociate records from a relation |
+| `getActionForm` | Get the form fields for a custom action |
+| `executeAction` | Execute a custom action |
+
 ## Usage
 
 ### With Forest Admin Agent
@@ -99,9 +114,7 @@ agent.mountAiMcpServer({
 });
 ```
 
-Available tool names: `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
-
-Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
+See [Available Tools](#available-tools) for the full list. Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
 
 ## API Endpoints
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -35,7 +35,9 @@ agent.mountAiMcpServer({
 });
 ```
 
-Available tool names: `describeCollection`, `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
+Available tool names: `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`.
+
+Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
 
 ### Standalone Server
 

--- a/packages/mcp-server/jest.config.ts
+++ b/packages/mcp-server/jest.config.ts
@@ -6,6 +6,7 @@ export default {
   collectCoverageFrom: [
     '<rootDir>/src/**/*.ts',
     '!<rootDir>/src/version.ts', // Mocked due to import.meta.url issues in Jest
+    '!<rootDir>/src/cli.ts', // CLI entrypoint with side effects, not unit-testable
     '!<rootDir>/src/__mocks__/**',
   ],
   testMatch: ['<rootDir>/test/**/*.test.ts'],

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import ForestMCPServer from './server';
+import parseDisabledTools from './utils/parse-disabled-tools';
 
 // Start the server when run directly as CLI
 const server = new ForestMCPServer({
@@ -8,6 +9,7 @@ const server = new ForestMCPServer({
   forestAppUrl: process.env.FOREST_APP_URL || 'https://app.forestadmin.com',
   envSecret: process.env.FOREST_ENV_SECRET,
   authSecret: process.env.FOREST_AUTH_SECRET,
+  disabledTools: parseDisabledTools(process.env.FOREST_MCP_DISABLED_TOOLS),
 });
 
 server.run().catch(error => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,6 +1,6 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
-export type { ForestMCPServerOptions, HttpCallback } from './server';
+export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
 export { MCP_PATHS, isMcpRoute } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -145,7 +145,9 @@ export default class ForestMCPServer {
     this.envSecret = options?.envSecret;
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
-    this.disabledTools = new Set(options?.disabledTools ?? []);
+    this.disabledTools = new Set(
+      options?.disabledTools?.filter(toolName => toolName !== 'describeCollection') ?? [],
+    );
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -103,6 +103,12 @@ export interface ForestMCPServerOptions {
   logger?: Logger;
   /** Optional Forest server client for dependency injection (from agent integration) */
   forestServerClient?: ForestServerClient;
+  /**
+   * List of tool names to disable. Use this to restrict which tools are exposed.
+   * Available tool names: describeCollection, list, listRelated, create, update,
+   * delete, associate, dissociate, getActionForm, executeAction
+   */
+  disabledTools?: string[];
 }
 
 /**
@@ -123,6 +129,7 @@ export default class ForestMCPServer {
   private authSecret?: string;
   private logger: Logger;
   private collectionNames: string[] = [];
+  private disabledTools: Set<string>;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -130,6 +137,7 @@ export default class ForestMCPServer {
     this.envSecret = options?.envSecret;
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
+    this.disabledTools = new Set(options?.disabledTools ?? []);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -161,33 +169,22 @@ export default class ForestMCPServer {
       icons: [{ src: LOGO_URL, mimeType: 'image/png' }],
     });
 
-    const toolNames = [
-      declareDescribeCollectionTool(
-        mcpServer,
-        this.forestServerClient,
-        this.logger,
-        this.collectionNames,
-      ),
-      declareListTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareListRelatedTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareCreateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareUpdateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareDeleteTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareAssociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareDissociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      declareGetActionFormTool(
-        mcpServer,
-        this.forestServerClient,
-        this.logger,
-        this.collectionNames,
-      ),
-      declareExecuteActionTool(
-        mcpServer,
-        this.forestServerClient,
-        this.logger,
-        this.collectionNames,
-      ),
+    const allTools: Array<{ name: string; register: () => string }> = [
+      { name: 'describeCollection', register: () => declareDescribeCollectionTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'list', register: () => declareListTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'listRelated', register: () => declareListRelatedTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'create', register: () => declareCreateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'update', register: () => declareUpdateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'delete', register: () => declareDeleteTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'associate', register: () => declareAssociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'dissociate', register: () => declareDissociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'getActionForm', register: () => declareGetActionFormTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      { name: 'executeAction', register: () => declareExecuteActionTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
     ];
+
+    const toolNames = allTools
+      .filter(tool => !this.disabledTools.has(tool.name))
+      .map(tool => tool.register());
 
     this.logger('Debug', `Registered ${toolNames.length} tools: ${toolNames.join(', ')}`);
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -137,7 +137,7 @@ export default class ForestMCPServer {
   private authSecret?: string;
   private logger: Logger;
   private collectionNames: string[] = [];
-  private disabledTools: Set<string>;
+  private disabledTools: Set<ToolName>;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -177,7 +177,7 @@ export default class ForestMCPServer {
       icons: [{ src: LOGO_URL, mimeType: 'image/png' }],
     });
 
-    const allTools: Array<{ name: string; register: () => string }> = [
+    const allTools: Array<{ name: ToolName; register: () => string }> = [
       {
         name: 'describeCollection',
         register: () =>

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -178,16 +178,86 @@ export default class ForestMCPServer {
     });
 
     const allTools: Array<{ name: string; register: () => string }> = [
-      { name: 'describeCollection', register: () => declareDescribeCollectionTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'list', register: () => declareListTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'listRelated', register: () => declareListRelatedTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'create', register: () => declareCreateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'update', register: () => declareUpdateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'delete', register: () => declareDeleteTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'associate', register: () => declareAssociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'dissociate', register: () => declareDissociateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'getActionForm', register: () => declareGetActionFormTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
-      { name: 'executeAction', register: () => declareExecuteActionTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames) },
+      {
+        name: 'describeCollection',
+        register: () =>
+          declareDescribeCollectionTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
+      {
+        name: 'list',
+        register: () =>
+          declareListTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
+      },
+      {
+        name: 'listRelated',
+        register: () =>
+          declareListRelatedTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
+      {
+        name: 'create',
+        register: () =>
+          declareCreateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
+      },
+      {
+        name: 'update',
+        register: () =>
+          declareUpdateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
+      },
+      {
+        name: 'delete',
+        register: () =>
+          declareDeleteTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
+      },
+      {
+        name: 'associate',
+        register: () =>
+          declareAssociateTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
+      {
+        name: 'dissociate',
+        register: () =>
+          declareDissociateTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
+      {
+        name: 'getActionForm',
+        register: () =>
+          declareGetActionFormTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
+      {
+        name: 'executeAction',
+        register: () =>
+          declareExecuteActionTool(
+            mcpServer,
+            this.forestServerClient,
+            this.logger,
+            this.collectionNames,
+          ),
+      },
     ];
 
     const toolNames = allTools

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -87,6 +87,18 @@ const SAFE_ARGUMENTS_FOR_LOGGING: Record<string, string[]> = {
   dissociate: ['collectionName', 'relationName', 'parentRecordId', 'targetRecordIds'],
 };
 
+export type ToolName =
+  | 'describeCollection'
+  | 'list'
+  | 'listRelated'
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'associate'
+  | 'dissociate'
+  | 'getActionForm'
+  | 'executeAction';
+
 /**
  * Options for configuring the Forest Admin MCP Server
  */
@@ -103,12 +115,8 @@ export interface ForestMCPServerOptions {
   logger?: Logger;
   /** Optional Forest server client for dependency injection (from agent integration) */
   forestServerClient?: ForestServerClient;
-  /**
-   * List of tool names to disable. Use this to restrict which tools are exposed.
-   * Available tool names: describeCollection, list, listRelated, create, update,
-   * delete, associate, dissociate, getActionForm, executeAction
-   */
-  disabledTools?: string[];
+  /** List of tool names to disable. Use this to restrict which tools are exposed. */
+  disabledTools?: ToolName[];
 }
 
 /**

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -145,9 +145,7 @@ export default class ForestMCPServer {
     this.envSecret = options?.envSecret;
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
-    this.disabledTools = new Set(
-      options?.disabledTools?.filter(toolName => toolName !== 'describeCollection') ?? [],
-    );
+    this.disabledTools = this.getToolsToDisable(options?.disabledTools ?? []);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -269,6 +267,20 @@ export default class ForestMCPServer {
     this.logger('Debug', `Registered ${toolNames.length} tools: ${toolNames.join(', ')}`);
 
     return mcpServer;
+  }
+
+  private getToolsToDisable(toolsToDisable: ToolName[]): Set<ToolName> {
+    const tools = new Set(toolsToDisable);
+
+    if (tools.has('describeCollection')) {
+      tools.delete('describeCollection');
+      this.logger(
+        'Warn',
+        'The "describeCollection" tool cannot be disabled as it is required for the MCP server to function properly.',
+      );
+    }
+
+    return tools;
   }
 
   private ensureSecretsAreSet(): { envSecret: string; authSecret: string } {

--- a/packages/mcp-server/src/utils/parse-disabled-tools.ts
+++ b/packages/mcp-server/src/utils/parse-disabled-tools.ts
@@ -1,0 +1,10 @@
+import type { ToolName } from '../server';
+
+export default function parseDisabledTools(envValue?: string): ToolName[] | undefined {
+  if (!envValue) return undefined;
+
+  return envValue
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean) as ToolName[];
+}

--- a/packages/mcp-server/test/cli.test.ts
+++ b/packages/mcp-server/test/cli.test.ts
@@ -1,0 +1,31 @@
+import parseDisabledTools from '../src/utils/parse-disabled-tools';
+
+describe('parseDisabledTools', () => {
+  it('should return undefined when env value is undefined', () => {
+    expect(parseDisabledTools(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when env value is empty string', () => {
+    expect(parseDisabledTools('')).toBeUndefined();
+  });
+
+  it('should parse comma-separated tool names', () => {
+    expect(parseDisabledTools('create,update,delete')).toEqual(['create', 'update', 'delete']);
+  });
+
+  it('should trim whitespace around tool names', () => {
+    expect(parseDisabledTools(' create , update , delete ')).toEqual([
+      'create',
+      'update',
+      'delete',
+    ]);
+  });
+
+  it('should filter out empty entries from trailing commas', () => {
+    expect(parseDisabledTools('create,,delete,')).toEqual(['create', 'delete']);
+  });
+
+  it('should handle a single tool name', () => {
+    expect(parseDisabledTools('delete')).toEqual(['delete']);
+  });
+});

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2806,10 +2806,8 @@ describe('disabledTools', () => {
     if (response.body && Object.keys(response.body).length > 0) {
       responseData = response.body;
     } else {
-      const dataLine = response.text
-        .split('\n')
-        .find((line: string) => line.startsWith('data: '));
-      responseData = JSON.parse(dataLine!.replace('data: ', ''));
+      const dataLine = response.text.split('\n').find((line: string) => line.startsWith('data: '));
+      responseData = JSON.parse((dataLine as string).replace('data: ', ''));
     }
 
     const toolNames = responseData.result.tools.map(t => t.name);

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2759,6 +2759,23 @@ describe('disabledTools', () => {
     const app = await disabledServer.buildExpressApp(new URL('http://localhost:3000'));
     expect(app).toBeDefined();
   });
+
+  it('should re-enable describeCollection and log a warning when it is passed as disabled', () => {
+    const logger = jest.fn();
+
+    const disabledServer = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      logger,
+      disabledTools: ['describeCollection'],
+    });
+
+    expect(disabledServer).toBeDefined();
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      'The "describeCollection" tool cannot be disabled as it is required for the MCP server to function properly.',
+    );
+  });
 });
 
 describe('Logo URL', () => {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2735,29 +2735,100 @@ describe('handleMcpRequest cleanup', () => {
 
 describe('disabledTools', () => {
   const savedFetch = global.fetch;
+  let disabledToolsServer: ForestMCPServer;
+  let disabledToolsHttpServer: http.Server;
+  let mockServer: MockServer;
 
-  afterEach(() => {
-    global.fetch = savedFetch;
-  });
-
-  it('should accept disabledTools option and build server', async () => {
-    const mockFetchServer = new MockServer();
-    mockFetchServer
+  beforeAll(async () => {
+    mockServer = new MockServer();
+    mockServer
       .get('/liana/environment', {
         data: { id: '12345', attributes: { api_endpoint: 'https://api.example.com' } },
       })
-      .get('/liana/forest-schema', { data: [], meta: {} });
+      .get('/liana/forest-schema', {
+        data: [
+          {
+            id: 'users',
+            type: 'collections',
+            attributes: { name: 'users', fields: [{ field: 'id', type: 'Number' }] },
+          },
+        ],
+        included: [],
+        meta: { liana: 'forest-express-sequelize', liana_version: '9.0.0', liana_features: null },
+      })
+      .get(/\/oauth\/register\//, { error: 'Client not found' }, 404);
 
-    global.fetch = mockFetchServer.fetch;
+    global.fetch = mockServer.fetch;
 
-    const disabledServer = new ForestMCPServer({
-      envSecret: 'ENV_SECRET',
-      authSecret: 'AUTH_SECRET',
+    disabledToolsServer = new ForestMCPServer({
+      envSecret: 'test-env-secret',
+      authSecret: 'test-auth-secret',
       disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate'],
     });
+    disabledToolsServer.run();
 
-    const app = await disabledServer.buildExpressApp(new URL('http://localhost:3000'));
-    expect(app).toBeDefined();
+    await new Promise(resolve => {
+      setTimeout(resolve, 500);
+    });
+
+    disabledToolsHttpServer = disabledToolsServer.httpServer as http.Server;
+  });
+
+  afterAll(async () => {
+    global.fetch = savedFetch;
+    await new Promise<void>(resolve => {
+      if (disabledToolsHttpServer) {
+        disabledToolsHttpServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  it('should not expose disabled tools and should expose enabled tools', async () => {
+    const validToken = jsonwebtoken.sign(
+      { id: 123, email: 'user@example.com', renderingId: 456 },
+      'test-auth-secret',
+      { expiresIn: '1h' },
+    );
+
+    const response = await request(disabledToolsHttpServer)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${validToken}`)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+
+    expect(response.status).toBe(200);
+
+    let responseData: { result: { tools: Array<{ name: string }> } };
+
+    if (response.body && Object.keys(response.body).length > 0) {
+      responseData = response.body;
+    } else {
+      const dataLine = response.text
+        .split('\n')
+        .find((line: string) => line.startsWith('data: '));
+      responseData = JSON.parse(dataLine!.replace('data: ', ''));
+    }
+
+    const toolNames = responseData.result.tools.map(t => t.name);
+
+    // Disabled tools should NOT be present
+    expect(toolNames).not.toContain('create');
+    expect(toolNames).not.toContain('update');
+    expect(toolNames).not.toContain('delete');
+    expect(toolNames).not.toContain('associate');
+    expect(toolNames).not.toContain('dissociate');
+
+    // Enabled tools SHOULD be present
+    expect(toolNames).toContain('describeCollection');
+    expect(toolNames).toContain('list');
+    expect(toolNames).toContain('listRelated');
+    expect(toolNames).toContain('getActionForm');
+    expect(toolNames).toContain('executeAction');
+
+    expect(toolNames).toHaveLength(5);
   });
 
   it('should re-enable describeCollection and log a warning when it is passed as disabled', () => {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2733,6 +2733,34 @@ describe('handleMcpRequest cleanup', () => {
   });
 });
 
+describe('disabledTools', () => {
+  const savedFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = savedFetch;
+  });
+
+  it('should accept disabledTools option and build server', async () => {
+    const mockFetchServer = new MockServer();
+    mockFetchServer
+      .get('/liana/environment', {
+        data: { id: '12345', attributes: { api_endpoint: 'https://api.example.com' } },
+      })
+      .get('/liana/forest-schema', { data: [], meta: {} });
+
+    global.fetch = mockFetchServer.fetch;
+
+    const disabledServer = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate'],
+    });
+
+    const app = await disabledServer.buildExpressApp(new URL('http://localhost:3000'));
+    expect(app).toBeDefined();
+  });
+});
+
 describe('Logo URL', () => {
   it('should reference an accessible PNG image', async () => {
     const response = await fetch(LOGO_URL, { method: 'HEAD' });


### PR DESCRIPTION
## Summary
- Add `disabledTools` option to `ForestMCPServerOptions` that accepts an array of tool names to exclude from registration
- Tools listed in `disabledTools` are never registered in the MCP server
- This allows users to run in read-only mode (disable `create`, `update`, `delete`, `associate`, `dissociate`) without monkey-patching

Available tool names: `describeCollection`, `list`, `listRelated`, `create`, `update`, `delete`, `associate`, `dissociate`, `getActionForm`, `executeAction`

## Test plan
- [x] All 521 mcp-server tests pass (1 new test)
- [ ] Verify disabled tools are not exposed to MCP clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `disabledTools` option to `ForestMCPServer` and `mountAiMcpServer`
> - Adds a `disabledTools?: ToolName[]` option to `ForestMCPServerOptions` in [server.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1543/files#diff-c54d7a276ef5be4d65ba37d55b279e77958ba4496af9d9ca7ec80c23c847d155); tools in the list are excluded from MCP tool registration at startup.
> - `describeCollection` cannot be disabled — if included, it is silently ignored and a warning is logged.
> - Exposes the option through `Agent.mountAiMcpServer` in [agent.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1543/files#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143) and through the `FOREST_MCP_DISABLED_TOOLS` environment variable (comma-separated) in the CLI via [parse-disabled-tools.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1543/files#diff-7dd488def7e36c0d8b4a8d0313d12ee061c823d41dc27a1b4ef914758e318d25).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc6ac57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->