### PR TITLE
fix(datasource-mongo): fix flaky create integration test

### DIFF
--- a/packages/datasource-mongo/test/create.integration.test.ts
+++ b/packages/datasource-mongo/test/create.integration.test.ts
@@ -10,11 +10,12 @@ describe('create', () => {
       'mongodb://forest:secret@127.0.0.1:27017/movies?authSource=admin',
     );
 
-    connection.dropDatabase();
+    await connection.dropDatabase();
 
     try {
       const movieSchema = new Schema({ title: String });
       const Movie = connection.model('Movies', movieSchema);
+      await Movie.createCollection();
       await new Movie({ title: 'Inception' }).save();
     } finally {
       await connection.close(true);

--- a/packages/datasource-mongo/test/index.ssh.integration.test.ts
+++ b/packages/datasource-mongo/test/index.ssh.integration.test.ts
@@ -12,11 +12,12 @@ describe('Datasource Mongo', () => {
         'mongodb://forest:secret@127.0.0.1:27017/movies-ssh?authSource=admin',
       );
 
-      connection.dropDatabase();
+      await connection.dropDatabase();
 
       try {
         const movieSchema = new Schema({ title: String });
         const Movie = connection.model('Movies', movieSchema);
+        await Movie.createCollection();
         await new Movie({ title: 'Inception' }).save();
       } finally {
         await connection.close(true);


### PR DESCRIPTION
## Summary

- Await `connection.dropDatabase()` (was fire-and-forget, causing race condition)
- Add explicit `await Movie.createCollection()` before saving data

The test was flaky because MongoDB introspection could run before the collection existed, resulting in `"Collection 'movies' not found"` with an empty collection list.

Matches the pattern already used in `index.integration.test.ts`.

## Test plan

- [x] Fix matches working pattern from `index.integration.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `beforeEach` setup in MongoDB create integration tests
> Awaits the `dropDatabase` call and adds an awaited `createCollection` call before seeding the `Inception` document in the `beforeEach` hooks of [create.integration.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1550/files#diff-347a364d6e7c81bcba010058999ffb72e54d54faae90a74eff1b2bfee3e02294) and [index.ssh.integration.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1550/files#diff-f99e57359308d8620edd81e54619482acd7d43bf8763013708f8b22013342bd8). This ensures the database is fully dropped and the `Movies` collection exists before each test runs, eliminating a race condition that caused intermittent failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13a37b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->