### PR TITLE
fix(mcp-server): retrieve collection id to send the right activity log

### DIFF
--- a/packages/agent-testing/CHANGELOG.md
+++ b/packages/agent-testing/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/agent-testing [1.1.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.7...@forestadmin/agent-testing@1.1.8) (2026-04-14)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent:** upgraded to 2.0.0
+
 ## @forestadmin/agent-testing [1.1.7](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.6...@forestadmin/agent-testing@1.1.7) (2026-04-14)
 
 

--- a/packages/agent-testing/CHANGELOG.md
+++ b/packages/agent-testing/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/agent-testing [1.1.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.8...@forestadmin/agent-testing@1.1.9) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+* **@forestadmin/agent:** upgraded to 2.0.1
+
 ## @forestadmin/agent-testing [1.1.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.7...@forestadmin/agent-testing@1.1.8) (2026-04-14)
 
 

--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-testing",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Testing utilities for Forest Admin agent",
   "author": "Vincent Molinié <vincent.m@forestadmin.com>",
   "homepage": "https://github.com/ForestAdmin/agent-nodejs#readme",
@@ -35,7 +35,7 @@
     "superagent": "^10.3.0"
   },
   "peerDependencies": {
-    "@forestadmin/agent": "1.77.1"
+    "@forestadmin/agent": "2.0.0"
   },
   "peerDependenciesMeta": {
     "@forestadmin/agent": {
@@ -43,7 +43,7 @@
     }
   },
   "devDependencies": {
-    "@forestadmin/agent": "1.77.1",
+    "@forestadmin/agent": "2.0.0",
     "@forestadmin/datasource-sql": "1.17.10",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/superagent": "^8.1.9",

--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-testing",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Testing utilities for Forest Admin agent",
   "author": "Vincent Molinié <vincent.m@forestadmin.com>",
   "homepage": "https://github.com/ForestAdmin/agent-nodejs#readme",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@forestadmin/agent-client": "1.4.23",
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "@forestadmin/forestadmin-client": "1.38.4",
     "jsonapi-serializer": "^3.6.9",
@@ -35,7 +35,7 @@
     "superagent": "^10.3.0"
   },
   "peerDependencies": {
-    "@forestadmin/agent": "2.0.0"
+    "@forestadmin/agent": "2.0.1"
   },
   "peerDependenciesMeta": {
     "@forestadmin/agent": {
@@ -43,7 +43,7 @@
     }
   },
   "devDependencies": {
-    "@forestadmin/agent": "2.0.0",
+    "@forestadmin/agent": "2.0.1",
     "@forestadmin/datasource-sql": "1.17.10",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/superagent": "^8.1.9",

--- a/packages/agent-testing/src/forest-admin-client-mock.ts
+++ b/packages/agent-testing/src/forest-admin-client-mock.ts
@@ -59,6 +59,7 @@ export default class ForestAdminClientMock implements ForestAdminClient {
   readonly activityLogsService: ForestAdminClient['activityLogsService'] = {
     createActivityLog: () => Promise.resolve({ id: '1', attributes: { index: '1' } }),
     updateActivityLogStatus: () => Promise.resolve(),
+    getCollectionId: () => Promise.resolve(null),
   };
 
   readonly permissionService: any;

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/agent [2.0.1](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@2.0.0...@forestadmin/agent@2.0.1) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 # @forestadmin/agent [2.0.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.77.1...@forestadmin/agent@2.0.0) (2026-04-14)
 
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,3 +1,63 @@
+# @forestadmin/agent [2.0.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.77.1...@forestadmin/agent@2.0.0) (2026-04-14)
+
+
+### Features
+
+* **mcp-server:** add enabledTools allowlist option ([#1547](https://github.com/ForestAdmin/agent-nodejs/issues/1547)) ([fc5127a](https://github.com/ForestAdmin/agent-nodejs/commit/fc5127a8903f758c9eb2c1493ea90a878695db45))
+
+
+### BREAKING CHANGES
+
+* **mcp-server:** `disabledTools` option has been removed. Use
+`enabledTools` instead. This is an allowlist: only listed tools are
+exposed. New tools in future releases will NOT be auto-enabled.
+
+- Remove disabledTools from ForestMCPServerOptions
+- Remove FOREST_MCP_DISABLED_TOOLS env var
+- Rename parse-disabled-tools.ts to parse-tool-list.ts
+- Simplify resolveEnabledTools (no more blocklist path)
+- Update agent mountAiMcpServer to only accept enabledTools
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* test(mcp-server): fix enabledTools tests and add empty array edge case
+
+- Fix port conflicts using getAvailablePort()
+- Replace no-op logging test with empty enabledTools edge case test
+- Verify enabledTools: [] only exposes describeCollection
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* feat(mcp-server): add warning and discovery logs for enabledTools
+
+- Warn when describeCollection is missing from enabledTools (auto-added)
+- Log available tools not enabled for discoverability on new releases
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* fix(mcp-server): validate enabledTools names and fix test port conflicts
+
+- Warn about unknown tool names in enabledTools (typo protection)
+- Fix test port conflicts by using buildExpressApp + listen instead of run()
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* chore(example): revert mountAiMcpServer to default (no options)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* docs(mcp-server): clarify read-only is an example of enabledTools usage
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/mcp-server:** upgraded to 2.0.0
+
 ## @forestadmin/agent [1.77.1](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.77.0...@forestadmin/agent@1.77.1) (2026-04-14)
 
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent",
-  "version": "1.77.1",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -17,7 +17,7 @@
     "@forestadmin/datasource-customizer": "1.69.2",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "@forestadmin/forestadmin-client": "1.38.4",
-    "@forestadmin/mcp-server": "1.9.1",
+    "@forestadmin/mcp-server": "2.0.0",
     "@koa/bodyparser": "^6.0.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^13.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fast-csv/format": "^4.3.5",
     "@forestadmin/agent-toolkit": "1.2.0",
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "@forestadmin/forestadmin-client": "1.38.4",
     "@forestadmin/mcp-server": "2.0.0",

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -48,7 +48,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
   /** Whether MCP server should be mounted */
   private mcpEnabled = false;
-  private mcpDisabledTools?: ToolName[];
+  private mcpEnabledTools?: ToolName[];
 
   /**
    * Create a new Agent Builder.
@@ -208,12 +208,12 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/ai/mcp-server}
    * @example
    * agent.mountAiMcpServer();
-   * // Or with options:
-   * agent.mountAiMcpServer({ disabledTools: ['create', 'update', 'delete'] });
+   * // Example: read-only mode (only browse data, no create/update/delete/actions)
+   * agent.mountAiMcpServer({ enabledTools: ['describeCollection', 'list', 'listRelated'] });
    */
-  mountAiMcpServer(options?: { disabledTools?: ToolName[] }): this {
+  mountAiMcpServer(options?: { enabledTools?: ToolName[] }): this {
     this.mcpEnabled = true;
-    this.mcpDisabledTools = options?.disabledTools;
+    this.mcpEnabledTools = options?.enabledTools;
 
     return this;
   }
@@ -331,7 +331,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         authSecret: this.options.authSecret,
         logger: mcpLogger,
         forestServerClient,
-        disabledTools: this.mcpDisabledTools,
+        enabledTools: this.mcpEnabledTools,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/test/__factories__/forest-admin-client.ts
+++ b/packages/agent/test/__factories__/forest-admin-client.ts
@@ -52,6 +52,7 @@ const forestAdminClientFactory = ForestAdminClientFactory.define(() => ({
   activityLogsService: {
     createActivityLog: jest.fn(),
     updateActivityLogStatus: jest.fn(),
+    getCollectionId: jest.fn().mockResolvedValue(null),
   },
   subscribeToServerEvents: jest.fn(),
   close: jest.fn(),

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -392,15 +392,17 @@ describe('Agent', () => {
       expect(mockLogger).toHaveBeenCalledWith('Info', '[MCP] Server initialized successfully');
     });
 
-    test('should pass disabledTools to ForestMCPServer', async () => {
+    test('should pass enabledTools to ForestMCPServer', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();
       const agent = new Agent(options);
 
-      agent.mountAiMcpServer({ disabledTools: ['create', 'update', 'delete'] });
+      agent.mountAiMcpServer({ enabledTools: ['describeCollection', 'list', 'listRelated'] });
       await agent.start();
 
       expect(mcpServerSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ disabledTools: ['create', 'update', 'delete'] }),
+        expect.objectContaining({
+          enabledTools: ['describeCollection', 'list', 'listRelated'],
+        }),
       );
     });
 

--- a/packages/datasource-customizer/CHANGELOG.md
+++ b/packages/datasource-customizer/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @forestadmin/datasource-customizer [1.69.3](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-customizer@1.69.2...@forestadmin/datasource-customizer@1.69.3) (2026-04-15)
+
+
+### Bug Fixes
+
+* **vulnerability:** use magic-bytes instead of FileType ([#1554](https://github.com/ForestAdmin/agent-nodejs/issues/1554)) ([4f9c004](https://github.com/ForestAdmin/agent-nodejs/commit/4f9c004e1aa39120c13cb2db7d9bc7a96bde87dd))
+
 ## @forestadmin/datasource-customizer [1.69.2](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-customizer@1.69.1...@forestadmin/datasource-customizer@1.69.2) (2026-03-31)
 
 

--- a/packages/datasource-customizer/package.json
+++ b/packages/datasource-customizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/datasource-customizer",
-  "version": "1.69.2",
+  "version": "1.69.3",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {

--- a/packages/datasource-customizer/package.json
+++ b/packages/datasource-customizer/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@forestadmin/datasource-toolkit": "1.53.1",
     "antlr4": "^4.13.1-patch-1",
-    "file-type": "^16.5.4",
+    "magic-bytes.js": "^1.13.0",
     "luxon": "^3.2.1",
     "object-hash": "^3.0.0",
     "uuid": "11.0.2"

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -17,7 +17,7 @@ import type {
 } from '@forestadmin/datasource-toolkit';
 
 import { CollectionDecorator, SchemaUtils } from '@forestadmin/datasource-toolkit';
-import FileType from 'file-type';
+import { filetypemime } from 'magic-bytes.js';
 
 /**
  * As the transport layer between the forest admin agent and the frontend is JSON-API, binary data
@@ -249,7 +249,7 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     const buffer = value as Buffer;
     if (useHex) return buffer.toString('hex');
 
-    const mime = (await FileType.fromBuffer(buffer))?.mime ?? 'application/octet-stream';
+    const mime = filetypemime([...buffer])?.[0] ?? 'application/octet-stream';
     const data = buffer.toString('base64');
 
     return `data:${mime};base64,${data}`;

--- a/packages/datasource-dummy/CHANGELOG.md
+++ b/packages/datasource-dummy/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/datasource-dummy [1.1.69](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-dummy@1.1.68...@forestadmin/datasource-dummy@1.1.69) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/datasource-dummy [1.1.68](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-dummy@1.1.67...@forestadmin/datasource-dummy@1.1.68) (2026-03-31)
 
 

--- a/packages/datasource-dummy/package.json
+++ b/packages/datasource-dummy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/datasource-dummy",
-  "version": "1.1.68",
+  "version": "1.1.69",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -12,7 +12,7 @@
     "directory": "packages/datasource-dummy"
   },
   "dependencies": {
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1"
   },
   "files": [

--- a/packages/datasource-mongo/CHANGELOG.md
+++ b/packages/datasource-mongo/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @forestadmin/datasource-mongo [1.6.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-mongo@1.6.8...@forestadmin/datasource-mongo@1.6.9) (2026-04-14)
+
+
+### Bug Fixes
+
+* **datasource-mongo:** fix flaky create integration test ([#1550](https://github.com/ForestAdmin/agent-nodejs/issues/1550)) ([ef90e90](https://github.com/ForestAdmin/agent-nodejs/commit/ef90e90cecefbd85dfd4f2a3e923bff543116788))
+
 ## @forestadmin/datasource-mongo [1.6.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-mongo@1.6.7...@forestadmin/datasource-mongo@1.6.8) (2026-03-31)
 
 

--- a/packages/datasource-mongo/package.json
+++ b/packages/datasource-mongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/datasource-mongo",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {

--- a/packages/datasource-mongo/test/create.integration.test.ts
+++ b/packages/datasource-mongo/test/create.integration.test.ts
@@ -10,11 +10,12 @@ describe('create', () => {
       'mongodb://forest:secret@127.0.0.1:27017/movies?authSource=admin',
     );
 
-    connection.dropDatabase();
+    await connection.dropDatabase();
 
     try {
       const movieSchema = new Schema({ title: String });
       const Movie = connection.model('Movies', movieSchema);
+      await Movie.createCollection();
       await new Movie({ title: 'Inception' }).save();
     } finally {
       await connection.close(true);

--- a/packages/datasource-mongo/test/index.ssh.integration.test.ts
+++ b/packages/datasource-mongo/test/index.ssh.integration.test.ts
@@ -12,11 +12,12 @@ describe('Datasource Mongo', () => {
         'mongodb://forest:secret@127.0.0.1:27017/movies-ssh?authSource=admin',
       );
 
-      connection.dropDatabase();
+      await connection.dropDatabase();
 
       try {
         const movieSchema = new Schema({ title: String });
         const Movie = connection.model('Movies', movieSchema);
+        await Movie.createCollection();
         await new Movie({ title: 'Inception' }).save();
       } finally {
         await connection.close(true);

--- a/packages/datasource-replica/CHANGELOG.md
+++ b/packages/datasource-replica/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/datasource-replica [1.8.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-replica@1.8.7...@forestadmin/datasource-replica@1.8.8) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/datasource-replica [1.8.7](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/datasource-replica@1.8.6...@forestadmin/datasource-replica@1.8.7) (2026-03-31)
 
 

--- a/packages/datasource-replica/package.json
+++ b/packages/datasource-replica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/datasource-replica",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -23,7 +23,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-sequelize": "1.13.8",
     "@forestadmin/datasource-sql": "1.17.10",
     "@forestadmin/datasource-toolkit": "1.53.1",

--- a/packages/forest-cloud/CHANGELOG.md
+++ b/packages/forest-cloud/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/forest-cloud [1.12.109](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.108...@forestadmin/forest-cloud@1.12.109) (2026-04-14)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent:** upgraded to 2.0.0
+* **@forestadmin/datasource-mongo:** upgraded to 1.6.9
+
 ## @forestadmin/forest-cloud [1.12.108](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.107...@forestadmin/forest-cloud@1.12.108) (2026-04-14)
 
 

--- a/packages/forest-cloud/CHANGELOG.md
+++ b/packages/forest-cloud/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/forest-cloud [1.12.110](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.109...@forestadmin/forest-cloud@1.12.110) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent:** upgraded to 2.0.1
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/forest-cloud [1.12.109](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.108...@forestadmin/forest-cloud@1.12.109) (2026-04-14)
 
 

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@forestadmin/forest-cloud",
-  "version": "1.12.108",
+  "version": "1.12.109",
   "description": "Utility to bootstrap and publish forest admin cloud projects customization",
   "dependencies": {
-    "@forestadmin/agent": "1.77.1",
+    "@forestadmin/agent": "2.0.0",
     "@forestadmin/datasource-customizer": "1.69.2",
-    "@forestadmin/datasource-mongo": "1.6.8",
+    "@forestadmin/datasource-mongo": "1.6.9",
     "@forestadmin/datasource-mongoose": "1.13.4",
     "@forestadmin/datasource-sequelize": "1.13.8",
     "@forestadmin/datasource-sql": "1.17.10",

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@forestadmin/forest-cloud",
-  "version": "1.12.109",
+  "version": "1.12.110",
   "description": "Utility to bootstrap and publish forest admin cloud projects customization",
   "dependencies": {
-    "@forestadmin/agent": "2.0.0",
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/agent": "2.0.1",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-mongo": "1.6.9",
     "@forestadmin/datasource-mongoose": "1.13.4",
     "@forestadmin/datasource-sequelize": "1.13.8",

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -8,6 +8,7 @@ import type {
 
 export type ActivityLogsOptions = {
   forestServerUrl: string;
+  envSecret?: string;
   headers?: Record<string, string>;
 };
 
@@ -83,16 +84,15 @@ export default class ActivityLogsService {
   }
 
   async getCollectionId(
-    bearerToken: string,
     renderingId: string,
     collectionName: string,
   ): Promise<string | null> {
-    if (!this.forestAdminServerInterface.getCollectionId) {
+    if (!this.forestAdminServerInterface.getCollectionId || !this.options.envSecret) {
       return null;
     }
 
     return this.forestAdminServerInterface.getCollectionId(
-      this.getHttpOptions(bearerToken),
+      { forestServerUrl: this.options.forestServerUrl, envSecret: this.options.envSecret },
       renderingId,
       collectionName,
     );

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -86,6 +86,10 @@ export default class ActivityLogsService {
   }
 
   async getCollectionId(renderingId: string, collectionName: string): Promise<string | null> {
+    if (!this.forestAdminServerInterface.getCollectionId) {
+      return null;
+    }
+
     return this.forestAdminServerInterface.getCollectionId(
       toHttpOptions(this.options),
       renderingId,

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -6,9 +6,11 @@ import type {
   UpdateActivityLogStatusParams,
 } from '../types';
 
+import { toHttpOptions } from '../utils/http-options';
+
 export type ActivityLogsOptions = {
   forestServerUrl: string;
-  envSecret?: string;
+  envSecret: string;
   headers?: Record<string, string>;
 };
 
@@ -87,12 +89,12 @@ export default class ActivityLogsService {
     renderingId: string,
     collectionName: string,
   ): Promise<string | null> {
-    if (!this.forestAdminServerInterface.getCollectionId || !this.options.envSecret) {
+    if (!this.forestAdminServerInterface.getCollectionId) {
       return null;
     }
 
     return this.forestAdminServerInterface.getCollectionId(
-      { forestServerUrl: this.options.forestServerUrl, envSecret: this.options.envSecret },
+      toHttpOptions(this.options),
       renderingId,
       collectionName,
     );

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -89,10 +89,6 @@ export default class ActivityLogsService {
     renderingId: string,
     collectionName: string,
   ): Promise<string | null> {
-    if (!this.forestAdminServerInterface.getCollectionId) {
-      return null;
-    }
-
     return this.forestAdminServerInterface.getCollectionId(
       toHttpOptions(this.options),
       renderingId,

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -6,6 +6,7 @@ import type {
   UpdateActivityLogStatusParams,
 } from '../types';
 
+import { NotFoundError } from '../auth/errors';
 import ServerUtils from '../utils/server';
 
 export type ActivityLogsOptions = {
@@ -120,9 +121,13 @@ export default class ActivityLogsService {
       }
 
       return collectionId;
-    } catch {
-      // Fallback: if endpoint doesn't exist (server not updated), use collectionName as before
-      return null;
+    } catch (error) {
+      // Fallback to collectionName if endpoint doesn't exist (server not yet updated)
+      if (error instanceof NotFoundError) {
+        return null;
+      }
+
+      throw error;
     }
   }
 

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -82,6 +82,22 @@ export default class ActivityLogsService {
     );
   }
 
+  async getCollectionId(
+    bearerToken: string,
+    renderingId: string,
+    collectionName: string,
+  ): Promise<string | null> {
+    if (!this.forestAdminServerInterface.getCollectionId) {
+      return null;
+    }
+
+    return this.forestAdminServerInterface.getCollectionId(
+      this.getHttpOptions(bearerToken),
+      renderingId,
+      collectionName,
+    );
+  }
+
   private getHttpOptions(bearerToken: string): ActivityLogHttpOptions {
     return {
       forestServerUrl: this.options.forestServerUrl,

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -59,12 +59,13 @@ export default class ActivityLogsService {
             },
           },
           collection: {
-            data: (collectionId || collectionName)
-              ? {
-                  id: collectionId || collectionName,
-                  type: 'collections',
-                }
-              : null,
+            data:
+              collectionId || collectionName
+                ? {
+                    id: collectionId || collectionName,
+                    type: 'collections',
+                  }
+                : null,
           },
         },
       },

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -6,18 +6,12 @@ import type {
   UpdateActivityLogStatusParams,
 } from '../types';
 
-import { NotFoundError } from '../auth/errors';
-import ServerUtils from '../utils/server';
-
 export type ActivityLogsOptions = {
   forestServerUrl: string;
   headers?: Record<string, string>;
 };
 
 export default class ActivityLogsService {
-  // Cache: renderingId → (collectionName → collectionId)
-  private collectionIdCache = new Map<string, Map<string, string>>();
-
   constructor(
     private forestAdminServerInterface: ForestAdminServerInterface,
     private options: ActivityLogsOptions,
@@ -34,10 +28,6 @@ export default class ActivityLogsService {
       recordIds,
       label,
     } = params;
-
-    const collectionId = collectionName
-      ? await this.resolveCollectionId(renderingId, collectionName, forestServerToken)
-      : null;
 
     const body = {
       data: {
@@ -59,13 +49,12 @@ export default class ActivityLogsService {
             },
           },
           collection: {
-            data:
-              collectionId || collectionName
-                ? {
-                    id: collectionId || collectionName,
-                    type: 'collections',
-                  }
-                : null,
+            data: collectionName
+              ? {
+                  id: collectionName,
+                  type: 'collections',
+                }
+              : null,
           },
         },
       },
@@ -91,45 +80,6 @@ export default class ActivityLogsService {
       activityLog.id,
       body,
     );
-  }
-
-  private async resolveCollectionId(
-    renderingId: string,
-    collectionName: string,
-    bearerToken: string,
-  ): Promise<string | null> {
-    const renderingCache = this.collectionIdCache.get(renderingId);
-
-    if (renderingCache?.has(collectionName)) {
-      return renderingCache.get(collectionName)!;
-    }
-
-    try {
-      const { collectionId } = await ServerUtils.queryWithBearerToken<{ collectionId: string }>({
-        forestServerUrl: this.options.forestServerUrl,
-        method: 'get',
-        path: `/api/renderings/${renderingId}/collections/${encodeURIComponent(collectionName)}/id`,
-        bearerToken,
-        headers: this.options.headers,
-      });
-
-      if (collectionId) {
-        if (!this.collectionIdCache.has(renderingId)) {
-          this.collectionIdCache.set(renderingId, new Map());
-        }
-
-        this.collectionIdCache.get(renderingId)!.set(collectionName, collectionId);
-      }
-
-      return collectionId;
-    } catch (error) {
-      // Fallback to collectionName if endpoint doesn't exist (server not yet updated)
-      if (error instanceof NotFoundError) {
-        return null;
-      }
-
-      throw error;
-    }
   }
 
   private getHttpOptions(bearerToken: string): ActivityLogHttpOptions {

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -85,10 +85,7 @@ export default class ActivityLogsService {
     );
   }
 
-  async getCollectionId(
-    renderingId: string,
-    collectionName: string,
-  ): Promise<string | null> {
+  async getCollectionId(renderingId: string, collectionName: string): Promise<string | null> {
     return this.forestAdminServerInterface.getCollectionId(
       toHttpOptions(this.options),
       renderingId,

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -6,14 +6,17 @@ import type {
   UpdateActivityLogStatusParams,
 } from '../types';
 
+import ServerUtils from '../utils/server';
+
 export type ActivityLogsOptions = {
   forestServerUrl: string;
   headers?: Record<string, string>;
-  /** When true, uses the /by-collection-name endpoint that resolves collection names to IDs server-side */
-  resolveCollectionName?: boolean;
 };
 
 export default class ActivityLogsService {
+  // Cache: renderingId → (collectionName → collectionId)
+  private collectionIdCache = new Map<string, Map<string, string>>();
+
   constructor(
     private forestAdminServerInterface: ForestAdminServerInterface,
     private options: ActivityLogsOptions,
@@ -30,6 +33,10 @@ export default class ActivityLogsService {
       recordIds,
       label,
     } = params;
+
+    const collectionId = collectionName
+      ? await this.resolveCollectionId(renderingId, collectionName, forestServerToken)
+      : null;
 
     const body = {
       data: {
@@ -51,9 +58,9 @@ export default class ActivityLogsService {
             },
           },
           collection: {
-            data: collectionName
+            data: (collectionId || collectionName)
               ? {
-                  id: collectionName,
+                  id: collectionId || collectionName,
                   type: 'collections',
                 }
               : null,
@@ -84,14 +91,46 @@ export default class ActivityLogsService {
     );
   }
 
+  private async resolveCollectionId(
+    renderingId: string,
+    collectionName: string,
+    bearerToken: string,
+  ): Promise<string | null> {
+    const renderingCache = this.collectionIdCache.get(renderingId);
+
+    if (renderingCache?.has(collectionName)) {
+      return renderingCache.get(collectionName)!;
+    }
+
+    try {
+      const { collectionId } = await ServerUtils.queryWithBearerToken<{ collectionId: string }>({
+        forestServerUrl: this.options.forestServerUrl,
+        method: 'get',
+        path: `/api/renderings/${renderingId}/collections/${encodeURIComponent(collectionName)}/id`,
+        bearerToken,
+        headers: this.options.headers,
+      });
+
+      if (collectionId) {
+        if (!this.collectionIdCache.has(renderingId)) {
+          this.collectionIdCache.set(renderingId, new Map());
+        }
+
+        this.collectionIdCache.get(renderingId)!.set(collectionName, collectionId);
+      }
+
+      return collectionId;
+    } catch {
+      // Fallback: if endpoint doesn't exist (server not updated), use collectionName as before
+      return null;
+    }
+  }
+
   private getHttpOptions(bearerToken: string): ActivityLogHttpOptions {
     return {
       forestServerUrl: this.options.forestServerUrl,
       bearerToken,
       headers: this.options.headers,
-      ...(this.options.resolveCollectionName && {
-        createPath: '/api/activity-logs-requests/by-collection-name',
-      }),
     };
   }
 }

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -9,6 +9,8 @@ import type {
 export type ActivityLogsOptions = {
   forestServerUrl: string;
   headers?: Record<string, string>;
+  /** When true, uses the /by-collection-name endpoint that resolves collection names to IDs server-side */
+  resolveCollectionName?: boolean;
 };
 
 export default class ActivityLogsService {
@@ -87,6 +89,9 @@ export default class ActivityLogsService {
       forestServerUrl: this.options.forestServerUrl,
       bearerToken,
       headers: this.options.headers,
+      ...(this.options.resolveCollectionName && {
+        createPath: '/api/activity-logs-requests/by-collection-name',
+      }),
     };
   }
 }

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -96,18 +96,38 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     options: ActivityLogHttpOptions,
     body: object,
   ): Promise<ActivityLogResponse> {
-    const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
-      data: ActivityLogResponse;
-    }>({
+    const queryOptions = {
       forestServerUrl: options.forestServerUrl,
-      method: 'post',
-      path: options.createPath || '/api/activity-logs-requests',
+      method: 'post' as const,
       bearerToken: options.bearerToken,
       body,
       headers: options.headers,
-    });
+    };
 
-    return activityLog;
+    try {
+      const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
+        data: ActivityLogResponse;
+      }>({
+        ...queryOptions,
+        path: options.createPath || '/api/activity-logs-requests',
+      });
+
+      return activityLog;
+    } catch (error) {
+      // Fallback to default endpoint if custom path returns 404 (server not yet updated)
+      if (options.createPath && (error as { name?: string }).name === 'NotFoundError') {
+        const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
+          data: ActivityLogResponse;
+        }>({
+          ...queryOptions,
+          path: '/api/activity-logs-requests',
+        });
+
+        return activityLog;
+      }
+
+      throw error;
+    }
   }
 
   async updateActivityLogStatus(

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -101,7 +101,7 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     }>({
       forestServerUrl: options.forestServerUrl,
       method: 'post',
-      path: '/api/activity-logs-requests',
+      path: options.createPath || '/api/activity-logs-requests',
       bearerToken: options.bearerToken,
       body,
       headers: options.headers,

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -127,17 +127,15 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
   }
 
   async getCollectionId(
-    options: ActivityLogHttpOptions,
+    options: HttpOptions,
     renderingId: string,
     collectionName: string,
   ): Promise<string | null> {
-    const { collectionId } = await ServerUtils.queryWithBearerToken<{ collectionId: string }>({
-      forestServerUrl: options.forestServerUrl,
-      method: 'get',
-      path: `/api/renderings/${renderingId}/collections/${encodeURIComponent(collectionName)}/id`,
-      bearerToken: options.bearerToken,
-      headers: options.headers,
-    });
+    const { collectionId } = await ServerUtils.query<{ collectionId: string }>(
+      options,
+      'get',
+      `/liana/renderings/${renderingId}/collections/${encodeURIComponent(collectionName)}/id`,
+    );
 
     return collectionId ?? null;
   }

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -96,38 +96,18 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     options: ActivityLogHttpOptions,
     body: object,
   ): Promise<ActivityLogResponse> {
-    const queryOptions = {
+    const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
+      data: ActivityLogResponse;
+    }>({
       forestServerUrl: options.forestServerUrl,
-      method: 'post' as const,
+      method: 'post',
+      path: '/api/activity-logs-requests',
       bearerToken: options.bearerToken,
       body,
       headers: options.headers,
-    };
+    });
 
-    try {
-      const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
-        data: ActivityLogResponse;
-      }>({
-        ...queryOptions,
-        path: options.createPath || '/api/activity-logs-requests',
-      });
-
-      return activityLog;
-    } catch (error) {
-      // Fallback to default endpoint if custom path returns 404 (server not yet updated)
-      if (options.createPath && (error as { name?: string }).name === 'NotFoundError') {
-        const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
-          data: ActivityLogResponse;
-        }>({
-          ...queryOptions,
-          path: '/api/activity-logs-requests',
-        });
-
-        return activityLog;
-      }
-
-      throw error;
-    }
+    return activityLog;
   }
 
   async updateActivityLogStatus(

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -125,4 +125,20 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
       headers: options.headers,
     });
   }
+
+  async getCollectionId(
+    options: ActivityLogHttpOptions,
+    renderingId: string,
+    collectionName: string,
+  ): Promise<string | null> {
+    const { collectionId } = await ServerUtils.queryWithBearerToken<{ collectionId: string }>({
+      forestServerUrl: options.forestServerUrl,
+      method: 'get',
+      path: `/api/renderings/${renderingId}/collections/${encodeURIComponent(collectionName)}/id`,
+      bearerToken: options.bearerToken,
+      headers: options.headers,
+    });
+
+    return collectionId ?? null;
+  }
 }

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -305,8 +305,6 @@ export type ActivityLogHttpOptions = {
   forestServerUrl: string;
   bearerToken: string;
   headers?: Record<string, string>;
-  /** Override the activity log creation path (e.g. for collection name resolution) */
-  createPath?: string;
 };
 
 export type IpWhitelistRulesResponse = {

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -263,6 +263,11 @@ export interface UpdateActivityLogStatusParams {
 export interface ActivityLogsServiceInterface {
   createActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
   updateActivityLogStatus: (params: UpdateActivityLogStatusParams) => Promise<void>;
+  getCollectionId?: (
+    bearerToken: string,
+    renderingId: string,
+    collectionName: string,
+  ) => Promise<string | null>;
 }
 
 /**

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -263,10 +263,7 @@ export interface UpdateActivityLogStatusParams {
 export interface ActivityLogsServiceInterface {
   createActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
   updateActivityLogStatus: (params: UpdateActivityLogStatusParams) => Promise<void>;
-  getCollectionId: (
-    renderingId: string,
-    collectionName: string,
-  ) => Promise<string | null>;
+  getCollectionId: (renderingId: string, collectionName: string) => Promise<string | null>;
 }
 
 /**

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -305,6 +305,8 @@ export type ActivityLogHttpOptions = {
   forestServerUrl: string;
   bearerToken: string;
   headers?: Record<string, string>;
+  /** Override the activity log creation path (e.g. for collection name resolution) */
+  createPath?: string;
 };
 
 export type IpWhitelistRulesResponse = {

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -264,7 +264,6 @@ export interface ActivityLogsServiceInterface {
   createActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
   updateActivityLogStatus: (params: UpdateActivityLogStatusParams) => Promise<void>;
   getCollectionId?: (
-    bearerToken: string,
     renderingId: string,
     collectionName: string,
   ) => Promise<string | null>;
@@ -307,7 +306,7 @@ export interface ForestAdminServerInterface {
 
   // Collection ID resolution (used by MCP server for activity logs)
   getCollectionId?: (
-    options: ActivityLogHttpOptions,
+    options: HttpOptions,
     renderingId: string,
     collectionName: string,
   ) => Promise<string | null>;

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -263,7 +263,7 @@ export interface UpdateActivityLogStatusParams {
 export interface ActivityLogsServiceInterface {
   createActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
   updateActivityLogStatus: (params: UpdateActivityLogStatusParams) => Promise<void>;
-  getCollectionId?: (
+  getCollectionId: (
     renderingId: string,
     collectionName: string,
   ) => Promise<string | null>;

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -299,6 +299,13 @@ export interface ForestAdminServerInterface {
     id: string,
     body: object,
   ) => Promise<void>;
+
+  // Collection ID resolution (used by MCP server for activity logs)
+  getCollectionId?: (
+    options: ActivityLogHttpOptions,
+    renderingId: string,
+    collectionName: string,
+  ) => Promise<string | null>;
 }
 
 export type ActivityLogHttpOptions = {

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -6,6 +6,7 @@ import * as factories from '../__factories__';
 describe('ActivityLogsService', () => {
   const options = {
     forestServerUrl: 'http://forestadmin-server.com',
+    envSecret: 'test-env-secret',
   };
   let mockForestAdminServerInterface: jest.Mocked<ForestAdminServerInterface>;
 

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -227,4 +227,29 @@ describe('ActivityLogsService', () => {
       );
     });
   });
+
+  describe('getCollectionId', () => {
+    it('should call forestAdminServerInterface.getCollectionId with httpOptions', async () => {
+      mockForestAdminServerInterface.getCollectionId = jest.fn().mockResolvedValue('col-123');
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      const result = await service.getCollectionId('456', 'users');
+
+      expect(result).toBe('col-123');
+      expect(mockForestAdminServerInterface.getCollectionId).toHaveBeenCalledWith(
+        { forestServerUrl: options.forestServerUrl, envSecret: options.envSecret },
+        '456',
+        'users',
+      );
+    });
+
+    it('should return null when getCollectionId is not implemented', async () => {
+      delete mockForestAdminServerInterface.getCollectionId;
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      const result = await service.getCollectionId('456', 'users');
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -1,11 +1,7 @@
 import type { ForestAdminServerInterface } from '../../src/types';
 
 import ActivityLogsService from '../../src/activity-logs';
-import { NotFoundError } from '../../src/auth/errors';
-import ServerUtils from '../../src/utils/server';
 import * as factories from '../__factories__';
-
-jest.mock('../../src/utils/server');
 
 describe('ActivityLogsService', () => {
   const options = {
@@ -13,14 +9,10 @@ describe('ActivityLogsService', () => {
   };
   let mockForestAdminServerInterface: jest.Mocked<ForestAdminServerInterface>;
 
-  const mockQueryWithBearerToken = ServerUtils.queryWithBearerToken as jest.Mock;
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockForestAdminServerInterface =
       factories.forestAdminServerInterface.build() as jest.Mocked<ForestAdminServerInterface>;
-    // Default: collection ID resolution succeeds
-    mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'resolved-id-123' });
   });
 
   describe('createActivityLog', () => {
@@ -65,7 +57,7 @@ describe('ActivityLogsService', () => {
               },
               collection: {
                 data: {
-                  id: 'resolved-id-123',
+                  id: 'users',
                   type: 'collections',
                 },
               },
@@ -162,113 +154,6 @@ describe('ActivityLogsService', () => {
         }),
         expect.anything(),
       );
-    });
-  });
-
-  describe('resolveCollectionId', () => {
-    it('should resolve collectionName to collectionId via server endpoint', async () => {
-      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
-        id: 'log-1',
-        attributes: { index: 'idx-1' },
-      });
-      mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'col-456' });
-
-      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
-      await service.createActivityLog({
-        forestServerToken: 'token',
-        renderingId: '100',
-        action: 'index',
-        type: 'read',
-        collectionName: 'users',
-      });
-
-      expect(mockQueryWithBearerToken).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: 'get',
-          path: '/api/renderings/100/collections/users/id',
-        }),
-      );
-      expect(mockForestAdminServerInterface.createActivityLog).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          data: expect.objectContaining({
-            relationships: expect.objectContaining({
-              collection: { data: { id: 'col-456', type: 'collections' } },
-            }),
-          }),
-        }),
-      );
-    });
-
-    it('should cache resolved collectionId and not call server again', async () => {
-      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
-        id: 'log-1',
-        attributes: { index: 'idx-1' },
-      });
-      mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'col-789' });
-
-      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
-
-      await service.createActivityLog({
-        forestServerToken: 'token',
-        renderingId: '100',
-        action: 'index',
-        type: 'read',
-        collectionName: 'users',
-      });
-      await service.createActivityLog({
-        forestServerToken: 'token',
-        renderingId: '100',
-        action: 'index',
-        type: 'read',
-        collectionName: 'users',
-      });
-
-      expect(mockQueryWithBearerToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('should fallback to collectionName when server returns 404', async () => {
-      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
-        id: 'log-1',
-        attributes: { index: 'idx-1' },
-      });
-      mockQueryWithBearerToken.mockRejectedValue(new NotFoundError('Not found'));
-
-      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
-      await service.createActivityLog({
-        forestServerToken: 'token',
-        renderingId: '100',
-        action: 'index',
-        type: 'read',
-        collectionName: 'users',
-      });
-
-      expect(mockForestAdminServerInterface.createActivityLog).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          data: expect.objectContaining({
-            relationships: expect.objectContaining({
-              collection: { data: { id: 'users', type: 'collections' } },
-            }),
-          }),
-        }),
-      );
-    });
-
-    it('should propagate non-404 errors', async () => {
-      mockQueryWithBearerToken.mockRejectedValue(new Error('Network error'));
-
-      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
-
-      await expect(
-        service.createActivityLog({
-          forestServerToken: 'token',
-          renderingId: '100',
-          action: 'index',
-          type: 'read',
-          collectionName: 'users',
-        }),
-      ).rejects.toThrow('Network error');
     });
   });
 

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -1,7 +1,7 @@
 import type { ForestAdminServerInterface } from '../../src/types';
 
