### PR TITLE
feat(ai-proxy): add Snowflake integration with PAT authentication

### DIFF
--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -5,11 +5,13 @@ import type { Logger } from '@forestadmin/datasource-toolkit';
 import { AIBadRequestError } from './errors';
 import getKolarTools, { type KolarConfig } from './integrations/kolar/tools';
 import { validateKolarConfig } from './integrations/kolar/utils';
+import getSnowflakeTools, { type SnowflakeConfig } from './integrations/snowflake/tools';
+import { validateSnowflakeConfig } from './integrations/snowflake/utils';
 import getZendeskTools, { type ZendeskConfig } from './integrations/zendesk/tools';
 import { validateZendeskConfig } from './integrations/zendesk/utils';
 
-export type CustomConfig = ZendeskConfig | KolarConfig;
-export type ForestIntegrationName = 'Zendesk' | 'Kolar';
+export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
+export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
 
 export interface ForestIntegrationConfig {
   integrationName: ForestIntegrationName;
@@ -45,6 +47,9 @@ export default class ForestIntegrationClient implements ToolProvider {
         case 'Kolar':
           tools.push(...getKolarTools(config as KolarConfig));
           break;
+        case 'Snowflake':
+          tools.push(...getSnowflakeTools(config as SnowflakeConfig));
+          break;
         default:
           this.logger?.('Warn', `Unsupported integration: ${integrationName}`);
       }
@@ -61,6 +66,8 @@ export default class ForestIntegrationClient implements ToolProvider {
             return validateZendeskConfig(config as ZendeskConfig);
           case 'Kolar':
             return validateKolarConfig(config as KolarConfig);
+          case 'Snowflake':
+            return validateSnowflakeConfig(config as SnowflakeConfig);
           default:
             throw new AIBadRequestError(`Unsupported integration: ${integrationName}`);
         }

--- a/packages/ai-proxy/src/integrations/snowflake/tools.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools.ts
@@ -1,0 +1,37 @@
+import type RemoteTool from '../../remote-tool';
+
+import ServerRemoteTool from '../../server-remote-tool';
+import createCortexAnalystTool from './tools/cortex-analyst';
+import createCortexSearchTool from './tools/cortex-search';
+import createExecuteQueryTool from './tools/execute-query';
+import { getSnowflakeAuthHeaders } from './utils';
+
+export interface SnowflakeConfig {
+  accountIdentifier: string;
+  programmaticAccessToken: string;
+  defaultWarehouse?: string;
+  defaultDatabase?: string;
+  defaultSchema?: string;
+  defaultRole?: string;
+}
+
+export function buildSnowflakeBaseUrl(config: SnowflakeConfig): string {
+  return `https://${config.accountIdentifier}.snowflakecomputing.com`;
+}
+
+export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[] {
+  const headers = getSnowflakeAuthHeaders(config);
+  const baseUrl = buildSnowflakeBaseUrl(config);
+
+  return [
+    createCortexSearchTool(headers, baseUrl),
+    createCortexAnalystTool(headers, baseUrl),
+    createExecuteQueryTool(headers, baseUrl, config),
+  ].map(
+    tool =>
+      new ServerRemoteTool({
+        sourceId: 'snowflake',
+        tool,
+      }),
+  );
+}

--- a/packages/ai-proxy/src/integrations/snowflake/tools.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools.ts
@@ -4,7 +4,7 @@ import ServerRemoteTool from '../../server-remote-tool';
 import createCortexAnalystTool from './tools/cortex-analyst';
 import createCortexSearchTool from './tools/cortex-search';
 import createExecuteQueryTool from './tools/execute-query';
-import { getSnowflakeAuthHeaders } from './utils';
+import { getSnowflakeAuthHeaders, getSnowflakeBaseUrl } from './utils';
 
 export interface SnowflakeConfig {
   accountIdentifier: string;
@@ -15,13 +15,9 @@ export interface SnowflakeConfig {
   defaultRole?: string;
 }
 
-export function buildSnowflakeBaseUrl(config: SnowflakeConfig): string {
-  return `https://${config.accountIdentifier}.snowflakecomputing.com`;
-}
-
 export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[] {
   const headers = getSnowflakeAuthHeaders(config);
-  const baseUrl = buildSnowflakeBaseUrl(config);
+  const baseUrl = getSnowflakeBaseUrl(config.accountIdentifier);
 
   return [
     createCortexSearchTool(headers, baseUrl),

--- a/packages/ai-proxy/src/integrations/snowflake/tools/cortex-analyst.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools/cortex-analyst.ts
@@ -1,0 +1,66 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { AIBadRequestError } from '../../../errors';
+import { assertResponseOk } from '../utils';
+
+export default function createCortexAnalystTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'snowflake_cortex_analyst',
+    description:
+      'Ask a natural-language analytical question against a Snowflake semantic model or ' +
+      'semantic view using Cortex Analyst. Returns a generated SQL query and the answer. ' +
+      'Exactly one of `semantic_model_file` or `semantic_view` must be provided.',
+    schema: z.object({
+      question: z.string().min(1).describe('The natural-language analytical question'),
+      semantic_model_file: z
+        .string()
+        .optional()
+        .describe(
+          'Stage path to the YAML semantic model file ' +
+            '(e.g. "@my_db.my_schema.my_stage/model.yaml")',
+        ),
+      semantic_view: z
+        .string()
+        .optional()
+        .describe('Fully qualified semantic view name (e.g. "my_db.my_schema.my_view")'),
+    }),
+    func: async ({ question, semantic_model_file, semantic_view }) => {
+      if (!semantic_model_file && !semantic_view) {
+        throw new AIBadRequestError(
+          'Either `semantic_model_file` or `semantic_view` must be provided.',
+        );
+      }
+
+      if (semantic_model_file && semantic_view) {
+        throw new AIBadRequestError(
+          'Provide only one of `semantic_model_file` or `semantic_view`, not both.',
+        );
+      }
+
+      const body: Record<string, unknown> = {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: question }],
+          },
+        ],
+        ...(semantic_model_file && { semantic_model_file }),
+        ...(semantic_view && { semantic_view }),
+      };
+
+      const response = await fetch(`${baseUrl}/api/v2/cortex/analyst/message`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      await assertResponseOk(response, 'cortex analyst');
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/snowflake/tools/cortex-search.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools/cortex-search.ts
@@ -1,0 +1,59 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { assertResponseOk } from '../utils';
+
+export default function createCortexSearchTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'snowflake_cortex_search',
+    description:
+      'Search data using a Snowflake Cortex Search service. ' +
+      'Returns semantic search results ranked by relevance. ' +
+      'The caller must provide the fully qualified service identifier (database, schema, service).',
+    schema: z.object({
+      database: z.string().min(1).describe('Name of the database containing the search service'),
+      schema: z.string().min(1).describe('Name of the schema containing the search service'),
+      service: z.string().min(1).describe('Name of the Cortex Search service'),
+      query: z.string().min(1).describe('The natural-language search query'),
+      columns: z
+        .array(z.string().min(1))
+        .optional()
+        .describe('Columns to include in the search results'),
+      filter: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Optional filter expression as a JSON object'),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(1000)
+        .optional()
+        .describe('Maximum number of results to return (default: service-defined)'),
+    }),
+    func: async ({ database, schema, service, query, columns, filter, limit }) => {
+      const url =
+        `${baseUrl}/api/v2/databases/${encodeURIComponent(database)}` +
+        `/schemas/${encodeURIComponent(schema)}` +
+        `/cortex-search-services/${encodeURIComponent(service)}:query`;
+
+      const body: Record<string, unknown> = { query };
+      if (columns) body.columns = columns;
+      if (filter) body.filter = filter;
+      if (limit !== undefined) body.limit = limit;
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      await assertResponseOk(response, 'cortex search');
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/snowflake/tools/execute-query.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools/execute-query.ts
@@ -1,0 +1,58 @@
+import type { SnowflakeConfig } from '../tools';
+
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { assertReadOnlySql, assertResponseOk, buildSessionContext } from '../utils';
+
+export default function createExecuteQueryTool(
+  headers: Record<string, string>,
+  baseUrl: string,
+  config: SnowflakeConfig,
+): DynamicStructuredTool {
+  return new DynamicStructuredTool({
+    name: 'snowflake_execute_query',
+    description:
+      'Execute a read-only SQL query on Snowflake and return the results. ' +
+      'Only SELECT, WITH, SHOW, DESCRIBE, and EXPLAIN statements are allowed. ' +
+      'Multiple statements are not permitted.',
+    schema: z.object({
+      statement: z.string().min(1).describe('The read-only SQL statement to execute'),
+      warehouse: z
+        .string()
+        .optional()
+        .describe('Warehouse to use for this query (overrides the default)'),
+      database: z
+        .string()
+        .optional()
+        .describe('Database to use for this query (overrides the default)'),
+      schema: z
+        .string()
+        .optional()
+        .describe('Schema to use for this query (overrides the default)'),
+      role: z.string().optional().describe('Role to use for this query (overrides the default)'),
+    }),
+    func: async ({ statement, warehouse, database, schema, role }) => {
+      assertReadOnlySql(statement);
+
+      const body = {
+        statement,
+        ...buildSessionContext(config),
+        ...(warehouse && { warehouse }),
+        ...(database && { database }),
+        ...(schema && { schema }),
+        ...(role && { role }),
+      };
+
+      const response = await fetch(`${baseUrl}/api/v2/statements`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      await assertResponseOk(response, 'execute query');
+
+      return JSON.stringify(await response.json());
+    },
+  });
+}

--- a/packages/ai-proxy/src/integrations/snowflake/tools/execute-query.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools/execute-query.ts
@@ -14,7 +14,7 @@ export default function createExecuteQueryTool(
     name: 'snowflake_execute_query',
     description:
       'Execute a read-only SQL query on Snowflake and return the results. ' +
-      'Only SELECT, WITH, SHOW, DESCRIBE, and EXPLAIN statements are allowed. ' +
+      'Only SELECT, SHOW, DESCRIBE, and EXPLAIN statements are allowed. ' +
       'Multiple statements are not permitted.',
     schema: z.object({
       statement: z.string().min(1).describe('The read-only SQL statement to execute'),

--- a/packages/ai-proxy/src/integrations/snowflake/utils.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/utils.ts
@@ -1,0 +1,114 @@
+import type { SnowflakeConfig } from './tools';
+
+import { AIBadRequestError, AIToolUnprocessableError, McpConnectionError } from '../../errors';
+
+const READ_ONLY_LEADING_KEYWORD_RE = /^\s*(select|show|describe|desc|explain)\b/i;
+const FORBIDDEN_KEYWORD_RE =
+  /\b(insert|update|delete|merge|drop|create|alter|truncate|rename|undrop|swap|grant|revoke|call|execute|copy|put|get|use|set|unset|begin|commit|rollback|with)\b/i;
+
+export function getSnowflakeAuthHeaders(config: SnowflakeConfig): Record<string, string> {
+  return {
+    Authorization: `Bearer ${config.programmaticAccessToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-Snowflake-Authorization-Token-Type': 'PROGRAMMATIC_ACCESS_TOKEN',
+  };
+}
+
+export function getSnowflakeValidationBaseUrl(accountIdentifier: string): string {
+  return `https://${accountIdentifier}.snowflakecomputing.com`;
+}
+
+export function buildSessionContext(config: SnowflakeConfig) {
+  return {
+    ...(config.defaultWarehouse && { warehouse: config.defaultWarehouse }),
+    ...(config.defaultDatabase && { database: config.defaultDatabase }),
+    ...(config.defaultSchema && { schema: config.defaultSchema }),
+    ...(config.defaultRole && { role: config.defaultRole }),
+  };
+}
+
+function normalizeSql(statement: string): string {
+  return statement
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n]*/g, '')
+    .replace(/'(?:''|[^'])*'/g, "''")
+    .replace(/"(?:""|[^"])*"/g, '""')
+    .trim();
+}
+
+export function assertReadOnlySql(statement: string): void {
+  const normalized = normalizeSql(statement);
+
+  if (!normalized) {
+    throw new AIBadRequestError('SQL statement is empty');
+  }
+
+  const withoutTrailingSemicolon = normalized.replace(/;\s*$/, '');
+
+  if (withoutTrailingSemicolon.includes(';')) {
+    throw new AIBadRequestError(
+      'Only a single SQL statement is allowed. Multiple statements are not permitted.',
+    );
+  }
+
+  if (!READ_ONLY_LEADING_KEYWORD_RE.test(withoutTrailingSemicolon)) {
+    throw new AIBadRequestError(
+      'Only read-only statements (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed.',
+    );
+  }
+
+  const forbiddenMatch = withoutTrailingSemicolon.match(FORBIDDEN_KEYWORD_RE);
+
+  if (forbiddenMatch) {
+    throw new AIBadRequestError(
+      `SQL statement contains a disallowed keyword: ${forbiddenMatch[0].toUpperCase()}`,
+    );
+  }
+}
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  const fallback = response.statusText || 'Unknown error';
+
+  try {
+    const json = await response.json();
+
+    return json.message || json.error || json.code || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function assertResponseOk(response: Response, action: string) {
+  if (response.ok) return;
+
+  const errorMessage = await extractErrorMessage(response);
+
+  throw new AIToolUnprocessableError(
+    `Snowflake ${action} failed (${response.status}): ${errorMessage}`,
+  );
+}
+
+export async function validateSnowflakeConfig(config: SnowflakeConfig) {
+  const baseUrl = getSnowflakeValidationBaseUrl(config.accountIdentifier);
+  const headers = getSnowflakeAuthHeaders(config);
+  const body = {
+    statement: 'SELECT 1',
+    ...buildSessionContext(config),
+  };
+  const url = `${baseUrl}/api/v2/statements`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (response.ok) return;
+
+  const errorMessage = await extractErrorMessage(response);
+
+  throw new McpConnectionError(
+    `Failed to validate Snowflake config (HTTP ${response.status} on ${url}): ${errorMessage}`,
+  );
+}

--- a/packages/ai-proxy/src/integrations/snowflake/utils.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/utils.ts
@@ -4,7 +4,19 @@ import { AIBadRequestError, AIToolUnprocessableError, McpConnectionError } from 
 
 const READ_ONLY_LEADING_KEYWORD_RE = /^\s*(select|show|describe|desc|explain)\b/i;
 const FORBIDDEN_KEYWORD_RE =
-  /\b(insert|delete|merge|drop|create|alter|truncate|rename|undrop|swap|grant|revoke|call|execute|copy|put|get|use|set|unset|begin|commit|rollback|with)\b/i;
+  /\b(insert|update|delete|merge|drop|create|alter|truncate|rename|undrop|swap|grant|revoke|call|execute|copy|put|get|use|set|unset|begin|commit|rollback|with)\b/i;
+// Snowflake account identifiers are alphanumeric segments optionally separated by `.` or `-`
+// (org-account or locator.region.cloud). Anything else could redirect URL building to an
+// attacker-controlled host (e.g. `attack.com#` makes `#` start the URL fragment).
+const ACCOUNT_IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,128}(\.[A-Za-z0-9_-]{1,128}){0,3}$/;
+
+export function assertValidAccountIdentifier(accountIdentifier: string): void {
+  if (typeof accountIdentifier !== 'string' || !ACCOUNT_IDENTIFIER_RE.test(accountIdentifier)) {
+    throw new AIBadRequestError(
+      `Invalid Snowflake account identifier: ${JSON.stringify(accountIdentifier)}`,
+    );
+  }
+}
 
 export function getSnowflakeAuthHeaders(config: SnowflakeConfig): Record<string, string> {
   return {
@@ -15,7 +27,9 @@ export function getSnowflakeAuthHeaders(config: SnowflakeConfig): Record<string,
   };
 }
 
-export function getSnowflakeValidationBaseUrl(accountIdentifier: string): string {
+export function getSnowflakeBaseUrl(accountIdentifier: string): string {
+  assertValidAccountIdentifier(accountIdentifier);
+
   return `https://${accountIdentifier}.snowflakecomputing.com`;
 }
 
@@ -122,7 +136,7 @@ export async function assertResponseOk(response: Response, action: string) {
 }
 
 export async function validateSnowflakeConfig(config: SnowflakeConfig) {
-  const baseUrl = getSnowflakeValidationBaseUrl(config.accountIdentifier);
+  const baseUrl = getSnowflakeBaseUrl(config.accountIdentifier);
   const headers = getSnowflakeAuthHeaders(config);
   const body = {
     statement: 'SELECT 1',

--- a/packages/ai-proxy/src/integrations/snowflake/utils.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/utils.ts
@@ -4,7 +4,7 @@ import { AIBadRequestError, AIToolUnprocessableError, McpConnectionError } from 
 
 const READ_ONLY_LEADING_KEYWORD_RE = /^\s*(select|show|describe|desc|explain)\b/i;
 const FORBIDDEN_KEYWORD_RE =
-  /\b(insert|update|delete|merge|drop|create|alter|truncate|rename|undrop|swap|grant|revoke|call|execute|copy|put|get|use|set|unset|begin|commit|rollback|with)\b/i;
+  /\b(insert|delete|merge|drop|create|alter|truncate|rename|undrop|swap|grant|revoke|call|execute|copy|put|get|use|set|unset|begin|commit|rollback|with)\b/i;
 
 export function getSnowflakeAuthHeaders(config: SnowflakeConfig): Record<string, string> {
   return {
@@ -28,13 +28,45 @@ export function buildSessionContext(config: SnowflakeConfig) {
   };
 }
 
+// Single-pass lexer: a regex pipeline cannot disambiguate `--` inside a string
+// from a comment containing `'`, so it is unsafe for security checks.
 function normalizeSql(statement: string): string {
-  return statement
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/--[^\n]*/g, '')
-    .replace(/'(?:''|[^'])*'/g, "''")
-    .replace(/"(?:""|[^"])*"/g, '""')
-    .trim();
+  let result = '';
+  let i = 0;
+
+  while (i < statement.length) {
+    const c = statement[i];
+    const next = statement[i + 1];
+
+    if (c === '/' && next === '*') {
+      const end = statement.indexOf('*/', i + 2);
+
+      i = end === -1 ? statement.length : end + 2;
+    } else if (c === '-' && next === '-') {
+      const end = statement.indexOf('\n', i + 2);
+
+      i = end === -1 ? statement.length : end;
+    } else if (c === "'" || c === '"') {
+      result += c === "'" ? "''" : '""';
+      i += 1;
+
+      while (i < statement.length) {
+        if (statement[i] === c && statement[i + 1] === c) {
+          i += 2;
+        } else if (statement[i] === c) {
+          i += 1;
+          break;
+        } else {
+          i += 1;
+        }
+      }
+    } else {
+      result += c;
+      i += 1;
+    }
+  }
+
+  return result.trim();
 }
 
 export function assertReadOnlySql(statement: string): void {

--- a/packages/ai-proxy/test/forest-integration-client.test.ts
+++ b/packages/ai-proxy/test/forest-integration-client.test.ts
@@ -1,9 +1,15 @@
 import ForestIntegrationClient from '../src/forest-integration-client';
 import { validateKolarConfig } from '../src/integrations/kolar/utils';
+import { validateSnowflakeConfig } from '../src/integrations/snowflake/utils';
 import { validateZendeskConfig } from '../src/integrations/zendesk/utils';
 
 const mockZendeskTools = [{ name: 'zendesk_get_tickets' }, { name: 'zendesk_get_ticket' }];
 const mockKolarTools = [{ name: 'kolar_screen_transaction' }, { name: 'kolar_get_result' }];
+const mockSnowflakeTools = [
+  { name: 'snowflake_cortex_search' },
+  { name: 'snowflake_cortex_analyst' },
+  { name: 'snowflake_execute_query' },
+];
 
 jest.mock('../src/integrations/zendesk/tools', () => ({
   __esModule: true,
@@ -15,8 +21,14 @@ jest.mock('../src/integrations/kolar/tools', () => ({
   default: jest.fn(() => mockKolarTools),
 }));
 
+jest.mock('../src/integrations/snowflake/tools', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockSnowflakeTools),
+}));
+
 jest.mock('../src/integrations/zendesk/utils');
 jest.mock('../src/integrations/kolar/utils');
+jest.mock('../src/integrations/snowflake/utils');
 
 describe('ForestIntegrationClient', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -61,6 +73,23 @@ describe('ForestIntegrationClient', () => {
       const tools = await client.loadTools();
 
       expect(tools).toEqual(mockKolarTools);
+    });
+
+    it('should load snowflake tools when integration is Snowflake', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          integrationName: 'Snowflake',
+          config: {
+            accountIdentifier: 'a',
+            programmaticAccessToken: 'tok',
+          },
+          isForestConnector: true,
+        },
+      ]);
+
+      const tools = await client.loadTools();
+
+      expect(tools).toEqual(mockSnowflakeTools);
     });
 
     it('should return empty array when no configs', async () => {
@@ -124,6 +153,20 @@ describe('ForestIntegrationClient', () => {
       await client.checkConnection();
 
       expect(validateKolarConfig).toHaveBeenCalledWith(kolarConfig);
+    });
+
+    it('should call validateSnowflakeConfig for Snowflake integration', async () => {
+      const snowflakeConfig = {
+        accountIdentifier: 'a',
+        programmaticAccessToken: 'tok',
+      };
+      const client = new ForestIntegrationClient([
+        { integrationName: 'Snowflake', config: snowflakeConfig, isForestConnector: true },
+      ]);
+
+      await client.checkConnection();
+
+      expect(validateSnowflakeConfig).toHaveBeenCalledWith(snowflakeConfig);
     });
 
     it('should throw for unsupported integration', async () => {

--- a/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
@@ -1,7 +1,4 @@
-import getSnowflakeTools, {
-  buildSnowflakeBaseUrl,
-  type SnowflakeConfig,
-} from '../../../src/integrations/snowflake/tools';
+import getSnowflakeTools, { type SnowflakeConfig } from '../../../src/integrations/snowflake/tools';
 import ServerRemoteTool from '../../../src/server-remote-tool';
 
 describe('getSnowflakeTools', () => {
@@ -9,12 +6,6 @@ describe('getSnowflakeTools', () => {
     accountIdentifier: 'my-account',
     programmaticAccessToken: 'pat-secret',
   };
-
-  describe('buildSnowflakeBaseUrl', () => {
-    it('should compose the URL from the account identifier', () => {
-      expect(buildSnowflakeBaseUrl(config)).toBe('https://my-account.snowflakecomputing.com');
-    });
-  });
 
   it('should return 3 tools wrapped in ServerRemoteTool', () => {
     const tools = getSnowflakeTools(config);

--- a/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
@@ -1,0 +1,40 @@
+import getSnowflakeTools, {
+  buildSnowflakeBaseUrl,
+  type SnowflakeConfig,
+} from '../../../src/integrations/snowflake/tools';
+import ServerRemoteTool from '../../../src/server-remote-tool';
+
+describe('getSnowflakeTools', () => {
+  const config: SnowflakeConfig = {
+    accountIdentifier: 'my-account',
+    programmaticAccessToken: 'pat-secret',
+  };
+
+  describe('buildSnowflakeBaseUrl', () => {
+    it('should compose the URL from the account identifier', () => {
+      expect(buildSnowflakeBaseUrl(config)).toBe('https://my-account.snowflakecomputing.com');
+    });
+  });
+
+  it('should return 3 tools wrapped in ServerRemoteTool', () => {
+    const tools = getSnowflakeTools(config);
+
+    expect(tools).toHaveLength(3);
+    tools.forEach(tool => {
+      expect(tool).toBeInstanceOf(ServerRemoteTool);
+      expect(tool.sourceId).toBe('snowflake');
+      expect(tool.sourceType).toBe('server');
+    });
+  });
+
+  it('should return tools with expected names', () => {
+    const tools = getSnowflakeTools(config);
+    const names = tools.map(t => t.base.name);
+
+    expect(names).toEqual([
+      'snowflake_cortex_search',
+      'snowflake_cortex_analyst',
+      'snowflake_execute_query',
+    ]);
+  });
+});

--- a/packages/ai-proxy/test/integrations/snowflake/tools/cortex-analyst.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools/cortex-analyst.test.ts
@@ -1,0 +1,92 @@
+import createCortexAnalystTool from '../../../../src/integrations/snowflake/tools/cortex-analyst';
+
+const mockResponse = { message: { content: [{ type: 'text', text: 'answer' }] } };
+
+global.fetch = jest.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve(mockResponse),
+}) as jest.Mock;
+
+describe('createCortexAnalystTool', () => {
+  const headers = { Authorization: 'Bearer token' };
+  const baseUrl = 'https://my-account.snowflakecomputing.com';
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should POST the question with semantic_model_file', async () => {
+    const tool = createCortexAnalystTool(headers, baseUrl);
+
+    const result = await tool.invoke({
+      question: 'What is the total revenue this year?',
+      semantic_model_file: '@db.sc.stage/model.yaml',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/v2/cortex/analyst/message`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the total revenue this year?' }],
+          },
+        ],
+        semantic_model_file: '@db.sc.stage/model.yaml',
+      }),
+    });
+    expect(result).toBe(JSON.stringify(mockResponse));
+  });
+
+  it('should POST the question with semantic_view', async () => {
+    const tool = createCortexAnalystTool(headers, baseUrl);
+
+    await tool.invoke({ question: 'q', semantic_view: 'db.sc.view' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/api/v2/cortex/analyst/message`,
+      expect.objectContaining({
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'q' }] }],
+          semantic_view: 'db.sc.view',
+        }),
+      }),
+    );
+  });
+
+  it('should throw when neither semantic_model_file nor semantic_view is provided', async () => {
+    const tool = createCortexAnalystTool(headers, baseUrl);
+
+    await expect(tool.invoke({ question: 'q' })).rejects.toThrow(
+      'Either `semantic_model_file` or `semantic_view` must be provided.',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should throw when both semantic_model_file and semantic_view are provided', async () => {
+    const tool = createCortexAnalystTool(headers, baseUrl);
+
+    await expect(
+      tool.invoke({
+        question: 'q',
+        semantic_model_file: '@s/f.yaml',
+        semantic_view: 'db.sc.v',
+      }),
+    ).rejects.toThrow('Provide only one of `semantic_model_file` or `semantic_view`, not both.');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should throw on HTTP error', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      json: async () => ({ message: 'Rate limited' }),
+    });
+
+    const tool = createCortexAnalystTool(headers, baseUrl);
+
+    await expect(
+      tool.invoke({ question: 'q', semantic_view: 'db.sc.v' }),
+    ).rejects.toThrow('Snowflake cortex analyst failed (429): Rate limited');
+  });
+});

--- a/packages/ai-proxy/test/integrations/snowflake/tools/cortex-search.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools/cortex-search.test.ts
@@ -1,0 +1,91 @@
+import createCortexSearchTool from '../../../../src/integrations/snowflake/tools/cortex-search';
+
+const mockResponse = { results: [{ id: 1, score: 0.9 }] };
+
+global.fetch = jest.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve(mockResponse),
+}) as jest.Mock;
+
+describe('createCortexSearchTool', () => {
+  const headers = { Authorization: 'Bearer token' };
+  const baseUrl = 'https://my-account.snowflakecomputing.com';
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should POST the query to the fully qualified cortex search service URL', async () => {
+    const tool = createCortexSearchTool(headers, baseUrl);
+
+    const result = await tool.invoke({
+      database: 'MY_DB',
+      schema: 'MY_SCHEMA',
+      service: 'MY_SVC',
+      query: 'find things',
+      columns: ['title', 'body'],
+      filter: { status: 'active' },
+      limit: 5,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/api/v2/databases/MY_DB/schemas/MY_SCHEMA/cortex-search-services/MY_SVC:query`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: 'find things',
+          columns: ['title', 'body'],
+          filter: { status: 'active' },
+          limit: 5,
+        }),
+      },
+    );
+    expect(result).toBe(JSON.stringify(mockResponse));
+  });
+
+  it('should URL-encode identifiers with special characters', async () => {
+    const tool = createCortexSearchTool(headers, baseUrl);
+
+    await tool.invoke({
+      database: 'my db',
+      schema: 'my/schema',
+      service: 'svc name',
+      query: 'q',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/api/v2/databases/my%20db/schemas/my%2Fschema/cortex-search-services/svc%20name:query`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('should omit optional fields when not provided', async () => {
+    const tool = createCortexSearchTool(headers, baseUrl);
+
+    await tool.invoke({
+      database: 'DB',
+      schema: 'SC',
+      service: 'SVC',
+      query: 'q',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify({ query: 'q' }) }),
+    );
+  });
+
+  it('should throw on HTTP error', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ message: 'Insufficient privileges' }),
+    });
+
+    const tool = createCortexSearchTool(headers, baseUrl);
+
+    await expect(
+      tool.invoke({ database: 'D', schema: 'S', service: 'V', query: 'q' }),
+    ).rejects.toThrow('Snowflake cortex search failed (403): Insufficient privileges');
+  });
+});

