### PR TITLE
fix(ai-proxy): add status and recepient mail to zendesk tools

### DIFF
--- a/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/create-ticket.ts
@@ -35,6 +35,15 @@ export default function createCreateTicketTool(
         .describe('Custom fields to set on the ticket'),
       requester_email: z.string().email().optional().describe('The email of the requester'),
       requester_name: z.string().optional().describe('The name of the requester'),
+      recipient_email: z
+        .string()
+        .email()
+        .optional()
+        .describe('The email of the recipient to notify about the ticket creation'),
+      status: z
+        .enum(['new', 'open', 'pending', 'solved', 'closed'])
+        .optional()
+        .describe('Status for the ticket'),
     }),
     func: async ({
       subject,
@@ -47,6 +56,8 @@ export default function createCreateTicketTool(
       custom_fields,
       requester_email,
       requester_name,
+      recipient_email,
+      status,
     }) => {
       const requester = {
         ...(requester_email && { email: requester_email }),
@@ -63,6 +74,8 @@ export default function createCreateTicketTool(
           ...(tags && { tags }),
           ...(custom_fields && { custom_fields }),
           ...(Object.keys(requester).length > 0 && { requester }),
+          ...(recipient_email && { recipient: recipient_email }),
+          ...(status && { status }),
         },
       };
 

--- a/packages/ai-proxy/src/integrations/zendesk/tools/update-ticket.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools/update-ticket.ts
@@ -14,7 +14,7 @@ export default function createUpdateTicketTool(
       ticket_id: z.number().int().positive().describe('The ID of the ticket to update'),
       subject: z.string().min(1).optional().describe('New subject for the ticket'),
       status: z
-        .enum(['new', 'open', 'pending', 'hold', 'solved', 'closed'])
+        .enum(['new', 'open', 'pending', 'solved', 'closed'])
         .optional()
         .describe('New status for the ticket'),
       priority: z

--- a/packages/ai-proxy/test/integrations/zendesk/tools/create-ticket.test.ts
+++ b/packages/ai-proxy/test/integrations/zendesk/tools/create-ticket.test.ts
@@ -53,6 +53,7 @@ describe('createCreateTicketTool', () => {
       type: 'incident',
       tags: ['urgent'],
       custom_fields: [{ id: 100, value: 'foo' }],
+      status: 'open',
     });
 
     expect(fetch).toHaveBeenCalledWith(`${baseUrl}/tickets.json`, {
@@ -68,6 +69,51 @@ describe('createCreateTicketTool', () => {
           type: 'incident',
           tags: ['urgent'],
           custom_fields: [{ id: 100, value: 'foo' }],
+          status: 'open',
+        },
+      }),
+    });
+  });
+
+  it('should create a ticket with recipient email', async () => {
+    const tool = createCreateTicketTool(headers, baseUrl);
+
+    await tool.invoke({
+      subject: 'Bug',
+      description: 'Broken',
+      recipient_email: 'notify@example.com',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(`${baseUrl}/tickets.json`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        ticket: {
+          subject: 'Bug',
+          comment: { body: 'Broken' },
+          recipient: 'notify@example.com',
+        },
+      }),
+    });
+  });
+
+  it('should create a ticket with status', async () => {
+    const tool = createCreateTicketTool(headers, baseUrl);
+
+    await tool.invoke({
+      subject: 'Bug',
+      description: 'Broken',
+      status: 'pending',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(`${baseUrl}/tickets.json`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        ticket: {
+          subject: 'Bug',
+          comment: { body: 'Broken' },
+          status: 'pending',
         },
       }),
     });


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `recipient_email` and `status` fields to Zendesk create-ticket tool
> - Adds two optional fields to the `zendesk_create_ticket` tool schema: `recipient_email` (validated as email, mapped to `recipient` in the payload) and `status` (enum of `new`, `open`, `pending`, `solved`, `closed`).
> - Removes `hold` as a valid `status` value in the `zendesk_update_ticket` tool schema to align both tools to the same set of allowed statuses.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 15219c5. 11 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->