### PR TITLE
fix(agent): avoid concurent restart lead to an empty schema sending

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -50,6 +50,8 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
   private mcpEnabled = false;
   private mcpEnabledTools?: ToolName[];
 
+  private isRestarting = false;
+
   /**
    * Create a new Agent Builder.
    * If any options are missing, the default will be applied:
@@ -111,11 +113,23 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Restart the agent at runtime (remount routes).
    */
   async restart(): Promise<void> {
+    if (this.isRestarting) {
+      this.options.logger('Debug', 'Agent is already restarting. Do nothing.');
+
+      return;
+    }
+
+    this.options.logger('Info', `Agent is restarting...`);
+
+    this.isRestarting = true;
+
     // We force sending schema when restarting
     const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
 
     this.setMcpCallback(mcpHttpCallback ?? null);
     await this.remount(router);
+
+    this.isRestarting = false;
   }
 
   /**

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -123,13 +123,15 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
     this.isRestarting = true;
 
-    // We force sending schema when restarting
-    const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
+    try {
+      // We force sending schema when restarting
+      const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
 
-    this.setMcpCallback(mcpHttpCallback ?? null);
-    await this.remount(router);
-
-    this.isRestarting = false;
+      this.setMcpCallback(mcpHttpCallback ?? null);
+      await this.remount(router);
+    } finally {
+      this.isRestarting = false;
+    }
   }
 
   /**

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -235,14 +235,13 @@ describe('Agent', () => {
         // Make the next getDataSource call hang so the first restart is still
         // in progress when the second one is triggered.
         let releaseFirstRestart: () => void = () => {};
-        jest
-          .mocked(DataSourceCustomizer.prototype.getDataSource)
-          .mockImplementationOnce(
-            () =>
-              new Promise(resolve => {
-                releaseFirstRestart = () => resolve(factories.dataSource.build());
-              }),
-          );
+
+        jest.mocked(DataSourceCustomizer.prototype.getDataSource).mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseFirstRestart = () => resolve(factories.dataSource.build());
+            }),
+        );
 
         const firstRestart = agent.restart();
         const secondRestart = agent.restart();

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -223,6 +223,69 @@ describe('Agent', () => {
 
       expect(DataSourceCustomizer.prototype.use).toHaveBeenCalledTimes(2);
     });
+
+    describe('when a restart is already in progress', () => {
+      test('should ignore concurrent restart calls and not rebuild routes again', async () => {
+        const mockLogger = jest.fn();
+        const agent = new Agent({ ...options, logger: mockLogger });
+
+        await agent.start();
+        jest.clearAllMocks();
+
+        // Make the next getDataSource call hang so the first restart is still
+        // in progress when the second one is triggered.
+        let releaseFirstRestart: () => void = () => {};
+        jest
+          .mocked(DataSourceCustomizer.prototype.getDataSource)
+          .mockImplementationOnce(
+            () =>
+              new Promise(resolve => {
+                releaseFirstRestart = () => resolve(factories.dataSource.build());
+              }),
+          );
+
+        const firstRestart = agent.restart();
+        const secondRestart = agent.restart();
+
+        releaseFirstRestart();
+        await Promise.all([firstRestart, secondRestart]);
+
+        expect(DataSourceCustomizer.prototype.getDataSource).toHaveBeenCalledTimes(1);
+        expect(mockSetupRoute).toHaveBeenCalledTimes(1);
+        expect(mockBootstrap).toHaveBeenCalledTimes(1);
+        expect(mockMakeRoutes).toHaveBeenCalledTimes(1);
+        expect(mockLogger).toHaveBeenCalledWith(
+          'Debug',
+          'Agent is already restarting. Do nothing.',
+        );
+      });
+
+      test('should allow a new restart once the previous one has finished', async () => {
+        const agent = new Agent(options);
+
+        await agent.start();
+        jest.clearAllMocks();
+
+        await agent.restart();
+        await agent.restart();
+
+        expect(DataSourceCustomizer.prototype.getDataSource).toHaveBeenCalledTimes(2);
+        expect(mockSetupRoute).toHaveBeenCalledTimes(2);
+        expect(mockBootstrap).toHaveBeenCalledTimes(2);
+      });
+
+      test('should log that the agent is restarting on each accepted restart', async () => {
+        const mockLogger = jest.fn();
+        const agent = new Agent({ ...options, logger: mockLogger });
+
+        await agent.start();
+        mockLogger.mockClear();
+
+        await agent.restart();
+
+        expect(mockLogger).toHaveBeenCalledWith('Info', 'Agent is restarting...');
+      });
+    });
   });
 
   describe('Production', () => {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix concurrent `Agent.restart` calls sending an empty schema
> - Adds an `isRestarting` boolean guard to `Agent` that prevents overlapping restart calls, logging a debug message and returning early when a restart is already in progress.
> - The guard is reset in a `try/finally` block so it clears correctly even if the rebuild throws.
> - New tests in [agent.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1577/files#diff-08f85356a04a295f1bc0513d943bdf5689cff22044cb5a3fc40969681f7a5683) cover single rebuild on concurrent calls, recovery after completion, and info logging on accepted restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d858470.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->