### PR TITLE
refactor(mcp-server): single source of truth for tool names

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,6 +1,6 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
-export type { ForestMCPServerOptions, HttpCallback } from './server';
+export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
 export { MCP_PATHS, isMcpRoute } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -73,8 +73,24 @@ function logErrorWithStack(logger: Logger, message: string, err: Error): void {
   }
 }
 
+/** Single source of truth for all tool names */
+const TOOL_NAMES = [
+  'describeCollection',
+  'list',
+  'listRelated',
+  'create',
+  'update',
+  'delete',
+  'associate',
+  'dissociate',
+  'getActionForm',
+  'executeAction',
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
 /** Fields that are safe to log for each tool (non-sensitive data) */
-const SAFE_ARGUMENTS_FOR_LOGGING: Record<string, string[]> = {
+const SAFE_ARGUMENTS_FOR_LOGGING: Record<ToolName, string[]> = {
   list: ['collectionName'],
   listRelated: ['collectionName', 'relationName', 'parentRecordId'],
   create: ['collectionName'],


### PR DESCRIPTION
## Summary

- Introduce `TOOL_NAMES` const array as the single source of truth for all MCP tool names
- Derive `ToolName` type from it (`typeof TOOL_NAMES[number]`) instead of a manually maintained union
- Type `SAFE_ARGUMENTS_FOR_LOGGING` as `Record<ToolName, string[]>` so the compiler enforces that every tool has a logging config entry
- Export `ToolName` type from the package index

Adding a new tool now requires adding it to `TOOL_NAMES` only — the type and the logging config will produce compile errors if not updated.

## Test plan

- [x] All 522 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ToolName` type and `TOOL_NAMES` constant as single source of truth in mcp-server
> Introduces a `TOOL_NAMES` const array and a `ToolName` union type alias in [server.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1546/files#diff-c54d7a276ef5be4d65ba37d55b279e77958ba4496af9d9ca7ec80c23c847d155), replacing ad-hoc string literals. The `SAFE_ARGUMENTS_FOR_LOGGING` record is narrowed from `Record<string, string[]>` to `Record<ToolName, string[]>`. `ToolName` is re-exported from [index.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1546/files#diff-0d61616d41c6fc88c7fba1074e28835c7a5a759f4d2189f92fe8eb4bc507abf7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d72cc5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->