### PR TITLE
chore(security): patch 1 Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,12 +58,7 @@
     "micromatch": "^4.0.8",
     "semantic-release": "^25.0.0",
     "qs": ">=6.14.1",
-    "axios": "^1.15.0",
-    "follow-redirects": "^1.16.0",
-    "hono": "^4.12.12",
-    "@hono/node-server": "^1.19.13",
-    "langsmith": "^0.5.18",
     "lodash": "^4.18.0",
-    "lodash-es": "^4.18.0"
+    "**/fast-xml-parser": ">=5.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1778,7 +1778,7 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hono/node-server@^1.19.13", "@hono/node-server@^1.19.9":
+"@hono/node-server@^1.19.9":
   version "1.19.14"
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
   integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
@@ -2591,6 +2591,11 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -8342,21 +8347,22 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-builder@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
-  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+fast-xml-builder@^1.1.7:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz#96bf8de1e3a5f560149b6092844db4e6fd0ee38f"
+  integrity sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==
   dependencies:
     path-expression-matcher "^1.1.3"
 
-fast-xml-parser@5.5.8:
-  version "5.5.8"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz"
-  integrity sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==
+fast-xml-parser@5.5.8, fast-xml-parser@>=5.7.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz#309b04b08d835defc62ab657a0bb340c0e0fbe6a"
+  integrity sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==
   dependencies:
-    fast-xml-builder "^1.1.4"
-    path-expression-matcher "^1.2.0"
-    strnum "^2.2.0"
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.7"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -8670,7 +8676,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.15.11, follow-redirects@^1.16.0:
+follow-redirects@^1.15.11:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -9401,7 +9407,7 @@ highlight.js@^10.7.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hono@^4.11.4, hono@^4.12.12:
+hono@^4.11.4:
   version "4.12.14"
   resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
   integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
@@ -11316,7 +11322,7 @@ koa@^3.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-"langsmith@>=0.4.0 <1.0.0", langsmith@^0.5.18:
+"langsmith@>=0.4.0 <1.0.0":
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.21.tgz#2f4cd30dafc22922e423cf0f151ead5f636e76b0"
   integrity sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==
@@ -11669,7 +11675,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21, lodash-es@^4.18.0:
+lodash-es@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -14091,10 +14097,15 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.1.3, path-expression-matcher@^1.2.0:
+path-expression-matcher@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz#9bdae3787f43b0857b0269e9caaa586c12c8abee"
   integrity sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==
+
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -16299,10 +16310,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strnum@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
-  integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
 
 subscriptions-transport-ws@^0.9.19:
   version "0.9.19"


### PR DESCRIPTION
## Summary
1 fixed, 6 ignored, 6 deferred, 1 resolution added, 6 resolutions removed. | label: :lock: security applied

## Fixed
| Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|
| #340 | fast-xml-parser | npm | 5.5.8 → 5.7.3 | medium | Yarn resolution `**/fast-xml-parser: ">=5.7.0"` (transitive via `@aws-sdk/client-s3 → @aws-sdk/core → @aws-sdk/xml-builder`); xml-builder pins `fast-xml-parser` exactly so a parent bump alone wouldn't close the alert |

