### PR TITLE
chore(security): patch 5 Dependabot alerts (2026-04-30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@hono/node-server": "^1.19.13",
     "langsmith": "^0.5.18",
     "lodash": "^4.18.0",
-    "lodash-es": "^4.18.0"
+    "lodash-es": "^4.18.0",
+    "fast-xml-parser": "^5.7.0"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -46,7 +46,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
-    "@fastify/express": "^1.1.0",
+    "@fastify/express": "^4.0.5",
     "@forestadmin/datasource-sql": "1.17.10",
     "@nestjs/common": "^10.4.16",
     "@nestjs/core": "^10.4.16",
@@ -72,7 +72,7 @@
     "@paralleldrive/cuid2": "2.2.2"
   },
   "peerDependencies": {
-    "@fastify/express": "^1.1.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+    "@fastify/express": "^4.0.5"
   },
   "peerDependenciesMeta": {
     "@fastify/express": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -46,7 +46,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {
-    "@fastify/express": "^4.0.5",
+    "@fastify/express": "^1.1.0",
     "@forestadmin/datasource-sql": "1.17.10",
     "@nestjs/common": "^10.4.16",
     "@nestjs/core": "^10.4.16",
@@ -72,7 +72,7 @@
     "@paralleldrive/cuid2": "2.2.2"
   },
   "peerDependencies": {
-    "@fastify/express": "^4.0.5"
+    "@fastify/express": "^1.1.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@fastify/express": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,13 +1671,13 @@
   resolved "https://registry.yarnpkg.com/@fastify/error/-/error-3.4.1.tgz#b14bb4cac3dd4ec614becbc643d1511331a6425c"
   integrity sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==
 
-"@fastify/express@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@fastify/express/-/express-4.0.5.tgz#e09da7a6d59ccf5686d7ce2b1fb0c19fc7dab202"
-  integrity sha512-Sd/6u38XGsOU4ETtw/xwPEZR3cDqEvidL6m+pJQDkvTPPDtXQvcfLZURmbVA1P6uTUhy2HkgV5nFcGatED5+aA==
+"@fastify/express@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/express/-/express-1.1.0.tgz#f2387b6ece4fef1ec7686302fe13a7ee4f20f4ce"
+  integrity sha512-hUqLYC3PTFwa/lwtuhtNeOrYuejyneG7A7ewO+2BM99lyasPK9ZAH1zyhBv6f5+3TU3nWpRh0pENLU70dw06gQ==
   dependencies:
-    express "^5.2.1"
-    fastify-plugin "^5.0.0"
+    express "^4.17.1"
+    fastify-plugin "^3.0.0"
 
 "@fastify/fast-json-stringify-compiler@^4.3.0":
   version "4.3.0"
@@ -8109,7 +8109,7 @@ express@5.1.0:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-express@^4.18.2:
+express@^4.17.1, express@^4.18.2:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.22.1.tgz#1de23a09745a4fffdb39247b344bb5eaff382069"
   integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
@@ -8369,15 +8369,15 @@ fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
   integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
+fastify-plugin@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-3.0.1.tgz#79e84c29f401020f38b524f59f2402103fd21ed2"
+  integrity sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==
+
 fastify-plugin@^4.0.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.1.tgz#44dc6a3cc2cce0988bc09e13f160120bbd91dbee"
   integrity sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==
-
-fastify-plugin@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-5.1.0.tgz#7083e039d6418415f9a669f8c25e72fc5bf2d3e7"
-  integrity sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==
 
 "fastify2@npm:fastify@^2.15.3":
   version "2.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,13 +1671,13 @@
   resolved "https://registry.yarnpkg.com/@fastify/error/-/error-3.4.1.tgz#b14bb4cac3dd4ec614becbc643d1511331a6425c"
   integrity sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==
 
-"@fastify/express@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@fastify/express/-/express-1.1.0.tgz#f2387b6ece4fef1ec7686302fe13a7ee4f20f4ce"
-  integrity sha512-hUqLYC3PTFwa/lwtuhtNeOrYuejyneG7A7ewO+2BM99lyasPK9ZAH1zyhBv6f5+3TU3nWpRh0pENLU70dw06gQ==
+"@fastify/express@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@fastify/express/-/express-4.0.5.tgz#e09da7a6d59ccf5686d7ce2b1fb0c19fc7dab202"
+  integrity sha512-Sd/6u38XGsOU4ETtw/xwPEZR3cDqEvidL6m+pJQDkvTPPDtXQvcfLZURmbVA1P6uTUhy2HkgV5nFcGatED5+aA==
   dependencies:
-    express "^4.17.1"
-    fastify-plugin "^3.0.0"
+    express "^5.2.1"
+    fastify-plugin "^5.0.0"
 
 "@fastify/fast-json-stringify-compiler@^4.3.0":
   version "4.3.0"
@@ -2591,6 +2591,11 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -8104,7 +8109,7 @@ express@5.1.0:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-express@^4.17.1, express@^4.18.2:
+express@^4.18.2:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.22.1.tgz#1de23a09745a4fffdb39247b344bb5eaff382069"
   integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
@@ -8342,36 +8347,37 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-builder@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
-  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+fast-xml-builder@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz#50188e1452a5fa095f415d3e63dcac0a1dbcbf11"
+  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
   dependencies:
     path-expression-matcher "^1.1.3"
 
-fast-xml-parser@5.5.8:
-  version "5.5.8"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz"
-  integrity sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==
+fast-xml-parser@5.5.8, fast-xml-parser@^5.7.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz#fecd0b054c6c132fc03dab994a413da781e0eb9f"
+  integrity sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==
   dependencies:
-    fast-xml-builder "^1.1.4"
-    path-expression-matcher "^1.2.0"
-    strnum "^2.2.0"
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.5"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
   integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
-fastify-plugin@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-3.0.1.tgz#79e84c29f401020f38b524f59f2402103fd21ed2"
-  integrity sha512-qKcDXmuZadJqdTm6vlCqioEbyewF60b/0LOFCcYN1B6BIZGlYJumWWOYs70SFYLDAH4YqdE1cxH/RKMG7rFxgA==
-
 fastify-plugin@^4.0.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-4.5.1.tgz#44dc6a3cc2cce0988bc09e13f160120bbd91dbee"
   integrity sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==
+
+fastify-plugin@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-5.1.0.tgz#7083e039d6418415f9a669f8c25e72fc5bf2d3e7"
+  integrity sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==
 
 "fastify2@npm:fastify@^2.15.3":
   version "2.15.3"
@@ -14091,10 +14097,15 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.1.3, path-expression-matcher@^1.2.0:
+path-expression-matcher@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz#9bdae3787f43b0857b0269e9caaa586c12c8abee"
   integrity sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==
+
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -16299,10 +16310,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strnum@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
-  integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
 
 subscriptions-transport-ws@^0.9.19:
   version "0.9.19"


### PR DESCRIPTION
## Summary

1 fixed, 3 ignored, 3 deferred, 1 resolutions added, 0 resolutions removed, 4 could-not-auto-fix. | label: :lock: security applied

## Fixed

| Alert | Package | Ecosystem | From → To | Severity | Bump |
|---|---|---|---|---|---|
| #340 | fast-xml-parser | npm | `5.5.8` → `5.7.2` (resolved) | medium | resolution; `@aws-sdk/xml-builder@3.972.16` pins the vulnerable `5.5.8` |

## Ignored

- **#336** `@fastify/middie` (high, middleware bypass via `ignoreDuplicateSlashes`) — _The package is dev/test/tooling only and the exploit requires untrusted input at runtime._ Pulled in only by `@nestjs/platform-fastify@10.x` (a `devDependency` of `packages/agent`), which is used in unit tests and the local `packages/_example/src/frameworks/nest-fastify-v8.ts` example. No direct import in our published source. The middleware-bypass exploit needs a server exposed to attacker-controlled URLs, which is not the case in tests/examples.
- **#337** `@fastify/middie` (critical, middleware auth bypass in child plugin scopes) — same reason as #336 (same package, same indirect path, same lack of runtime exposure).
- **#339** `uuid` < 14.0.0 (medium, missing buffer bounds check in v3/v5/v6 when `buf` is provided) — _The vulnerable code path is unreachable from our code._ Verified by grepping the repo: only `v1`, `v4`, and `validate` are imported from `uuid` (`packages/agent/src/utils/query-string.ts`, `packages/agent/src/routes/access/*.ts`, `packages/datasource-toolkit/src/validation/type-getter.ts`, `packages/datasource-customizer/src/decorators/search/filter-builder/build-uuid-field-filter.ts`). The advisory affects only `v3`/`v5`/`v6` when callers pass a too-short `buf`, which we never do.

## Could not auto-fix

- **#330, #331, #332, #333** `@fastify/express` <= 4.0.4 (critical, middleware auth bypass via URL normalization gaps / path doubling in child plugin scopes).
  - **Why no fix:** the patched version is `4.0.5`, but `@fastify/express@4.x` is built on `fastify-plugin@^5.0.0`, which hard-checks for `fastify@5.x` at registration time. The agent's `packages/agent/test/framework-mounter.test.ts` covers fastify `v2`/`v3`/`v4` (declared via the `fastify`, `fastify2`, `fastify4` aliased dev-deps and the `peerDependency` range `^1.1.0 || ^2.0.0 || ^3.0.0 || ^4.0.0`). With `@fastify/express@^4.0.5` in place, those registrations fail with `FastifyError: fastify-plugin: @fastify/express - expected '5.x' fastify version, '3.29.5' is installed` (and the same against `4.29.1`).
  - **What was attempted:** bumped `@fastify/express` from `^1.1.0` → `^4.0.5` in `packages/agent/package.json` (devDep + peerDep). Pushed in commit `268bf4d`. CI failed in `Linting & Testing (agent)` at the `Test code` step with the version-mismatch error above. Reverted in commit `1a57b1d`.
  - **Next step (not done in this PR):** migrating the agent to fastify `5.x` (and dropping fastify `2`/`3`/`4` from `peerDependencies` / matrix tests) is a project-level breaking change that exceeds the scope of an automated security-fix PR. Tracking separately is recommended before the next vuln scan run.

## Deferred

- **#341** `uuid` (medium, `packages/agent/package.json`, created 2026-04-23, < 7 days old)
- **#342** `uuid` (medium, `packages/datasource-customizer/package.json`, created 2026-04-23, < 7 days old)
- **#343** `uuid` (medium, `packages/datasource-toolkit/package.json`, created 2026-04-23, < 7 days old)

(Same root cause as #339 above — likely IGNORE on next run too.)

## Resolutions added

- **#340** — `fast-xml-parser`: `^5.7.0`
  - **Parent chain tried:** `plugin-aws-s3 → @aws-sdk/client-s3 → @aws-sdk/core → @aws-sdk/xml-builder → fast-xml-parser`. `@aws-sdk/xml-builder@3.972.16` (the version satisfying `@aws-sdk/core`'s `^3.972.6`) tightly pins `fast-xml-parser` to exactly `5.5.8`.
  - **Why no parent bump:** newer `@aws-sdk/xml-builder@3.972.20+` ships `fast-xml-parser@5.7.2`, but the version is selected transitively by `@aws-sdk/core` and not pinnable from our manifests without a deeper bump of the entire `@aws-sdk` family. A scoped resolution under `@aws-sdk/xml-builder` would be ideal but Yarn 1's nested-resolution syntax (`"@aws-sdk/xml-builder/fast-xml-parser"`) was tried first and did not deduplicate the version (a second copy was added instead of overriding the existing one).
  - **Placed in:** root `package.json` (Yarn 1 ignores workspace-level `resolutions`).
  - **Form:** unconditional root entry (last-resort fallback). Acceptable here because `fast-xml-parser` only appears in this single chain — verified with `yarn why fast-xml-parser`.

## Resolutions removed

None. Existing root resolutions (`tar`, `micromatch`, `qs`, `axios`, `follow-redirects`, `lerna/**/glob`, `semantic-release`, `hono`, `@hono/node-server`, `langsmith`, `lodash`, `lodash-es`) were sampled by removing each, re-running `yarn install`, and inspecting `yarn why`:
- `tar` → without pin drops to `tar@6.2.1` via `sqlite3`. Pin needed.
- `micromatch` → without pin, `semantic-release-slack-bot` pulls `4.0.2` (vulnerable). Pin needed.
- `qs` → without pin, `body-parser`/`@nestjs/platform-express` pull `6.13.0` (vulnerable). Pin needed.
- The remaining entries are likely still-needed security pins; full removal-and-reinstall sweep was not performed for all 12 to keep this PR's scope contained. They will be re-audited in subsequent runs.

## Risks

- **`fast-xml-parser` 5.5.8 → 5.7.2** is a minor bump within the same major. The `@aws-sdk/xml-builder` consumer code only uses `fast-xml-parser` for parsing AWS XML responses; the patched API surface (`XMLParser`/`XMLBuilder`) is unchanged in 5.7.x. No behavior change beyond the patched vuln expected.

## Manual testing

Covered by CI (`yarn lint` + `yarn test` matrix per workspace).

## Validation

✅ CI green (after cycle-2 revert of @fastify/express bump)
