### PR TITLE
fix(activity-logs): remove errorMessage from updateActivityLogStatus

### DIFF
--- a/packages/forestadmin-client/src/activity-logs/index.ts
+++ b/packages/forestadmin-client/src/activity-logs/index.ts
@@ -95,12 +95,9 @@ export default class ActivityLogsService {
   }
 
   async updateActivityLogStatus(params: UpdateActivityLogStatusParams): Promise<void> {
-    const { forestServerToken, activityLog, status, errorMessage } = params;
+    const { forestServerToken, activityLog, status } = params;
 
-    const body = {
-      status,
-      ...(errorMessage && { errorMessage }),
-    };
+    const body = { status };
 
     await this.forestAdminServerInterface.updateActivityLogStatus(
       this.getHttpOptions(forestServerToken),

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -255,7 +255,6 @@ export interface UpdateActivityLogStatusParams {
   forestServerToken: string;
   activityLog: ActivityLogResponse;
   status: 'completed' | 'failed';
-  errorMessage?: string;
 }
 
 /**

--- a/packages/forestadmin-client/test/activity-logs/index.test.ts
+++ b/packages/forestadmin-client/test/activity-logs/index.test.ts
@@ -291,7 +291,7 @@ describe('ActivityLogsService', () => {
       );
     });
 
-    it('should update activity log status to failed with error message', async () => {
+    it('should update activity log status to failed', async () => {
       mockForestAdminServerInterface.updateActivityLogStatus.mockResolvedValue(undefined);
 
       const service = new ActivityLogsService(mockForestAdminServerInterface, options);
@@ -301,14 +301,13 @@ describe('ActivityLogsService', () => {
         forestServerToken: 'test-token',
         activityLog,
         status: 'failed',
-        errorMessage: 'Something went wrong',
       });
 
       expect(mockForestAdminServerInterface.updateActivityLogStatus).toHaveBeenCalledWith(
         { forestServerUrl: options.forestServerUrl, bearerToken: 'test-token', headers: undefined },
         'idx-456',
         'log-123',
-        { status: 'failed', errorMessage: 'Something went wrong' },
+        { status: 'failed' },
       );
     });
 

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -74,7 +74,6 @@ interface UpdateActivityLogOptions {
   request: RequestHandlerExtra<ServerRequest, ServerNotification>;
   activityLog: ActivityLogResponse;
   status: 'completed' | 'failed';
-  errorMessage?: string;
   logger: Logger;
 }
 
@@ -120,19 +119,17 @@ interface MarkActivityLogAsFailedOptions {
   forestServerClient: ForestServerClient;
   request: RequestHandlerExtra<ServerRequest, ServerNotification>;
   activityLog: ActivityLogResponse;
-  errorMessage: string;
   logger: Logger;
 }
 
 export function markActivityLogAsFailed(options: MarkActivityLogAsFailedOptions): void {
-  const { forestServerClient, request, activityLog, errorMessage, logger } = options;
+  const { forestServerClient, request, activityLog, logger } = options;
   // Fire-and-forget: don't block error response on activity log update
   updateActivityLogStatus({
     forestServerClient,
     request,
     activityLog,
     status: 'failed',
-    errorMessage,
     logger,
   }).catch(error => {
     logger('Error', `Unexpected error updating activity log to 'failed': ${error}`);

--- a/packages/mcp-server/src/utils/with-activity-log.ts
+++ b/packages/mcp-server/src/utils/with-activity-log.ts
@@ -78,7 +78,6 @@ export default async function withActivityLog<T>(options: WithActivityLogOptions
       forestServerClient,
       request,
       activityLog,
-      errorMessage,
       logger,
     });
 

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -288,7 +288,6 @@ describe('markActivityLogAsFailed', () => {
       forestServerClient: mockForestServerClient,
       request,
       activityLog,
-      errorMessage: 'Something went wrong',
       logger: mockLogger,
     });
 
@@ -323,7 +322,6 @@ describe('markActivityLogAsFailed', () => {
       forestServerClient: mockForestServerClient,
       request,
       activityLog,
-      errorMessage: 'Something went wrong',
       logger: mockLogger,
     });
 
@@ -357,7 +355,6 @@ describe('markActivityLogAsFailed', () => {
       forestServerClient: mockForestServerClient,
       request,
       activityLog,
-      errorMessage: 'Something went wrong',
       logger: mockLogger,
     });
 
@@ -387,7 +384,6 @@ describe('markActivityLogAsFailed', () => {
       forestServerClient: mockForestServerClient,
       request,
       activityLog,
-      errorMessage: 'Something went wrong',
       logger: mockLogger,
     });
 
@@ -445,7 +441,6 @@ describe('markActivityLogAsSucceeded', () => {
       forestServerToken: 'test-forest-token',
       activityLog,
       status: 'completed',
-      errorMessage: undefined,
     });
 
     jest.useRealTimers();

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -279,7 +279,7 @@ describe('markActivityLogAsFailed', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
   }
 
-  it('should call updateActivityLogStatus with failed status and error message', async () => {
+  it('should call updateActivityLogStatus with failed status', async () => {
     const request = createMockRequest();
     const activityLog = { id: 'log-123', attributes: { index: 'idx-456' } };
     const mockLogger = jest.fn();
@@ -446,29 +446,4 @@ describe('markActivityLogAsSucceeded', () => {
     jest.useRealTimers();
   });
 
-  it('should not include errorMessage in completed status', async () => {
-    jest.useFakeTimers();
-
-    const request = createMockRequest();
-    const activityLog = { id: 'log-123', attributes: { index: 'idx-456' } };
-    const mockLogger = jest.fn();
-
-    markActivityLogAsSucceeded({
-      forestServerClient: mockForestServerClient,
-      request,
-      activityLog,
-      logger: mockLogger,
-    });
-
-    // Wait for the fire-and-forget promise to resolve
-    await jest.advanceTimersByTimeAsync(0);
-
-    expect(mockForestServerClient.updateActivityLogStatus).toHaveBeenCalledWith({
-      forestServerToken: 'test-forest-token',
-      activityLog,
-      status: 'completed',
-    });
-
-    jest.useRealTimers();
-  });
 });

--- a/packages/mcp-server/test/utils/activity-logs-creator.test.ts
+++ b/packages/mcp-server/test/utils/activity-logs-creator.test.ts
@@ -445,5 +445,4 @@ describe('markActivityLogAsSucceeded', () => {
 
     jest.useRealTimers();
   });
-
 });

--- a/packages/mcp-server/test/utils/with-activity-log.test.ts
+++ b/packages/mcp-server/test/utils/with-activity-log.test.ts
@@ -116,7 +116,6 @@ describe('withActivityLog', () => {
       forestServerClient: mockForestServerClient,
       request: mockRequest,
       activityLog: mockActivityLog,
-      errorMessage: 'Operation failed',
       logger: mockLogger,
     });
   });
@@ -162,7 +161,6 @@ describe('withActivityLog', () => {
       forestServerClient: mockForestServerClient,
       request: mockRequest,
       activityLog: mockActivityLog,
-      errorMessage: 'Invalid field value',
       logger: mockLogger,
     });
   });
@@ -185,7 +183,6 @@ describe('withActivityLog', () => {
       forestServerClient: mockForestServerClient,
       request: mockRequest,
       activityLog: mockActivityLog,
-      errorMessage: 'string error',
       logger: mockLogger,
     });
   });
@@ -258,7 +255,6 @@ describe('withActivityLog', () => {
         forestServerClient: mockForestServerClient,
         request: mockRequest,
         activityLog: mockActivityLog,
-        errorMessage: 'Enhanced error message',
         logger: mockLogger,
       });
     });
@@ -282,7 +278,6 @@ describe('withActivityLog', () => {
         forestServerClient: mockForestServerClient,
         request: mockRequest,
         activityLog: mockActivityLog,
-        errorMessage: 'Original error',
         logger: mockLogger,
       });
     });


### PR DESCRIPTION
## Summary

- Removes `errorMessage` from `UpdateActivityLogStatusParams` in `forestadmin-client`
- Removes the field from all callers in `mcp-server` (source + tests)
- Removes from `forestadmin-client` body construction (`{ status }` only)

## Context

The server Joi validator only accepts `{ status }` in the PATCH body for activity log status updates. `errorMessage` was added to the client interfaces but never implemented server-side, causing `400 ValidationFailedError: "errorMessage" is not allowed` on every activity log status update call.

## Test plan

- [x] `yarn workspace @forestadmin/forestadmin-client test` — 283 tests pass
- [x] `yarn workspace @forestadmin/mcp-server test` — 541 tests pass
- [x] Both packages build without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `errorMessage` from `updateActivityLogStatus` request body
> Strips the `errorMessage` field from activity log status update payloads across the `forestadmin-client` and `mcp-server` packages. `markActivityLogAsFailed` now calls `updateActivityLogStatus` with only `{ status: 'failed' }`, and the `UpdateActivityLogStatusParams` interface and related types no longer include an `errorMessage` property.
>
> - Behavioral Change: failed activity logs no longer report an error message to the Forest Admin server; the message is still used locally to construct the thrown `Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a48ca8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->