### PR TITLE
chore(security): patch 15 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,12 @@
     "micromatch": "^4.0.8",
     "semantic-release": "^25.0.0",
     "qs": ">=6.14.1",
-    "lerna/js-yaml": "4.1.1",
-    "@lerna/create/js-yaml": "4.1.1"
+    "lodash": ">=4.18.1",
+    "lodash-es": ">=4.18.1",
+    "hono": ">=4.12.14",
+    "@hono/node-server": ">=1.19.13 <2",
+    "langsmith": ">=0.5.19",
+    "follow-redirects": ">=1.16.0",
+    "axios": ">=1.15.0"
   }
 }

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -14,7 +14,7 @@
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "commander": "^11.1.0",
     "dotenv": "^16.4.1",
     "forest-cli": "5.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,10 +1778,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hono/node-server@^1.19.9":
-  version "1.19.12"
-  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.12.tgz#dae075247959b6d7d2dba4c8bdc8c452ca0c7b40"
-  integrity sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==
+"@hono/node-server@>=1.19.13 <2", "@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
@@ -5515,14 +5515,14 @@ avvio@^8.3.0:
     "@fastify/error" "^3.3.0"
     fastq "^1.17.1"
 
-axios@^1.13.5, axios@^1.8.3:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+axios@>=1.15.0, axios@^1.15.0, axios@^1.8.3:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -6563,13 +6563,6 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
-
-console-table-printer@^2.12.1:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.15.0.tgz#5c808204640b8f024d545bde8aabe5d344dfadc1"
-  integrity sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==
-  dependencies:
-    simple-wcswidth "^1.1.2"
 
 content-disposition@0.5.4, content-disposition@^0.5.3, content-disposition@~0.5.2, content-disposition@~0.5.4:
   version "0.5.4"
@@ -8670,10 +8663,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@>=1.16.0, follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -9401,10 +9394,10 @@ highlight.js@^10.7.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hono@^4.11.4:
-  version "4.12.9"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.9.tgz#7cd59dec4abf02022f5baad87f6413a04081144c"
-  integrity sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==
+hono@>=4.12.14, hono@^4.11.4:
+  version "4.12.14"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
+  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
 
 hook-std@^4.0.0:
   version "4.0.0"
@@ -10931,10 +10924,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@4.1.1, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@4.1.0, js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 
@@ -10946,10 +10939,10 @@ js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 
@@ -11316,17 +11309,13 @@ koa@^3.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-"langsmith@>=0.4.0 <1.0.0":
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.11.tgz#98994aaa051b0c807c31731ac3664f9415174f51"
-  integrity sha512-Yio502Ow2vbVt16P1sybNMNpMsr5BMqoeonoi4flrcDsP55No/aCe2zydtBNOv0+kjKQw4WSKAzTsNwenDeD5w==
+"langsmith@>=0.4.0 <1.0.0", langsmith@>=0.5.19:
+  version "0.5.22"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.22.tgz#bce117f1b370a46adae3c43b8dda09abdfa7c7d8"
+  integrity sha512-ed/Qi65m/yB+D13u+Y49IutbODmzOZfZQX+RT+vRIYb6FoI3Z3E4uQK2UIXuPbQpnqPcvG/MqUP2Mq55wVzE7g==
   dependencies:
-    "@types/uuid" "^10.0.0"
-    chalk "^5.6.2"
-    console-table-printer "^2.12.1"
-    p-queue "^6.6.2"
-    semver "^7.6.3"
-    uuid "^10.0.0"
+    p-queue "6.6.2"
+    uuid "10.0.0"
 
 lerna@^8.2.3:
   version "8.2.3"
@@ -11673,10 +11662,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@>=4.18.1, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -11813,10 +11802,10 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.23, lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@4.17.23, lodash@>=4.18.1, lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -14638,10 +14627,10 @@ proxy-addr@^2.0.6, proxy-addr@^2.0.7, proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pstree.remy@^1.1.8:
   version "1.1.8"
@@ -15740,11 +15729,6 @@ simple-update-notifier@^2.0.0:
   integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
   dependencies:
     semver "^7.5.3"
-
-simple-wcswidth@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz#66722f37629d5203f9b47c5477b1225b85d6525b"
-  integrity sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -17296,6 +17280,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@10.0.0, uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
 uuid@11.0.2:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.2.tgz#a8d68ba7347d051e7ea716cc8dcbbab634d66875"
@@ -17305,11 +17294,6 @@ uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
-
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^13.0.0:
   version "13.0.0"


### PR DESCRIPTION
## Summary
15 fixed, 4 ignored, 5 deferred, 7 resolutions added, 2 resolutions removed.

## Fixed

| # | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---------|-----------|-----------|----------|-----------------|
| #312 | lodash-es | npm | 4.17.23 → 4.18.1 | high | root resolution `lodash-es: ">=4.18.1"` (only parent is dev-only `@qiwi/multi-semantic-release`, which has not yet released a version that pulls in patched lodash-es) |
| #313 | lodash-es | npm | 4.17.23 → 4.18.1 | medium | same resolution as #312 |
| #317 | @hono/node-server | npm | 1.19.12 → 1.19.14 | medium | root resolution `@hono/node-server: ">=1.19.13 <2"` (transitive via `@modelcontextprotocol/sdk` — no parent bump pulls in the patch) |
| #318 | hono | npm | 4.12.9 → 4.12.14 | medium | root resolution `hono: ">=4.12.14"` (transitive via `@modelcontextprotocol/sdk`) |
| #319 | hono | npm | 4.12.9 → 4.12.14 | medium | same resolution as #318 |
| #320 | hono | npm | 4.12.9 → 4.12.14 | medium | same resolution as #318 |
| #321 | hono | npm | 4.12.9 → 4.12.14 | medium | same resolution as #318 |
| #322 | hono | npm | 4.12.9 → 4.12.14 | medium | same resolution as #318 |
| #323 | lodash | npm | 4.17.23 → 4.18.1 | medium | root resolution `lodash: ">=4.18.1"` (many transitive chains; runtime path via `forest-ip-utils → ip-address`) |
| #324 | lodash | npm | 4.17.23 → 4.18.1 | high | same resolution as #323 |
| #326 | langsmith | npm | 0.5.11 → 0.5.22 | medium | root resolution `langsmith: ">=0.5.19"` (transitive via `@forestadmin/ai-proxy → @langchain/core`) |
| #328 | follow-redirects | npm | 1.15.11 → 1.16.0 | medium | root resolution `follow-redirects: ">=1.16.0"` (transitive via axios; axios 1.15.x still pins `follow-redirects ^1.15.11`, so bumping axios alone does not close this alert) |
| #329 | axios | npm | 1.13.5 → 1.15.2 | medium | bumped direct dep in `packages/forest-cloud` `^1.13.5` → `^1.15.0`; added root resolution `axios: ">=1.15.0"` to also cover the `lerna → nx → axios` chain |
| #334 | langsmith | npm | 0.5.11 → 0.5.22 | medium | same resolution as #326 |
| #335 | hono | npm | 4.12.9 → 4.12.14 | medium | same resolution as #318 |

## Ignored

| # | Package | Severity | Reason |
|---|---------|----------|--------|
| #330 | @fastify/express | critical | Dev/test/tooling only; exploit requires untrusted input at runtime. `@fastify/express` is declared as a `devDependency` and as an optional `peerDependency` in `packages/agent/package.json` — it is used only from the agent's test suite and is installed by end-users (not us) at runtime. The only patched version, `4.0.5`, depends on `express ^5.2.1` + `fastify-plugin ^5.0.0` (i.e. Fastify 5), while our tests explicitly target Fastify 2/3/4 via the `fastify2`, `fastify`, and `fastify4` aliases in `packages/agent/package.json`. No patched release exists for the 1.x/2.x/3.x lines, so there is no compatible resolution target. Users continue to install their own `@fastify/express` at runtime; the peer range (`^1.1.0 \|\| ^2.0.0 \|\| ^3.0.0 \|\| ^4.0.0`) is unchanged. |
| #331 | @fastify/express | critical | Same package/same reason as #330 (middleware auth bypass variant of the path-doubling advisory). |
| #332 | @fastify/express | critical | Same package/same reason as #330 — this alert has `manifest_path: yarn.lock` but refers to the same install as #330. |
| #333 | @fastify/express | critical | Same package/same reason as #331 — duplicate with `manifest_path: yarn.lock`. |

## Deferred (age gate: opened < 7 days ago)

- #336 — `@fastify/middie` <= 9.3.1 (high, 6.5d)
- #337 — `@fastify/middie` <= 9.3.1 (critical, 6.5d)
- #338 — `axios` < 1.15.0 (medium, 6.1d — second axios advisory)
- #339 — `uuid` < 14.0.0 (medium, <1d)
- #340 — `fast-xml-parser` < 5.7.0 (medium, <1d)

## Resolutions added

All new resolutions were placed at the root `package.json`. Yarn v1 (`packageManager: "yarn@1.22.19"`) does not honor `resolutions` fields in non-root workspace `package.json` files, so workspace-level placement is not available. Parent-scoped syntax (`"parent/child": "X"`) was considered but most of these packages appear via several unrelated chains (see "yarn why" snippets above), which made unconditional root entries the more reliable option.