## Ignored
- **#330 (@fastify/express, GHSA-hrwm-hgmj-7p9c, critical)** — *dev/test only and the exploit requires untrusted input at runtime.* Listed only in `packages/agent` `devDependencies` (and as an optional peer dep). Fixed version 4.0.5 requires `express ^5.2.1` and `fastify-plugin ^5.0.0` (i.e. fastify v5). We ship support for fastify v2/v3/v4. The auth bypass requires a real HTTP server with untrusted input; our test suite drives only controlled requests.
- **#331 (@fastify/express, GHSA-6hw5-45gm-fj88, critical)** — same reasoning as #330 (dev/test only + untrusted-input requirement).
- **#332 (@fastify/express, GHSA-hrwm-hgmj-7p9c)** — *duplicates #330* on the same root cause (both reference the `@fastify/express` peer/dev install at `packages/agent`).
- **#333 (@fastify/express, GHSA-6hw5-45gm-fj88)** — *duplicates #331* on the same root cause.
- **#336 (@fastify/middie, GHSA-v9ww-2j6r-98q6, medium)** — *dev/test only and the exploit requires untrusted input at runtime.* Pulled in only by `@nestjs/platform-fastify@10.x`, which is in `devDependencies` of `packages/agent` and `packages/_example`; `@nestjs/platform-fastify@10.4.16` exact-pins `@fastify/middie@8.3.3`. Patched version 9.3.2 requires `fastify-plugin@5` / `@fastify/error@4` (fastify v5 ecosystem). Tests do not expose untrusted HTTP input.
- **#337 (@fastify/middie, GHSA-72c6-fx6q-fr5w, critical)** — same reasoning as #336.

## Deferred
Skipped by the 7-day age gate (will be picked up next run): #344, #345, #346, #347, #348 (all uuid, 2 days old), #349 (ip-address, 0 days).

## Resolutions added
- **#340 fast-xml-parser → `>=5.7.0`** — placed at root `package.json` under `resolutions`, **unconditional `**/` form**.
  - Parent chains tried: bumping `@aws-sdk/client-s3` (`^3.750.0` → latest 3.1044.0) would not deterministically close the alert because xml-builder pins `fast-xml-parser` to an exact version — only the latest xml-builder builds use 5.7.x. A parent bump is therefore non-deterministic; a resolution is required.
  - Workspace-level placement isn't applicable for Yarn classic in this repo (workspace-level `resolutions` aren't honored by Yarn 1).
  - Scoped form `"@aws-sdk/xml-builder/fast-xml-parser": ">=5.7.0"` was tried first and did not override the xml-builder request (Yarn 1 oddity with scoped-package paths). Fell back to the `**/` form, which only matches one chain in this repo so the blast radius is narrow.

## Resolutions removed
Audited every entry in root `resolutions` by temporarily removing it, running `yarn install`, and checking whether the natural resolution still satisfied the original pin. Removed when redundant (parent packages now pull a satisfying version on their own).

| File | Pinned package + version | Reason |
|---|---|---|
| `package.json` | `axios: ^1.15.0` | Redundant — natural resolution is `1.15.2` |
| `package.json` | `follow-redirects: ^1.16.0` | Redundant — natural resolution is `1.16.0` |
| `package.json` | `hono: ^4.12.12` | Redundant — natural resolution is `4.12.14` |
| `package.json` | `@hono/node-server: ^1.19.13` | Redundant — natural resolution is `1.19.14` |
| `package.json` | `langsmith: ^0.5.18` | Redundant — natural resolution is `0.5.21` |
| `package.json` | `lodash-es: ^4.18.0` | Redundant — natural resolution is `4.18.1` |

Pins kept (still needed): `tar`, `lerna/**/glob`, `micromatch`, `semantic-release`, `qs`, `lodash`. Removing `semantic-release` triggered a Yarn 1 `Invariant Violation` during install regardless of resolved version, so the pin was kept on stability grounds rather than vulnerability grounds.

## Risks
- **fast-xml-parser 5.5.8 → 5.7.3**: per the upstream changelog (5.6.x–5.7.x), the bump introduces `strnum`/`@nodable/entities`/`path-expression-matcher` runtime deps and tightens the XML escaping rules used by the *builder* (the patched code path). The *parser* API surface used by `@aws-sdk/xml-builder` for response parsing in `@aws-sdk/client-s3` is unchanged. No expected behavior change beyond the patched vuln.
- **Removed redundant resolutions**: no behavior change — every removed pin's natural resolution already satisfied the original constraint.

## Manual testing
Covered by CI.

## Validation
✅ CI green
