### PR TITLE
ci: add manual workflow to unpublish @forestadmin/agent v2+

### DIFF
--- a/.github/workflows/unpublish-agent-v2.yml
+++ b/.github/workflows/unpublish-agent-v2.yml
@@ -1,0 +1,116 @@
+name: Unpublish @forestadmin/agent v2+
+
+# WARNING: unpublishing is destructive and largely irreversible.
+# - npm only allows `unpublish` within 72 hours of a version's publish time.
+#   Older versions must use `npm deprecate` instead.
+# - Once unpublished, a version number cannot be reused for 24 hours.
+# - Downstream users pinning `^2.0.0` will fail to install.
+#
+# This workflow is manual-only and defaults to dry-run. Review the dry-run
+# output before running with dry-run disabled.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'unpublish @forestadmin/agent v2' to confirm"
+        required: true
+        type: string
+      dry-run:
+        description: "Dry run: list matching versions without unpublishing"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  unpublish:
+    name: Unpublish @forestadmin/agent v2+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate confirmation string
+        run: |
+          expected="unpublish @forestadmin/agent v2"
+          if [ "${{ inputs.confirm }}" != "$expected" ]; then
+            echo "::error::Confirmation did not match. Expected: '$expected'"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      - name: List matching versions (major >= 2)
+        id: list
+        run: |
+          set -euo pipefail
+          versions=$(npm view @forestadmin/agent versions --json \
+            | jq -r '.[] | select((split(".")[0] | tonumber) >= 2)')
+
+          if [ -z "$versions" ]; then
+            echo "No versions of @forestadmin/agent with major >= 2 found."
+            {
+              echo "versions<<EOF"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "Matching versions:"
+            echo "$versions"
+            {
+              echo "versions<<EOF"
+              echo "$versions"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write summary
+        run: |
+          {
+            echo "## @forestadmin/agent v2+ — versions matched"
+            echo ""
+            echo "Dry-run: \`${{ inputs.dry-run }}\`"
+            echo ""
+            if [ -z "${{ steps.list.outputs.versions }}" ]; then
+              echo "_No matching versions._"
+            else
+              echo '```'
+              echo "${{ steps.list.outputs.versions }}"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Unpublish versions
+        if: ${{ inputs.dry-run == false && steps.list.outputs.versions != '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN secret is not set. Configure an npm token with unpublish rights on @forestadmin."
+            exit 1
+          fi
+
+          {
+            echo ""
+            echo "## Unpublish results"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          while IFS= read -r version; do
+            [ -z "$version" ] && continue
+            echo "::group::Unpublishing @forestadmin/agent@$version"
+            if npm unpublish "@forestadmin/agent@$version"; then
+              echo "- [x] \`@forestadmin/agent@$version\`" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "- [ ] \`@forestadmin/agent@$version\` (failed)" >> "$GITHUB_STEP_SUMMARY"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done <<< "${{ steps.list.outputs.versions }}"
+
+          exit $failed


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/unpublish-agent-v2.yml`, a **manual-only** (`workflow_dispatch`) workflow that unpublishes every `@forestadmin/agent` version with major version `>= 2`.
- Defaults to **dry-run**: the first execution only lists matching versions and writes them to the job summary. A confirmation phrase (`unpublish @forestadmin/agent v2`) is required on every run, and a second run with `dry-run = false` is needed to actually unpublish.
- Motivation: remove the v2 releases from npm. At the time of authoring, `2.0.0` and `2.0.1` exist and are both within npm's 72-hour unpublish window.

## Things to verify before running

- [ ] `NPM_TOKEN` secret is configured and has **unpublish** rights on the `@forestadmin` scope (publish-only tokens won't work).
- [ ] npm 2FA policy on the `@forestadmin` org does not block automation-token unpublishes.
- [ ] All v2 versions are still within the 72-hour window at run time — otherwise `npm deprecate` is the fallback.

## Test plan

- [ ] Trigger the workflow with `dry-run = true` and confirm the summary lists `2.0.0` and `2.0.1` (plus any newer v2 published since merge).
- [ ] Trigger with `dry-run = false` and confirm both versions are unpublished and `latest` dist-tag moves to `1.77.1`.
- [ ] Confirm the workflow fails fast if the confirmation string is wrong or `NPM_TOKEN` is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual workflow to unpublish `@forestadmin/agent` v2+
> Adds a [`workflow_dispatch`-triggered GitHub Actions workflow](https://github.com/ForestAdmin/agent-nodejs/pull/1556/files#diff-9c49e5cac58b3352fc2d440ba982b54e91cfe71e85848228b2eb28f1b95e9620) to list or unpublish all `@forestadmin/agent` versions with major >= 2.
>
> - Requires a confirmation string (`unpublish @forestadmin/agent v2`) to prevent accidental runs.
> - Defaults to dry-run mode, which lists matched versions without unpublishing.
> - When dry-run is disabled, unpublishes each matched version using `NODE_AUTH_TOKEN` (from `NPM_TOKEN`) and fails the job if any unpublish step errors.
> - Risk: disabling dry-run with a valid `NPM_TOKEN` will permanently remove matching versions from the npm registry.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e4f4ff7. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->