### PR TITLE
fix(mcp-server): add resource_metadata to WWW-Authenticate header

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -547,6 +547,10 @@ export default class ForestMCPServer {
       requireBearerAuth({
         verifier: oauthProvider,
         requiredScopes: ['mcp:read'],
+        resourceMetadataUrl: new URL(
+          '/.well-known/oauth-protected-resource/mcp',
+          effectiveBaseUrl,
+        ).href,
       }),
       (req, res) => {
         this.handleMcpRequest(req, res).catch(error => {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -547,10 +547,8 @@ export default class ForestMCPServer {
       requireBearerAuth({
         verifier: oauthProvider,
         requiredScopes: ['mcp:read'],
-        resourceMetadataUrl: new URL(
-          '/.well-known/oauth-protected-resource/mcp',
-          effectiveBaseUrl,
-        ).href,
+        resourceMetadataUrl: new URL('/.well-known/oauth-protected-resource/mcp', effectiveBaseUrl)
+          .href,
       }),
       (req, res) => {
         this.handleMcpRequest(req, res).catch(error => {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -991,6 +991,20 @@ describe('ForestMCPServer Instance', () => {
       expect(response.status).toBe(401);
     });
 
+    it('should include resource_metadata in WWW-Authenticate header on 401', async () => {
+      const response = await request(listHttpServer).post('/mcp').send({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        id: 1,
+      });
+
+      expect(response.status).toBe(401);
+      const wwwAuth = response.headers['www-authenticate'];
+      expect(wwwAuth).toBeDefined();
+      expect(wwwAuth).toContain('resource_metadata=');
+      expect(wwwAuth).toContain('/.well-known/oauth-protected-resource/mcp');
+    });
+
     it('should reject requests with invalid bearer token', async () => {
       const response = await request(listHttpServer)
         .post('/mcp')


### PR DESCRIPTION
## Summary

- Add `resource_metadata` parameter to the `WWW-Authenticate` header in 401 responses on `POST /mcp`
- Required by RFC 9728 and MCP 2025-06-18 spec for OAuth discovery flow
- The SDK already supported `resourceMetadataUrl` option — it was just not being passed

**Context:** Client reported that MCP clients cannot complete the OAuth discovery flow because the 401 response is missing the `resource_metadata` parameter that tells them where to find `/.well-known/oauth-protected-resource/mcp`.

## Test plan

- [x] All 534 MCP server tests pass
- [ ] Verify 401 response includes `WWW-Authenticate: Bearer ... resource_metadata="..."` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `resource_metadata` URL to `WWW-Authenticate` header on POST `/mcp` 401 responses
> Passes a `resourceMetadataUrl` option to the `requireBearerAuth` middleware in [server.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1558/files#diff-c54d7a276ef5be4d65ba37d55b279e77958ba4496af9d9ca7ec80c23c847d155), pointing to `/.well-known/oauth-protected-resource/mcp`. This causes unauthenticated requests to `/mcp` to receive a `WWW-Authenticate` header that includes `resource_metadata=`, allowing clients to discover resource-specific OAuth metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1efbbf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->