--- a/packages/ai-proxy/test/integrations/snowflake/tools/execute-query.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools/execute-query.test.ts
@@ -1,0 +1,98 @@
+import type { SnowflakeConfig } from '../../../../src/integrations/snowflake/tools';
+
+import createExecuteQueryTool from '../../../../src/integrations/snowflake/tools/execute-query';
+
+const mockResponse = { resultSetMetaData: {}, data: [[1]] };
+
+global.fetch = jest.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve(mockResponse),
+}) as jest.Mock;
+
+describe('createExecuteQueryTool', () => {
+  const headers = { Authorization: 'Bearer token' };
+  const baseUrl = 'https://my-account.snowflakecomputing.com';
+  const config: SnowflakeConfig = {
+    accountIdentifier: 'my-account',
+    programmaticAccessToken: 'pat-secret',
+    defaultWarehouse: 'WH_DEFAULT',
+    defaultDatabase: 'DB_DEFAULT',
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should POST the statement with default session context', async () => {
+    const tool = createExecuteQueryTool(headers, baseUrl, config);
+
+    const result = await tool.invoke({ statement: 'SELECT 1' });
+
+    expect(fetch).toHaveBeenCalledWith(`${baseUrl}/api/v2/statements`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        statement: 'SELECT 1',
+        warehouse: 'WH_DEFAULT',
+        database: 'DB_DEFAULT',
+      }),
+    });
+    expect(result).toBe(JSON.stringify(mockResponse));
+  });
+
+  it('should let per-call overrides win over defaults', async () => {
+    const tool = createExecuteQueryTool(headers, baseUrl, config);
+
+    await tool.invoke({
+      statement: 'SELECT 1',
+      warehouse: 'WH_OVERRIDE',
+      database: 'DB_OVERRIDE',
+      schema: 'SC_OVERRIDE',
+      role: 'RL_OVERRIDE',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          statement: 'SELECT 1',
+          warehouse: 'WH_OVERRIDE',
+          database: 'DB_OVERRIDE',
+          schema: 'SC_OVERRIDE',
+          role: 'RL_OVERRIDE',
+        }),
+      }),
+    );
+  });
+
+  it('should reject non-read-only statements before calling Snowflake', async () => {
+    const tool = createExecuteQueryTool(headers, baseUrl, config);
+
+    await expect(tool.invoke({ statement: 'DELETE FROM users' })).rejects.toThrow(
+      'Only read-only statements (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed.',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should reject multi-statement payloads', async () => {
+    const tool = createExecuteQueryTool(headers, baseUrl, config);
+
+    await expect(tool.invoke({ statement: 'SELECT 1; DROP TABLE t' })).rejects.toThrow(
+      'Only a single SQL statement is allowed. Multiple statements are not permitted.',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should throw on HTTP error', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ message: 'SQL compilation error' }),
+    });
+
+    const tool = createExecuteQueryTool(headers, baseUrl, config);
+
+    await expect(tool.invoke({ statement: 'SELECT bad' })).rejects.toThrow(
+      'Snowflake execute query failed (400): SQL compilation error',
+    );
+  });
+});

