### PR TITLE
fix(schema): increase default schema publication timeout

### DIFF
--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -75,7 +75,15 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
   }
 
   async postSchema(options: HttpOptions, schema: object): Promise<void> {
-    await ServerUtils.query(options, 'post', '/forest/apimaps', {}, schema);
+    const schemaPublicationTimeout = 30_000;
+    await ServerUtils.query(
+      options,
+      'post',
+      '/forest/apimaps',
+      {},
+      schema,
+      schemaPublicationTimeout,
+    );
   }
 
   async checkSchemaHash(options: HttpOptions, hash: string): Promise<{ sendSchema: boolean }> {

--- a/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
+++ b/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
@@ -91,7 +91,7 @@ describe('ForestHttpApi', () => {
   });
 
   describe('postSchema', () => {
-    it('should call the right endpoint with schema', async () => {
+    it('should call the right endpoint with schema and a 30s timeout', async () => {
       const schema = { data: [], meta: { schemaFileHash: 'abc123' } };
 
       await new ForestHttpApi().postSchema(options, schema);
@@ -102,6 +102,7 @@ describe('ForestHttpApi', () => {
         '/forest/apimaps',
         {},
         schema,
+        30_000,
       );
     });
   });


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `ForestHttpApi.postSchema` timeout to 30s when posting to `/forest/apimaps`
> Passes an explicit 30,000ms timeout to `ServerUtils.query` in `postSchema`, replacing the previous default (unspecified) timeout. The change addresses schema publication failures likely caused by the default timeout being too short.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f5e3f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->