### PR TITLE
fix(agent-client): convert filter operators to snake_case for Ruby compatibility

### DIFF
--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -28,7 +28,38 @@ export default class QuerySerializer {
   private static formatFilters(filters: PlainFilter['conditionTree']): string {
     if (!filters) return undefined;
 
-    return JSON.stringify(filters);
+    return JSON.stringify(QuerySerializer.toSnakeCaseOperators(filters));
+  }
+
+  private static toSnakeCaseOperators(node: unknown): unknown {
+    if (!node || typeof node !== 'object') return node;
+
+    const obj = node as Record<string, unknown>;
+
+    // Leaf: { field, operator, value }
+    if ('operator' in obj) {
+      return {
+        ...obj,
+        operator: QuerySerializer.toSnakeCase(obj.operator as string),
+      };
+    }
+
+    // Branch: { aggregator, conditions }
+    if ('aggregator' in obj && Array.isArray(obj.conditions)) {
+      return {
+        aggregator: (obj.aggregator as string).toLowerCase(),
+        conditions: obj.conditions.map(c => QuerySerializer.toSnakeCaseOperators(c)),
+      };
+    }
+
+    return obj;
+  }
+
+  private static toSnakeCase(value: string): string {
+    return value
+      .replace(/([a-z])([A-Z])/g, '$1_$2')
+      .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+      .toLowerCase();
   }
 
   private static formatFields(collectionName: string, fields: string[]): Record<string, string[]> {

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -24,18 +24,30 @@ export default class QuerySerializer {
     return sort.ascending ? sort.field : `-${sort.field}`;
   }
 
+  /**
+   * Serialize filters to JSON with snake_case operators and aggregators.
+   *
+   * Internally, operators use PascalCase (e.g. `Equal`, `GreaterThan`) to match
+   * the datasource-toolkit convention. However, HTTP backends expect snake_case:
+   * - Ruby (forest_liana): requires `equal`, `greater_than`, etc.
+   * - Node (@forestadmin/agent): accepts snake_case via ConditionTreeParser.toPascalCase()
+   *
+   * Converting to snake_case here ensures compatibility with both backends.
+   */
   private static formatFilters(filters: PlainFilter['conditionTree']): string {
     if (!filters) return undefined;
 
     return JSON.stringify(QuerySerializer.toSnakeCaseOperators(filters));
   }
 
+  /**
+   * Recursively walk the condition tree and convert operators/aggregators to snake_case.
+   */
   private static toSnakeCaseOperators(node: unknown): unknown {
     if (!node || typeof node !== 'object') return node;
 
     const obj = node as Record<string, unknown>;
 
-    // Leaf: { field, operator, value }
     if ('operator' in obj) {
       return {
         ...obj,
@@ -43,7 +55,6 @@ export default class QuerySerializer {
       };
     }
 
-    // Branch: { aggregator, conditions }
     if ('aggregator' in obj && Array.isArray(obj.conditions)) {
       return {
         aggregator: (obj.aggregator as string).toLowerCase(),
@@ -54,6 +65,12 @@ export default class QuerySerializer {
     return obj;
   }
 
+  /**
+   * Convert PascalCase to snake_case.
+   * Two passes handle different patterns:
+   * - Pass 1: lowercase→uppercase boundaries (e.g. `greaterThan` → `greater_Than`)
+   * - Pass 2: uppercase sequences (e.g. `IContains` → `I_Contains`, `PreviousXDays` → `PreviousX_Days`)
+   */
   private static toSnakeCase(value: string): string {
     return value
       .replace(/([a-z])([A-Z])/g, '$1_$2')

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -9,7 +9,6 @@ export default class QuerySerializer {
 
     return {
       ...query,
-      ...query.filters,
       sort: QuerySerializer.formatSort(query.sort),
       filters: QuerySerializer.formatFilters(query.filters),
       searchExtended: !!query.shouldSearchInRelation,

--- a/packages/agent-client/test/query-serializer.test.ts
+++ b/packages/agent-client/test/query-serializer.test.ts
@@ -150,6 +150,22 @@ describe('QuerySerializer', () => {
       expect(parsed.conditions[2].operator).toBe('before_x_hours_ago');
     });
 
+    it('should convert I-prefixed operators to snake_case', () => {
+      const filters = {
+        aggregator: 'And' as const,
+        conditions: [
+          { field: 'name', operator: 'IContains' as const, value: 'foo' },
+          { field: 'name', operator: 'ILike' as const, value: '%bar%' },
+          { field: 'name', operator: 'NotIContains' as const, value: 'baz' },
+        ],
+      };
+      const result = QuerySerializer.serialize({ filters }, 'users');
+      const parsed = JSON.parse(result.filters as string);
+      expect(parsed.conditions[0].operator).toBe('i_contains');
+      expect(parsed.conditions[1].operator).toBe('i_like');
+      expect(parsed.conditions[2].operator).toBe('not_i_contains');
+    });
+
     it('should serialize complex query with multiple options', () => {
       const filters = {
         aggregator: 'And' as const,

--- a/packages/agent-client/test/query-serializer.test.ts
+++ b/packages/agent-client/test/query-serializer.test.ts
@@ -106,14 +106,48 @@ describe('QuerySerializer', () => {
       expect(result.sort).toBe('-name');
     });
 
-    it('should serialize filters with conditionTree', () => {
+    it('should serialize filters with conditionTree and convert operators to snake_case', () => {
       const filters = {
         field: 'status',
         operator: 'Equal' as const,
         value: 'active',
       };
       const result = QuerySerializer.serialize({ filters }, 'users');
-      expect(result.filters).toBe(JSON.stringify(filters));
+      expect(result.filters).toBe(
+        JSON.stringify({ field: 'status', operator: 'equal', value: 'active' }),
+      );
+    });
+
+    it('should convert PascalCase operators to snake_case in nested conditions', () => {
+      const filters = {
+        aggregator: 'And' as const,
+        conditions: [
+          { field: 'status', operator: 'Equal' as const, value: 'active' },
+          { field: 'age', operator: 'GreaterThan' as const, value: 18 },
+        ],
+      };
+      const result = QuerySerializer.serialize({ filters }, 'users');
+      const parsed = JSON.parse(result.filters as string);
+      expect(parsed.aggregator).toBe('and');
+      expect(parsed.conditions[0].operator).toBe('equal');
+      expect(parsed.conditions[1].operator).toBe('greater_than');
+    });
+
+    it('should convert multi-word PascalCase operators to snake_case', () => {
+      const filters = {
+        aggregator: 'Or' as const,
+        conditions: [
+          { field: 'date', operator: 'PreviousXDaysToDate' as const, value: 7 },
+          { field: 'name', operator: 'NotContains' as const, value: 'test' },
+          { field: 'time', operator: 'BeforeXHoursAgo' as const, value: 24 },
+        ],
+      };
+      const result = QuerySerializer.serialize({ filters }, 'users');
+      const parsed = JSON.parse(result.filters as string);
+      expect(parsed.aggregator).toBe('or');
+      expect(parsed.conditions[0].operator).toBe('previous_x_days_to_date');
+      expect(parsed.conditions[1].operator).toBe('not_contains');
+      expect(parsed.conditions[2].operator).toBe('before_x_hours_ago');
     });
 
     it('should serialize complex query with multiple options', () => {
@@ -140,7 +174,9 @@ describe('QuerySerializer', () => {
       expect(result['page[number]']).toBe(1);
       expect(result['fields[users]']).toEqual(['id', 'name']);
       expect(result.sort).toBe('-createdAt');
-      expect(result.filters).toBe(JSON.stringify(filters));
+      const parsed = JSON.parse(result.filters as string);
+      expect(parsed.conditions[0].operator).toBe('equal');
+      expect(parsed.conditions[1].operator).toBe('greater_than');
     });
 
     it('should handle collection names with special characters', () => {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -1500,8 +1500,8 @@ describe('ForestMCPServer Instance', () => {
           expect(response.status).toBe(200);
           const filters = JSON.parse(capturedQueryParams.filters as string);
           expect(filters).toEqual({
-            aggregator: 'And',
-            conditions: [{ field: 'name', operator: 'Equal', value: 'John' }],
+            aggregator: 'and',
+            conditions: [{ field: 'name', operator: 'equal', value: 'John' }],
           });
         });
 
@@ -1534,10 +1534,10 @@ describe('ForestMCPServer Instance', () => {
           expect(response.status).toBe(200);
           const filters = JSON.parse(capturedQueryParams.filters as string);
           expect(filters).toEqual({
-            aggregator: 'And',
+            aggregator: 'and',
             conditions: [
-              { field: 'name', operator: 'Contains', value: 'John' },
-              { field: 'email', operator: 'EndsWith', value: '@example.com' },
+              { field: 'name', operator: 'contains', value: 'John' },
+              { field: 'email', operator: 'ends_with', value: '@example.com' },
             ],
           });
         });
@@ -1576,7 +1576,7 @@ describe('ForestMCPServer Instance', () => {
 
           expect(response.status).toBe(200);
           const filters = JSON.parse(capturedQueryParams.filters as string);
-          expect(filters.aggregator).toBe('Or');
+          expect(filters.aggregator).toBe('or');
           expect(filters.conditions).toHaveLength(2);
         });
 
@@ -1609,7 +1609,10 @@ describe('ForestMCPServer Instance', () => {
 
           expect(response.status).toBe(200);
           const filters = JSON.parse(capturedQueryParams.filters as string);
-          expect(filters).toEqual(filterObject);
+          expect(filters).toEqual({
+            aggregator: 'and',
+            conditions: [{ field: 'name', operator: 'equal', value: 'Jane' }],
+          });
         });
       });
 
@@ -1913,8 +1916,12 @@ describe('ForestMCPServer Instance', () => {
           const listParams = JSON.parse(listCalls[0]);
           const countParams = JSON.parse(countCalls[0]);
 
-          expect(JSON.parse(listParams.filters)).toEqual(filterCondition);
-          expect(JSON.parse(countParams.filters)).toEqual(filterCondition);
+          const expectedSnakeCase = {
+            aggregator: 'and',
+            conditions: [{ field: 'id', operator: 'greater_than', value: 5 }],
+          };
+          expect(JSON.parse(listParams.filters)).toEqual(expectedSnakeCase);
+          expect(JSON.parse(countParams.filters)).toEqual(expectedSnakeCase);
         });
       });
 
@@ -1957,8 +1964,8 @@ describe('ForestMCPServer Instance', () => {
 
           const filters = JSON.parse(capturedQueryParams.filters as string);
           expect(filters).toEqual({
-            aggregator: 'And',
-            conditions: [{ field: 'email', operator: 'Present' }],
+            aggregator: 'and',
+            conditions: [{ field: 'email', operator: 'present' }],
           });
         });
       });


### PR DESCRIPTION
## Summary
- The MCP server defines operators in PascalCase (`Equal`, `GreaterThan`, `NotContains`) and the agent-client serializes them as-is in query strings
- `forest_liana` (Ruby) expects snake_case (`equal`, `greater_than`, `not_contains`) and returns 422 "Unknown provided operator" for PascalCase
- Convert operators and aggregators to snake_case in `QuerySerializer.formatFilters()` before serializing
- The Node agent already has `ConditionTreeParser.toPascalCase()` to convert back, so this is fully compatible

## Test plan
- [x] All 283 agent-client tests pass (3 new tests)
- [ ] Verify filters work with Ruby backend without using search as workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert filter operators and aggregators to snake_case in `QuerySerializer` for Ruby compatibility
> - Adds `toSnakeCase` and `toSnakeCaseOperators` helpers in [`query-serializer.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1544/files#diff-c9087a46acb037e536ea20624c746a833e1111f77ec399817cfa5855403fdf2e) that recursively walk the condition tree and convert `operator`/`aggregator` values from PascalCase to snake_case (e.g. `GreaterThan` → `greater_than`).
> - `formatFilters` now passes filters through `toSnakeCaseOperators` before stringifying, so the Ruby agent receives correctly cased operators.
> - `serialize` no longer spreads `query.filters` properties into the top-level result object.
> - Behavioral Change: serialized filter output now always uses snake_case operators/aggregators; any callers relying on PascalCase in the serialized string will receive different output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ff4248.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->