### PR TITLE
fix(datasource-customizer): bump file-type to patch ASF parser DoS

### DIFF
--- a/packages/datasource-customizer/package.json
+++ b/packages/datasource-customizer/package.json
@@ -21,7 +21,7 @@
     "build:watch": "tsc --watch",
     "clean": "rm -rf coverage dist",
     "lint": "eslint src test",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
     "@types/luxon": "^3.2.0",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@forestadmin/datasource-toolkit": "1.53.1",
     "antlr4": "^4.13.1-patch-1",
-    "file-type": "^16.5.4",
+    "file-type": "^21.3.1",
     "luxon": "^3.2.1",
     "object-hash": "^3.0.0",
     "uuid": "11.0.2"

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -15,9 +15,15 @@ import type {
   Projection,
   RecordData,
 } from '@forestadmin/datasource-toolkit';
+import type * as FileTypeModule from 'file-type';
 
 import { CollectionDecorator, SchemaUtils } from '@forestadmin/datasource-toolkit';
-import FileType from 'file-type';
+
+// `file-type` is ESM-only; `new Function` prevents TS from rewriting import() into require().
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const importFileType = new Function('return import("file-type")') as () => Promise<
+  typeof FileTypeModule
+>;
 
 /**
  * As the transport layer between the forest admin agent and the frontend is JSON-API, binary data
@@ -249,7 +255,9 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     const buffer = value as Buffer;
     if (useHex) return buffer.toString('hex');
 
-    const mime = (await FileType.fromBuffer(buffer))?.mime ?? 'application/octet-stream';
+    const { fileTypeFromBuffer } = await importFileType();
+    const bytes = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    const mime = (await fileTypeFromBuffer(bytes))?.mime ?? 'application/octet-stream';
     const data = buffer.toString('base64');
 
     return `data:${mime};base64,${data}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,6 +1371,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@borewit/text-codec@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.2.tgz#75025f735c0983b3a871668804a57387e3649375"
+  integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
+
 "@cfworker/json-schema@^4.0.2":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@cfworker/json-schema/-/json-schema-4.1.1.tgz#4a2a3947ee9fa7b7c24be981422831b8674c3be6"
@@ -4205,6 +4210,14 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@tokenizer/inflate@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.4.1.tgz#fa6cdb8366151b3cc8426bf9755c1ea03a2fba08"
+  integrity sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==
+  dependencies:
+    debug "^4.4.3"
+    token-types "^6.1.1"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -8523,14 +8536,15 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-type@^16.5.4:
-  version "16.5.4"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
-  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
+file-type@^21.3.1:
+  version "21.3.4"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-21.3.4.tgz#e3f902faee8ec4aa152909fc902a7a77f9c06725"
+  integrity sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==
   dependencies:
-    readable-web-to-node-stream "^3.0.0"
-    strtok3 "^6.2.4"
-    token-types "^4.1.1"
+    "@tokenizer/inflate" "^0.4.1"
+    strtok3 "^10.3.4"
+    token-types "^6.1.1"
+    uint8array-extras "^1.4.0"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -14172,11 +14186,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-peek-readable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
-  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
-
 pg-cloudflare@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
@@ -14922,13 +14931,6 @@ readable-stream@^4.2.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readable-web-to-node-stream@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
-  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
-  dependencies:
-    readable-stream "^3.6.0"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -16314,13 +16316,12 @@ strnum@^2.2.0:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
   integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
 
-strtok3@^6.2.4:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
-  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+strtok3@^10.3.4:
+  version "10.3.5"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-10.3.5.tgz#7213285da0dc3dec0fc8ce5df4b8b7a733f14360"
+  integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
-    peek-readable "^4.1.0"
 
 subscriptions-transport-ws@^0.9.19:
   version "0.9.19"
@@ -16657,11 +16658,12 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-token-types@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.1.tgz#0f897f03665846982806e138977dbe72d44df753"
-  integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
+token-types@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.2.tgz#18d0fd59b996d421f9f83914d6101c201bd08129"
+  integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
   dependencies:
+    "@borewit/text-codec" "^0.2.1"
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
@@ -17105,6 +17107,11 @@ uid@2.0.2:
   integrity sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==
   dependencies:
     "@lukeed/csprng" "^1.0.0"
+
+uint8array-extras@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
+  integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

Closes #1552. Bumps `file-type` from `^16.5.4` to `^21.3.1` in `@forestadmin/datasource-customizer`, resolving [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473) (moderate-severity DoS — a 55-byte malformed ASF payload causes an infinite loop in the parser, halting the Node event loop).

## Changes

- `package.json`: `file-type` `^16.5.4` → `^21.3.1` (resolves to `21.3.4`).
- `src/decorators/binary/collection.ts`:
  - `file-type` is ESM-only from v17, so the CJS build uses a `new Function` escape hatch to emit a genuine runtime `import()` that TypeScript does not rewrite to `require()`.
  - Renamed call from `FileType.fromBuffer` to `fileTypeFromBuffer` (new API).
  - Wrapped the incoming `Buffer` as a zero-copy `Uint8Array` view to satisfy the stricter typing in v21.
- `package.json` test script now runs Jest with `NODE_OPTIONS=--experimental-vm-modules` (same pattern `@forestadmin/agent` already uses for its dynamic `import()`).

## Breaking change for consumers

`file-type@21` declares `engines: { node: ">=20" }`, so this bumps the implicit Node floor for `@forestadmin/datasource-customizer` to Node ≥ 20. Worth calling out in release notes.

## Why `new Function` instead of migrating the package to ESM

A full ESM migration would be intrusive and touch every consumer. The `new Function('return import("file-type")')` pattern is a contained ~10-line change that keeps the CJS build intact and is the standard workaround for this exact scenario.

## Test plan

- [x] `yarn workspace @forestadmin/datasource-customizer test --testPathPattern=binary` — 19/19 binary decorator tests pass, including the MIME detection path (`records should be transformed` verifies `image/gif` from a real GIF buffer).
- [x] `yarn workspace @forestadmin/datasource-customizer lint` — no new errors.
- [x] Prettier — clean.
- [ ] CI green on the full monorepo.

## Security

- [x] Fixes an advertised CVE in a direct runtime dependency.
- [x] No new attack surface introduced; same buffer is still passed to the type sniffer, just through the patched parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)