### PR TITLE
fix(logger): add logger in case of start failure

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -82,13 +82,19 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Start the agent.
    */
   async start(): Promise<void> {
-    const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
+    try {
+      const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
 
-    await this.options.forestAdminClient.subscribeToServerEvents();
-    this.options.forestAdminClient.onRefreshCustomizations(this.restart.bind(this));
+      await this.options.forestAdminClient.subscribeToServerEvents();
+      this.options.forestAdminClient.onRefreshCustomizations(this.restart.bind(this));
 
-    this.setMcpCallback(mcpHttpCallback ?? null);
-    await this.mount(router);
+      this.setMcpCallback(mcpHttpCallback ?? null);
+      await this.mount(router);
+    } catch (error) {
+      const { message } = error as Error;
+      this.options.logger('Error', `Forest Admin agent startup failure: ${message}`);
+      throw error;
+    }
   }
 
   /**

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -282,6 +282,44 @@ describe('Agent', () => {
     });
   });
 
+  describe('start error handling', () => {
+    test('should log the error and re-throw when buildRouterAndSendSchema fails', async () => {
+      const mockLogger = jest.fn();
+      const options = factories.forestAdminHttpDriverOptions.build({ logger: mockLogger });
+      const agent = new Agent(options);
+
+      jest
+        .mocked(DataSourceCustomizer.prototype.getDataSource)
+        .mockRejectedValueOnce(new Error('datasource connection failed'));
+
+      await expect(() => agent.start()).rejects.toThrow('datasource connection failed');
+
+      expect(mockLogger).toHaveBeenCalledWith(
+        'Error',
+        'Forest Admin agent startup failure: datasource connection failed',
+      );
+    });
+
+    test('should log the error and re-throw when subscribeToServerEvents fails', async () => {
+      const mockLogger = jest.fn();
+      const forestAdminClient = factories.forestAdminClient.build({
+        subscribeToServerEvents: jest.fn().mockRejectedValue(new Error('subscription failed')),
+      });
+      const options = factories.forestAdminHttpDriverOptions.build({
+        logger: mockLogger,
+        forestAdminClient,
+      });
+      const agent = new Agent(options);
+
+      await expect(() => agent.start()).rejects.toThrow('subscription failed');
+
+      expect(mockLogger).toHaveBeenCalledWith(
+        'Error',
+        'Forest Admin agent startup failure: subscription failed',
+      );
+    });
+  });
+
   describe('stop', () => {
     test('stop should close the Forest Admin client', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log startup failures in `Agent.start` before rethrowing
> Wraps the `Agent.start` startup sequence in a try/catch block. On any error, it logs `'Forest Admin agent startup failure: <message>'` through the configured logger at `Error` level, then rethrows the error so the caller still sees the exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 774e072.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->