| Alert(s) | Package + pin | Parent chain considered | Why no parent bump | Placed in | Form |
|----------|---------------|-------------------------|--------------------|-----------|------|
| #312, #313 | `lodash-es: ">=4.18.1"` | `@qiwi/multi-semantic-release → semantic-release → lodash-es` | No upstream release of `@qiwi/multi-semantic-release` or `semantic-release` yet pulls patched `lodash-es` | root `package.json` | unconditional |
| #317 | `@hono/node-server: ">=1.19.13 <2"` | `@modelcontextprotocol/sdk → @hono/node-server`; also `@langchain/mcp-adapters → @modelcontextprotocol/sdk → @hono/node-server` | Latest `@modelcontextprotocol/sdk` still pins a sub-1.19.13 `@hono/node-server`. Upper bound `<2` avoids the major 2.0.0 which is a breaking change for MCP | root `package.json` | unconditional |
| #318–#322, #335 | `hono: ">=4.12.14"` | Same MCP SDK chain as above | Same reason as `@hono/node-server` | root `package.json` | unconditional |
| #323, #324 | `lodash: ">=4.18.1"` | ~17 distinct hoisted chains (lerna, jsonapi-serializer, inquirer, sequelize, markdown-link-check, semantic-release, prettier-eslint, forest-ip-utils→ip-address, …) | Parent bump is not feasible with this many unrelated ancestors | root `package.json` | unconditional (multiple chains) |
| #326, #334 | `langsmith: ">=0.5.19"` | `@forestadmin/ai-proxy → @langchain/core → langsmith` and `… → @langchain/community → @langchain/classic → langsmith` | Our pinned `@langchain/core@1.x` / `@langchain/community@1.1.19` still resolve to langsmith < 0.5.19 | root `package.json` | unconditional (two chains) |
| #328 | `follow-redirects: ">=1.16.0"` | `@forestadmin/forest-cloud → axios → follow-redirects` | Bumping axios to 1.15.2 does not fix this — axios 1.15.x still depends on `follow-redirects ^1.15.11`, which yarn resolves to 1.15.11 (vulnerable) | root `package.json` | unconditional |
| #329 | `axios: ">=1.15.0"` (plus direct dep bump in `packages/forest-cloud/package.json`) | `@forestadmin/forest-cloud → axios` (direct) and `lerna → nx → axios` (transitive) | Direct bump handles forest-cloud; a root resolution also covers the `lerna/nx` chain which we don't own | `packages/forest-cloud/package.json` (direct) + root `package.json` (resolution) | direct dep + unconditional resolution |

## Resolutions removed

| File | Entry removed | Why removal is safe |
|------|---------------|---------------------|
| root `package.json` | `"lerna/js-yaml": "4.1.1"` | Stale. Yarn was emitting `Resolution field "js-yaml@4.1.1" is incompatible with requested version "js-yaml@4.1.0"` and ignoring it. After removal, a fresh `yarn install` still resolves `js-yaml` to 4.1.0 everywhere (unchanged) and the warning disappears. |
| root `package.json` | `"@lerna/create/js-yaml": "4.1.1"` | Stale, same reason as above (same warning, same behavior). |

## Risks

- **lodash 4.17.23 → 4.18.1** — 4.18 is a security-patch minor; no API removals touched. The `_.template` / prototype-pollution fixes are behavioral hardening.
- **lodash-es 4.17.23 → 4.18.1** — same as lodash above.
- **hono 4.12.9 → 4.12.14** — patch-range bumps within 4.12.x; fixes are middleware-slash-handling, path-traversal in `toSSG`, IP-range match correctness, cookie-name validation, and JSX attribute handling. Hono is only used transitively by the MCP SDK; we do not call Hono APIs directly.
- **@hono/node-server 1.19.12 → 1.19.14** — minor patch within 1.19.x, no API surface we touch.
- **langsmith 0.5.11 → 0.5.22** — minor-range bump; the 0.5.19 release fixes prototype-pollution in `_deepCopy` and 0.5.22 tightens streaming-token output parsing. We consume langsmith only transitively via `@langchain/core`.
- **follow-redirects 1.15.11 → 1.16.0** — minor bump; patches authentication-header leakage on cross-origin redirects. Used transitively by axios.
- **axios 1.13.5 → 1.15.2** — minor-range bump across 1.13 → 1.15. 1.15.0 restricts cloud-metadata exfiltration and adds NO_PROXY hostname normalization; no breaking changes to request/response APIs we call. The direct bump in `packages/forest-cloud` changes the minimum resolved axios from 1.13.x to 1.15.x.
- **@fastify/express**: not bumped — see "Ignored" above.

No behavior changes beyond the patched vulnerabilities are expected for any of the above.

## Manual testing

Covered by CI.

## Validation

✅ CI green



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch 15 Dependabot security alerts by updating vulnerable dependencies
> - Adds overrides in [package.json](https://github.com/ForestAdmin/agent-nodejs/pull/1569/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) for `lodash`, `lodash-es`, `hono`, `@hono/node-server`, `langsmith`, `follow-redirects`, and `axios` to enforce patched minimum versions.
> - Bumps `axios` in [packages/forest-cloud/package.json](https://github.com/ForestAdmin/agent-nodejs/pull/1569/files#diff-adcf20c73543716fd205794f6a5f1eb64ca750d8e476a2de9e732c0b41d99f6c) from `^1.13.5` to `^1.15.0`.
> - Removes overrides for `@lerna/js-yaml` and `@lerna/create/js-yaml` (no longer needed).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa16c89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