--- a/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
@@ -1,0 +1,221 @@
+import { AIBadRequestError, McpConnectionError } from '../../../src/errors';
+import {
+  assertReadOnlySql,
+  assertResponseOk,
+  buildSessionContext,
+  getSnowflakeAuthHeaders,
+  getSnowflakeValidationBaseUrl,
+  validateSnowflakeConfig,
+} from '../../../src/integrations/snowflake/utils';
+
+describe('snowflake/utils', () => {
+  const baseConfig = {
+    accountIdentifier: 'my-account',
+    programmaticAccessToken: 'pat-secret',
+  };
+
+  describe('getSnowflakeAuthHeaders', () => {
+    it('should return PAT bearer headers', () => {
+      expect(getSnowflakeAuthHeaders(baseConfig)).toEqual({
+        Authorization: 'Bearer pat-secret',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Snowflake-Authorization-Token-Type': 'PROGRAMMATIC_ACCESS_TOKEN',
+      });
+    });
+  });
+
+  describe('getSnowflakeValidationBaseUrl', () => {
+    it('should build the validation URL from the account identifier only', () => {
+      expect(getSnowflakeValidationBaseUrl('my-account')).toBe(
+        'https://my-account.snowflakecomputing.com',
+      );
+    });
+  });
+
+  describe('buildSessionContext', () => {
+    it('should return empty object when no defaults are set', () => {
+      expect(buildSessionContext(baseConfig)).toEqual({});
+    });
+
+    it('should include only the provided defaults', () => {
+      const result = buildSessionContext({
+        ...baseConfig,
+        defaultWarehouse: 'WH',
+        defaultDatabase: 'DB',
+        defaultSchema: 'SC',
+        defaultRole: 'RL',
+      });
+
+      expect(result).toEqual({ warehouse: 'WH', database: 'DB', schema: 'SC', role: 'RL' });
+    });
+  });
+
+  describe('assertReadOnlySql', () => {
+    it.each([
+      'SELECT * FROM users',
+      '  select 1',
+      'SHOW TABLES',
+      'DESCRIBE TABLE users',
+      'DESC users',
+      'EXPLAIN SELECT 1',
+      'SELECT 1;',
+    ])('should accept read-only statement: %s', statement => {
+      expect(() => assertReadOnlySql(statement)).not.toThrow();
+    });
+
+    it('should strip line and block comments before evaluating', () => {
+      expect(() => assertReadOnlySql('-- a comment\n/* block */ SELECT 1')).not.toThrow();
+    });
+
+    it('should accept semicolons inside string literals (no false positive)', () => {
+      expect(() => assertReadOnlySql("SELECT 'a;b' FROM t")).not.toThrow();
+    });
+
+    it('should accept disallowed keywords inside string literals', () => {
+      expect(() => assertReadOnlySql("SELECT * FROM t WHERE name = 'DROP TABLE x'")).not.toThrow();
+    });
+
+    it('should accept disallowed keywords inside double-quoted identifiers', () => {
+      expect(() => assertReadOnlySql('SELECT * FROM "DROP"')).not.toThrow();
+    });
+
+    it('should reject empty statements', () => {
+      expect(() => assertReadOnlySql('   ')).toThrow(AIBadRequestError);
+      expect(() => assertReadOnlySql('   ')).toThrow('SQL statement is empty');
+    });
+
+    it.each([
+      'INSERT INTO t VALUES (1)',
+      'UPDATE t SET a=1',
+      'DELETE FROM t',
+      'DROP TABLE t',
+      'CALL proc()',
+      'GRANT SELECT ON t TO r',
+      'WITH cte AS (SELECT 1) SELECT * FROM cte',
+      'WITH cte AS (SELECT 1) DELETE FROM t WHERE id IN (SELECT id FROM cte)',
+    ])('should reject statement that does not start with a read-only keyword: %s', statement => {
+      expect(() => assertReadOnlySql(statement)).toThrow(AIBadRequestError);
+      expect(() => assertReadOnlySql(statement)).toThrow(
+        'Only read-only statements (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed.',
+      );
+    });
+
+    it.each([
+      'EXPLAIN INSERT INTO t VALUES (1)',
+      'SELECT 1 -- ;\nDROP TABLE t',
+      'SELECT 1 /* */ DROP TABLE t',
+    ])('should reject hidden write keyword in: %s', statement => {
+      expect(() => assertReadOnlySql(statement)).toThrow(AIBadRequestError);
+      expect(() => assertReadOnlySql(statement)).toThrow(
+        /SQL statement contains a disallowed keyword/,
+      );
+    });
+
+    it('should mention the offending keyword in the error message', () => {
+      expect(() => assertReadOnlySql('EXPLAIN INSERT INTO t VALUES (1)')).toThrow(
+        'SQL statement contains a disallowed keyword: INSERT',
+      );
+    });
+
+    it('should reject multiple statements separated by ;', () => {
+      expect(() => assertReadOnlySql('SELECT 1; SELECT 2')).toThrow(AIBadRequestError);
+      expect(() => assertReadOnlySql('SELECT 1; SELECT 2')).toThrow(
+        'Only a single SQL statement is allowed. Multiple statements are not permitted.',
+      );
+    });
+  });
+
+  describe('assertResponseOk', () => {
+    it('should not throw when response is ok', async () => {
+      const response = { ok: true } as Response;
+      await expect(assertResponseOk(response, 'test')).resolves.toBeUndefined();
+    });
+
+    it('should throw with message field from JSON body', async () => {
+      const response = {
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({ message: 'Invalid identifier' }),
+      } as unknown as Response;
+
+      await expect(assertResponseOk(response, 'execute query')).rejects.toThrow(
+        'Snowflake execute query failed (400): Invalid identifier',
+      );
+    });
+
+    it('should fall back to statusText when JSON parsing fails', async () => {
+      const response = {
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: async () => {
+          throw new Error('not json');
+        },
+      } as unknown as Response;
+
+      await expect(assertResponseOk(response, 'cortex search')).rejects.toThrow(
+        'Snowflake cortex search failed (502): Bad Gateway',
+      );
+    });
+  });
+
+  describe('validateSnowflakeConfig', () => {
+    beforeEach(() => jest.restoreAllMocks());
+
+    it('should POST SELECT 1 to the account-identifier-only URL with default session context', async () => {
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ resultSetMetaData: {} }),
+      } as Response);
+
+      await expect(
+        validateSnowflakeConfig({ ...baseConfig, defaultWarehouse: 'WH' }),
+      ).resolves.toBeUndefined();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://my-account.snowflakecomputing.com/api/v2/statements',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer pat-secret',
+            'X-Snowflake-Authorization-Token-Type': 'PROGRAMMATIC_ACCESS_TOKEN',
+          }),
+          body: JSON.stringify({ statement: 'SELECT 1', warehouse: 'WH' }),
+        }),
+      );
+    });
+
+    it('should throw McpConnectionError including status, URL and server message on failure', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({ message: 'Invalid token' }),
+      } as unknown as Response);
+
+      await expect(validateSnowflakeConfig(baseConfig)).rejects.toThrow(McpConnectionError);
+      await expect(validateSnowflakeConfig(baseConfig)).rejects.toThrow(
+        'Failed to validate Snowflake config (HTTP 401 on ' +
+          'https://my-account.snowflakecomputing.com/api/v2/statements): Invalid token',
+      );
+    });
+
+    it('should fall back to statusText when response body is not JSON', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+        json: async () => {
+          throw new Error('not json');
+        },
+      } as unknown as Response);
+
+      await expect(validateSnowflakeConfig(baseConfig)).rejects.toThrow(
+        'Failed to validate Snowflake config (HTTP 502 on ' +
+          'https://my-account.snowflakecomputing.com/api/v2/statements): Bad Gateway',
+      );
+    });
+  });
+});

