### PR TITLE
feat(mcp-server): expose polymorphic relations in describeCollection

### DIFF
--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -163,6 +163,6 @@ export default class FieldFormStates {
 
     this.clearFieldsAndLayout();
     this.addFields(queryResults.fields);
-    this.layout.push(...queryResults.layout);
+    this.layout.push(...(queryResults.layout ?? []));
   }
 }

--- a/packages/agent-client/src/action-fields/types.ts
+++ b/packages/agent-client/src/action-fields/types.ts
@@ -2,7 +2,7 @@ import type { ForestServerActionFormLayoutElement } from '@forestadmin/forestadm
 
 export type ResponseBody = {
   fields: PlainField[];
-  layout: ForestServerActionFormLayoutElement[];
+  layout?: ForestServerActionFormLayoutElement[];
 };
 
 export type PlainFieldOption = {

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -178,7 +178,7 @@ export interface ForestSchemaField {
   defaultValue?: unknown;
   isPrimaryKey: boolean;
   relationship?: 'HasMany' | 'BelongsToMany' | 'BelongsTo' | 'HasOne' | null;
-  'polymorphic-referenced-models'?: string[];
+  polymorphicReferencedModels?: string[];
 }
 
 /**

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -178,6 +178,7 @@ export interface ForestSchemaField {
   defaultValue?: unknown;
   isPrimaryKey: boolean;
   relationship?: 'HasMany' | 'BelongsToMany' | 'BelongsTo' | 'HasOne' | null;
+  'polymorphic-referenced-models'?: string[];
 }
 
 /**

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -32,7 +32,7 @@ import declareGetActionFormTool from './tools/get-action-form';
 import declareListTool from './tools/list';
 import declareListRelatedTool from './tools/list-related';
 import declareUpdateTool from './tools/update';
-import { fetchForestSchema, getCollectionNames } from './utils/schema-fetcher';
+import { fetchForestSchema, getActionEndpoints, getCollectionNames } from './utils/schema-fetcher';
 import interceptResponseForErrorLogging from './utils/sse-error-logger';
 import { NAME, VERSION } from './version';
 
@@ -162,17 +162,7 @@ export default class ForestMCPServer {
     try {
       const schema = await fetchForestSchema(this.forestServerClient);
       this.collectionNames = getCollectionNames(schema);
-
-      for (const collection of schema.collections) {
-        for (const action of collection.actions || []) {
-          if (!action.endpoint) {
-            this.logger(
-              'Warn',
-              `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
-            );
-          }
-        }
-      }
+      getActionEndpoints(schema, this.logger);
     } catch (error) {
       this.logger(
         'Warn',

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -32,7 +32,7 @@ import declareGetActionFormTool from './tools/get-action-form';
 import declareListTool from './tools/list';
 import declareListRelatedTool from './tools/list-related';
 import declareUpdateTool from './tools/update';
-import { fetchForestSchema, getActionEndpoints, getCollectionNames } from './utils/schema-fetcher';
+import { fetchForestSchema, getCollectionNames } from './utils/schema-fetcher';
 import interceptResponseForErrorLogging from './utils/sse-error-logger';
 import { NAME, VERSION } from './version';
 
@@ -162,7 +162,17 @@ export default class ForestMCPServer {
     try {
       const schema = await fetchForestSchema(this.forestServerClient);
       this.collectionNames = getCollectionNames(schema);
-      getActionEndpoints(schema, this.logger);
+
+      for (const collection of schema.collections) {
+        for (const action of collection.actions || []) {
+          if (!action.endpoint) {
+            this.logger(
+              'Warn',
+              `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
+            );
+          }
+        }
+      }
     } catch (error) {
       this.logger(
         'Warn',

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -163,22 +163,8 @@ export default class ForestMCPServer {
       const schema = await fetchForestSchema(this.forestServerClient);
       this.collectionNames = getCollectionNames(schema);
 
-      this.logger(
-        'Debug',
-        `Schema loaded: ${schema.collections.length} collections [${this.collectionNames.join(', ')}]`,
-      );
-
       for (const collection of schema.collections) {
-        const actions = collection.actions || [];
-
-        if (actions.length > 0) {
-          this.logger(
-            'Debug',
-            `Collection "${collection.name}" actions: ${actions.map(a => `${a.name} → ${a.endpoint || '(no endpoint)'}`).join(', ')}`,
-          );
-        }
-
-        for (const action of actions) {
+        for (const action of collection.actions || []) {
           if (!action.endpoint) {
             this.logger(
               'Warn',

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -162,6 +162,31 @@ export default class ForestMCPServer {
     try {
       const schema = await fetchForestSchema(this.forestServerClient);
       this.collectionNames = getCollectionNames(schema);
+
+      this.logger(
+        'Debug',
+        `Schema loaded: ${schema.collections.length} collections [${this.collectionNames.join(', ')}]`,
+      );
+
+      for (const collection of schema.collections) {
+        const actions = collection.actions || [];
+
+        if (actions.length > 0) {
+          this.logger(
+            'Debug',
+            `Collection "${collection.name}" actions: ${actions.map(a => `${a.name} → ${a.endpoint || '(no endpoint)'}`).join(', ')}`,
+          );
+        }
+
+        for (const action of actions) {
+          if (!action.endpoint) {
+            this.logger(
+              'Warn',
+              `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
+            );
+          }
+        }
+      }
     } catch (error) {
       this.logger(
         'Warn',

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -162,17 +162,6 @@ export default class ForestMCPServer {
     try {
       const schema = await fetchForestSchema(this.forestServerClient);
       this.collectionNames = getCollectionNames(schema);
-
-      for (const collection of schema.collections) {
-        for (const action of collection.actions || []) {
-          if (!action.endpoint) {
-            this.logger(
-              'Warn',
-              `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
-            );
-          }
-        }
-      }
     } catch (error) {
       this.logger(
         'Warn',

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -155,11 +155,8 @@ Check \`_meta\` for data availability context.`,
           const relations = schemaFields
             .filter(f => f.relationship)
             .map(f => {
-              const fieldData = f as unknown as Record<string, unknown>;
               // forest-rails sends polymorphic-referenced-models (kebab-case in JSON:API)
-              const polymorphicTargets = fieldData['polymorphic-referenced-models'] as
-                | string[]
-                | undefined;
+              const polymorphicTargets = f['polymorphic-referenced-models'];
               const isPolymorphic =
                 Array.isArray(polymorphicTargets) && polymorphicTargets.length > 0;
 
@@ -173,7 +170,7 @@ Check \`_meta\` for data availability context.`,
 
           // Extract actions from schema
           const schemaActions = getActionsOfCollection(schema, options.collectionName);
-          const actions = schemaActions.map(action => ({
+          const actions = schemaActions.filter(action => action.endpoint).map(action => ({
             name: action.name,
             type: action.type, // 'single', 'bulk', or 'global'
             description: action.description || null,

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -178,6 +178,10 @@ Check \`_meta\` for data availability context.`,
             download: action.download,
           }));
 
+          const skippedActions = schemaActions
+            .filter(action => !action.endpoint)
+            .map(action => ({ name: action.name, reason: 'no endpoint configured' }));
+
           const result = {
             collection: options.collectionName,
             fields,
@@ -190,6 +194,7 @@ Check \`_meta\` for data availability context.`,
                 : {
                     note: 'Operators unavailable (older agent version). Fields have operators: null.',
                   }),
+              ...(skippedActions.length > 0 && { skippedActions }),
             },
           };
 

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -155,8 +155,7 @@ Check \`_meta\` for data availability context.`,
           const relations = schemaFields
             .filter(f => f.relationship)
             .map(f => {
-              // forest-rails sends polymorphic-referenced-models (kebab-case in JSON:API)
-              const polymorphicTargets = f['polymorphic-referenced-models'];
+              const polymorphicTargets = f.polymorphicReferencedModels;
               const isPolymorphic =
                 Array.isArray(polymorphicTargets) && polymorphicTargets.length > 0;
 

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -170,13 +170,15 @@ Check \`_meta\` for data availability context.`,
 
           // Extract actions from schema
           const schemaActions = getActionsOfCollection(schema, options.collectionName);
-          const actions = schemaActions.filter(action => action.endpoint).map(action => ({
-            name: action.name,
-            type: action.type, // 'single', 'bulk', or 'global'
-            description: action.description || null,
-            hasForm: action.fields.length > 0 || action.hooks.load,
-            download: action.download,
-          }));
+          const actions = schemaActions
+            .filter(action => action.endpoint)
+            .map(action => ({
+              name: action.name,
+              type: action.type, // 'single', 'bulk', or 'global'
+              description: action.description || null,
+              hasForm: action.fields.length > 0 || action.hooks.load,
+              download: action.download,
+            }));
 
           const skippedActions = schemaActions
             .filter(action => !action.endpoint)

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -98,6 +98,8 @@ Actions properties:
 - hasForm: true if action requires form input (use getActionForm to see fields)
 - download: true if action returns a file download (not executable via AI)
 
+Polymorphic relations (isPolymorphic=true) point to multiple collections. When creating/updating, you must set both the _id and _type fields (e.g. commentable_id and commentable_type).
+
 Check \`_meta\` for data availability context.`,
       inputSchema: argumentShape,
     },
@@ -152,11 +154,22 @@ Check \`_meta\` for data availability context.`,
           // Extract relations from schema
           const relations = schemaFields
             .filter(f => f.relationship)
-            .map(f => ({
-              name: f.field,
-              type: mapRelationType(f.relationship),
-              targetCollection: f.reference?.split('.')[0] || null,
-            }));
+            .map(f => {
+              const fieldData = f as unknown as Record<string, unknown>;
+              // forest-rails sends polymorphic-referenced-models (kebab-case in JSON:API)
+              const polymorphicTargets = fieldData['polymorphic-referenced-models'] as
+                | string[]
+                | undefined;
+              const isPolymorphic =
+                Array.isArray(polymorphicTargets) && polymorphicTargets.length > 0;
+
+              return {
+                name: f.field,
+                type: mapRelationType(f.relationship),
+                targetCollection: isPolymorphic ? null : f.reference?.split('.')[0] || null,
+                ...(isPolymorphic && { isPolymorphic: true, polymorphicTargets }),
+              };
+            });
 
           // Extract actions from schema
           const schemaActions = getActionsOfCollection(schema, options.collectionName);

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -28,7 +28,7 @@ const listArgumentSchema = z.object({
   search: z.string().optional(),
   filters: filtersWithPreprocess
     .describe(
-      'Filters to apply on collection. To filter on a relation field, use ":" as separator in the field name, e.g. { "field": "relationName:fieldName", "operator": "Equal", "value": "..." }. One level deep max.',
+      'Filters to apply on collection. To filter on a relation field, use ":" as separator in the field name, e.g. { "field": "relationName:fieldName", "operator": "Equal", "value": "..." }. One level deep max. For polymorphic relations, do NOT filter via relation:field (returns 500). Instead use two steps: 1) list the target collection to get IDs, 2) filter on the _type and _id fields directly, e.g. { "field": "commentable_type", "operator": "Equal", "value": "Post" }.',
     )
     .optional(),
   sort: z

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -28,12 +28,16 @@ const listArgumentSchema = z.object({
   search: z.string().optional(),
   filters: filtersWithPreprocess
     .describe(
-      'Filters to apply on collection. To filter on a nested field, use "@@@" to separate relations, e.g. "relationName@@@fieldName". One level deep max.',
+      'Filters to apply on collection. To filter on a relation field, use ":" as separator in the field name, e.g. { "field": "relationName:fieldName", "operator": "Equal", "value": "..." }. One level deep max.',
     )
     .optional(),
   sort: z
     .object({
-      field: z.string(),
+      field: z
+        .string()
+        .describe(
+          'Field to sort by. For relation fields, use ":" as separator, e.g. "relationName:fieldName".',
+        ),
       ascending: z.boolean().optional().default(true),
     })
     .optional(),

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -28,7 +28,7 @@ const listArgumentSchema = z.object({
   search: z.string().optional(),
   filters: filtersWithPreprocess
     .describe(
-      'Filters to apply on collection. To filter on a relation field, use ":" as separator in the field name, e.g. { "field": "relationName:fieldName", "operator": "Equal", "value": "..." }. One level deep max. For polymorphic relations, do NOT filter via relation:field (returns 500). Instead use two steps: 1) list the target collection to get IDs, 2) filter on the _type and _id fields directly, e.g. { "field": "commentable_type", "operator": "Equal", "value": "Post" }.',
+      'Filters to apply on collection. To filter on a relation field, use ":" as separator in the field name, e.g. { "field": "relationName:fieldName", "operator": "Equal", "value": "..." }. One level deep max. For polymorphic relations, filtering via relation:field is not supported and will fail. Instead use two steps: 1) list the target collection to get IDs, 2) filter on the _type and _id fields directly, e.g. { "field": "commentable_type", "operator": "Equal", "value": "Post" }.',
     )
     .optional(),
   sort: z

--- a/packages/mcp-server/src/utils/schema-fetcher.ts
+++ b/packages/mcp-server/src/utils/schema-fetcher.ts
@@ -128,6 +128,8 @@ export function getActionEndpoints(schema: ForestSchema): ActionEndpoints {
       actionEndpoints[collection.name] = {};
 
       for (const action of collection.actions) {
+        if (!action.endpoint) continue;
+
         actionEndpoints[collection.name][action.name] = {
           id: action.id,
           name: action.name,

--- a/packages/mcp-server/src/utils/schema-fetcher.ts
+++ b/packages/mcp-server/src/utils/schema-fetcher.ts
@@ -120,7 +120,10 @@ export function getActionsOfCollection(
  * @param schema - The Forest Admin schema
  * @returns A mapping of collection names to action names to their endpoints
  */
-export function getActionEndpoints(schema: ForestSchema): ActionEndpoints {
+export function getActionEndpoints(
+  schema: ForestSchema,
+  logger?: (level: string, message: string) => void,
+): ActionEndpoints {
   const actionEndpoints: ActionEndpoints = {};
 
   for (const collection of schema.collections) {
@@ -128,7 +131,14 @@ export function getActionEndpoints(schema: ForestSchema): ActionEndpoints {
       actionEndpoints[collection.name] = {};
 
       for (const action of collection.actions) {
-        if (!action.endpoint) continue;
+        if (!action.endpoint) {
+          logger?.(
+            'Warn',
+            `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
+          );
+
+          continue;
+        }
 
         actionEndpoints[collection.name][action.name] = {
           id: action.id,

--- a/packages/mcp-server/src/utils/schema-fetcher.ts
+++ b/packages/mcp-server/src/utils/schema-fetcher.ts
@@ -128,15 +128,15 @@ export function getActionEndpoints(schema: ForestSchema): ActionEndpoints {
       actionEndpoints[collection.name] = {};
 
       for (const action of collection.actions) {
-        if (!action.endpoint) continue;
-
-        actionEndpoints[collection.name][action.name] = {
-          id: action.id,
-          name: action.name,
-          endpoint: action.endpoint,
-          hooks: action.hooks,
-          fields: action.fields,
-        };
+        if (action.endpoint) {
+          actionEndpoints[collection.name][action.name] = {
+            id: action.id,
+            name: action.name,
+            endpoint: action.endpoint,
+            hooks: action.hooks,
+            fields: action.fields,
+          };
+        }
       }
     }
   }

--- a/packages/mcp-server/src/utils/schema-fetcher.ts
+++ b/packages/mcp-server/src/utils/schema-fetcher.ts
@@ -120,10 +120,7 @@ export function getActionsOfCollection(
  * @param schema - The Forest Admin schema
  * @returns A mapping of collection names to action names to their endpoints
  */
-export function getActionEndpoints(
-  schema: ForestSchema,
-  logger?: (level: string, message: string) => void,
-): ActionEndpoints {
+export function getActionEndpoints(schema: ForestSchema): ActionEndpoints {
   const actionEndpoints: ActionEndpoints = {};
 
   for (const collection of schema.collections) {
@@ -131,14 +128,7 @@ export function getActionEndpoints(
       actionEndpoints[collection.name] = {};
 
       for (const action of collection.actions) {
-        if (!action.endpoint) {
-          logger?.(
-            'Warn',
-            `Action "${action.name}" on collection "${collection.name}" has no endpoint and will be ignored by the MCP server.`,
-          );
-
-          continue;
-        }
+        if (!action.endpoint) continue;
 
         actionEndpoints[collection.name][action.name] = {
           id: action.id,

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -620,7 +620,7 @@ describe('declareDescribeCollectionTool', () => {
             enum: null,
             reference: 'commentable.id',
             relationship: 'BelongsTo',
-            'polymorphic-referenced-models': ['Post', 'Video'],
+            polymorphicReferencedModels: ['Post', 'Video'],
           },
         ] as unknown as schemaFetcher.ForestField[];
         mockFetchForestSchema.mockResolvedValue({
@@ -684,7 +684,7 @@ describe('declareDescribeCollectionTool', () => {
             enum: null,
             reference: 'commentable.id',
             relationship: 'BelongsTo',
-            'polymorphic-referenced-models': [],
+            polymorphicReferencedModels: [],
           },
         ] as unknown as schemaFetcher.ForestField[];
         mockFetchForestSchema.mockResolvedValue({

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -607,6 +607,101 @@ describe('declareDescribeCollectionTool', () => {
           targetCollection: null,
         });
       });
+
+      it('should detect polymorphic BelongsTo relations from forest-rails schema', async () => {
+        const mockFields = [
+          {
+            field: 'commentable',
+            type: 'Number',
+            isSortable: false,
+            isPrimaryKey: false,
+            isReadOnly: false,
+            isRequired: false,
+            enum: null,
+            reference: 'commentable.id',
+            relationship: 'BelongsTo',
+            'polymorphic-referenced-models': ['Post', 'Video'],
+          },
+        ] as unknown as schemaFetcher.ForestField[];
+        mockFetchForestSchema.mockResolvedValue({
+          collections: [{ name: 'comments', fields: mockFields }],
+        });
+        mockGetFieldsOfCollection.mockReturnValue(mockFields);
+
+        const result = (await registeredToolHandler({ collectionName: 'comments' }, mockExtra)) as {
+          content: { type: string; text: string }[];
+        };
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.relations).toContainEqual({
+          name: 'commentable',
+          type: 'many-to-one',
+          targetCollection: null,
+          isPolymorphic: true,
+          polymorphicTargets: ['Post', 'Video'],
+        });
+      });
+
+      it('should not add polymorphic fields to non-polymorphic relations', async () => {
+        const mockFields: schemaFetcher.ForestField[] = [
+          {
+            field: 'user',
+            type: 'Number',
+            isSortable: false,
+            isPrimaryKey: false,
+            isReadOnly: false,
+            isRequired: false,
+            enum: null,
+            reference: 'users.id',
+            relationship: 'BelongsTo',
+          },
+        ];
+        mockFetchForestSchema.mockResolvedValue({
+          collections: [{ name: 'comments', fields: mockFields }],
+        });
+        mockGetFieldsOfCollection.mockReturnValue(mockFields);
+
+        const result = (await registeredToolHandler({ collectionName: 'comments' }, mockExtra)) as {
+          content: { type: string; text: string }[];
+        };
+
+        const parsed = JSON.parse(result.content[0].text);
+        const relation = parsed.relations[0];
+        expect(relation.targetCollection).toBe('users');
+        expect(relation.isPolymorphic).toBeUndefined();
+        expect(relation.polymorphicTargets).toBeUndefined();
+      });
+
+      it('should treat empty polymorphic-referenced-models as non-polymorphic', async () => {
+        const mockFields = [
+          {
+            field: 'commentable',
+            type: 'Number',
+            isSortable: false,
+            isPrimaryKey: false,
+            isReadOnly: false,
+            isRequired: false,
+            enum: null,
+            reference: 'commentable.id',
+            relationship: 'BelongsTo',
+            'polymorphic-referenced-models': [],
+          },
+        ] as unknown as schemaFetcher.ForestField[];
+        mockFetchForestSchema.mockResolvedValue({
+          collections: [{ name: 'comments', fields: mockFields }],
+        });
+        mockGetFieldsOfCollection.mockReturnValue(mockFields);
+
+        const result = (await registeredToolHandler({ collectionName: 'comments' }, mockExtra)) as {
+          content: { type: string; text: string }[];
+        };
+
+        const parsed = JSON.parse(result.content[0].text);
+        const relation = parsed.relations[0];
+        expect(relation.targetCollection).toBe('commentable');
+        expect(relation.isPolymorphic).toBeUndefined();
+        expect(relation.polymorphicTargets).toBeUndefined();
+      });
     });
 
     describe('actions extraction', () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -862,6 +862,46 @@ describe('declareDescribeCollectionTool', () => {
         const parsed = JSON.parse(result.content[0].text);
         expect(parsed.actions).toEqual([]);
       });
+
+      it('should exclude actions without endpoint', async () => {
+        mockGetActionsOfCollection.mockReturnValue([
+          {
+            id: 'action-with-endpoint',
+            name: 'Valid Action',
+            type: 'single',
+            endpoint: '/forest/actions/valid',
+            fields: [],
+            hooks: { load: false, change: [] },
+            download: false,
+          },
+          {
+            id: 'action-without-endpoint',
+            name: 'Invalid Action',
+            type: 'single',
+            endpoint: '',
+            fields: [],
+            hooks: { load: false, change: [] },
+            download: false,
+          },
+          {
+            id: 'action-null-endpoint',
+            name: 'Null Endpoint Action',
+            type: 'global',
+            endpoint: null,
+            fields: [],
+            hooks: { load: false, change: [] },
+            download: false,
+          },
+        ]);
+
+        const result = (await registeredToolHandler({ collectionName: 'users' }, mockExtra)) as {
+          content: { type: string; text: string }[];
+        };
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.actions).toHaveLength(1);
+        expect(parsed.actions[0].name).toBe('Valid Action');
+      });
     });
 
     describe('response format', () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -863,7 +863,7 @@ describe('declareDescribeCollectionTool', () => {
         expect(parsed.actions).toEqual([]);
       });
 
-      it('should exclude actions without endpoint', async () => {
+      it('should exclude actions without endpoint and expose them in _meta.skippedActions', async () => {
         mockGetActionsOfCollection.mockReturnValue([
           {
             id: 'action-with-endpoint',
@@ -901,6 +901,10 @@ describe('declareDescribeCollectionTool', () => {
         const parsed = JSON.parse(result.content[0].text);
         expect(parsed.actions).toHaveLength(1);
         expect(parsed.actions[0].name).toBe('Valid Action');
+        expect(parsed._meta.skippedActions).toEqual([
+          { name: 'Invalid Action', reason: 'no endpoint configured' },
+          { name: 'Null Endpoint Action', reason: 'no endpoint configured' },
+        ]);
       });
     });
 

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -898,10 +898,10 @@ describe('declareDescribeCollectionTool', () => {
           content: { type: string; text: string }[];
         };
 
-        const parsed = JSON.parse(result.content[0].text);
-        expect(parsed.actions).toHaveLength(1);
-        expect(parsed.actions[0].name).toBe('Valid Action');
-        expect(parsed._meta.skippedActions).toEqual([
+        const { actions, _meta: meta } = JSON.parse(result.content[0].text);
+        expect(actions).toHaveLength(1);
+        expect(actions[0].name).toBe('Valid Action');
+        expect(meta.skippedActions).toEqual([
           { name: 'Invalid Action', reason: 'no endpoint configured' },
           { name: 'Null Endpoint Action', reason: 'no endpoint configured' },
         ]);

--- a/packages/mcp-server/test/utils/schema-fetcher.test.ts
+++ b/packages/mcp-server/test/utils/schema-fetcher.test.ts
@@ -282,5 +282,42 @@ describe('schema-fetcher', () => {
 
       expect(result).toEqual({});
     });
+
+    it('should skip actions without endpoint', () => {
+      const schema: ForestSchema = {
+        collections: [
+          {
+            name: 'users',
+            fields: [],
+            actions: [
+              createAction('Send Email', '/forest/_actions/users/0/send-email'),
+              {
+                id: 'action-no-endpoint',
+                name: 'No Endpoint Action',
+                type: 'single' as const,
+                endpoint: '',
+                download: false,
+                fields: [],
+                hooks: { load: false, change: [] },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = getActionEndpoints(schema);
+
+      expect(result).toEqual({
+        users: {
+          'Send Email': {
+            id: 'action-send-email',
+            name: 'Send Email',
+            endpoint: '/forest/_actions/users/0/send-email',
+            hooks: { load: false, change: [] },
+            fields: [],
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Detect `polymorphic-referenced-models` from forest-rails schema in `describeCollection`
- Expose `isPolymorphic: true` and `polymorphicTargets: ['Post', 'Video']` in the relation output
- Set `targetCollection: null` for polymorphic relations (since the reference name isn't a real collection)
- Add LLM guidance in the tool description about polymorphic _id and _type fields

## Why

When a Ruby agent has polymorphic relations (e.g. `commentable` on `comments`), the MCP server didn't expose this info. LLMs couldn't know they need to pass both `commentable_id` AND `commentable_type` for create/update, or that `listRelated` won't work on polymorphic BelongsTo relations.

## Example output

```json
{
  "relations": [
    {
      "name": "commentable",
      "type": "many-to-one",
      "targetCollection": null,
      "isPolymorphic": true,
      "polymorphicTargets": ["Post", "Video"]
    }
  ]
}
```

## Test plan

- [x] Polymorphic BelongsTo relation detected and exposed with targets
- [x] Non-polymorphic relations unchanged (no extra fields)
- [x] Build passes, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose polymorphic relations in `describeCollection` MCP tool output
> - Relation entries in `describeCollection` now include `isPolymorphic: true` and `polymorphicTargets` when `polymorphicReferencedModels` is present on a field; `targetCollection` is set to `null` for these relations.
> - Actions without a configured endpoint are excluded from the `actions` array and surfaced in `_meta.skippedActions` with reason `'no endpoint configured'`; `getActionEndpoints` also skips endpoint-less actions.
> - Fixes a runtime error in `FieldFormStates` when a change-hook response omits `layout`, by treating missing layout as an empty array.
> - Documentation strings in the `list` tool are updated to explain the `:` separator for relation fields and limitations for polymorphic relations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5d7cf7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->