### PR TITLE
fix(workflow-executor): use last step from history (orchestrator as source of truth)

### DIFF
--- a/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
+++ b/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
@@ -131,7 +131,7 @@ export default class ForestServerWorkflowPort implements WorkflowPort {
     run: ServerHydratedWorkflowRun,
     err: WorkflowExecutorError,
   ): MalformedRunInfo {
-    const pending = run.workflowHistory.find(s => !s.done && !s.cancelled && !s.context?.error);
+    const pending = run.workflowHistory.at(-1) ?? null;
 
     return {
       runId: String(run.id),

--- a/packages/workflow-executor/src/adapters/run-to-available-step-mapper.ts
+++ b/packages/workflow-executor/src/adapters/run-to-available-step-mapper.ts
@@ -137,7 +137,7 @@ export default function toAvailableStepExecution(
   }
 
   const pending = run.workflowHistory.at(-1) ?? null;
-  if (!pending) return null;
+  if (!pending || pending.done) return null;
 
   const result = {
     runId: String(run.id),

--- a/packages/workflow-executor/src/adapters/run-to-available-step-mapper.ts
+++ b/packages/workflow-executor/src/adapters/run-to-available-step-mapper.ts
@@ -136,7 +136,7 @@ export default function toAvailableStepExecution(
     );
   }
 
-  const pending = run.workflowHistory.find(s => !s.done && !s.cancelled && !s.context?.error);
+  const pending = run.workflowHistory.at(-1) ?? null;
   if (!pending) return null;
 
   const result = {

--- a/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
@@ -94,41 +94,18 @@ describe('toAvailableStepExecution', () => {
     expect(result?.baseRecordRef.recordId).toEqual(['rec-abc']);
   });
 
-  it('should return null when all steps are done', () => {
-    const run = makeRun({
-      workflowHistory: [
-        makeStepHistory({ stepIndex: 0, done: true }),
-        makeStepHistory({ stepIndex: 1, done: true }),
-      ],
-    });
-
-    expect(toAvailableStepExecution(run)).toBeNull();
-  });
-
-  it('should return null when all steps are done or cancelled', () => {
-    const run = makeRun({
-      workflowHistory: [
-        makeStepHistory({ stepIndex: 0, done: true }),
-        makeStepHistory({ stepIndex: 1, done: false, cancelled: true }),
-      ],
-    });
-
-    expect(toAvailableStepExecution(run)).toBeNull();
-  });
-
   it('should return null when workflowHistory is empty', () => {
     const run = makeRun({ workflowHistory: [] });
 
     expect(toAvailableStepExecution(run)).toBeNull();
   });
 
-  it('should pick the first non-done, non-cancelled step as pending', () => {
+  it('picks the last step — orchestrator is the source of truth for which step to execute', () => {
     const run = makeRun({
       workflowHistory: [
         makeStepHistory({ stepName: 's0', stepIndex: 0, done: true }),
-        makeStepHistory({ stepName: 's1', stepIndex: 1, done: false, cancelled: true }),
+        makeStepHistory({ stepName: 's1', stepIndex: 1, done: true }),
         makeStepHistory({ stepName: 's2', stepIndex: 2, done: false }),
-        makeStepHistory({ stepName: 's3', stepIndex: 3, done: false }),
       ],
     });
 
@@ -136,33 +113,6 @@ describe('toAvailableStepExecution', () => {
 
     expect(result?.stepId).toBe('s2');
     expect(result?.stepIndex).toBe(2);
-  });
-
-  it('errored step (done:false + context.error) is skipped — next pending step is returned', () => {
-    // Scenario: back changed errored steps to done:false so the front can offer Continue/Revise.
-    // The executor must skip the errored step and pick the next pending one.
-    const run = makeRun({
-      workflowHistory: [
-        makeStepHistory({ stepName: 's0', stepIndex: 0, done: false, context: { error: 'boom' } }),
-        makeStepHistory({ stepName: 's1', stepIndex: 1, done: false }),
-      ],
-    });
-
-    const result = toAvailableStepExecution(run);
-
-    expect(result?.stepId).toBe('s1');
-    expect(result?.stepIndex).toBe(1);
-  });
-
-  it('returns null when the only non-done step is errored', () => {
-    const run = makeRun({
-      workflowHistory: [
-        makeStepHistory({ stepIndex: 0, done: true }),
-        makeStepHistory({ stepIndex: 1, done: false, context: { error: 'failed' } }),
-      ],
-    });
-
-    expect(toAvailableStepExecution(run)).toBeNull();
   });
 
   it('should strip unknown server keys (e.g. automaticExecution) from guidance step without throwing', () => {
@@ -404,18 +354,19 @@ describe('toAvailableStepExecution', () => {
       });
     });
 
-    it('should not include done steps that are after the available step', () => {
+    it('should not include the pending step itself in previousSteps', () => {
       const run = makeRun({
         workflowHistory: [
-          makeStepHistory({ stepName: 's0', stepIndex: 0, done: false }),
-          makeStepHistory({ stepName: 's1', stepIndex: 1, done: true }),
+          makeStepHistory({ stepName: 's0', stepIndex: 0, done: true }),
+          makeStepHistory({ stepName: 's1', stepIndex: 1, done: false }),
         ],
       });
 
       const result = toAvailableStepExecution(run);
 
-      expect(result?.stepId).toBe('s0');
-      expect(result?.previousSteps).toHaveLength(0);
+      expect(result?.stepId).toBe('s1');
+      expect(result?.previousSteps).toHaveLength(1);
+      expect(result?.previousSteps[0].stepOutcome.stepId).toBe('s0');
     });
 
     it.each([


### PR DESCRIPTION
## Summary

- Replace `workflowHistory.find(s => !s.done && !s.cancelled && !s.context?.error)` with `workflowHistory.at(-1)` — the orchestrator is the source of truth for which step to execute next
- Add `if (pending.done) return null` to handle completed runs gracefully (last step done = nothing to execute)
- Remove tests that asserted the old filtering logic; update remaining tests to reflect the new contract

## Test plan

- [ ] `yarn workspace @forestadmin/workflow-executor test` passes
- [ ] Empty history → `null`
- [ ] Last step `done: true` → `null` (run complete)
- [ ] Last step `done: false` → step is executed regardless of `cancelled`/`error` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pending step selection to use last workflowHistory entry as source of truth
> - `toAvailableStepExecution` in [run-to-available-step-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1582/files#diff-d8e6d94d08cd810252fadde0e0f846eca9f05c1b39b880ed4bb1d2357ca64abf) now selects the last entry in `workflowHistory` as the pending step, returning null if that step is done.
> - `ForestServerWorkflowPort.toMalformedInfo` in [forest-server-workflow-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1582/files#diff-70b42aec8454fc9dce637bd3559a6e947379c05eea7f496ee4dac1e9323c8c5d) applies the same logic for `stepId`/`stepIndex` resolution.
> - Behavioral Change: cancelled steps and steps with `context.error` are no longer skipped during pending step selection — only the position (last) in history matters now.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efc8559.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->