-import { NotFoundError } from '../../src/auth/errors';
 import ActivityLogsService from '../../src/activity-logs';
+import { NotFoundError } from '../../src/auth/errors';
 import ServerUtils from '../../src/utils/server';
 import * as factories from '../__factories__';
 

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -1,7 +1,11 @@
 import type { ForestAdminServerInterface } from '../../src/types';
 
+import { NotFoundError } from '../../src/auth/errors';
 import ActivityLogsService from '../../src/activity-logs';
+import ServerUtils from '../../src/utils/server';
 import * as factories from '../__factories__';
+
+jest.mock('../../src/utils/server');
 
 describe('ActivityLogsService', () => {
   const options = {
@@ -9,10 +13,14 @@ describe('ActivityLogsService', () => {
   };
   let mockForestAdminServerInterface: jest.Mocked<ForestAdminServerInterface>;
 
+  const mockQueryWithBearerToken = ServerUtils.queryWithBearerToken as jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockForestAdminServerInterface =
       factories.forestAdminServerInterface.build() as jest.Mocked<ForestAdminServerInterface>;
+    // Default: collection ID resolution succeeds
+    mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'resolved-id-123' });
   });
 
   describe('createActivityLog', () => {
@@ -57,7 +65,7 @@ describe('ActivityLogsService', () => {
               },
               collection: {
                 data: {
-                  id: 'users',
+                  id: 'resolved-id-123',
                   type: 'collections',
                 },
               },
@@ -154,6 +162,113 @@ describe('ActivityLogsService', () => {
         }),
         expect.anything(),
       );
+    });
+  });
+
+  describe('resolveCollectionId', () => {
+    it('should resolve collectionName to collectionId via server endpoint', async () => {
+      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
+        id: 'log-1',
+        attributes: { index: 'idx-1' },
+      });
+      mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'col-456' });
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      await service.createActivityLog({
+        forestServerToken: 'token',
+        renderingId: '100',
+        action: 'index',
+        type: 'read',
+        collectionName: 'users',
+      });
+
+      expect(mockQueryWithBearerToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'get',
+          path: '/api/renderings/100/collections/users/id',
+        }),
+      );
+      expect(mockForestAdminServerInterface.createActivityLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            relationships: expect.objectContaining({
+              collection: { data: { id: 'col-456', type: 'collections' } },
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should cache resolved collectionId and not call server again', async () => {
+      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
+        id: 'log-1',
+        attributes: { index: 'idx-1' },
+      });
+      mockQueryWithBearerToken.mockResolvedValue({ collectionId: 'col-789' });
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+
+      await service.createActivityLog({
+        forestServerToken: 'token',
+        renderingId: '100',
+        action: 'index',
+        type: 'read',
+        collectionName: 'users',
+      });
+      await service.createActivityLog({
+        forestServerToken: 'token',
+        renderingId: '100',
+        action: 'index',
+        type: 'read',
+        collectionName: 'users',
+      });
+
+      expect(mockQueryWithBearerToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fallback to collectionName when server returns 404', async () => {
+      mockForestAdminServerInterface.createActivityLog.mockResolvedValue({
+        id: 'log-1',
+        attributes: { index: 'idx-1' },
+      });
+      mockQueryWithBearerToken.mockRejectedValue(new NotFoundError('Not found'));
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      await service.createActivityLog({
+        forestServerToken: 'token',
+        renderingId: '100',
+        action: 'index',
+        type: 'read',
+        collectionName: 'users',
+      });
+
+      expect(mockForestAdminServerInterface.createActivityLog).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            relationships: expect.objectContaining({
+              collection: { data: { id: 'users', type: 'collections' } },
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should propagate non-404 errors', async () => {
+      mockQueryWithBearerToken.mockRejectedValue(new Error('Network error'));
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+
+      await expect(
+        service.createActivityLog({
+          forestServerToken: 'token',
+          renderingId: '100',
+          action: 'index',
+          type: 'read',
+          collectionName: 'users',
+        }),
+      ).rejects.toThrow('Network error');
     });
   });
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,55 @@
+# @forestadmin/mcp-server [2.0.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.9.1...@forestadmin/mcp-server@2.0.0) (2026-04-14)
+
+
+### Features
+
+* **mcp-server:** add enabledTools allowlist option ([#1547](https://github.com/ForestAdmin/agent-nodejs/issues/1547)) ([fc5127a](https://github.com/ForestAdmin/agent-nodejs/commit/fc5127a8903f758c9eb2c1493ea90a878695db45))
+
+
+### BREAKING CHANGES
+
+* **mcp-server:** `disabledTools` option has been removed. Use
+`enabledTools` instead. This is an allowlist: only listed tools are
+exposed. New tools in future releases will NOT be auto-enabled.
+
+- Remove disabledTools from ForestMCPServerOptions
+- Remove FOREST_MCP_DISABLED_TOOLS env var
+- Rename parse-disabled-tools.ts to parse-tool-list.ts
+- Simplify resolveEnabledTools (no more blocklist path)
+- Update agent mountAiMcpServer to only accept enabledTools
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* test(mcp-server): fix enabledTools tests and add empty array edge case
+
+- Fix port conflicts using getAvailablePort()
+- Replace no-op logging test with empty enabledTools edge case test
+- Verify enabledTools: [] only exposes describeCollection
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* feat(mcp-server): add warning and discovery logs for enabledTools
+
+- Warn when describeCollection is missing from enabledTools (auto-added)
+- Log available tools not enabled for discoverability on new releases
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* fix(mcp-server): validate enabledTools names and fix test port conflicts
+
+- Warn about unknown tool names in enabledTools (typo protection)
+- Fix test port conflicts by using buildExpressApp + listen instead of run()
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* chore(example): revert mountAiMcpServer to default (no options)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+* docs(mcp-server): clarify read-only is an example of enabledTools usage
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
 ## @forestadmin/mcp-server [1.9.1](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.9.0...@forestadmin/mcp-server@1.9.1) (2026-04-14)
 
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -62,7 +62,7 @@ yarn start:dev       # Development (loads .env file automatically)
 | `FOREST_ENV_SECRET` | **Yes** | - | Your Forest Admin environment secret |
 | `FOREST_AUTH_SECRET` | **Yes** | - | Your Forest Admin authentication secret (must match your agent) |
 | `MCP_SERVER_PORT` | No | `3931` | Port for the HTTP server |
-| `FOREST_MCP_DISABLED_TOOLS` | No | - | Comma-separated list of tools to disable (e.g. `create,update,delete`) |
+| `FOREST_MCP_ENABLED_TOOLS` | No | - | Comma-separated list of tools to enable (allowlist) |
 
 #### Example Configuration
 
@@ -85,36 +85,28 @@ Or set the variables inline:
 FOREST_ENV_SECRET="your-env-secret" FOREST_AUTH_SECRET="your-auth-secret" npx forest-mcp-server
 ```
 
-## Disabling Tools
+## Restrict Tools
 
-You can restrict which tools are exposed by the MCP server.
+You can restrict which tools the MCP server exposes using `enabledTools`. Only the listed tools will be available. **New tools added in future releases will NOT be automatically enabled** — you must explicitly add them.
 
-**Read-only mode** — disable all write operations:
+For example, to set up a **read-only mode** where the AI assistant can only browse data (no create, update, delete or action execution):
 
 ```typescript
-// With Forest Admin Agent
+// With Forest Admin Agent — read-only example
 agent.mountAiMcpServer({
-  disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate', 'getActionForm', 'executeAction'],
+  enabledTools: ['describeCollection', 'list', 'listRelated'],
 });
 ```
 
 ```bash
 # Standalone
-export FOREST_MCP_DISABLED_TOOLS="create,update,delete,associate,dissociate,getActionForm,executeAction"
+export FOREST_MCP_ENABLED_TOOLS="describeCollection,list,listRelated"
 npx forest-mcp-server
 ```
 
-This keeps only `list`, `listRelated` and `describeCollection` available.
+When `enabledTools` is not set, all tools are enabled by default.
 
-**Custom selection** — disable specific tools:
-
-```typescript
-agent.mountAiMcpServer({
-  disabledTools: ['create', 'delete'],
-});
-```
-
-See [Available Tools](#available-tools) for the full list. Note: `describeCollection` cannot be disabled as it is required for the MCP server to function properly.
+See [Available Tools](#available-tools) for the full list. `describeCollection` is always enabled as it is required for the MCP server to function properly.
 
 ## API Endpoints
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/mcp-server",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "description": "Model Context Protocol server for Forest Admin with OAuth authentication",
   "main": "dist/index.js",
   "bin": {

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import ForestMCPServer from './server';
-import parseDisabledTools from './utils/parse-disabled-tools';
+import parseToolList from './utils/parse-tool-list';
 
 // Start the server when run directly as CLI
 const server = new ForestMCPServer({
@@ -9,7 +9,7 @@ const server = new ForestMCPServer({
   forestAppUrl: process.env.FOREST_APP_URL || 'https://app.forestadmin.com',
   envSecret: process.env.FOREST_ENV_SECRET,
   authSecret: process.env.FOREST_AUTH_SECRET,
-  disabledTools: parseDisabledTools(process.env.FOREST_MCP_DISABLED_TOOLS),
+  enabledTools: parseToolList(process.env.FOREST_MCP_ENABLED_TOOLS),
 });
 
 server.run().catch(error => {

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -26,7 +26,6 @@ export function createForestServerClient(
   const activityLogsService = new ActivityLogsService(forestHttpApi, {
     ...serviceOptions,
     headers: { 'Forest-Application-Source': 'MCP' },
-    resolveCollectionName: true,
   });
 
   return new ForestServerClientImpl(schemaService, activityLogsService);

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -28,7 +28,12 @@ export function createForestServerClient(
     headers: { 'Forest-Application-Source': 'MCP' },
   });
 
-  return new ForestServerClientImpl(schemaService, activityLogsService);
+  return new ForestServerClientImpl(
+    schemaService,
+    activityLogsService,
+    forestHttpApi,
+    options.forestServerUrl,
+  );
 }
 
 export { ForestServerClientImpl };

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -26,6 +26,7 @@ export function createForestServerClient(
   const activityLogsService = new ActivityLogsService(forestHttpApi, {
     ...serviceOptions,
     headers: { 'Forest-Application-Source': 'MCP' },
+    resolveCollectionName: true,
   });
 
   return new ForestServerClientImpl(schemaService, activityLogsService);

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -28,12 +28,7 @@ export function createForestServerClient(
     headers: { 'Forest-Application-Source': 'MCP' },
   });
 
-  return new ForestServerClientImpl(
-    schemaService,
-    activityLogsService,
-    forestHttpApi,
-    options.forestServerUrl,
-  );
+  return new ForestServerClientImpl(schemaService, activityLogsService);
 }
 
 export { ForestServerClientImpl };

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -33,12 +33,11 @@ export default class ForestServerClientImpl implements ForestServerClient {
   async getCollectionId(
     renderingId: string,
     collectionName: string,
-    bearerToken: string,
   ): Promise<string | null> {
     if (!this.activityLogsService.getCollectionId) {
       return null;
     }
 
-    return this.activityLogsService.getCollectionId(bearerToken, renderingId, collectionName);
+    return this.activityLogsService.getCollectionId(renderingId, collectionName);
   }
 }

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -7,7 +7,6 @@ import type {
   SchemaServiceInterface,
   UpdateActivityLogStatusParams,
 } from './types';
-import type { ForestAdminServerInterface } from '@forestadmin/forestadmin-client';
 
 /**
  * Default implementation of ForestServerClient that uses SchemaService and ActivityLogsService.
@@ -17,8 +16,6 @@ export default class ForestServerClientImpl implements ForestServerClient {
   constructor(
     private readonly schemaService: SchemaServiceInterface,
     private readonly activityLogsService: ActivityLogsServiceInterface,
-    private readonly forestHttpApi: ForestAdminServerInterface,
-    private readonly forestServerUrl: string,
   ) {}
 
   async fetchSchema(): Promise<ForestSchemaCollection[]> {
@@ -38,14 +35,10 @@ export default class ForestServerClientImpl implements ForestServerClient {
     collectionName: string,
     bearerToken: string,
   ): Promise<string | null> {
-    if (!this.forestHttpApi.getCollectionId) {
+    if (!this.activityLogsService.getCollectionId) {
       return null;
     }
 
-    return this.forestHttpApi.getCollectionId(
-      { forestServerUrl: this.forestServerUrl, bearerToken },
-      renderingId,
-      collectionName,
-    );
+    return this.activityLogsService.getCollectionId(bearerToken, renderingId, collectionName);
   }
 }

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -30,10 +30,7 @@ export default class ForestServerClientImpl implements ForestServerClient {
     return this.activityLogsService.updateActivityLogStatus(params);
   }
 
-  async getCollectionId(
-    renderingId: string,
-    collectionName: string,
-  ): Promise<string | null> {
+  async getCollectionId(renderingId: string, collectionName: string): Promise<string | null> {
     return this.activityLogsService.getCollectionId(renderingId, collectionName);
   }
 }

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -7,6 +7,7 @@ import type {
   SchemaServiceInterface,
   UpdateActivityLogStatusParams,
 } from './types';
+import type { ForestAdminServerInterface } from '@forestadmin/forestadmin-client';
 
 /**
  * Default implementation of ForestServerClient that uses SchemaService and ActivityLogsService.
@@ -16,6 +17,8 @@ export default class ForestServerClientImpl implements ForestServerClient {
   constructor(
     private readonly schemaService: SchemaServiceInterface,
     private readonly activityLogsService: ActivityLogsServiceInterface,
+    private readonly forestHttpApi: ForestAdminServerInterface,
+    private readonly forestServerUrl: string,
   ) {}
 
   async fetchSchema(): Promise<ForestSchemaCollection[]> {
@@ -28,5 +31,21 @@ export default class ForestServerClientImpl implements ForestServerClient {
 
   async updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void> {
     return this.activityLogsService.updateActivityLogStatus(params);
+  }
+
+  async getCollectionId(
+    renderingId: string,
+    collectionName: string,
+    bearerToken: string,
+  ): Promise<string | null> {
+    if (!this.forestHttpApi.getCollectionId) {
+      return null;
+    }
+
+    return this.forestHttpApi.getCollectionId(
+      { forestServerUrl: this.forestServerUrl, bearerToken },
+      renderingId,
+      collectionName,
+    );
   }
 }

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -34,10 +34,6 @@ export default class ForestServerClientImpl implements ForestServerClient {
     renderingId: string,
     collectionName: string,
   ): Promise<string | null> {
-    if (!this.activityLogsService.getCollectionId) {
-      return null;
-    }
-
     return this.activityLogsService.getCollectionId(renderingId, collectionName);
   }
 }

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -51,6 +51,5 @@ export interface ForestServerClient {
   getCollectionId(
     renderingId: string,
     collectionName: string,
-    bearerToken: string,
   ): Promise<string | null>;
 }

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -48,8 +48,5 @@ export interface ForestServerClient {
   /**
    * Resolves a collection name to its internal ID for a given rendering.
    */
-  getCollectionId(
-    renderingId: string,
-    collectionName: string,
-  ): Promise<string | null>;
+  getCollectionId(renderingId: string, collectionName: string): Promise<string | null>;
 }

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -44,4 +44,13 @@ export interface ForestServerClient {
    * Updates an activity log status.
    */
   updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void>;
+
+  /**
+   * Resolves a collection name to its internal ID for a given rendering.
+   */
+  getCollectionId(
+    renderingId: string,
+    collectionName: string,
+    bearerToken: string,
+  ): Promise<string | null>;
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -115,8 +115,8 @@ export interface ForestMCPServerOptions {
   logger?: Logger;
   /** Optional Forest server client for dependency injection (from agent integration) */
   forestServerClient?: ForestServerClient;
-  /** List of tool names to disable. Use this to restrict which tools are exposed. */
-  disabledTools?: ToolName[];
+  /** List of tool names to enable (allowlist). Only these tools will be exposed. New tools in future releases will NOT be auto-enabled. */
+  enabledTools?: ToolName[];
 }
 
 /**
@@ -137,7 +137,7 @@ export default class ForestMCPServer {
   private authSecret?: string;
   private logger: Logger;
   private collectionNames: string[] = [];
-  private disabledTools: Set<ToolName>;
+  private enabledTools: Set<ToolName>;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -145,7 +145,7 @@ export default class ForestMCPServer {
     this.envSecret = options?.envSecret;
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
-    this.disabledTools = this.getToolsToDisable(options?.disabledTools ?? []);
+    this.enabledTools = this.resolveEnabledTools(options);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -260,27 +260,80 @@ export default class ForestMCPServer {
       },
     ];
 
-    const toolNames = allTools
-      .filter(tool => !this.disabledTools.has(tool.name))
-      .map(tool => tool.register());
+    const enabledToolEntries = allTools.filter(tool => this.enabledTools.has(tool.name));
+    const disabledToolNames = allTools
+      .filter(tool => !this.enabledTools.has(tool.name))
+      .map(tool => tool.name);
 
-    this.logger('Debug', `Registered ${toolNames.length} tools: ${toolNames.join(', ')}`);
+    const toolNames = enabledToolEntries.map(tool => tool.register());
+
+    this.logger(
+      'Info',
+      `Tools enabled: ${toolNames.join(', ')} (${toolNames.length}/${allTools.length})`,
+    );
+
+    if (disabledToolNames.length > 0) {
+      const total = allTools.length;
+      this.logger(
+        'Info',
+        `Tools disabled: ${disabledToolNames.join(', ')} (${disabledToolNames.length}/${total})`,
+      );
+    }
 
     return mcpServer;
   }
 
-  private getToolsToDisable(toolsToDisable: ToolName[]): Set<ToolName> {
-    const tools = new Set(toolsToDisable);
+  private resolveEnabledTools(options?: ForestMCPServerOptions): Set<ToolName> {
+    const allToolNames: ToolName[] = [
+      'describeCollection',
+      'list',
+      'listRelated',
+      'create',
+      'update',
+      'delete',
+      'associate',
+      'dissociate',
+      'getActionForm',
+      'executeAction',
+    ];
 
-    if (tools.has('describeCollection')) {
-      tools.delete('describeCollection');
-      this.logger(
-        'Warn',
-        'The "describeCollection" tool cannot be disabled as it is required for the MCP server to function properly.',
+    const enabled = new Set(options?.enabledTools ?? allToolNames);
+
+    if (options?.enabledTools) {
+      const allToolNamesSet = new Set<string>(allToolNames);
+      const unknownTools = options.enabledTools.filter(name => !allToolNamesSet.has(name));
+
+      if (unknownTools.length > 0) {
+        this.logger(
+          'Warn',
+          `Unknown tool names in enabledTools: ${unknownTools.join(', ')}. These will be ignored.`,
+        );
+      }
+
+      if (!options.enabledTools.includes('describeCollection')) {
+        this.logger(
+          'Warn',
+          'describeCollection was automatically enabled — it is required for the MCP server to function properly.',
+        );
+      }
+
+      const notEnabled = allToolNames.filter(
+        name => name !== 'describeCollection' && !enabled.has(name),
       );
+
+      if (notEnabled.length > 0) {
+        const toolList = notEnabled.join(', ');
+        this.logger(
+          'Info',
+          `Available tools not enabled: ${toolList}. Add them to enabledTools to use them.`,
+        );
+      }
     }
 
-    return tools;
+    // describeCollection is always required
+    enabled.add('describeCollection');
+
+    return enabled;
   }
 
   private ensureSecretsAreSet(): { envSecret: string; authSecret: string } {

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -12,6 +12,45 @@ import { NotFoundError } from '@forestadmin/forestadmin-client';
 
 export type { ActivityLogAction, ActivityLogResponse };
 
+// Cache: renderingId → (collectionName → collectionId)
+const collectionIdCache = new Map<string, Map<string, string>>();
+
+async function resolveCollectionId(
+  forestServerClient: ForestServerClient,
+  renderingId: string,
+  collectionName: string,
+  bearerToken: string,
+): Promise<string | null> {
+  const cached = collectionIdCache.get(renderingId)?.get(collectionName);
+
+  if (cached) return cached;
+
+  try {
+    const collectionId = await forestServerClient.getCollectionId(
+      renderingId,
+      collectionName,
+      bearerToken,
+    );
+
+    if (collectionId) {
+      if (!collectionIdCache.has(renderingId)) {
+        collectionIdCache.set(renderingId, new Map());
+      }
+
+      collectionIdCache.get(renderingId)!.set(collectionName, collectionId);
+    }
+
+    return collectionId;
+  } catch (error) {
+    // Fallback to collectionName if endpoint doesn't exist (server not yet updated)
+    if (error instanceof NotFoundError) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 const ACTION_TO_TYPE: Record<ActivityLogAction, ActivityLogType> = {
   index: 'read',
   search: 'read',
@@ -57,12 +96,17 @@ export default async function createPendingActivityLog(
   const type = ACTION_TO_TYPE[action];
   const { forestServerToken, renderingId } = getAuthContext(request);
 
+  // Resolve collectionName → collectionId if possible, fallback to name
+  const collectionId = extra?.collectionName
+    ? await resolveCollectionId(forestServerClient, renderingId, extra.collectionName, forestServerToken)
+    : null;
+
   return forestServerClient.createActivityLog({
     forestServerToken,
     renderingId,
     action,
     type,
-    collectionName: extra?.collectionName,
+    collectionName: collectionId || extra?.collectionName,
     recordId: extra?.recordId,
     recordIds: extra?.recordIds,
     label: extra?.label,

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -19,7 +19,6 @@ async function resolveCollectionId(
   forestServerClient: ForestServerClient,
   renderingId: string,
   collectionName: string,
-  bearerToken: string,
 ): Promise<string | null> {
   const cached = collectionIdCache.get(renderingId)?.get(collectionName);
 
@@ -29,7 +28,6 @@ async function resolveCollectionId(
     const collectionId = await forestServerClient.getCollectionId(
       renderingId,
       collectionName,
-      bearerToken,
     );
 
     if (collectionId) {
@@ -98,7 +96,7 @@ export default async function createPendingActivityLog(
 
   // Resolve collectionName → collectionId if possible, fallback to name
   const collectionId = extra?.collectionName
-    ? await resolveCollectionId(forestServerClient, renderingId, extra.collectionName, forestServerToken)
+    ? await resolveCollectionId(forestServerClient, renderingId, extra.collectionName)
     : null;
 
   return forestServerClient.createActivityLog({

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -15,6 +15,7 @@ export type { ActivityLogAction, ActivityLogResponse };
 // Cache: renderingId → (collectionName → collectionId)
 const collectionIdCache = new Map<string, Map<string, string>>();
 
+
 async function resolveCollectionId(
   forestServerClient: ForestServerClient,
   renderingId: string,

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -15,7 +15,6 @@ export type { ActivityLogAction, ActivityLogResponse };
 // Cache: renderingId → (collectionName → collectionId)
 const collectionIdCache = new Map<string, Map<string, string>>();
 
-
 async function resolveCollectionId(
   forestServerClient: ForestServerClient,
   renderingId: string,

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -25,10 +25,7 @@ async function resolveCollectionId(
   if (cached) return cached;
 
   try {
-    const collectionId = await forestServerClient.getCollectionId(
-      renderingId,
-      collectionName,
-    );
+    const collectionId = await forestServerClient.getCollectionId(renderingId, collectionName);
 
     if (collectionId) {
       if (!collectionIdCache.has(renderingId)) {

--- a/packages/mcp-server/src/utils/parse-tool-list.ts
+++ b/packages/mcp-server/src/utils/parse-tool-list.ts
@@ -1,6 +1,6 @@
 import type { ToolName } from '../server';
 
-export default function parseDisabledTools(envValue?: string): ToolName[] | undefined {
+export default function parseToolList(envValue?: string): ToolName[] | undefined {
   if (!envValue) return undefined;
 
   return envValue

--- a/packages/mcp-server/test/cli.test.ts
+++ b/packages/mcp-server/test/cli.test.ts
@@ -1,31 +1,27 @@
-import parseDisabledTools from '../src/utils/parse-disabled-tools';
+import parseToolList from '../src/utils/parse-tool-list';
 
-describe('parseDisabledTools', () => {
+describe('parseToolList', () => {
   it('should return undefined when env value is undefined', () => {
-    expect(parseDisabledTools(undefined)).toBeUndefined();
+    expect(parseToolList(undefined)).toBeUndefined();
   });
 
   it('should return undefined when env value is empty string', () => {
-    expect(parseDisabledTools('')).toBeUndefined();
+    expect(parseToolList('')).toBeUndefined();
   });
 
   it('should parse comma-separated tool names', () => {
-    expect(parseDisabledTools('create,update,delete')).toEqual(['create', 'update', 'delete']);
+    expect(parseToolList('create,update,delete')).toEqual(['create', 'update', 'delete']);
   });
 
   it('should trim whitespace around tool names', () => {
-    expect(parseDisabledTools(' create , update , delete ')).toEqual([
-      'create',
-      'update',
-      'delete',
-    ]);
+    expect(parseToolList(' create , update , delete ')).toEqual(['create', 'update', 'delete']);
   });
 
   it('should filter out empty entries from trailing commas', () => {
-    expect(parseDisabledTools('create,,delete,')).toEqual(['create', 'delete']);
+    expect(parseToolList('create,,delete,')).toEqual(['create', 'delete']);
   });
 
   it('should handle a single tool name', () => {
-    expect(parseDisabledTools('delete')).toEqual(['delete']);
+    expect(parseToolList('delete')).toEqual(['delete']);
   });
 });

--- a/packages/mcp-server/test/helpers/forest-server-client.ts
+++ b/packages/mcp-server/test/helpers/forest-server-client.ts
@@ -10,6 +10,7 @@ export default function createMockForestServerClient(
       attributes: { index: 'mock-index' },
     }),
     updateActivityLogStatus: jest.fn().mockResolvedValue(undefined),
+    getCollectionId: jest.fn().mockResolvedValue(null),
     ...overrides,
   } as jest.Mocked<ForestServerClient>;
 }

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -10,6 +10,7 @@ import ForestServerClientImpl from '../../src/http-client/mcp-http-client';
 describe('ForestServerClientImpl', () => {
   let mockSchemaService: jest.Mocked<SchemaServiceInterface>;
   let mockActivityLogsService: jest.Mocked<ActivityLogsServiceInterface>;
+  let mockForestHttpApi: { getCollectionId: jest.Mock };
   let client: ForestServerClientImpl;
 
   beforeEach(() => {
@@ -20,7 +21,15 @@ describe('ForestServerClientImpl', () => {
       createActivityLog: jest.fn(),
       updateActivityLogStatus: jest.fn(),
     };
-    client = new ForestServerClientImpl(mockSchemaService, mockActivityLogsService);
+    mockForestHttpApi = {
+      getCollectionId: jest.fn(),
+    };
+    client = new ForestServerClientImpl(
+      mockSchemaService,
+      mockActivityLogsService,
+      mockForestHttpApi as never,
+      'http://forest-server.com',
+    );
   });
 
   describe('fetchSchema', () => {

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -19,6 +19,7 @@ describe('ForestServerClientImpl', () => {
     mockActivityLogsService = {
       createActivityLog: jest.fn(),
       updateActivityLogStatus: jest.fn(),
+      getCollectionId: jest.fn().mockResolvedValue(null),
     };
     client = new ForestServerClientImpl(mockSchemaService, mockActivityLogsService);
   });

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -10,7 +10,6 @@ import ForestServerClientImpl from '../../src/http-client/mcp-http-client';
 describe('ForestServerClientImpl', () => {
   let mockSchemaService: jest.Mocked<SchemaServiceInterface>;
   let mockActivityLogsService: jest.Mocked<ActivityLogsServiceInterface>;
-  let mockForestHttpApi: { getCollectionId: jest.Mock };
   let client: ForestServerClientImpl;
 
   beforeEach(() => {
@@ -21,15 +20,7 @@ describe('ForestServerClientImpl', () => {
       createActivityLog: jest.fn(),
       updateActivityLogStatus: jest.fn(),
     };
-    mockForestHttpApi = {
-      getCollectionId: jest.fn(),
-    };
-    client = new ForestServerClientImpl(
-      mockSchemaService,
-      mockActivityLogsService,
-      mockForestHttpApi as never,
-      'http://forest-server.com',
-    );
+    client = new ForestServerClientImpl(mockSchemaService, mockActivityLogsService);
   });
 
   describe('fetchSchema', () => {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2733,13 +2733,15 @@ describe('handleMcpRequest cleanup', () => {
   });
 });
 
-describe('disabledTools', () => {
+describe('enabledTools', () => {
   const savedFetch = global.fetch;
-  let disabledToolsServer: ForestMCPServer;
-  let disabledToolsHttpServer: http.Server;
+  const savedPort = process.env.MCP_SERVER_PORT;
+  let enabledToolsServer: ForestMCPServer;
+  let enabledToolsHttpServer: http.Server;
   let mockServer: MockServer;
 
   beforeAll(async () => {
+    process.env.MCP_SERVER_PORT = (await getAvailablePort()).toString();
     mockServer = new MockServer();
     mockServer
       .get('/liana/environment', {
@@ -2760,39 +2762,40 @@ describe('disabledTools', () => {
 
     global.fetch = mockServer.fetch;
 
-    disabledToolsServer = new ForestMCPServer({
+    enabledToolsServer = new ForestMCPServer({
       envSecret: 'test-env-secret',
       authSecret: 'test-auth-secret',
-      disabledTools: ['create', 'update', 'delete', 'associate', 'dissociate'],
-    });
-    disabledToolsServer.run();
-
-    await new Promise(resolve => {
-      setTimeout(resolve, 500);
+      enabledTools: ['list', 'listRelated'],
     });
 
-    disabledToolsHttpServer = disabledToolsServer.httpServer as http.Server;
+    const app = await enabledToolsServer.buildExpressApp();
+    enabledToolsHttpServer = app.listen(Number(process.env.MCP_SERVER_PORT)) as http.Server;
+
+    await new Promise<void>(resolve => {
+      enabledToolsHttpServer.on('listening', resolve);
+    });
   });
 
   afterAll(async () => {
     global.fetch = savedFetch;
+    process.env.MCP_SERVER_PORT = savedPort;
     await new Promise<void>(resolve => {
-      if (disabledToolsHttpServer) {
-        disabledToolsHttpServer.close(() => resolve());
+      if (enabledToolsHttpServer) {
+        enabledToolsHttpServer.close(() => resolve());
       } else {
         resolve();
       }
     });
   });
 
-  it('should not expose disabled tools and should expose enabled tools', async () => {
+  it('should only expose enabled tools plus describeCollection', async () => {
     const validToken = jsonwebtoken.sign(
       { id: 123, email: 'user@example.com', renderingId: 456 },
       'test-auth-secret',
       { expiresIn: '1h' },
     );
 
-    const response = await request(disabledToolsHttpServer)
+    const response = await request(enabledToolsHttpServer)
       .post('/mcp')
       .set('Authorization', `Bearer ${validToken}`)
       .set('Content-Type', 'application/json')
@@ -2807,43 +2810,180 @@ describe('disabledTools', () => {
       responseData = response.body;
     } else {
       const dataLine = response.text.split('\n').find((line: string) => line.startsWith('data: '));
-      responseData = JSON.parse((dataLine as string).replace('data: ', ''));
+      if (!dataLine) throw new Error('Expected SSE data line not found in response');
+      responseData = JSON.parse(dataLine.replace('data: ', ''));
     }
 
     const toolNames = responseData.result.tools.map(t => t.name);
 
-    // Disabled tools should NOT be present
-    expect(toolNames).not.toContain('create');
-    expect(toolNames).not.toContain('update');
-    expect(toolNames).not.toContain('delete');
-    expect(toolNames).not.toContain('associate');
-    expect(toolNames).not.toContain('dissociate');
-
-    // Enabled tools SHOULD be present
+    // Only enabled tools + describeCollection (always forced)
     expect(toolNames).toContain('describeCollection');
     expect(toolNames).toContain('list');
     expect(toolNames).toContain('listRelated');
-    expect(toolNames).toContain('getActionForm');
-    expect(toolNames).toContain('executeAction');
+    expect(toolNames).toHaveLength(3);
 
-    expect(toolNames).toHaveLength(5);
+    // Write tools should NOT be present
+    expect(toolNames).not.toContain('create');
+    expect(toolNames).not.toContain('update');
+    expect(toolNames).not.toContain('delete');
   });
 
-  it('should re-enable describeCollection and log a warning when it is passed as disabled', () => {
+  it('should warn when describeCollection is not in enabledTools', () => {
     const logger = jest.fn();
 
-    const disabledServer = new ForestMCPServer({
+    const server = new ForestMCPServer({
       envSecret: 'ENV_SECRET',
       authSecret: 'AUTH_SECRET',
       logger,
-      disabledTools: ['describeCollection'],
+      enabledTools: ['list'],
     });
 
-    expect(disabledServer).toBeDefined();
+    expect(server).toBeDefined();
     expect(logger).toHaveBeenCalledWith(
       'Warn',
-      'The "describeCollection" tool cannot be disabled as it is required for the MCP server to function properly.',
+      'describeCollection was automatically enabled — it is required for the MCP server to function properly.',
     );
+  });
+
+  it('should log available tools not included in enabledTools', () => {
+    const logger = jest.fn();
+
+    const server = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      logger,
+      enabledTools: ['describeCollection', 'list', 'listRelated'],
+    });
+
+    expect(server).toBeDefined();
+    expect(logger).toHaveBeenCalledWith(
+      'Info',
+      expect.stringContaining('Available tools not enabled:'),
+    );
+    expect(logger).toHaveBeenCalledWith('Info', expect.stringContaining('create'));
+    expect(logger).toHaveBeenCalledWith(
+      'Info',
+      expect.stringContaining('Add them to enabledTools to use them.'),
+    );
+  });
+
+  it('should not log discovery message when all tools are enabled', () => {
+    const logger = jest.fn();
+
+    const server = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      logger,
+      enabledTools: [
+        'describeCollection',
+        'list',
+        'listRelated',
+        'create',
+        'update',
+        'delete',
+        'associate',
+        'dissociate',
+        'getActionForm',
+        'executeAction',
+      ],
+    });
+
+    expect(server).toBeDefined();
+    const infoCalls = logger.mock.calls.filter(
+      ([level, msg]: [string, string]) =>
+        level === 'Info' && msg.includes('Available tools not enabled'),
+    );
+    expect(infoCalls).toHaveLength(0);
+  });
+
+  it('should warn about unknown tool names in enabledTools', () => {
+    const logger = jest.fn();
+
+    const server = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      logger,
+      enabledTools: ['list', 'lst', 'creat' as any],
+    });
+
+    expect(server).toBeDefined();
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      'Unknown tool names in enabledTools: lst, creat. These will be ignored.',
+    );
+  });
+
+  it('should only expose describeCollection when enabledTools is empty', async () => {
+    const savedFetch2 = global.fetch;
+    const savedPort2 = process.env.MCP_SERVER_PORT;
+    process.env.MCP_SERVER_PORT = (await getAvailablePort()).toString();
+    const mockServer2 = new MockServer();
+    mockServer2
+      .get('/liana/environment', {
+        data: { id: '12345', attributes: { api_endpoint: 'https://api.example.com' } },
+      })
+      .get('/liana/forest-schema', {
+        data: [
+          {
+            id: 'users',
+            type: 'collections',
+            attributes: { name: 'users', fields: [{ field: 'id', type: 'Number' }] },
+          },
+        ],
+        included: [],
+        meta: { liana: 'forest-express-sequelize', liana_version: '9.0.0', liana_features: null },
+      })
+      .get(/\/oauth\/register\//, { error: 'Client not found' }, 404);
+
+    global.fetch = mockServer2.fetch;
+
+    const emptyServer = new ForestMCPServer({
+      envSecret: 'test-env-secret',
+      authSecret: 'test-auth-secret',
+      enabledTools: [],
+    });
+
+    const emptyApp = await emptyServer.buildExpressApp();
+    const emptyHttpServer = emptyApp.listen(Number(process.env.MCP_SERVER_PORT)) as http.Server;
+
+    await new Promise<void>(resolve => {
+      emptyHttpServer.on('listening', resolve);
+    });
+
+    const validToken = jsonwebtoken.sign(
+      { id: 123, email: 'user@example.com', renderingId: 456 },
+      'test-auth-secret',
+      { expiresIn: '1h' },
+    );
+
+    const response = await request(emptyHttpServer)
+      .post('/mcp')
+      .set('Authorization', `Bearer ${validToken}`)
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+
+    expect(response.status).toBe(200);
+
+    let responseData: { result: { tools: Array<{ name: string }> } };
+
+    if (response.body && Object.keys(response.body).length > 0) {
+      responseData = response.body;
+    } else {
+      const dataLine = response.text.split('\n').find((line: string) => line.startsWith('data: '));
+      if (!dataLine) throw new Error('Expected SSE data line not found in response');
+      responseData = JSON.parse(dataLine.replace('data: ', ''));
+    }
+
+    const toolNames = responseData.result.tools.map(t => t.name);
+
+    expect(toolNames).toEqual(['describeCollection']);
+
+    await new Promise<void>(resolve => {
+      emptyHttpServer.close(() => resolve());
+    });
+    global.fetch = savedFetch2;
+    process.env.MCP_SERVER_PORT = savedPort2;
   });
 });
 

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -16,6 +16,7 @@ const mockForestServerClient: ForestServerClient = {
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
+  getCollectionId: jest.fn().mockResolvedValue(null),
 };
 
 const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction<

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -14,6 +14,7 @@ const mockForestServerClient: ForestServerClient = {
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
+  getCollectionId: jest.fn().mockResolvedValue(null),
 };
 
 const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction<

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -154,6 +154,23 @@ describe('createPendingActivityLog', () => {
       );
     });
 
+    it('should cache resolved collectionId and not call server again', async () => {
+      const request = createMockRequest();
+      mockForestServerClient.getCollectionId.mockResolvedValue('cached-id-456');
+
+      await createPendingActivityLog(mockForestServerClient, request, 'index', {
+        collectionName: 'trees',
+      });
+      await createPendingActivityLog(mockForestServerClient, request, 'index', {
+        collectionName: 'trees',
+      });
+
+      expect(mockForestServerClient.getCollectionId).toHaveBeenCalledTimes(1);
+      expect(mockForestServerClient.createActivityLog).toHaveBeenLastCalledWith(
+        expect.objectContaining({ collectionName: 'cached-id-456' }),
+      );
+    });
+
     it('should fallback to collectionName when getCollectionId returns null', async () => {
       const request = createMockRequest();
       mockForestServerClient.getCollectionId.mockResolvedValue(null);
@@ -516,6 +533,32 @@ describe('markActivityLogAsSucceeded', () => {
       activityLog,
       status: 'completed',
     });
+
+    jest.useRealTimers();
+  });
+
+  it('should log error when updateActivityLogStatus fails', async () => {
+    jest.useFakeTimers();
+
+    mockForestServerClient.updateActivityLogStatus.mockRejectedValue(new Error('update failed'));
+
+    const request = createMockRequest();
+    const activityLog = { id: 'log-123', attributes: { index: 'idx-456' } };
+    const mockLogger = jest.fn();
+
+    markActivityLogAsSucceeded({
+      forestServerClient: mockForestServerClient,
+      request,
+      activityLog,
+      logger: mockLogger,
+    });
+
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(mockLogger).toHaveBeenCalledWith(
+      'Error',
+      expect.stringContaining('Unexpected error updating activity log'),
+    );
 
     jest.useRealTimers();
   });

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -138,18 +138,61 @@ describe('createPendingActivityLog', () => {
       );
     });
 
-    it('should include collection name when provided', async () => {
+    it('should use resolved collectionId when getCollectionId returns an ID', async () => {
       const request = createMockRequest();
+      mockForestServerClient.getCollectionId.mockResolvedValue('resolved-id-123');
 
       await createPendingActivityLog(mockForestServerClient, request, 'index', {
         collectionName: 'users',
       });
 
+      expect(mockForestServerClient.getCollectionId).toHaveBeenCalledWith('12345', 'users');
       expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
-          collectionName: 'users',
+          collectionName: 'resolved-id-123',
         }),
       );
+    });
+
+    it('should fallback to collectionName when getCollectionId returns null', async () => {
+      const request = createMockRequest();
+      mockForestServerClient.getCollectionId.mockResolvedValue(null);
+
+      await createPendingActivityLog(mockForestServerClient, request, 'index', {
+        collectionName: 'orders',
+      });
+
+      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectionName: 'orders',
+        }),
+      );
+    });
+
+    it('should fallback to collectionName when getCollectionId throws NotFoundError', async () => {
+      const request = createMockRequest();
+      mockForestServerClient.getCollectionId.mockRejectedValue(new NotFoundError('not found'));
+
+      await createPendingActivityLog(mockForestServerClient, request, 'index', {
+        collectionName: 'products',
+      });
+
+      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectionName: 'products',
+        }),
+      );
+    });
+
+    it('should propagate non-NotFoundError from getCollectionId', async () => {
+      const request = createMockRequest();
+      mockForestServerClient.getCollectionId.mockRejectedValue(new Error('network error'));
+
+      await expect(
+        createPendingActivityLog(mockForestServerClient, request, 'index', {
+          collectionName: 'categories',
+        }),
+      ).rejects.toThrow('network error');
     });
 
     it('should not include collectionName when not provided', async () => {

--- a/packages/plugin-aws-s3/CHANGELOG.md
+++ b/packages/plugin-aws-s3/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/plugin-aws-s3 [1.5.13](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-aws-s3@1.5.12...@forestadmin/plugin-aws-s3@1.5.13) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/plugin-aws-s3 [1.5.12](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-aws-s3@1.5.11...@forestadmin/plugin-aws-s3@1.5.12) (2026-03-31)
 
 

--- a/packages/plugin-aws-s3/package.json
+++ b/packages/plugin-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/plugin-aws-s3",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -17,7 +17,7 @@
     "@forestadmin/datasource-toolkit": "1.53.1"
   },
   "devDependencies": {
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1"
   },
   "files": [

--- a/packages/plugin-export-advanced/CHANGELOG.md
+++ b/packages/plugin-export-advanced/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/plugin-export-advanced [1.1.43](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-export-advanced@1.1.42...@forestadmin/plugin-export-advanced@1.1.43) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/plugin-export-advanced [1.1.42](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-export-advanced@1.1.41...@forestadmin/plugin-export-advanced@1.1.42) (2026-03-31)
 
 

--- a/packages/plugin-export-advanced/package.json
+++ b/packages/plugin-export-advanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/plugin-export-advanced",
-  "version": "1.1.42",
+  "version": "1.1.43",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -15,7 +15,7 @@
     "excel4node": "^1.8.0"
   },
   "devDependencies": {
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1"
   },
   "files": [

--- a/packages/plugin-flattener/CHANGELOG.md
+++ b/packages/plugin-flattener/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/plugin-flattener [1.4.27](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-flattener@1.4.26...@forestadmin/plugin-flattener@1.4.27) (2026-04-15)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/datasource-customizer:** upgraded to 1.69.3
+
 ## @forestadmin/plugin-flattener [1.4.26](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/plugin-flattener@1.4.25...@forestadmin/plugin-flattener@1.4.26) (2026-03-31)
 
 

--- a/packages/plugin-flattener/package.json
+++ b/packages/plugin-flattener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/plugin-flattener",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "A plugin that allows to flatten columns and relations in Forest Admin",
   "main": "dist/index.js",
   "license": "GPL-3.0",
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@forestadmin/datasource-customizer": "1.69.2",
+    "@forestadmin/datasource-customizer": "1.69.3",
     "@types/object-hash": "^3.0.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4206,11 +4206,6 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
-"@tokenizer/token@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
-  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -8523,15 +8518,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-type@^16.5.4:
-  version "16.5.4"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
-  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
-  dependencies:
-    readable-web-to-node-stream "^3.0.0"
-    strtok3 "^6.2.4"
-    token-types "^4.1.1"
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -11928,6 +11914,11 @@ luxon@^3.2.1:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
   integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
 
+magic-bytes.js@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz#b86cc065639368599034ec67941da39d88d7795e"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
+
 make-asynchronous@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/make-asynchronous/-/make-asynchronous-1.0.1.tgz#5ff174bae4e4371746debff112103545037373ee"
@@ -14172,11 +14163,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-peek-readable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
-  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
-
 pg-cloudflare@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
@@ -14922,13 +14908,6 @@ readable-stream@^4.2.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readable-web-to-node-stream@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
-  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
-  dependencies:
-    readable-stream "^3.6.0"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -16314,14 +16293,6 @@ strnum@^2.2.0:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
   integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
 
-strtok3@^6.2.4:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
-  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    peek-readable "^4.1.0"
-
 subscriptions-transport-ws@^0.9.19:
   version "0.9.19"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz#10ca32f7e291d5ee8eb728b9c02e43c52606cdcf"
@@ -16656,14 +16627,6 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
-
-token-types@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.1.tgz#0f897f03665846982806e138977dbe72d44df753"
-  integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    ieee754 "^1.2.1"
 
 toposort-class@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

- MCP activity logs now call `/api/activity-logs-requests/by-collection-name` instead of `/api/activity-logs-requests`
- The server-side endpoint resolves collection names to IDs before storing
- Adds `resolveCollectionName` option to `ActivityLogsService` and `createPath` to `ActivityLogHttpOptions`

**Context:** The MCP server sends collection names (e.g. `"Address"`) because it doesn't have access to internal collection IDs. This caused the collection field to appear blank in the Activity Logs UI.

**Depends on:** ForestAdmin/forestadmin-server#8163 (new server endpoint)

## Test plan

- [x] forestadmin-client tests pass (269)
- [x] mcp-server tests pass (535)
- [ ] E2E: create activity log via MCP, verify collection shows in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP server activity logs to send collection ID instead of collection name
> - Adds `getCollectionId(renderingId, collectionName)` to `ActivityLogsService` and `ForestHttpApi`, fetching the collection ID from `/liana/renderings/{renderingId}/collections/{name}/id`.
> - Updates `createPendingActivityLog` in the MCP server to resolve the collection name to its ID before sending the activity log, falling back to the name when the ID cannot be resolved.
> - Caches resolved collection IDs per rendering in a module-level map to avoid redundant HTTP calls.
> - Returns `null` on `NotFoundError` and propagates other errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db1d81f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->