### PR TITLE
fix(mcp server): do not pass the whole query in requests

### DIFF
--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -7,8 +7,16 @@ export default class QuerySerializer {
   static serialize(query: SelectOptions, collectionName: string): Record<string, unknown> {
     if (!query) return {};
 
-    const { fields, sort, filters, shouldSearchInRelation, pagination, search } = query;
-    const extra = query as Record<string, unknown>;
+    const {
+      fields,
+      sort,
+      filters,
+      shouldSearchInRelation,
+      pagination,
+      search,
+      segmentQuery,
+      connectionName,
+    } = query;
 
     return {
       search,
@@ -18,9 +26,8 @@ export default class QuerySerializer {
       'page[size]': pagination?.size,
       'page[number]': pagination?.number,
       ...(fields?.length ? QuerySerializer.formatFields(collectionName, fields) : {}),
-      // Extra params passed by Segment (segmentQuery, connectionName)
-      ...(extra.segmentQuery !== undefined && { segmentQuery: extra.segmentQuery }),
-      ...(extra.connectionName !== undefined && { connectionName: extra.connectionName }),
+      ...(segmentQuery !== undefined && { segmentQuery }),
+      ...(connectionName !== undefined && { connectionName }),
     };
   }
 

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -20,14 +20,14 @@ export default class QuerySerializer {
 
     return {
       search,
+      segmentQuery,
+      connectionName,
       sort: QuerySerializer.formatSort(sort),
       filters: QuerySerializer.formatFilters(filters),
       searchExtended: !!shouldSearchInRelation,
       'page[size]': pagination?.size,
       'page[number]': pagination?.number,
       ...(fields?.length ? QuerySerializer.formatFields(collectionName, fields) : {}),
-      ...(segmentQuery !== undefined && { segmentQuery }),
-      ...(connectionName !== undefined && { connectionName }),
     };
   }
 

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -7,16 +7,20 @@ export default class QuerySerializer {
   static serialize(query: SelectOptions, collectionName: string): Record<string, unknown> {
     if (!query) return {};
 
-    const { fields, sort, filters, shouldSearchInRelation, pagination, ...rest } = query;
+    const { fields, sort, filters, shouldSearchInRelation, pagination, search } = query;
+    const extra = query as Record<string, unknown>;
 
     return {
-      ...rest,
+      search,
       sort: QuerySerializer.formatSort(sort),
       filters: QuerySerializer.formatFilters(filters),
       searchExtended: !!shouldSearchInRelation,
       'page[size]': pagination?.size,
       'page[number]': pagination?.number,
       ...(fields?.length ? QuerySerializer.formatFields(collectionName, fields) : {}),
+      // Extra params passed by Segment (segmentQuery, connectionName)
+      ...(extra.segmentQuery !== undefined && { segmentQuery: extra.segmentQuery }),
+      ...(extra.connectionName !== undefined && { connectionName: extra.connectionName }),
     };
   }
 

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -8,10 +8,10 @@ export default class QuerySerializer {
     if (!query) return {};
 
     return {
-      ...query,
       sort: QuerySerializer.formatSort(query.sort),
       filters: QuerySerializer.formatFilters(query.filters),
       searchExtended: !!query.shouldSearchInRelation,
+      search: query.search,
       'page[size]': query.pagination?.size,
       'page[number]': query.pagination?.number,
       ...(query.fields?.length ? QuerySerializer.formatFields(collectionName, query.fields) : {}),

--- a/packages/agent-client/src/query-serializer.ts
+++ b/packages/agent-client/src/query-serializer.ts
@@ -7,14 +7,16 @@ export default class QuerySerializer {
   static serialize(query: SelectOptions, collectionName: string): Record<string, unknown> {
     if (!query) return {};
 
+    const { fields, sort, filters, shouldSearchInRelation, pagination, ...rest } = query;
+
     return {
-      sort: QuerySerializer.formatSort(query.sort),
-      filters: QuerySerializer.formatFilters(query.filters),
-      searchExtended: !!query.shouldSearchInRelation,
-      search: query.search,
-      'page[size]': query.pagination?.size,
-      'page[number]': query.pagination?.number,
-      ...(query.fields?.length ? QuerySerializer.formatFields(collectionName, query.fields) : {}),
+      ...rest,
+      sort: QuerySerializer.formatSort(sort),
+      filters: QuerySerializer.formatFilters(filters),
+      searchExtended: !!shouldSearchInRelation,
+      'page[size]': pagination?.size,
+      'page[number]': pagination?.number,
+      ...(fields?.length ? QuerySerializer.formatFields(collectionName, fields) : {}),
     };
   }
 

--- a/packages/agent-client/src/types.ts
+++ b/packages/agent-client/src/types.ts
@@ -27,4 +27,6 @@ export type SelectOptions = BaseOptions & {
     size?: number; // number of items per page
     number?: number; // current page number
   };
+  segmentQuery?: string; // SQL query for live query segments
+  connectionName?: string; // Connection name for live query segments
 };


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `QuerySerializer.serialize` to exclude arbitrary query properties from requests
> Previously, `serialize` spread all input query properties into the output, which caused unintended fields to be forwarded in requests. The method now emits only an explicit set of known keys (`search`, `sort`, `filters`, `searchExtended`, `page[size]`, `page[number]`, `fields`). Risk: any callers relying on arbitrary query properties being forwarded will no longer receive them.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1548 opened
>
> - Modified `QuerySerializer.serialize` method to forward all additional query properties [7e67658]
> - Modified `QuerySerializer.serialize` method in the `agent-client` package to explicitly control forwarded query properties [76396e4]
> - Modified `QuerySerializer.serialize` method to explicitly destructure `segmentQuery` and `connectionName` from query object and added corresponding optional fields to `SelectOptions` type [1787757]
> - Modified `QuerySerializer.serialize` method to always include `segmentQuery` and `connectionName` as top-level properties in the serialized output [a91b14d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bef5acf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->