### PR TITLE
fix(agent-client): accept composite PKs as arrays

### DIFF
--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -1,6 +1,7 @@
 import type ActionField from '../action-fields/action-field';
 import type FieldFormStates from '../action-fields/field-form-states';
 import type HttpRequester from '../http-requester';
+import type { RecordId } from '../types';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
 
 import ActionFieldCheckbox from '../action-fields/action-field-checkbox';
@@ -18,8 +19,8 @@ import ActionFieldStringList from '../action-fields/action-field-string-list';
 import ActionLayoutRoot from '../action-layout/action-layout-root';
 
 export type BaseActionContext = {
-  recordId?: string | number;
-  recordIds?: string[] | number[];
+  recordId?: RecordId;
+  recordIds?: RecordId[];
 };
 
 export type ActionEndpointsByCollection = {

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -10,7 +10,7 @@ import Relation from './relation';
 import Segment from './segment';
 import FieldFormStates from '../action-fields/field-form-states';
 import QuerySerializer from '../query-serializer';
-import encodeRecordId from '../record-id';
+import serializeRecordId from '../record-id';
 
 export default class Collection extends CollectionChart {
   protected readonly name: string;
@@ -31,7 +31,7 @@ export default class Collection extends CollectionChart {
     const actionInfo = this.getActionInfo(this.actionEndpoints, this.name, actionName);
     const ids = (actionContext?.recordIds ?? [actionContext?.recordId])
       .filter((id): id is RecordId => Boolean(id))
-      .map(encodeRecordId);
+      .map(serializeRecordId);
 
     const fieldsFormStates = new FieldFormStates(
       actionName,
@@ -135,7 +135,7 @@ export default class Collection extends CollectionChart {
   }
 
   async delete<Data = unknown>(ids: RecordId[]): Promise<Data> {
-    const serializedIds = ids.map(encodeRecordId);
+    const serializedIds = ids.map(serializeRecordId);
     const requestBody = {
       data: {
         attributes: { collection_name: this.name, ids: serializedIds },
@@ -161,7 +161,7 @@ export default class Collection extends CollectionChart {
   }
 
   async update<Data = unknown>(id: RecordId, attributes: Record<string, unknown>): Promise<Data> {
-    const encodedId = encodeRecordId(id);
+    const encodedId = serializeRecordId(id);
     const requestBody = { data: { attributes, type: this.name, id: encodedId } };
 
     return this.httpRequester.query<Data>({

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -1,4 +1,4 @@
-import type { ExportOptions, LiveQueryOptions, SelectOptions } from '../types';
+import type { ExportOptions, LiveQueryOptions, RecordId, SelectOptions } from '../types';
 import type { ActionEndpointsByCollection, BaseActionContext } from './action';
 import type HttpRequester from '../http-requester';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
@@ -10,6 +10,7 @@ import Relation from './relation';
 import Segment from './segment';
 import FieldFormStates from '../action-fields/field-form-states';
 import QuerySerializer from '../query-serializer';
+import encodeRecordId from '../record-id';
 
 export default class Collection extends CollectionChart {
   protected readonly name: string;
@@ -28,7 +29,9 @@ export default class Collection extends CollectionChart {
 
   async action(actionName: string, actionContext?: BaseActionContext): Promise<Action> {
     const actionInfo = this.getActionInfo(this.actionEndpoints, this.name, actionName);
-    const ids = (actionContext?.recordIds ?? [actionContext?.recordId]).filter(Boolean).map(String);
+    const ids = (actionContext?.recordIds ?? [actionContext?.recordId])
+      .filter((id): id is RecordId => Boolean(id))
+      .map(encodeRecordId);
 
     const fieldsFormStates = new FieldFormStates(
       actionName,
@@ -63,7 +66,7 @@ export default class Collection extends CollectionChart {
     return new Segment(undefined, this.name, this.httpRequester, options);
   }
 
-  relation(name: string, parentId: string | number): Relation {
+  relation(name: string, parentId: RecordId): Relation {
     return new Relation(name, this.name, parentId, this.httpRequester);
   }
 
@@ -131,8 +134,8 @@ export default class Collection extends CollectionChart {
     return { fields: collection.fields };
   }
 
-  async delete<Data = unknown>(ids: string[] | number[]): Promise<Data> {
-    const serializedIds = ids.map((id: string | number) => id.toString());
+  async delete<Data = unknown>(ids: RecordId[]): Promise<Data> {
+    const serializedIds = ids.map(encodeRecordId);
     const requestBody = {
       data: {
         attributes: { collection_name: this.name, ids: serializedIds },
@@ -157,15 +160,13 @@ export default class Collection extends CollectionChart {
     });
   }
 
-  async update<Data = unknown>(
-    id: string | number,
-    attributes: Record<string, unknown>,
-  ): Promise<Data> {
-    const requestBody = { data: { attributes, type: this.name, id: id.toString() } };
+  async update<Data = unknown>(id: RecordId, attributes: Record<string, unknown>): Promise<Data> {
+    const encodedId = encodeRecordId(id);
+    const requestBody = { data: { attributes, type: this.name, id: encodedId } };
 
     return this.httpRequester.query<Data>({
       method: 'put',
-      path: `/forest/${this.name}/${id.toString()}`,
+      path: `/forest/${this.name}/${encodedId}`,
       body: requestBody,
     });
   }

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -161,12 +161,12 @@ export default class Collection extends CollectionChart {
   }
 
   async update<Data = unknown>(id: RecordId, attributes: Record<string, unknown>): Promise<Data> {
-    const encodedId = serializeRecordId(id);
-    const requestBody = { data: { attributes, type: this.name, id: encodedId } };
+    const serializedId = serializeRecordId(id);
+    const requestBody = { data: { attributes, type: this.name, id: serializedId } };
 
     return this.httpRequester.query<Data>({
       method: 'put',
-      path: `/forest/${this.name}/${encodedId}`,
+      path: `/forest/${this.name}/${serializedId}`,
       body: requestBody,
     });
   }

--- a/packages/agent-client/src/domains/relation.ts
+++ b/packages/agent-client/src/domains/relation.ts
@@ -2,7 +2,7 @@ import type HttpRequester from '../http-requester';
 import type { RecordId, SelectOptions } from '../types';
 
 import QuerySerializer from '../query-serializer';
-import encodeRecordId from '../record-id';
+import serializeRecordId from '../record-id';
 
 export default class Relation {
   private readonly name: string;
@@ -19,7 +19,7 @@ export default class Relation {
     this.name = name;
     this.collectionName = collectionName;
     this.httpRequester = httpRequester;
-    this.parentId = encodeRecordId(parentId);
+    this.parentId = serializeRecordId(parentId);
   }
 
   list<Data = unknown>(options?: SelectOptions): Promise<Data[]> {
@@ -47,7 +47,7 @@ export default class Relation {
       method: 'post',
       path: `/forest/${this.collectionName}/${this.parentId}/relationships/${this.name}`,
       body: {
-        data: [{ id: encodeRecordId(targetRecordId), type: this.name }],
+        data: [{ id: serializeRecordId(targetRecordId), type: this.name }],
       },
     });
   }
@@ -59,7 +59,7 @@ export default class Relation {
       body: {
         data: {
           attributes: {
-            ids: targetRecordIds.map(encodeRecordId),
+            ids: targetRecordIds.map(serializeRecordId),
             collection_name: this.name,
             all_records: false,
             all_records_ids_excluded: [],

--- a/packages/agent-client/src/domains/relation.ts
+++ b/packages/agent-client/src/domains/relation.ts
@@ -1,24 +1,25 @@
 import type HttpRequester from '../http-requester';
-import type { SelectOptions } from '../types';
+import type { RecordId, SelectOptions } from '../types';
 
 import QuerySerializer from '../query-serializer';
+import encodeRecordId from '../record-id';
 
 export default class Relation {
   private readonly name: string;
   private readonly collectionName: string;
-  private readonly parentId: string | number;
+  private readonly parentId: string;
   private readonly httpRequester: HttpRequester;
 
   constructor(
     name: string,
     collectionName: string,
-    parentId: string | number,
+    parentId: RecordId,
     httpRequester: HttpRequester,
   ) {
     this.name = name;
     this.collectionName = collectionName;
     this.httpRequester = httpRequester;
-    this.parentId = parentId;
+    this.parentId = encodeRecordId(parentId);
   }
 
   list<Data = unknown>(options?: SelectOptions): Promise<Data[]> {
@@ -41,24 +42,24 @@ export default class Relation {
     );
   }
 
-  async associate(targetRecordId: string | number): Promise<void> {
+  async associate(targetRecordId: RecordId): Promise<void> {
     await this.httpRequester.query({
       method: 'post',
       path: `/forest/${this.collectionName}/${this.parentId}/relationships/${this.name}`,
       body: {
-        data: [{ id: String(targetRecordId), type: this.name }],
+        data: [{ id: encodeRecordId(targetRecordId), type: this.name }],
       },
     });
   }
 
-  async dissociate(targetRecordIds: (string | number)[]): Promise<void> {
+  async dissociate(targetRecordIds: RecordId[]): Promise<void> {
     await this.httpRequester.query({
       method: 'delete',
       path: `/forest/${this.collectionName}/${this.parentId}/relationships/${this.name}`,
       body: {
         data: {
           attributes: {
-            ids: targetRecordIds.map(String),
+            ids: targetRecordIds.map(encodeRecordId),
             collection_name: this.name,
             all_records: false,
             all_records_ids_excluded: [],

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -33,4 +33,4 @@ export function createRemoteAgentClient(params: {
   });
 }
 
-export type { SelectOptions } from './types';
+export type { RecordId, SelectOptions } from './types';

--- a/packages/agent-client/src/record-id.ts
+++ b/packages/agent-client/src/record-id.ts
@@ -1,10 +1,12 @@
 import type { RecordId } from './types';
 
 // Forest Admin backend expects composite PKs pipe-joined (e.g. "k1|k2"). Centralizing the
-// encoding here lets callers pass structured arrays and keeps the convention out of their code.
-// Throws rather than silently corrupting the key when parts are nullish or contain the "|"
-// separator — either case would produce a malformed id that could match the wrong record.
-export default function encodeRecordId(id: RecordId): string {
+// serialization here lets callers pass structured arrays and keeps the convention out of their
+// code. URL-encoding of the resulting string (e.g. "|" → "%7C" in paths) is handled downstream
+// by HttpRequester. Throws rather than silently corrupting the key when parts are nullish or
+// contain the "|" separator — either case would produce a malformed id that could match the
+// wrong record.
+export default function serializeRecordId(id: RecordId): string {
   if (!Array.isArray(id)) return String(id);
   if (id.length === 0) throw new Error('Composite record id cannot be empty');
 

--- a/packages/agent-client/src/record-id.ts
+++ b/packages/agent-client/src/record-id.ts
@@ -1,0 +1,7 @@
+import type { RecordId } from './types';
+
+// Forest Admin backend expects composite PKs pipe-joined (e.g. "k1|k2"). Centralizing the
+// encoding here lets callers pass structured arrays and keeps the convention out of their code.
+export default function encodeRecordId(id: RecordId): string {
+  return Array.isArray(id) ? id.map(v => String(v)).join('|') : String(id);
+}

--- a/packages/agent-client/src/record-id.ts
+++ b/packages/agent-client/src/record-id.ts
@@ -2,6 +2,27 @@ import type { RecordId } from './types';
 
 // Forest Admin backend expects composite PKs pipe-joined (e.g. "k1|k2"). Centralizing the
 // encoding here lets callers pass structured arrays and keeps the convention out of their code.
+// Throws rather than silently corrupting the key when parts are nullish or contain the "|"
+// separator — either case would produce a malformed id that could match the wrong record.
 export default function encodeRecordId(id: RecordId): string {
-  return Array.isArray(id) ? id.map(v => String(v)).join('|') : String(id);
+  if (!Array.isArray(id)) return String(id);
+  if (id.length === 0) throw new Error('Composite record id cannot be empty');
+
+  return id
+    .map(part => {
+      if (part === null || part === undefined) {
+        throw new Error('Composite record id parts cannot be null or undefined');
+      }
+
+      const serialized = String(part);
+
+      if (serialized.includes('|')) {
+        throw new Error(
+          `Composite record id part "${serialized}" cannot contain the "|" separator`,
+        );
+      }
+
+      return serialized;
+    })
+    .join('|');
 }

--- a/packages/agent-client/src/types.ts
+++ b/packages/agent-client/src/types.ts
@@ -1,5 +1,7 @@
 import type { PlainFilter, PlainSortClause } from '@forestadmin/datasource-toolkit';
 
+export type RecordId = string | number | Array<string | number>;
+
 export type BaseOptions = {
   filters?: PlainFilter['conditionTree']; // Filters to apply to the query
   sort?: PlainSortClause; // Sort clause for the query

--- a/packages/agent-client/test/domains/collection.test.ts
+++ b/packages/agent-client/test/domains/collection.test.ts
@@ -158,6 +158,20 @@ describe('Collection', () => {
         }),
       });
     });
+
+    it('should pipe-encode composite primary keys', async () => {
+      httpRequester.query.mockResolvedValue({});
+
+      await collection.update([1, 'abc'], { name: 'Test' });
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'put',
+        path: '/forest/users/1|abc',
+        body: expect.objectContaining({
+          data: expect.objectContaining({ id: '1|abc' }),
+        }),
+      });
+    });
   });
 
   describe('delete', () => {
@@ -194,6 +208,29 @@ describe('Collection', () => {
             attributes: {
               collection_name: 'users',
               ids: ['abc', 'def'],
+            },
+            type: 'action-requests',
+          },
+        },
+      });
+    });
+
+    it('should pipe-encode composite primary keys', async () => {
+      httpRequester.query.mockResolvedValue({});
+
+      await collection.delete([
+        [1, 'abc'],
+        [2, 'def'],
+      ]);
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'delete',
+        path: '/forest/users',
+        body: {
+          data: {
+            attributes: {
+              collection_name: 'users',
+              ids: ['1|abc', '2|def'],
             },
             type: 'action-requests',
           },
@@ -255,6 +292,18 @@ describe('Collection', () => {
     it('should return a Relation instance', () => {
       const relation = collection.relation('posts', 1);
       expect(relation).toBeDefined();
+    });
+
+    it('should pipe-encode composite parent ids when querying the relationship', async () => {
+      httpRequester.query.mockResolvedValue([]);
+
+      await collection.relation('posts', [1, 'abc']).list();
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'get',
+        path: '/forest/users/1|abc/relationships/posts',
+        query: expect.any(Object),
+      });
     });
   });
 
@@ -318,6 +367,47 @@ describe('Collection', () => {
       const result = await collection.action('sendEmail', {});
 
       expect(result).toBeDefined();
+    });
+
+    it('should pipe-encode composite recordIds when executing the action', async () => {
+      const action = await collection.action('sendEmail', {
+        recordIds: [
+          [1, 'abc'],
+          [2, 'def'],
+        ],
+      });
+      httpRequester.query.mockResolvedValue({ success: 'ok' });
+
+      await action.execute();
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'post',
+          path: '/forest/actions/send-email',
+          body: expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({ ids: ['1|abc', '2|def'] }),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should pipe-encode a composite recordId when executing the action', async () => {
+      const action = await collection.action('sendEmail', { recordId: [42, 'x'] });
+      httpRequester.query.mockResolvedValue({ success: 'ok' });
+
+      await action.execute();
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            data: expect.objectContaining({
+              attributes: expect.objectContaining({ ids: ['42|x'] }),
+            }),
+          }),
+        }),
+      );
     });
   });
 

--- a/packages/agent-client/test/domains/relation.test.ts
+++ b/packages/agent-client/test/domains/relation.test.ts
@@ -44,6 +44,19 @@ describe('Relation', () => {
       });
     });
 
+    it('should pipe-encode composite parent id', async () => {
+      const relation = new Relation('posts', 'users', [1, 'abc'], httpRequester);
+      httpRequester.query.mockResolvedValue([]);
+
+      await relation.list();
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'get',
+        path: '/forest/users/1|abc/relationships/posts',
+        query: expect.any(Object),
+      });
+    });
+
     it('should pass options to query serializer', async () => {
       const relation = new Relation('posts', 'users', 1, httpRequester);
       httpRequester.query.mockResolvedValue([]);
@@ -145,6 +158,21 @@ describe('Relation', () => {
         },
       });
     });
+
+    it('should pipe-encode composite target record id', async () => {
+      const relation = new Relation('tags', 'posts', [1, 'abc'], httpRequester);
+      httpRequester.query.mockResolvedValue(undefined);
+
+      await relation.associate([42, 'x']);
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'post',
+        path: '/forest/posts/1|abc/relationships/tags',
+        body: {
+          data: [{ id: '42|x', type: 'tags' }],
+        },
+      });
+    });
   });
 
   describe('dissociate', () => {
@@ -207,6 +235,32 @@ describe('Relation', () => {
           data: {
             attributes: {
               ids: ['99'],
+              collection_name: 'tags',
+              all_records: false,
+              all_records_ids_excluded: [],
+            },
+            type: 'action-requests',
+          },
+        },
+      });
+    });
+
+    it('should pipe-encode composite target record ids', async () => {
+      const relation = new Relation('tags', 'posts', [1, 'abc'], httpRequester);
+      httpRequester.query.mockResolvedValue(undefined);
+
+      await relation.dissociate([
+        [42, 'x'],
+        [43, 'y'],
+      ]);
+
+      expect(httpRequester.query).toHaveBeenCalledWith({
+        method: 'delete',
+        path: '/forest/posts/1|abc/relationships/tags',
+        body: {
+          data: {
+            attributes: {
+              ids: ['42|x', '43|y'],
               collection_name: 'tags',
               all_records: false,
               all_records_ids_excluded: [],

--- a/packages/agent-client/test/integration/composite-pk.integration.test.ts
+++ b/packages/agent-client/test/integration/composite-pk.integration.test.ts
@@ -1,0 +1,212 @@
+import http from 'http';
+
+import { createRemoteAgentClient } from '../../src/index';
+
+// End-to-end wire check — spins up a real HTTP server and asserts that composite PKs
+// passed as arrays (e.g. [1, 'abc']) arrive at the agent as pipe-joined ids. On the wire
+// the pipe is %7C-encoded by HttpRequester.escapeUrlSlug (standard HTTP URL encoding),
+// which is identical to how scalar callers passing "1|abc" as a string have always been
+// encoded — so this PR changes nothing in what the backend receives. decodeURIComponent
+// on the received path yields the same "1|abc" the agent has always decoded.
+describe('Composite primary keys (integration)', () => {
+  let server: http.Server;
+  let serverPort: number;
+  let requestLog: Array<{
+    method: string;
+    pathname: string;
+    rawUrl: string;
+    body: string;
+  }>;
+
+  beforeAll(() => {
+    requestLog = [];
+
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+
+      req.on('end', () => {
+        const parsed = new URL(req.url!, `http://localhost:${serverPort}`);
+        requestLog.push({
+          method: req.method!,
+          pathname: parsed.pathname,
+          rawUrl: req.url!,
+          body,
+        });
+
+        res.setHeader('Content-Type', 'application/json');
+
+        if (req.method === 'PUT') {
+          const parsedBody = JSON.parse(body);
+          res.statusCode = 200;
+          res.end(
+            JSON.stringify({
+              data: {
+                id: parsedBody.data.id,
+                type: 'record',
+                attributes: { ...parsedBody.data.attributes, id: parsedBody.data.id },
+              },
+            }),
+          );
+
+          return;
+        }
+
+        if (req.method === 'DELETE') {
+          res.statusCode = 204;
+          res.end();
+
+          return;
+        }
+
+        if (req.method === 'GET') {
+          res.statusCode = 200;
+          res.end(JSON.stringify({ data: [] }));
+
+          return;
+        }
+
+        if (req.method === 'POST') {
+          res.statusCode = 200;
+          res.end(JSON.stringify({ data: null }));
+
+          return;
+        }
+
+        res.statusCode = 404;
+        res.end();
+      });
+    });
+
+    return new Promise<void>(resolve => {
+      server.listen(0, () => {
+        serverPort = (server.address() as any).port;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    return new Promise<void>(resolve => {
+      server.close(() => resolve());
+    });
+  });
+
+  beforeEach(() => {
+    requestLog = [];
+  });
+
+  it('update should send "1|abc" in both URL path and body', async () => {
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client.collection('users').update([1, 'abc'], { name: 'John' });
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('PUT');
+    // The wire URL is %7C-encoded (standard HTTP); decoding yields the pipe-joined id.
+    expect(requestLog[0].rawUrl).toContain('1%7Cabc');
+    expect(decodeURIComponent(requestLog[0].pathname)).toBe('/forest/users/1|abc');
+
+    const parsedBody = JSON.parse(requestLog[0].body);
+    expect(parsedBody.data.id).toBe('1|abc');
+  });
+
+  it('delete should send composite ids as "k1|k2" strings in the body', async () => {
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client.collection('users').delete([
+      [1, 'abc'],
+      [2, 'def'],
+    ]);
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('DELETE');
+
+    const parsedBody = JSON.parse(requestLog[0].body);
+    expect(parsedBody.data.attributes.ids).toEqual(['1|abc', '2|def']);
+  });
+
+  it('relation.list should send "1|abc" as parent id in the URL path', async () => {
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client.collection('users').relation('posts', [1, 'abc']).list();
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('GET');
+    expect(requestLog[0].rawUrl).toContain('1%7Cabc');
+    expect(decodeURIComponent(requestLog[0].pathname)).toBe(
+      '/forest/users/1|abc/relationships/posts',
+    );
+  });
+
+  it('associate should send composite parent id in path and composite target id in body', async () => {
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client.collection('users').relation('tags', [1, 'abc']).associate([42, 'x']);
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('POST');
+    expect(decodeURIComponent(requestLog[0].pathname)).toBe(
+      '/forest/users/1|abc/relationships/tags',
+    );
+
+    const parsedBody = JSON.parse(requestLog[0].body);
+    expect(parsedBody.data).toEqual([{ id: '42|x', type: 'tags' }]);
+  });
+
+  it('dissociate should send composite target ids as pipe-joined strings', async () => {
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client
+      .collection('users')
+      .relation('tags', [1, 'abc'])
+      .dissociate([
+        [42, 'x'],
+        [43, 'y'],
+      ]);
+
+    expect(requestLog).toHaveLength(1);
+    expect(requestLog[0].method).toBe('DELETE');
+    expect(decodeURIComponent(requestLog[0].pathname)).toBe(
+      '/forest/users/1|abc/relationships/tags',
+    );
+
+    const parsedBody = JSON.parse(requestLog[0].body);
+    expect(parsedBody.data.attributes.ids).toEqual(['42|x', '43|y']);
+  });
+
+  it('should produce the same wire format as a legacy pipe-encoded string caller', async () => {
+    // Regression guard: passing a composite array must produce the exact same HTTP
+    // request as passing the already pipe-encoded string "1|abc". This proves the
+    // refactor is wire-compatible and the backend cannot distinguish the two.
+    const client = createRemoteAgentClient({
+      url: `http://localhost:${serverPort}`,
+      token: 'test-token',
+    });
+
+    await client.collection('users').update([1, 'abc'], { name: 'John' });
+    await client.collection('users').update('1|abc', { name: 'John' });
+
+    expect(requestLog).toHaveLength(2);
+    expect(requestLog[0].method).toBe(requestLog[1].method);
+    expect(requestLog[0].rawUrl).toBe(requestLog[1].rawUrl);
+    expect(requestLog[0].body).toBe(requestLog[1].body);
+  });
+});

--- a/packages/agent-client/test/record-id.test.ts
+++ b/packages/agent-client/test/record-id.test.ts
@@ -1,0 +1,23 @@
+import encodeRecordId from '../src/record-id';
+
+describe('encodeRecordId', () => {
+  it('should return a string as-is', () => {
+    expect(encodeRecordId('abc')).toBe('abc');
+  });
+
+  it('should coerce a number to string', () => {
+    expect(encodeRecordId(42)).toBe('42');
+  });
+
+  it('should pipe-join a composite array of strings and numbers', () => {
+    expect(encodeRecordId([1, 'abc', 2])).toBe('1|abc|2');
+  });
+
+  it('should handle a single-element array', () => {
+    expect(encodeRecordId([42])).toBe('42');
+  });
+
+  it('should handle an empty array', () => {
+    expect(encodeRecordId([])).toBe('');
+  });
+});

--- a/packages/agent-client/test/record-id.test.ts
+++ b/packages/agent-client/test/record-id.test.ts
@@ -1,40 +1,40 @@
-import encodeRecordId from '../src/record-id';
+import serializeRecordId from '../src/record-id';
 
-describe('encodeRecordId', () => {
+describe('serializeRecordId', () => {
   it('should return a string as-is', () => {
-    expect(encodeRecordId('abc')).toBe('abc');
+    expect(serializeRecordId('abc')).toBe('abc');
   });
 
   it('should coerce a number to string', () => {
-    expect(encodeRecordId(42)).toBe('42');
+    expect(serializeRecordId(42)).toBe('42');
   });
 
   it('should pipe-join a composite array of strings and numbers', () => {
-    expect(encodeRecordId([1, 'abc', 2])).toBe('1|abc|2');
+    expect(serializeRecordId([1, 'abc', 2])).toBe('1|abc|2');
   });
 
   it('should handle a single-element array', () => {
-    expect(encodeRecordId([42])).toBe('42');
+    expect(serializeRecordId([42])).toBe('42');
   });
 
   it('should throw on an empty composite array', () => {
-    expect(() => encodeRecordId([])).toThrow('Composite record id cannot be empty');
+    expect(() => serializeRecordId([])).toThrow('Composite record id cannot be empty');
   });
 
   it('should throw when a composite part is null', () => {
-    expect(() => encodeRecordId([1, null as unknown as string])).toThrow(
+    expect(() => serializeRecordId([1, null as unknown as string])).toThrow(
       'Composite record id parts cannot be null or undefined',
     );
   });
 
   it('should throw when a composite part is undefined', () => {
-    expect(() => encodeRecordId([1, undefined as unknown as string])).toThrow(
+    expect(() => serializeRecordId([1, undefined as unknown as string])).toThrow(
       'Composite record id parts cannot be null or undefined',
     );
   });
 
   it('should throw when a composite part contains the pipe separator', () => {
-    expect(() => encodeRecordId(['1|abc', 2])).toThrow(
+    expect(() => serializeRecordId(['1|abc', 2])).toThrow(
       'Composite record id part "1|abc" cannot contain the "|" separator',
     );
   });

--- a/packages/agent-client/test/record-id.test.ts
+++ b/packages/agent-client/test/record-id.test.ts
@@ -17,7 +17,25 @@ describe('encodeRecordId', () => {
     expect(encodeRecordId([42])).toBe('42');
   });
 
-  it('should handle an empty array', () => {
-    expect(encodeRecordId([])).toBe('');
+  it('should throw on an empty composite array', () => {
+    expect(() => encodeRecordId([])).toThrow('Composite record id cannot be empty');
+  });
+
+  it('should throw when a composite part is null', () => {
+    expect(() => encodeRecordId([1, null as unknown as string])).toThrow(
+      'Composite record id parts cannot be null or undefined',
+    );
+  });
+
+  it('should throw when a composite part is undefined', () => {
+    expect(() => encodeRecordId([1, undefined as unknown as string])).toThrow(
+      'Composite record id parts cannot be null or undefined',
+    );
+  });
+
+  it('should throw when a composite part contains the pipe separator', () => {
+    expect(() => encodeRecordId(['1|abc', 2])).toThrow(
+      'Composite record id part "1|abc" cannot contain the "|" separator',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Widen `update`, `delete`, `relation`, `action`, `associate` and `dissociate` on `@forestadmin/agent-client` to accept `string | number | Array<string | number>`.
- Centralize pipe-encoding of composite primary keys inside the library via a new internal helper (`encodeRecordId`) + exported `RecordId` type.
- Backward-compatible: all existing scalar PK callers keep working unchanged.

## Why

The public API was inconsistent on composite primary keys: `list({ filters })` accepts structured multi-field PKs, but `update`, `relation` and `action` all required the caller to pre-pipe-encode the id (`"k1|k2"`). The convention leaked into every consumer — each reinvents its own `encodePk` helper.

This PR makes the convention a library-internal detail. Consumers can now pass `[k1, k2]` natively; the library handles the encoding.

## Follow-up

- Clean up `encodePk` / manual pipe-joining in `packages/workflow-executor/src/adapters/agent-client-agent-port.ts` once the workflow-executor package lands on `main` (currently on its feature branch, so out of scope here).

## Test plan

- [x] `yarn workspace @forestadmin/agent-client build`
- [x] `yarn workspace @forestadmin/agent-client lint` (0 errors)
- [x] `yarn workspace @forestadmin/agent-client test` — 312/312 passing, including new composite cases on update / delete / relation / action / associate / dissociate + 5 unit tests on `encodeRecordId`
- [x] Non-regression on `@forestadmin/mcp-server` — 540/540
- [x] Non-regression on `@forestadmin/agent-testing` — 33/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept composite PKs as arrays in agent-client collection, relation, and action methods
> - Introduces a `RecordId = string | number | Array<string | number>` type and an `encodeRecordId` utility in [record-id.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1565/files#diff-4b446e96098e791d7789156e10404fb0d4148d85b5f02611ab4632934bc684ac) that serializes composite ids to pipe-joined strings (e.g. `[1, 2]` → `"1|2"`).
> - Updates `Collection.update`, `Collection.delete`, `Collection.action`, `Collection.relation`, and all `Relation` methods to accept `RecordId` / `RecordId[]` instead of plain `string | number`.
> - Composite ids are pipe-encoded before being placed in URL paths and request bodies; the encoded form is URL-encoded in paths (e.g. `%7C`).
> - Risk: passing an empty array, a part containing `'|'`, or a `null`/`undefined` part now throws at call time rather than sending a malformed id silently.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1565 opened
>
> - Renamed `encodeRecordId` to `serializeRecordId` in the `agent-client` package [0dd5d99]
> - renamed local variable in Collection.update method [3db0fd2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e52b00e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->