--- a/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
@@ -105,6 +105,8 @@ describe('snowflake/utils', () => {
       'EXPLAIN INSERT INTO t VALUES (1)',
       'SELECT 1 -- ;\nDROP TABLE t',
       'SELECT 1 /* */ DROP TABLE t',
+      "SELECT '--' DELETE FROM users",
+      "SELECT '/*' DROP TABLE t",
     ])('should reject hidden write keyword in: %s', statement => {
       expect(() => assertReadOnlySql(statement)).toThrow(AIBadRequestError);
       expect(() => assertReadOnlySql(statement)).toThrow(

--- a/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/utils.test.ts
@@ -2,9 +2,10 @@ import { AIBadRequestError, McpConnectionError } from '../../../src/errors';
 import {
   assertReadOnlySql,
   assertResponseOk,
+  assertValidAccountIdentifier,
   buildSessionContext,
   getSnowflakeAuthHeaders,
-  getSnowflakeValidationBaseUrl,
+  getSnowflakeBaseUrl,
   validateSnowflakeConfig,
 } from '../../../src/integrations/snowflake/utils';
 
@@ -25,11 +26,65 @@ describe('snowflake/utils', () => {
     });
   });
 
-  describe('getSnowflakeValidationBaseUrl', () => {
-    it('should build the validation URL from the account identifier only', () => {
-      expect(getSnowflakeValidationBaseUrl('my-account')).toBe(
-        'https://my-account.snowflakecomputing.com',
+  describe('getSnowflakeBaseUrl', () => {
+    it('should build the URL from the account identifier', () => {
+      expect(getSnowflakeBaseUrl('my-account')).toBe('https://my-account.snowflakecomputing.com');
+    });
+
+    it.each(['attack.com#', 'attack.com/', 'attack.com:8080', 'attack.com?x=1'])(
+      'should reject injection attempt: %s',
+      identifier => {
+        expect(() => getSnowflakeBaseUrl(identifier)).toThrow(AIBadRequestError);
+      },
+    );
+  });
+
+  describe('assertValidAccountIdentifier', () => {
+    it.each([
+      'xy12345',
+      'XY12345',
+      'myorg-myaccount',
+      'my_org-my_account',
+      'xy12345.us-east-1.aws',
+      'xy12345.us-east-1.gcp',
+      'xy12345.eu-west-1.azure',
+    ])('should accept valid identifier: %s', identifier => {
+      expect(() => assertValidAccountIdentifier(identifier)).not.toThrow();
+    });
+
+    it.each([
+      '',
+      'attack.com#',
+      'attack.com/',
+      'attack.com:8080',
+      'attack.com?x=1',
+      'attack.com\\foo',
+      'attack.com foo',
+      'attack.com\nfoo',
+      'attack.com@evil.com',
+      'a..b',
+      '.leading-dot',
+      'trailing-dot.',
+      'a.b.c.d.e',
+    ])('should reject invalid identifier: %j', identifier => {
+      expect(() => assertValidAccountIdentifier(identifier)).toThrow(AIBadRequestError);
+      expect(() => assertValidAccountIdentifier(identifier)).toThrow(
+        /Invalid Snowflake account identifier/,
       );
+    });
+
+    it('should reject non-string input', () => {
+      expect(() => assertValidAccountIdentifier(undefined as unknown as string)).toThrow(
+        AIBadRequestError,
+      );
+      expect(() => assertValidAccountIdentifier(123 as unknown as string)).toThrow(
+        AIBadRequestError,
+      );
+    });
+
+    it('should reject identifier exceeding the per-segment length cap', () => {
+      const tooLong = 'a'.repeat(129);
+      expect(() => assertValidAccountIdentifier(tooLong)).toThrow(AIBadRequestError);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a new Forest integration in `@forestadmin/ai-proxy` that exposes 3 MCP tools backed by Snowflake's REST API v2, authenticated via **Programmatic Access Tokens** (PAT).

**Tools shipped:**
- `snowflake_cortex_search` — semantic search via a Cortex Search service (caller passes `database`/`schema`/`service` as arguments).
- `snowflake_cortex_analyst` — natural-language analytical Q&A backed by a semantic model file (`@stage/model.yaml`) or a semantic view (XOR validated at runtime).
- `snowflake_execute_query` — synchronous SQL execution restricted to read-only statements.

**Authentication:** PAT bearer token (`Authorization: Bearer <pat>` + `X-Snowflake-Authorization-Token-Type: PROGRAMMATIC_ACCESS_TOKEN`). The token is passed per-request via the integration config — no shared OAuth flow.

**Config shape:**
\`\`\`ts
{
  accountIdentifier: string;       // e.g. "myorg-myaccount" or account locator
  programmaticAccessToken: string;
  defaultWarehouse?: string;
  defaultDatabase?: string;
  defaultSchema?: string;
  defaultRole?: string;
}
\`\`\`

**Read-only SQL guard (defense-in-depth):**
- Allowlist of leading keywords: \`SELECT | SHOW | DESCRIBE | DESC | EXPLAIN\`.
- Multi-statement detection runs after stripping comments **and** string/identifier literals (no false positive on \`SELECT 'a;b' FROM t\`).
- Forbidden-keyword scan over the normalized SQL covers bypasses like \`EXPLAIN INSERT …\`, \`WITH cte AS (…) DELETE …\`, and \`SELECT 1 -- ;\nDROP …\`.
- Primary safety net remains the Snowflake role bound to the PAT — give it SELECT/USAGE only.

## Test plan

- [x] \`yarn workspace @forestadmin/ai-proxy lint\`
- [x] \`yarn workspace @forestadmin/ai-proxy build\`
- [x] \`yarn workspace @forestadmin/ai-proxy test\` (328 passed, 64 new)
- [ ] End-to-end smoke test against a real Snowflake account with a PAT (warehouse + role with read-only privileges)
- [ ] Verify error path: invalid PAT → \`McpConnectionError\` with status + URL in the message
- [ ] Verify SQL guard blocks \`WITH cte … DELETE …\` end-to-end via the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Snowflake integration with PAT authentication to ai-proxy
> - Adds a `Snowflake` integration to `ForestIntegrationClient`, wiring up `loadTools` and `checkConnection` alongside existing integrations.
> - Introduces three LangChain `DynamicStructuredTool` instances: `snowflake_cortex_search`, `snowflake_cortex_analyst`, and `snowflake_execute_query`, each calling Snowflake's REST API with Programmatic Access Token (PAT) auth headers.
> - `snowflake_execute_query` enforces read-only SQL by rejecting mutating keywords and multi-statement queries before any network call via `assertReadOnlySql` in [utils.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1573/files#diff-8f9a8f096c9cdc4d866070b89bb39a01d5b3ac59f3fd355e287c9a16af5cdceb).
> - `validateSnowflakeConfig` performs a live connectivity check by executing `SELECT 1` against the Snowflake statements API, throwing `McpConnectionError` on failure.
> - Risk: `normalizeSql` in [utils.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1573/files#diff-8f9a8f096c9cdc4d866070b89bb39a01d5b3ac59f3fd355e287c9a16af5cdceb) contains a reported syntax error (stray leading `+`) that may cause a load-time `SyntaxError` in the utils module.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1573 opened
>
> - Added account identifier validation that throws `AIBadRequestError` for invalid Snowflake account identifiers [534eaae]
> - Refactored Snowflake base URL construction to centralize validation logic and remove local implementations [534eaae]
> - Extended SQL statement restrictions to forbid UPDATE operations in addition to existing forbidden keywords [534eaae]
> - Updated test suites to cover new account identifier validation behavior and removed tests for deprecated functions [534eaae]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d4ba41.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->