### PR TITLE
fix(mcp server): create activity logs from modelname

### DIFF
--- a/packages/agent-testing/src/forest-admin-client-mock.ts
+++ b/packages/agent-testing/src/forest-admin-client-mock.ts
@@ -58,6 +58,7 @@ export default class ForestAdminClientMock implements ForestAdminClient {
 
   readonly activityLogsService: ForestAdminClient['activityLogsService'] = {
     createActivityLog: () => Promise.resolve({ id: '1', attributes: { index: '1' } }),
+    createMcpActivityLog: () => Promise.resolve({ id: '1', attributes: { index: '1' } }),
     updateActivityLogStatus: () => Promise.resolve(),
   };
 

--- a/packages/agent/test/__factories__/forest-admin-client.ts
+++ b/packages/agent/test/__factories__/forest-admin-client.ts
@@ -51,6 +51,7 @@ const forestAdminClientFactory = ForestAdminClientFactory.define(() => ({
   },
   activityLogsService: {
     createActivityLog: jest.fn(),
+    createMcpActivityLog: jest.fn(),
     updateActivityLogStatus: jest.fn(),
   },
   subscribeToServerEvents: jest.fn(),

--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -66,6 +66,34 @@ export default class ActivityLogsService {
     );
   }
 
+  async createMcpActivityLog(params: CreateActivityLogParams): Promise<ActivityLogResponse> {
+    const {
+      forestServerToken,
+      renderingId,
+      action,
+      type,
+      collectionName,
+      recordId,
+      recordIds,
+      label,
+    } = params;
+
+    const body = {
+      type,
+      action,
+      label,
+      status: 'pending',
+      records: (recordIds || (recordId ? [recordId] : [])).map(String),
+      renderingId,
+      collectionModelName: collectionName,
+    };
+
+    return this.forestAdminServerInterface.createMcpActivityLog(
+      this.getHttpOptions(forestServerToken),
+      body,
+    );
+  }
+
   async updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void> {
     const { forestServerToken, activityLog, status, errorMessage } = params;
 

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -110,6 +110,24 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     return activityLog;
   }
 
+  async createMcpActivityLog(
+    options: ActivityLogHttpOptions,
+    body: object,
+  ): Promise<ActivityLogResponse> {
+    const { data: activityLog } = await ServerUtils.queryWithBearerToken<{
+      data: ActivityLogResponse;
+    }>({
+      forestServerUrl: options.forestServerUrl,
+      method: 'post',
+      path: '/api/activity-logs-requests/mcp',
+      bearerToken: options.bearerToken,
+      body,
+      headers: options.headers,
+    });
+
+    return activityLog;
+  }
+
   async updateActivityLogStatus(
     options: ActivityLogHttpOptions,
     index: string,

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -262,6 +262,7 @@ export interface UpdateActivityLogStatusParams {
  */
 export interface ActivityLogsServiceInterface {
   createActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
+  createMcpActivityLog: (params: CreateActivityLogParams) => Promise<ActivityLogResponse>;
   updateActivityLogStatus: (params: UpdateActivityLogStatusParams) => Promise<void>;
 }
 
@@ -290,6 +291,10 @@ export interface ForestAdminServerInterface {
 
   // Activity logs operations
   createActivityLog?: (
+    options: ActivityLogHttpOptions,
+    body: object,
+  ) => Promise<ActivityLogResponse>;
+  createMcpActivityLog?: (
     options: ActivityLogHttpOptions,
     body: object,
   ) => Promise<ActivityLogResponse>;

--- a/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
+++ b/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
@@ -16,6 +16,7 @@ const forestAdminServerInterface = {
     getIpWhitelistRules: jest.fn(),
     // Activity logs operations
     createActivityLog: jest.fn(),
+    createMcpActivityLog: jest.fn(),
     updateActivityLogStatus: jest.fn(),
   }),
 };

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -157,6 +157,119 @@ describe('ActivityLogsService', () => {
     });
   });
 
+  describe('createMcpActivityLog', () => {
+    it('should create an MCP activity log with flat body and collectionModelName', async () => {
+      const mockActivityLog = {
+        id: 'log-123',
+        attributes: { index: 'idx-456' },
+      };
+      mockForestAdminServerInterface.createMcpActivityLog.mockResolvedValue(mockActivityLog);
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      const result = await service.createMcpActivityLog({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        action: 'index',
+        type: 'read',
+        collectionName: 'users',
+        recordId: '42',
+        label: 'Custom Label',
+      });
+
+      expect(result).toEqual(mockActivityLog);
+      expect(mockForestAdminServerInterface.createMcpActivityLog).toHaveBeenCalledWith(
+        { forestServerUrl: options.forestServerUrl, bearerToken: 'test-token', headers: undefined },
+        {
+          type: 'read',
+          action: 'index',
+          label: 'Custom Label',
+          status: 'pending',
+          records: ['42'],
+          renderingId: '12345',
+          collectionModelName: 'users',
+        },
+      );
+    });
+
+    it('should map recordIds array to records', async () => {
+      const mockActivityLog = {
+        id: 'log-123',
+        attributes: { index: 'idx-456' },
+      };
+      mockForestAdminServerInterface.createMcpActivityLog.mockResolvedValue(mockActivityLog);
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      await service.createMcpActivityLog({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        action: 'delete',
+        type: 'write',
+        collectionName: 'users',
+        recordIds: ['1', '2', '3'],
+      });
+
+      expect(mockForestAdminServerInterface.createMcpActivityLog).toHaveBeenCalledWith(
+        expect.objectContaining({ bearerToken: 'test-token' }),
+        expect.objectContaining({
+          records: ['1', '2', '3'],
+          collectionModelName: 'users',
+        }),
+      );
+    });
+
+    it('should send undefined collectionModelName when collection is omitted', async () => {
+      const mockActivityLog = {
+        id: 'log-123',
+        attributes: { index: 'idx-456' },
+      };
+      mockForestAdminServerInterface.createMcpActivityLog.mockResolvedValue(mockActivityLog);
+
+      const service = new ActivityLogsService(mockForestAdminServerInterface, options);
+      await service.createMcpActivityLog({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        action: 'search',
+        type: 'read',
+      });
+
+      expect(mockForestAdminServerInterface.createMcpActivityLog).toHaveBeenCalledWith(
+        expect.objectContaining({ bearerToken: 'test-token' }),
+        expect.objectContaining({
+          records: [],
+          collectionModelName: undefined,
+        }),
+      );
+    });
+
+    it('should pass custom headers when provided', async () => {
+      const mockActivityLog = {
+        id: 'log-123',
+        attributes: { index: 'idx-456' },
+      };
+      mockForestAdminServerInterface.createMcpActivityLog.mockResolvedValue(mockActivityLog);
+
+      const optionsWithHeaders = {
+        ...options,
+        headers: { 'Custom-Header': 'value' },
+      };
+      const service = new ActivityLogsService(mockForestAdminServerInterface, optionsWithHeaders);
+      await service.createMcpActivityLog({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        action: 'search',
+        type: 'read',
+      });
+
+      expect(mockForestAdminServerInterface.createMcpActivityLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bearerToken: 'test-token',
+          headers: { 'Custom-Header': 'value' },
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
   describe('updateActivityLogStatus', () => {
     it('should update activity log status to completed', async () => {
       mockForestAdminServerInterface.updateActivityLogStatus.mockResolvedValue(undefined);

--- a/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
+++ b/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
@@ -148,6 +148,38 @@ describe('ForestHttpApi', () => {
     });
   });
 
+  describe('createMcpActivityLog', () => {
+    it('should call the mcp endpoint with body', async () => {
+      const mockActivityLog = { id: 'log-123', attributes: { index: 'idx-456' } };
+      (ServerUtils.queryWithBearerToken as jest.Mock).mockResolvedValue({ data: mockActivityLog });
+
+      const body = {
+        type: 'read',
+        action: 'index',
+        status: 'pending',
+        records: [],
+        renderingId: '12345',
+        collectionModelName: 'users',
+      };
+      const activityLogOptions = {
+        forestServerUrl: options.forestServerUrl,
+        bearerToken: 'bearer-token',
+        headers: { 'Custom-Header': 'value' },
+      };
+      const result = await new ForestHttpApi().createMcpActivityLog(activityLogOptions, body);
+
+      expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith({
+        forestServerUrl: options.forestServerUrl,
+        method: 'post',
+        path: '/api/activity-logs-requests/mcp',
+        bearerToken: 'bearer-token',
+        body,
+        headers: { 'Custom-Header': 'value' },
+      });
+      expect(result).toEqual(mockActivityLog);
+    });
+  });
+
   describe('updateActivityLogStatus', () => {
     it('should call the right endpoint with status', async () => {
       const body = { status: 'completed' };

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -26,6 +26,10 @@ export default class ForestServerClientImpl implements ForestServerClient {
     return this.activityLogsService.createActivityLog(params);
   }
 
+  async createMcpActivityLog(params: CreateActivityLogParams): Promise<ActivityLogResponse> {
+    return this.activityLogsService.createMcpActivityLog(params);
+  }
+
   async updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void> {
     return this.activityLogsService.updateActivityLogStatus(params);
   }

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -41,6 +41,11 @@ export interface ForestServerClient {
   createActivityLog(params: CreateActivityLogParams): Promise<ActivityLogResponse>;
 
   /**
+   * Creates a pending activity log using the MCP-dedicated route.
+   */
+  createMcpActivityLog(params: CreateActivityLogParams): Promise<ActivityLogResponse>;
+
+  /**
    * Updates an activity log status.
    */
   updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void>;

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -57,7 +57,7 @@ export default function declareCreateTool(
         forestServerClient,
         request: extra,
         action: 'create',
-        context: { collectionName: options.collectionName },
+        context: { collectionName: options.collectionName, label: 'created' },
         logger,
         operation: async () => {
           const record = await rpcClient

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -51,6 +51,7 @@ export default function declareDeleteTool(
         action: 'delete',
         context: {
           collectionName: options.collectionName,
+          label: 'deleted',
           recordIds,
         },
         logger,

--- a/packages/mcp-server/src/tools/update.ts
+++ b/packages/mcp-server/src/tools/update.ts
@@ -62,6 +62,7 @@ export default function declareUpdateTool(
         context: {
           collectionName: options.collectionName,
           recordId: options.recordId,
+          label: 'updated',
         },
         logger,
         operation: async () => {

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -57,7 +57,7 @@ export default async function createPendingActivityLog(
   const type = ACTION_TO_TYPE[action];
   const { forestServerToken, renderingId } = getAuthContext(request);
 
-  return forestServerClient.createActivityLog({
+  return forestServerClient.createMcpActivityLog({
     forestServerToken,
     renderingId,
     action,

--- a/packages/mcp-server/src/utils/with-activity-log.ts
+++ b/packages/mcp-server/src/utils/with-activity-log.ts
@@ -42,10 +42,11 @@ export default async function withActivityLog<T>(options: WithActivityLogOptions
 
   // We want to create the activity log before executing the operation
   // If activity log creation fails, we must prevent the execution of the operation
-  const activityLog = await createPendingActivityLog(forestServerClient, request, action, context);
+  const activityLogPromise = createPendingActivityLog(forestServerClient, request, action, context);
 
   try {
     const result = await operation();
+    const activityLog = await activityLogPromise;
 
     markActivityLogAsSucceeded({
       forestServerClient,
@@ -76,7 +77,7 @@ export default async function withActivityLog<T>(options: WithActivityLogOptions
     markActivityLogAsFailed({
       forestServerClient,
       request,
-      activityLog,
+      activityLog: await activityLogPromise,
       errorMessage,
       logger,
     });

--- a/packages/mcp-server/src/utils/with-activity-log.ts
+++ b/packages/mcp-server/src/utils/with-activity-log.ts
@@ -1,5 +1,5 @@
 import type { ActivityLogAction } from './activity-logs-creator';
-import type { ActivityLogResponse, ForestServerClient } from '../http-client';
+import type { ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';

--- a/packages/mcp-server/src/utils/with-activity-log.ts
+++ b/packages/mcp-server/src/utils/with-activity-log.ts
@@ -1,5 +1,5 @@
 import type { ActivityLogAction } from './activity-logs-creator';
-import type { ForestServerClient } from '../http-client';
+import type { ActivityLogResponse, ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -42,11 +42,11 @@ export default async function withActivityLog<T>(options: WithActivityLogOptions
 
   // We want to create the activity log before executing the operation
   // If activity log creation fails, we must prevent the execution of the operation
-  const activityLogPromise = createPendingActivityLog(forestServerClient, request, action, context);
+
+  const activityLog = await createPendingActivityLog(forestServerClient, request, action, context);
 
   try {
     const result = await operation();
-    const activityLog = await activityLogPromise;
 
     markActivityLogAsSucceeded({
       forestServerClient,
@@ -77,7 +77,7 @@ export default async function withActivityLog<T>(options: WithActivityLogOptions
     markActivityLogAsFailed({
       forestServerClient,
       request,
-      activityLog: await activityLogPromise,
+      activityLog,
       errorMessage,
       logger,
     });

--- a/packages/mcp-server/test/helpers/forest-server-client.ts
+++ b/packages/mcp-server/test/helpers/forest-server-client.ts
@@ -9,6 +9,10 @@ export default function createMockForestServerClient(
       id: 'mock-log-id',
       attributes: { index: 'mock-index' },
     }),
+    createMcpActivityLog: jest.fn().mockResolvedValue({
+      id: 'mock-log-id',
+      attributes: { index: 'mock-index' },
+    }),
     updateActivityLogStatus: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   } as jest.Mocked<ForestServerClient>;

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -18,6 +18,7 @@ describe('ForestServerClientImpl', () => {
     };
     mockActivityLogsService = {
       createActivityLog: jest.fn(),
+      createMcpActivityLog: jest.fn(),
       updateActivityLogStatus: jest.fn(),
     };
     client = new ForestServerClientImpl(mockSchemaService, mockActivityLogsService);
@@ -58,6 +59,26 @@ describe('ForestServerClientImpl', () => {
       const result = await client.createActivityLog(params);
 
       expect(mockActivityLogsService.createActivityLog).toHaveBeenCalledWith(params);
+      expect(result).toBe(mockActivityLog);
+    });
+  });
+
+  describe('createMcpActivityLog', () => {
+    it('should delegate to activityLogsService.createMcpActivityLog()', async () => {
+      const mockActivityLog = { id: 'log-123', attributes: { index: 'idx-456' } };
+      mockActivityLogsService.createMcpActivityLog.mockResolvedValue(mockActivityLog);
+
+      const params = {
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        action: 'index' as const,
+        type: 'read' as const,
+        collectionName: 'users',
+      };
+
+      const result = await client.createMcpActivityLog(params);
+
+      expect(mockActivityLogsService.createMcpActivityLog).toHaveBeenCalledWith(params);
       expect(result).toBe(mockActivityLog);
     });
   });
@@ -106,6 +127,7 @@ describe('createForestServerClient', () => {
     expect(client).toBeDefined();
     expect(client.fetchSchema).toBeDefined();
     expect(client.createActivityLog).toBeDefined();
+    expect(client.createMcpActivityLog).toBeDefined();
     expect(client.updateActivityLogStatus).toBeDefined();
   });
 });

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -1138,11 +1138,9 @@ describe('ForestMCPServer Instance', () => {
       // The tool call should succeed (or fail on agent call, but activity log should be created first)
       expect(response.status).toBe(200);
 
-      // Verify activity log API was called with the correct forestServerToken
-      // The mock httpClient captures all createActivityLog calls
-      expect(listMockForestServerClient.createActivityLog).toHaveBeenCalled();
+      expect(listMockForestServerClient.createMcpActivityLog).toHaveBeenCalled();
 
-      const activityLogCall = listMockForestServerClient.createActivityLog.mock.calls[0][0];
+      const activityLogCall = listMockForestServerClient.createMcpActivityLog.mock.calls[0][0];
       expect(activityLogCall.forestServerToken).toBe(forestServerToken);
       expect(activityLogCall.action).toBe('index');
       expect(activityLogCall.collectionName).toBe('users');

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -192,7 +192,7 @@ describe('declareCreateTool', () => {
           forestServerClient: mockForestServerClient,
           request: mockExtra,
           action: 'create',
-          context: { collectionName: 'users' },
+          context: { collectionName: 'users', label: 'created' },
           logger: mockLogger,
           operation: expect.any(Function),
         });

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -211,7 +211,7 @@ describe('declareDeleteTool', () => {
           forestServerClient: mockForestServerClient,
           request: mockExtra,
           action: 'delete',
-          context: { collectionName: 'users', recordIds },
+          context: { collectionName: 'users', recordIds, label: 'deleted' },
           logger: mockLogger,
           operation: expect.any(Function),
         });

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -15,6 +15,7 @@ const mockLogger: Logger = jest.fn();
 const mockForestServerClient: ForestServerClient = {
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
+  createMcpActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
 };
 

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -13,6 +13,7 @@ const mockLogger: Logger = jest.fn();
 const mockForestServerClient: ForestServerClient = {
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
+  createMcpActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
 };
 

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -204,7 +204,7 @@ describe('declareUpdateTool', () => {
           forestServerClient: mockForestServerClient,
           request: mockExtra,
           action: 'update',
-          context: { collectionName: 'users', recordId: 42 },
+          context: { collectionName: 'users', recordId: 42, label: 'updated' },
           logger: mockLogger,
           operation: expect.any(Function),
         });

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -45,7 +45,7 @@ describe('createPendingActivityLog', () => {
 
       await createPendingActivityLog(mockForestServerClient, request, action);
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           action,
           type: expectedType,
@@ -55,12 +55,12 @@ describe('createPendingActivityLog', () => {
   });
 
   describe('request formatting', () => {
-    it('should call createActivityLog with forestServerToken from authInfo.extra', async () => {
+    it('should call createMcpActivityLog with forestServerToken from authInfo.extra', async () => {
       const request = createMockRequest();
 
       await createPendingActivityLog(mockForestServerClient, request, 'index');
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           forestServerToken: 'test-forest-token',
           renderingId: '12345',
@@ -81,7 +81,7 @@ describe('createPendingActivityLog', () => {
 
       await createPendingActivityLog(mockForestServerClient, request, 'index');
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           forestServerToken: 'original-forest-server-token',
         }),
@@ -131,7 +131,7 @@ describe('createPendingActivityLog', () => {
 
       await createPendingActivityLog(mockForestServerClient, request, 'index');
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           renderingId: '456', // should be converted to string
         }),
@@ -145,7 +145,7 @@ describe('createPendingActivityLog', () => {
         collectionName: 'users',
       });
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           collectionName: 'users',
         }),
@@ -157,7 +157,7 @@ describe('createPendingActivityLog', () => {
 
       await createPendingActivityLog(mockForestServerClient, request, 'index');
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           collectionName: undefined,
         }),
@@ -171,7 +171,7 @@ describe('createPendingActivityLog', () => {
         label: 'Custom Action Label',
       });
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           label: 'Custom Action Label',
         }),
@@ -185,7 +185,7 @@ describe('createPendingActivityLog', () => {
         recordId: 42,
       });
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           recordId: 42,
         }),
@@ -199,7 +199,7 @@ describe('createPendingActivityLog', () => {
         recordIds: [1, 2, 3],
       });
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           recordIds: [1, 2, 3],
         }),
@@ -214,7 +214,7 @@ describe('createPendingActivityLog', () => {
         recordIds: [1, 2, 3],
       });
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           recordId: 99,
           recordIds: [1, 2, 3],
@@ -227,7 +227,7 @@ describe('createPendingActivityLog', () => {
 
       await createPendingActivityLog(mockForestServerClient, request, 'search');
 
-      expect(mockForestServerClient.createActivityLog).toHaveBeenCalledWith(
+      expect(mockForestServerClient.createMcpActivityLog).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'search',
         }),
@@ -236,8 +236,8 @@ describe('createPendingActivityLog', () => {
   });
 
   describe('error handling', () => {
-    it('should propagate error when createActivityLog fails', async () => {
-      mockForestServerClient.createActivityLog.mockRejectedValue(
+    it('should propagate error when createMcpActivityLog fails', async () => {
+      mockForestServerClient.createMcpActivityLog.mockRejectedValue(
         new Error('Failed to create activity log: Server error message'),
       );
 
@@ -248,7 +248,7 @@ describe('createPendingActivityLog', () => {
       ).rejects.toThrow('Failed to create activity log: Server error message');
     });
 
-    it('should not throw when createActivityLog succeeds', async () => {
+    it('should not throw when createMcpActivityLog succeeds', async () => {
       const request = createMockRequest();
 
       await expect(


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP server activity log creation to use `createMcpActivityLog` instead of `createActivityLog`
> - Adds a new `createMcpActivityLog` method to `ActivityLogsService` and `ForestHttpApi` that POSTs to `/api/activity-logs-requests/mcp` with a flat body including `collectionModelName`.
> - Updates [`activity-logs-creator.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1561/files#diff-8479a6bc2cdaf8ef367e8b278ce15ab7bd390fa48e51363c1f1e068feeea8021) to call `createMcpActivityLog` instead of the generic `createActivityLog`.
> - Changes [`with-activity-log.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1561/files#diff-e4315d245b0931574ae06a34167549cd3e82fb75fd0d8b5a8f593ccb598a9678) to start activity log creation concurrently with the wrapped operation, awaiting the promise only when marking success or failure.
> - Behavioral Change: activity log creation no longer blocks the start of the MCP operation; the two now run concurrently.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1561 opened
>
> - Added operation-specific labels to activity log context [ef5fc54]
> - Changed `withActivityLog` utility function to synchronously await the creation of a pending activity log before executing the wrapped operation [fa92907]
> - Added `label` field to the context parameter expected by `withActivityLog` in test files [fa92907]
> - Removed `ActivityLogResponse` type from type-only import in `mcp-server` package [dc1e22c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f81e96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->