### PR TITLE
docs(mcp-server): fix README with correct env vars, commands and endpoints

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -46,8 +46,6 @@ yarn start:dev       # Development (loads .env file automatically)
 |----------|----------|---------|-------------|
 | `FOREST_ENV_SECRET` | **Yes** | - | Your Forest Admin environment secret |
 | `FOREST_AUTH_SECRET` | **Yes** | - | Your Forest Admin authentication secret (must match your agent) |
-| `FOREST_SERVER_URL` | No | `https://api.forestadmin.com` | Forest Admin API URL |
-| `FOREST_APP_URL` | No | `https://app.forestadmin.com` | Forest Admin application URL |
 | `MCP_SERVER_PORT` | No | `3931` | Port for the HTTP server |
 
 #### Example Configuration
@@ -122,6 +120,15 @@ yarn test
 ```bash
 yarn clean
 ```
+
+### Internal Environment Variables
+
+These are only needed by Forest Admin developers (e.g. to point to a local or staging server):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FOREST_SERVER_URL` | `https://api.forestadmin.com` | Forest Admin API URL |
+| `FOREST_APP_URL` | `https://app.forestadmin.com` | Forest Admin application URL |
 
 ## Architecture
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -27,50 +27,67 @@ The MCP server will be automatically initialized and mounted on your application
 
 ### Standalone Server
 
-You can also run the MCP server standalone using the CLI:
+You can run the MCP server standalone using the CLI:
 
 ```bash
 npx forest-mcp-server
 ```
 
-Or programmatically:
+Or from the package directory:
 
 ```bash
-node dist/index.js
+yarn start           # Production
+yarn start:dev       # Development (loads .env file automatically)
 ```
 
 #### Environment Variables
-
-The following environment variables are required to run the server as a standalone:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `FOREST_ENV_SECRET` | **Yes** | - | Your Forest Admin environment secret |
 | `FOREST_AUTH_SECRET` | **Yes** | - | Your Forest Admin authentication secret (must match your agent) |
+| `FOREST_SERVER_URL` | No | `https://api.forestadmin.com` | Forest Admin API URL |
+| `FOREST_APP_URL` | No | `https://app.forestadmin.com` | Forest Admin application URL |
 | `MCP_SERVER_PORT` | No | `3931` | Port for the HTTP server |
 
 #### Example Configuration
 
-```bash
-export FOREST_ENV_SECRET="your-env-secret"
-export FOREST_AUTH_SECRET="your-auth-secret"
-export MCP_SERVER_PORT=3931
+Create a `.env` file in the package directory:
 
-npx forest-mcp-server
+```bash
+FOREST_ENV_SECRET="your-env-secret"
+FOREST_AUTH_SECRET="your-auth-secret"
 ```
 
-## API Endpoint
+Then run:
 
-Once running, the MCP server exposes a single endpoint:
+```bash
+yarn start:dev
+```
 
-- **POST** `/mcp` - Main MCP protocol endpoint
+Or set the variables inline:
 
-The server expects MCP protocol messages in the request body and returns MCP-formatted responses.
+```bash
+FOREST_ENV_SECRET="your-env-secret" FOREST_AUTH_SECRET="your-auth-secret" npx forest-mcp-server
+```
+
+## API Endpoints
+
+Once running, the MCP server exposes the following endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/mcp` | Main MCP protocol endpoint (requires Bearer token) |
+| POST | `/oauth/authorize` | OAuth 2.0 authorization |
+| POST | `/oauth/token` | OAuth 2.0 token exchange |
+| GET | `/.well-known/oauth-protected-resource/mcp` | OAuth metadata discovery |
+
+The `/mcp` endpoint expects MCP protocol messages (JSON-RPC 2.0) and requires a valid OAuth Bearer token with at least the `mcp:read` scope.
 
 ## Features
 
 - **HTTP Transport**: Uses streamable HTTP transport for MCP communication
-- **OAuth Authentication**: Built-in support for Forest Admin OAuth
+- **OAuth Authentication**: Built-in OAuth 2.0 with scopes (`mcp:read`, `mcp:write`, `mcp:action`, `mcp:admin`)
 - **CORS Enabled**: Allows cross-origin requests
 - **Express-based**: Built on top of Express.js for reliability and extensibility
 
@@ -79,31 +96,31 @@ The server expects MCP protocol messages in the request body and returns MCP-for
 ### Building
 
 ```bash
-npm run build
+yarn build
 ```
 
 ### Watch Mode
 
 ```bash
-npm run build:watch
+yarn build:watch
 ```
 
 ### Linting
 
 ```bash
-npm run lint
+yarn lint
 ```
 
 ### Testing
 
 ```bash
-npm test
+yarn test
 ```
 
 ### Cleaning
 
 ```bash
-npm run clean
+yarn clean
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Add missing environment variables (`FOREST_SERVER_URL`, `FOREST_APP_URL`) to the documentation
- Fix startup commands (`node dist/index.js` → `yarn start` / `yarn start:dev`)
- Replace `npm` with `yarn` in all dev commands
- Document all API endpoints (OAuth authorize/token, well-known metadata) instead of just `/mcp`
- Document OAuth scopes (`mcp:read`, `mcp:write`, `mcp:action`, `mcp:admin`)

## Test plan

- [ ] Verify env vars match `packages/mcp-server/src/cli.ts` and `server.ts`
- [ ] Verify commands work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mcp-server README with correct env vars, endpoints, and commands
> Updates [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1545/files#diff-46a7a23fdaae3bf8011f1ddca552c21b774309bc427c931469d104619efa28a8) to accurately reflect the current state of the MCP server.
>
> - Adds `FOREST_SERVER_URL` and `FOREST_APP_URL` environment variables and reformats the env vars section
> - Expands the API Endpoints section into a table covering `POST /mcp`, `POST /oauth/authorize`, `POST /oauth/token`, and `GET /.well-known/oauth-protected-resource/mcp`, noting that `/mcp` uses JSON-RPC 2.0 and requires a Bearer token with `mcp:read` scope
> - Replaces `npm` commands with `yarn` equivalents and swaps `node dist/index.js` for `yarn start` / `yarn start:dev`
> - Updates OAuth 2.0 feature description to list specific scopes: `mcp:read`, `mcp:write`, `mcp:action`, `mcp:admin`
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1545 opened
>
> - Reorganized environment variable documentation in the `mcp-server` package README [4ba6ac1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01bf32b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->