### PR TITLE
fix(workflow-executor): align getMcpServerConfigs port with Record shape

### DIFF
--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -14,6 +14,7 @@ export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
 export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
 
 export interface ForestIntegrationConfig {
+  id?: string;
   integrationName: ForestIntegrationName;
   config: CustomConfig;
   isForestConnector: true;
@@ -39,16 +40,16 @@ export default class ForestIntegrationClient implements ToolProvider {
   async loadTools(): Promise<RemoteTool[]> {
     const tools: RemoteTool[] = [];
 
-    this.configs.forEach(({ integrationName, config }) => {
+    this.configs.forEach(({ id: mcpServerId, integrationName, config }) => {
       switch (integrationName) {
         case 'Zendesk':
-          tools.push(...getZendeskTools(config as ZendeskConfig));
+          tools.push(...getZendeskTools(config as ZendeskConfig, mcpServerId));
           break;
         case 'Kolar':
-          tools.push(...getKolarTools(config as KolarConfig));
+          tools.push(...getKolarTools(config as KolarConfig, mcpServerId));
           break;
         case 'Snowflake':
-          tools.push(...getSnowflakeTools(config as SnowflakeConfig));
+          tools.push(...getSnowflakeTools(config as SnowflakeConfig, mcpServerId));
           break;
         default:
           this.logger?.('Warn', `Unsupported integration: ${integrationName}`);

--- a/packages/ai-proxy/src/integrations/kolar/tools.ts
+++ b/packages/ai-proxy/src/integrations/kolar/tools.ts
@@ -11,7 +11,7 @@ export interface KolarConfig {
   apiKey: string;
 }
 
-export default function getKolarTools(config: KolarConfig): RemoteTool[] {
+export default function getKolarTools(config: KolarConfig, mcpServerId?: string): RemoteTool[] {
   const { baseUrl, headers } = getKolarConfig(config);
 
   return [
@@ -23,6 +23,7 @@ export default function getKolarTools(config: KolarConfig): RemoteTool[] {
     tool =>
       new ServerRemoteTool({
         sourceId: 'kolar',
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/snowflake/tools.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools.ts
@@ -15,7 +15,10 @@ export interface SnowflakeConfig {
   defaultRole?: string;
 }
 
-export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[] {
+export default function getSnowflakeTools(
+  config: SnowflakeConfig,
+  mcpServerId?: string,
+): RemoteTool[] {
   const headers = getSnowflakeAuthHeaders(config);
   const baseUrl = getSnowflakeBaseUrl(config.accountIdentifier);
 
@@ -27,6 +30,7 @@ export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[]
     tool =>
       new ServerRemoteTool({
         sourceId: 'snowflake',
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/zendesk/tools.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools.ts
@@ -15,7 +15,7 @@ export interface ZendeskConfig {
   apiToken: string;
 }
 
-export default function getZendeskTools(config: ZendeskConfig): RemoteTool[] {
+export default function getZendeskTools(config: ZendeskConfig, mcpServerId?: string): RemoteTool[] {
   const { baseUrl, headers } = getZendeskConfig(config);
 
   return [
@@ -29,6 +29,7 @@ export default function getZendeskTools(config: ZendeskConfig): RemoteTool[] {
     tool =>
       new ServerRemoteTool({
         sourceId: 'zendesk',
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -8,14 +8,17 @@ import McpServerRemoteTool from './mcp-server-remote-tool';
 
 export type McpServers = MultiServerMCPClient['config']['mcpServers'];
 
-export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string];
+export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string] & {
+  id?: string;
+};
 
 export type McpConfiguration = {
-  configs: McpServers;
+  configs: Record<string, McpServerConfig>;
 } & Omit<MultiServerMCPClient['config'], 'mcpServers'>;
 
 export default class McpClient implements ToolProvider {
   private readonly mcpClients: Record<string, MultiServerMCPClient> = {};
+  private readonly mcpServerIdsByName: Record<string, string | undefined> = {};
   private readonly logger?: Logger;
 
   constructor(config: McpConfiguration, logger?: Logger) {
@@ -23,8 +26,11 @@ export default class McpClient implements ToolProvider {
     // split the config into several clients to be more resilient
     // if a mcp server is down, the others will still work
     Object.entries(config.configs).forEach(([name, serverConfig]) => {
+      const { id: mcpServerId, ...rest } = serverConfig as McpServerConfig &
+        Record<string, unknown>;
+      this.mcpServerIdsByName[name] = mcpServerId;
       this.mcpClients[name] = new MultiServerMCPClient({
-        mcpServers: { [name]: serverConfig },
+        mcpServers: { [name]: rest as McpServerConfig },
         ...config,
       });
     });
@@ -39,7 +45,12 @@ export default class McpClient implements ToolProvider {
         try {
           const loadedTools = (await client.getTools()) ?? [];
           const extendedTools = loadedTools.map(
-            tool => new McpServerRemoteTool({ tool, sourceId: name }),
+            tool =>
+              new McpServerRemoteTool({
+                tool,
+                sourceId: name,
+                mcpServerId: this.mcpServerIdsByName[name],
+              }),
           );
           tools.push(...extendedTools);
         } catch (error) {

--- a/packages/ai-proxy/src/mcp-server-remote-tool.ts
+++ b/packages/ai-proxy/src/mcp-server-remote-tool.ts
@@ -3,7 +3,11 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import RemoteTool from './remote-tool';
 
 export default class McpServerRemoteTool<ToolType = unknown> extends RemoteTool {
-  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+  constructor(options: {
+    tool: StructuredToolInterface<ToolType>;
+    sourceId?: string;
+    mcpServerId?: string;
+  }) {
     super({ ...options, sourceType: 'mcp-server' });
   }
 }

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -4,15 +4,20 @@ export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
   sourceType: string;
+  // Shared across McpServerRemoteTool and ServerRemoteTool because the orchestrator
+  // stores Forest connectors alongside user MCP servers in the same ai_mcp_configs table.
+  mcpServerId?: string;
 
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
     sourceType?: string;
+    mcpServerId?: string;
   }) {
     this.base = options.tool;
     this.sourceId = options.sourceId;
     this.sourceType = options.sourceType;
+    this.mcpServerId = options.mcpServerId;
   }
 
   get sanitizedName() {

--- a/packages/ai-proxy/src/server-remote-tool.ts
+++ b/packages/ai-proxy/src/server-remote-tool.ts
@@ -3,7 +3,11 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import RemoteTool from './remote-tool';
 
 export default class ServerRemoteTool<ToolType = unknown> extends RemoteTool {
-  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+  constructor(options: {
+    tool: StructuredToolInterface<ToolType>;
+    sourceId?: string;
+    mcpServerId?: string;
+  }) {
     super({ ...options, sourceType: 'server' });
   }
 }

--- a/packages/ai-proxy/test/forest-integration-client.test.ts
+++ b/packages/ai-proxy/test/forest-integration-client.test.ts
@@ -1,6 +1,9 @@
 import ForestIntegrationClient from '../src/forest-integration-client';
+import getKolarTools from '../src/integrations/kolar/tools';
 import { validateKolarConfig } from '../src/integrations/kolar/utils';
+import getSnowflakeTools from '../src/integrations/snowflake/tools';
 import { validateSnowflakeConfig } from '../src/integrations/snowflake/utils';
+import getZendeskTools from '../src/integrations/zendesk/tools';
 import { validateZendeskConfig } from '../src/integrations/zendesk/utils';
 
 const mockZendeskTools = [{ name: 'zendesk_get_tickets' }, { name: 'zendesk_get_ticket' }];
@@ -37,6 +40,7 @@ describe('ForestIntegrationClient', () => {
     it('should load zendesk tools when integration is zendesk', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
@@ -52,7 +56,7 @@ describe('ForestIntegrationClient', () => {
       const logger = jest.fn();
       const client = new ForestIntegrationClient(
         // @ts-expect-error Testing unsupported integration
-        [{ integrationName: 'unknown', config: {} as any, isForestConnector: true }],
+        [{ id: '1', integrationName: 'unknown', config: {} as any, isForestConnector: true }],
         logger,
       );
 
@@ -64,6 +68,7 @@ describe('ForestIntegrationClient', () => {
     it('should load kolar tools when integration is Kolar', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Kolar',
           config: { apiKey: 'key' },
           isForestConnector: true,
@@ -78,6 +83,7 @@ describe('ForestIntegrationClient', () => {
     it('should load snowflake tools when integration is Snowflake', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Snowflake',
           config: {
             accountIdentifier: 'a',
@@ -101,11 +107,13 @@ describe('ForestIntegrationClient', () => {
     it('should load tools from multiple configs', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'a', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
         },
         {
+          id: '2',
           integrationName: 'Zendesk',
           config: { subdomain: 'b', email: 'c@d.com', apiToken: 'tok2' },
           isForestConnector: true,
@@ -122,7 +130,7 @@ describe('ForestIntegrationClient', () => {
     it('should call validateZendeskConfig for Zendesk integration', async () => {
       const zendeskConfig = { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Zendesk', config: zendeskConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Zendesk', config: zendeskConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -133,6 +141,7 @@ describe('ForestIntegrationClient', () => {
     it('should return true on success', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
@@ -147,7 +156,7 @@ describe('ForestIntegrationClient', () => {
     it('should call validateKolarConfig for Kolar integration', async () => {
       const kolarConfig = { apiKey: 'key' };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Kolar', config: kolarConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Kolar', config: kolarConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -161,7 +170,7 @@ describe('ForestIntegrationClient', () => {
         programmaticAccessToken: 'tok',
       };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Snowflake', config: snowflakeConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Snowflake', config: snowflakeConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -172,12 +181,10 @@ describe('ForestIntegrationClient', () => {
     it('should throw for unsupported integration', async () => {
       const client = new ForestIntegrationClient([
         // @ts-expect-error Testing unsupported integration
-        { integrationName: 'Unknown', config: {}, isForestConnector: true },
+        { id: '1', integrationName: 'Unknown', config: {}, isForestConnector: true },
       ]);
 
-      await expect(client.checkConnection()).rejects.toThrow(
-        'Unsupported integration: Unknown',
-      );
+      await expect(client.checkConnection()).rejects.toThrow('Unsupported integration: Unknown');
     });
   });
 
@@ -186,6 +193,79 @@ describe('ForestIntegrationClient', () => {
       const client = new ForestIntegrationClient([]);
 
       await expect(client.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('ForestIntegrationConfig.id is threaded as mcpServerId into integration tool factories', () => {
+    it('passes the config id to getZendeskTools so produced tools can be matched by step.mcpServerId', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-zendesk-42',
+          integrationName: 'Zendesk',
+          config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
+          isForestConnector: true,
+        },
+      ]);
+
+      await client.loadTools();
+
+      expect(getZendeskTools).toHaveBeenCalledWith(
+        expect.objectContaining({ subdomain: 'test' }),
+        'forest-zendesk-42',
+      );
+    });
+
+    it('passes the config id to getKolarTools', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-kolar-7',
+          integrationName: 'Kolar',
+          config: { apiKey: 'key' },
+          isForestConnector: true,
+        },
+      ]);
+
+      await client.loadTools();
+
+      expect(getKolarTools).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'key' }),
+        'forest-kolar-7',
+      );
+    });
+
+    it('passes the config id to getSnowflakeTools', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-snowflake-99',
+          integrationName: 'Snowflake',
+          config: { accountIdentifier: 'a', programmaticAccessToken: 'tok' },
+          isForestConnector: true,
+        },
+      ]);
+
+      await client.loadTools();
+
+      expect(getSnowflakeTools).toHaveBeenCalledWith(
+        expect.objectContaining({ accountIdentifier: 'a' }),
+        'forest-snowflake-99',
+      );
+    });
+
+    it('passes undefined to the factory when the config entry has no id', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          integrationName: 'Zendesk',
+          config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
+          isForestConnector: true,
+        },
+      ]);
+
+      await client.loadTools();
+
+      expect(getZendeskTools).toHaveBeenCalledWith(
+        expect.objectContaining({ subdomain: 'test' }),
+        undefined,
+      );
     });
   });
 });

--- a/packages/ai-proxy/test/integrations/kolar/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/kolar/tools.test.ts
@@ -26,4 +26,23 @@ describe('getKolarTools', () => {
       'kolar_get_screening_result',
     ]);
   });
+
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getKolarTools(config, 'forest-kolar-7');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBe('forest-kolar-7');
+      });
+    });
+
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
+      const tools = getKolarTools(config);
+
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
@@ -28,4 +28,23 @@ describe('getSnowflakeTools', () => {
       'snowflake_execute_query',
     ]);
   });
+
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getSnowflakeTools(config, 'forest-snowflake-99');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBe('forest-snowflake-99');
+      });
+    });
+
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
+      const tools = getSnowflakeTools(config);
+
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
@@ -28,4 +28,23 @@ describe('getZendeskTools', () => {
       'zendesk_update_ticket',
     ]);
   });
+
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getZendeskTools(config, 'forest-zendesk-42');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBe('forest-zendesk-42');
+      });
+    });
+
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
+      const tools = getZendeskTools(config);
+
+      tools.forEach(tool => {
+        expect(tool.mcpServerId).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -80,6 +80,51 @@ describe('McpClient', () => {
       });
     });
 
+    describe('mcpServerId threaded from config entry into McpServerRemoteTool', () => {
+      it('sets RemoteTool.mcpServerId from the config entry id alongside sourceId from the map key', async () => {
+        const tool1 = tool(() => {}, {
+          name: 'tool1',
+          description: 'description1',
+          schema: undefined,
+          responseFormat: 'content',
+        });
+        const configWithId = {
+          configs: {
+            slack: {
+              transport: 'stdio' as const,
+              command: 'npx',
+              args: ['-y', '@modelcontextprotocol/server-slack'],
+              env: {},
+              id: 'config-id-42',
+            },
+          },
+        } as unknown as McpConfiguration;
+        const mcpClient = new McpClient(configWithId);
+        getToolsMock.mockResolvedValue([tool1]);
+
+        const tools = await mcpClient.loadTools();
+
+        expect(tools).toHaveLength(1);
+        expect(tools[0].sourceId).toBe('slack');
+        expect(tools[0].mcpServerId).toBe('config-id-42');
+      });
+
+      it('leaves RemoteTool.mcpServerId undefined when the config entry has no id (legacy / unenriched payload)', async () => {
+        const tool1 = tool(() => {}, {
+          name: 'tool1',
+          description: 'description1',
+          schema: undefined,
+          responseFormat: 'content',
+        });
+        const mcpClient = new McpClient(aConfig);
+        getToolsMock.mockResolvedValue([tool1]);
+
+        const tools = await mcpClient.loadTools();
+
+        expect(tools[0].mcpServerId).toBeUndefined();
+      });
+    });
+
     describe('when there is an error while loading the tools', () => {
       it('should not throw an error and try to load every mcp tools', async () => {
         const mcpClient = new McpClient({
@@ -396,6 +441,7 @@ describe('McpClient', () => {
       const configs = {
         server1: { type: 'http' as const, url: 'https://server1.com' },
         zendesk: {
+          id: '1',
           isForestConnector: true as const,
           integrationName: 'Zendesk' as const,
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },

--- a/packages/ai-proxy/test/tool-provider-factory.test.ts
+++ b/packages/ai-proxy/test/tool-provider-factory.test.ts
@@ -35,14 +35,12 @@ describe('createToolProviders', () => {
     const providers = createToolProviders(configs as any);
 
     expect(providers).toHaveLength(1);
-    expect(McpClient).toHaveBeenCalledWith(
-      { configs: { slack: configs.slack } },
-      undefined,
-    );
+    expect(McpClient).toHaveBeenCalledWith({ configs: { slack: configs.slack } }, undefined);
   });
 
   it('should create ForestIntegrationClient for ForestIntegration configs', () => {
     const zendeskConfig = {
+      id: '1',
       isForestConnector: true as const,
       integrationName: 'Zendesk' as const,
       config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
@@ -58,6 +56,7 @@ describe('createToolProviders', () => {
     const configs = {
       slack: { command: 'npx', args: [] },
       zendesk: {
+        id: '1',
         isForestConnector: true as const,
         integrationName: 'Zendesk' as const,
         config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
@@ -67,10 +66,7 @@ describe('createToolProviders', () => {
     const providers = createToolProviders(configs as any);
 
     expect(providers).toHaveLength(2);
-    expect(McpClient).toHaveBeenCalledWith(
-      { configs: { slack: configs.slack } },
-      undefined,
-    );
+    expect(McpClient).toHaveBeenCalledWith({ configs: { slack: configs.slack } }, undefined);
     expect(ForestIntegrationClient).toHaveBeenCalledWith([configs.zendesk], undefined);
   });
 
@@ -85,6 +81,7 @@ describe('createToolProviders', () => {
     const configs = {
       slack: { command: 'npx', args: [] },
       zendesk: {
+        id: '1',
         isForestConnector: true as const,
         integrationName: 'Zendesk' as const,
         config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },

--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@forestadmin/agent-client": "1.5.6",
-    "@forestadmin/ai-proxy": "1.8.0",
+    "@forestadmin/ai-proxy": "1.9.0",
     "@langchain/openai": "1.2.5",
-    "@forestadmin/forestadmin-client": "1.39.5",
+    "@forestadmin/forestadmin-client": "1.39.7",
     "@koa/bodyparser": "^6.1.0",
     "@koa/router": "^13.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
+++ b/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
@@ -4,7 +4,7 @@ import type {
   AvailableRunDispatch,
   AvailableRunsBatch,
   MalformedRunInfo,
-  McpConfiguration,
+  McpServers,
   WorkflowPort,
 } from '../ports/workflow-port';
 import type { StepUser } from '../types/execution-context';
@@ -203,10 +203,10 @@ export default class ForestServerWorkflowPort implements WorkflowPort {
     );
   }
 
-  async getMcpServerConfigs(): Promise<McpConfiguration[]> {
+  async getMcpServerConfigs(): Promise<McpServers> {
     return this.callPort(
       'getMcpServerConfigs',
-      () => ServerUtils.query<McpConfiguration[]>(this.options, 'get', ROUTES.mcpServerConfigs),
+      () => ServerUtils.query<McpServers>(this.options, 'get', ROUTES.mcpServerConfigs),
       { retry: true },
     );
   }

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -203,8 +203,13 @@ export class StepTimeoutError extends WorkflowExecutorError {
 }
 
 export class NoMcpToolsError extends WorkflowExecutorError {
-  constructor() {
-    super('No MCP tools available', 'No tools are available to execute this step.');
+  constructor(requestedMcpServerId?: string, loadedMcpServerIds?: readonly string[]) {
+    const technical = requestedMcpServerId
+      ? `No MCP tools available for mcpServerId="${requestedMcpServerId}". Loaded MCP server ids: [${(
+          loadedMcpServerIds ?? []
+        ).join(', ')}]`
+      : 'No MCP tools available';
+    super(technical, 'No tools are available to execute this step.');
   }
 }
 

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -224,13 +224,26 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     );
   }
 
-  /** Returns tools filtered by mcpServerId (if specified). Throws NoMcpToolsError if empty. */
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId
-      ? this.remoteTools.filter(t => t.sourceId === mcpServerId)
+      ? this.remoteTools.filter(t => t.mcpServerId === mcpServerId)
       : [...this.remoteTools];
-    if (tools.length === 0) throw new NoMcpToolsError();
+
+    if (tools.length === 0) {
+      const loadedMcpServerIds = this.remoteTools
+        .map(t => t.mcpServerId)
+        .filter((value): value is string => !!value);
+      const error = new NoMcpToolsError(mcpServerId, loadedMcpServerIds);
+      this.context.logger.error(error.message, {
+        runId: this.context.runId,
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        requestedMcpServerId: mcpServerId,
+        loadedMcpServerIds,
+      });
+      throw error;
+    }
 
     return tools;
   }

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -68,7 +68,7 @@ export type {
   Limit,
   UpdateRecordQuery,
 } from './ports/agent-port';
-export type { McpConfiguration, McpServers, WorkflowPort } from './ports/workflow-port';
+export type { McpServers, WorkflowPort } from './ports/workflow-port';
 export type { RunStore } from './ports/run-store';
 export type { Logger } from './ports/logger-port';
 export { default as ConsoleLogger } from './adapters/console-logger';

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -68,7 +68,7 @@ export type {
   Limit,
   UpdateRecordQuery,
 } from './ports/agent-port';
-export type { McpConfiguration, WorkflowPort } from './ports/workflow-port';
+export type { McpConfiguration, McpServers, WorkflowPort } from './ports/workflow-port';
 export type { RunStore } from './ports/run-store';
 export type { Logger } from './ports/logger-port';
 export { default as ConsoleLogger } from './adapters/console-logger';

--- a/packages/workflow-executor/src/ports/workflow-port.ts
+++ b/packages/workflow-executor/src/ports/workflow-port.ts
@@ -3,9 +3,9 @@
 import type { AvailableStepExecution, StepUser } from '../types/execution-context';
 import type { CollectionSchema } from '../types/validated/collection';
 import type { StepOutcome } from '../types/validated/step-outcome';
-import type { McpConfiguration, McpServers } from '@forestadmin/ai-proxy';
+import type { McpServers } from '@forestadmin/ai-proxy';
 
-export type { McpConfiguration, McpServers };
+export type { McpServers };
 
 export interface MalformedRunInfo {
   runId: string;
@@ -39,8 +39,6 @@ export interface WorkflowPort {
     stepOutcome: StepOutcome,
   ): Promise<AvailableRunDispatch | null>;
   getCollectionSchema(collectionName: string, runId: string): Promise<CollectionSchema>;
-  // The orchestrator's GET /liana/mcp-server-configs-with-details returns a
-  // Record<string, ToolConfig> map keyed by server name — not an array.
   getMcpServerConfigs(): Promise<McpServers>;
   hasRunAccess(runId: string, user: StepUser): Promise<boolean>;
 }

--- a/packages/workflow-executor/src/ports/workflow-port.ts
+++ b/packages/workflow-executor/src/ports/workflow-port.ts
@@ -3,9 +3,9 @@
 import type { AvailableStepExecution, StepUser } from '../types/execution-context';
 import type { CollectionSchema } from '../types/validated/collection';
 import type { StepOutcome } from '../types/validated/step-outcome';
-import type { McpConfiguration } from '@forestadmin/ai-proxy';
+import type { McpConfiguration, McpServers } from '@forestadmin/ai-proxy';
 
-export type { McpConfiguration };
+export type { McpConfiguration, McpServers };
 
 export interface MalformedRunInfo {
   runId: string;
@@ -39,6 +39,8 @@ export interface WorkflowPort {
     stepOutcome: StepOutcome,
   ): Promise<AvailableRunDispatch | null>;
   getCollectionSchema(collectionName: string, runId: string): Promise<CollectionSchema>;
-  getMcpServerConfigs(): Promise<McpConfiguration[]>;
+  // The orchestrator's GET /liana/mcp-server-configs-with-details returns a
+  // Record<string, ToolConfig> map keyed by server name — not an array.
+  getMcpServerConfigs(): Promise<McpServers>;
   hasRunAccess(runId: string, user: StepUser): Promise<boolean>;
 }

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -4,12 +4,7 @@ import type { AgentPort } from './ports/agent-port';
 import type { AiModelPort } from './ports/ai-model-port';
 import type { Logger } from './ports/logger-port';
 import type { RunStore } from './ports/run-store';
-import type {
-  AvailableRunDispatch,
-  MalformedRunInfo,
-  McpConfiguration,
-  WorkflowPort,
-} from './ports/workflow-port';
+import type { AvailableRunDispatch, MalformedRunInfo, WorkflowPort } from './ports/workflow-port';
 import type SchemaCache from './schema-cache';
 import type { AvailableStepExecution, StepExecutionResult } from './types/execution-context';
 import type { StepExecutionData } from './types/step-execution-data';
@@ -262,14 +257,9 @@ export default class Runner {
 
   private async fetchRemoteTools(): Promise<RemoteTool[]> {
     const configs = await this.config.workflowPort.getMcpServerConfigs();
-    if (configs.length === 0) return [];
+    if (Object.keys(configs).length === 0) return [];
 
-    const mergedConfig: McpConfiguration = {
-      ...configs[0],
-      configs: Object.assign({}, ...configs.map(c => c.configs)),
-    };
-
-    return this.config.aiModelPort.loadRemoteTools(mergedConfig);
+    return this.config.aiModelPort.loadRemoteTools({ configs });
   }
 
   private executeStep(

--- a/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
@@ -732,8 +732,10 @@ describe('ForestServerWorkflowPort', () => {
   });
 
   describe('getMcpServerConfigs', () => {
-    it('fetches mcp server configs', async () => {
-      const configs = [{ name: 'mcp-1' }];
+    it('returns the Record<string, ToolConfig> map verbatim from the orchestrator', async () => {
+      const configs = {
+        'data-gouv': { url: 'https://mcp.example.com', type: 'http', headers: {} },
+      };
       mockQuery.mockResolvedValue(configs);
 
       const result = await port.getMcpServerConfigs();
@@ -744,6 +746,14 @@ describe('ForestServerWorkflowPort', () => {
         '/liana/mcp-server-configs-with-details',
       );
       expect(result).toEqual(configs);
+    });
+
+    it('returns an empty Record when the orchestrator has no MCP servers configured', async () => {
+      mockQuery.mockResolvedValue({});
+
+      const result = await port.getMcpServerConfigs();
+
+      expect(result).toEqual({});
     });
   });
 

--- a/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
@@ -734,7 +734,7 @@ describe('ForestServerWorkflowPort', () => {
   describe('getMcpServerConfigs', () => {
     it('returns the Record<string, ToolConfig> map verbatim from the orchestrator', async () => {
       const configs = {
-        'data-gouv': { url: 'https://mcp.example.com', type: 'http', headers: {} },
+        'mcp-server-1': { url: 'https://mcp.example.com', type: 'http', headers: {} },
       };
       mockQuery.mockResolvedValue(configs);
 

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -1,4 +1,4 @@
-import { extractErrorMessage } from '../src/errors';
+import { NoMcpToolsError, extractErrorMessage } from '../src/errors';
 
 describe('extractErrorMessage', () => {
   it('returns err.message when non-empty', () => {
@@ -56,5 +56,41 @@ describe('extractErrorMessage', () => {
     (err as Error & { cause?: unknown }).cause = new Error('from cause');
 
     expect(extractErrorMessage(err)).toBe('from cause');
+  });
+});
+
+describe('NoMcpToolsError', () => {
+  it('produces a fully generic technical message when no mcpServerId was requested (no filter case)', () => {
+    const err = new NoMcpToolsError();
+
+    expect(err.message).toBe('No MCP tools available');
+    expect(err.userMessage).toBe('No tools are available to execute this step.');
+  });
+
+  it('includes the requested mcpServerId in the technical message when a filter was active', () => {
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
+
+    expect(err.message).toMatch(/id-missing/);
+  });
+
+  it('lists the loaded mcpServerIds in the technical message so misconfigurations are diagnosable', () => {
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
+
+    expect(err.message).toMatch(/id-A/);
+    expect(err.message).toMatch(/id-B/);
+  });
+
+  it('handles an empty loaded-id list without producing a malformed message', () => {
+    const err = new NoMcpToolsError('id-missing', []);
+
+    expect(err.message).toMatch(/id-missing/);
+    expect(err.message).not.toMatch(/undefined|null|\[object/i);
+  });
+
+  it('keeps the user-facing message generic — no internal ids must leak', () => {
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
+
+    expect(err.userMessage).toBe('No tools are available to execute this step.');
+    expect(err.userMessage).not.toMatch(/id-missing|id-A|id-B/);
   });
 });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -102,7 +102,7 @@ function makeMockWorkflowPort(
           schemasByCollection[name] ?? makeCollectionSchema({ collectionName: name }),
         ),
       ),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -61,7 +61,7 @@ function makeMockWorkflowPort(): WorkflowPort {
       fields: [],
       actions: [],
     }),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -16,7 +16,12 @@ import { StepType } from '../../src/types/validated/step-definition';
 // ---------------------------------------------------------------------------
 
 class MockRemoteTool extends RemoteTool {
-  constructor(options: { name: string; sourceId?: string; invoke?: jest.Mock }) {
+  constructor(options: {
+    name: string;
+    sourceId?: string;
+    mcpServerId?: string;
+    invoke?: jest.Mock;
+  }) {
     const invokeFn = options.invoke ?? jest.fn().mockResolvedValue('tool-result');
     super({
       tool: {
@@ -27,6 +32,7 @@ class MockRemoteTool extends RemoteTool {
       } as unknown as RemoteTool['base'],
       sourceId: options.sourceId ?? 'mcp-server-1',
       sourceType: 'mcp',
+      mcpServerId: options.mcpServerId,
     });
   }
 }
@@ -439,14 +445,23 @@ describe('McpStepExecutor', () => {
     });
   });
 
-  describe('mcpServerId filter', () => {
-    it('passes only tools from the specified server to the AI', async () => {
-      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A' });
-      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B' });
+  describe('mcpServerId filter (matches by tool.mcpServerId, not tool.sourceId)', () => {
+    it('passes only tools whose mcpServerId matches step.mcpServerId to the AI', async () => {
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'zendesk',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'zendesk',
+        mcpServerId: 'id-B',
+      });
       const invokeFn = jest.fn().mockResolvedValue('ok');
       const toolB2 = new MockRemoteTool({
         name: 'tool_b2',
-        sourceId: 'server-B',
+        sourceId: 'zendesk',
+        mcpServerId: 'id-B',
         invoke: invokeFn,
       });
 
@@ -455,18 +470,85 @@ describe('McpStepExecutor', () => {
       const context = makeContext({
         model,
         runStore,
-        stepDefinition: makeStep({ mcpServerId: 'server-B', automaticExecution: true }),
+        stepDefinition: makeStep({ mcpServerId: 'id-B', automaticExecution: true }),
       });
       const executor = new McpStepExecutor(context, [toolA, toolB, toolB2]);
 
       await executor.execute();
 
-      // bindTools should only receive server-B tools
       const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
       const boundNames = boundTools.map(t => t.name);
       expect(boundNames).not.toContain('tool_a');
       expect(boundNames).toContain('tool_b');
       expect(boundNames).toContain('tool_b2');
+    });
+
+    it('does not match by sourceId — server-name collisions must not leak tools across configs', async () => {
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-B',
+        mcpServerId: 'id-99',
+      });
+      const context = makeContext({
+        stepDefinition: makeStep({ mcpServerId: 'server-B' }),
+      });
+      const executor = new McpStepExecutor(context, [tool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+    });
+
+    it('returns all tools (no filter) when step.mcpServerId is absent', async () => {
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'server-B',
+        mcpServerId: 'id-B',
+      });
+      const { model, bindTools } = makeMockModel('tool_a', {});
+      const context = makeContext({
+        model,
+        stepDefinition: makeStep({ automaticExecution: true }),
+      });
+      const executor = new McpStepExecutor(context, [toolA, toolB]);
+
+      await executor.execute();
+
+      const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
+      const boundNames = boundTools.map(t => t.name);
+      expect(boundNames).toEqual(expect.arrayContaining(['tool_a', 'tool_b']));
+    });
+
+    it('resolves a Forest-connector-backed tool when its mcpServerId is threaded through', async () => {
+      const invokeFn = jest.fn().mockResolvedValue('done');
+      const forestTool = new MockRemoteTool({
+        name: 'zendesk_get_tickets',
+        sourceId: 'zendesk',
+        mcpServerId: 'forest-connector-42',
+        invoke: invokeFn,
+      });
+      const { model, bindTools } = makeMockModel('zendesk_get_tickets', {});
+      const context = makeContext({
+        model,
+        stepDefinition: makeStep({
+          mcpServerId: 'forest-connector-42',
+          automaticExecution: true,
+        }),
+      });
+      const executor = new McpStepExecutor(context, [forestTool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
+      expect(boundTools.map(t => t.name)).toEqual(['zendesk_get_tickets']);
+      expect(invokeFn).toHaveBeenCalled();
     });
   });
 
@@ -482,9 +564,13 @@ describe('McpStepExecutor', () => {
     });
 
     it('returns error when mcpServerId filter yields no tools', async () => {
-      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A' });
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
       const context = makeContext({
-        stepDefinition: makeStep({ mcpServerId: 'server-B' }),
+        stepDefinition: makeStep({ mcpServerId: 'id-B' }),
       });
       const executor = new McpStepExecutor(context, [tool]);
 
@@ -492,6 +578,50 @@ describe('McpStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('error');
       expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+    });
+
+    it('keeps the user-facing error message generic regardless of the misconfigured mcpServerId', async () => {
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
+      const context = makeContext({ stepDefinition: makeStep({ mcpServerId: 'id-B' }) });
+      const executor = new McpStepExecutor(context, [tool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+      expect(result.stepOutcome.error).not.toMatch(/id-B/);
+    });
+
+    it('logs the technical message with the requested mcpServerId and loaded mcpServerIds when filter misses', async () => {
+      const logger = { info: jest.fn(), error: jest.fn() };
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'server-B',
+        mcpServerId: 'id-B',
+      });
+      const context = makeContext({
+        logger,
+        stepDefinition: makeStep({ mcpServerId: 'id-missing' }),
+      });
+      const executor = new McpStepExecutor(context, [toolA, toolB]);
+
+      await executor.execute();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringMatching(/id-missing/),
+        expect.objectContaining({
+          requestedMcpServerId: 'id-missing',
+          loadedMcpServerIds: expect.arrayContaining(['id-A', 'id-B']),
+        }),
+      );
     });
   });
 

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -85,7 +85,7 @@ function makeMockWorkflowPort(
           schemasByCollection[name] ?? makeCollectionSchema({ collectionName: name }),
         ),
       ),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -87,7 +87,7 @@ function makeMockWorkflowPort(
           schemasByCollection[name] ?? makeCollectionSchema({ collectionName: name }),
         ),
       ),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -85,7 +85,7 @@ function makeMockWorkflowPort(
           schemasByCollection[name] ?? makeCollectionSchema({ collectionName: name }),
         ),
       ),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -30,7 +30,7 @@ function createMockWorkflowPort(overrides: Partial<WorkflowPort> = {}): Workflow
     getAvailableRun: jest.fn(),
     updateStepExecution: jest.fn().mockResolvedValue(undefined),
     getCollectionSchema: jest.fn(),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
     ...overrides,
   } as unknown as WorkflowPort;

--- a/packages/workflow-executor/test/integration/workflow-execution.test.ts
+++ b/packages/workflow-executor/test/integration/workflow-execution.test.ts
@@ -139,7 +139,7 @@ function createMockWorkflowPort(overrides: Partial<WorkflowPort> = {}): jest.Moc
     getAvailableRun: jest.fn().mockResolvedValue(null),
     updateStepExecution: jest.fn().mockResolvedValue(null),
     getCollectionSchema: jest.fn().mockResolvedValue(COLLECTION_SCHEMA),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
     ...overrides,
   } as jest.Mocked<WorkflowPort>;
@@ -573,9 +573,7 @@ describe('workflow execution (integration)', () => {
       getAvailableRun: jest
         .fn()
         .mockResolvedValue({ step, auth: { forestServerToken: 'test-forest-token' } }),
-      getMcpServerConfigs: jest
-        .fn()
-        .mockResolvedValue([{ type: 'sse', configs: { 'mcp-1': { url: 'http://fake' } } }]),
+      getMcpServerConfigs: jest.fn().mockResolvedValue({ 'mcp-1': { url: 'http://fake' } }),
     });
 
     const { server, runStore } = createIntegrationSetup({

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -45,7 +45,7 @@ function createMockWorkflowPort(): jest.Mocked<WorkflowPort> {
     getAvailableRun: jest.fn(),
     updateStepExecution: jest.fn().mockResolvedValue(null),
     getCollectionSchema: jest.fn(),
-    getMcpServerConfigs: jest.fn().mockResolvedValue([]),
+    getMcpServerConfigs: jest.fn().mockResolvedValue({}),
     hasRunAccess: jest.fn().mockResolvedValue(true),
   };
 }
@@ -1150,7 +1150,7 @@ describe('MCP lazy loading (via once thunk)', () => {
     expect(aiClient.loadRemoteTools).not.toHaveBeenCalled();
   });
 
-  it('calls fetchRemoteTools once for an McpTask step', async () => {
+  it('wraps the orchestrator Record-shape configs as { configs } and calls loadRemoteTools once', async () => {
     const workflowPort = createMockWorkflowPort();
     const aiClient = createMockAiClient();
     const step = makePendingStep({
@@ -1162,8 +1162,10 @@ describe('MCP lazy loading (via once thunk)', () => {
       step,
       auth: { forestServerToken: 'test-forest-token' },
     });
-    // Provide a non-empty config so fetchRemoteTools actually calls loadRemoteTools
-    workflowPort.getMcpServerConfigs.mockResolvedValue([{ configs: {} }] as never);
+    const realConfigs = {
+      'data-gouv': { url: 'https://mcp.example.com', type: 'http' as const, headers: {} },
+    };
+    workflowPort.getMcpServerConfigs.mockResolvedValue(realConfigs);
 
     runner = new Runner(
       createRunnerConfig({ workflowPort, aiModelPort: aiClient as unknown as AiModelPort }),
@@ -1172,6 +1174,36 @@ describe('MCP lazy loading (via once thunk)', () => {
 
     expect(workflowPort.getMcpServerConfigs).toHaveBeenCalledTimes(1);
     expect(aiClient.loadRemoteTools).toHaveBeenCalledTimes(1);
+    expect(aiClient.loadRemoteTools).toHaveBeenCalledWith({ configs: realConfigs });
+  });
+
+  it('skips loadRemoteTools when the orchestrator returns an empty Record', async () => {
+    const workflowPort = createMockWorkflowPort();
+    const aiClient = createMockAiClient();
+    const step = makePendingStep({
+      runId: 'run-1',
+      stepId: 'step-mcp-1',
+      stepType: StepType.Mcp,
+    });
+    workflowPort.getAvailableRun.mockResolvedValue({
+      step,
+      auth: { forestServerToken: 'test-forest-token' },
+    });
+    workflowPort.getMcpServerConfigs.mockResolvedValue({});
+
+    runner = new Runner(
+      createRunnerConfig({ workflowPort, aiModelPort: aiClient as unknown as AiModelPort }),
+    );
+    await runner.triggerPoll('run-1');
+
+    expect(workflowPort.getMcpServerConfigs).toHaveBeenCalledTimes(1);
+    expect(aiClient.loadRemoteTools).not.toHaveBeenCalled();
+    // Distinguish the short-circuit from a regression that throws before reaching the guard:
+    // the step must actually have executed and reported a success outcome.
+    expect(workflowPort.updateStepExecution).toHaveBeenCalledWith(
+      'run-1',
+      expect.objectContaining({ status: 'success' }),
+    );
   });
 });
 

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1163,7 +1163,7 @@ describe('MCP lazy loading (via once thunk)', () => {
       auth: { forestServerToken: 'test-forest-token' },
     });
     const realConfigs = {
-      'data-gouv': { url: 'https://mcp.example.com', type: 'http' as const, headers: {} },
+      'mcp-server-1': { url: 'https://mcp.example.com', type: 'http' as const, headers: {} },
     };
     workflowPort.getMcpServerConfigs.mockResolvedValue(realConfigs);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,21 +1851,6 @@
     jsonapi-serializer "^3.6.9"
     superagent "^10.3.0"
 
-"@forestadmin/ai-proxy@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@forestadmin/ai-proxy/-/ai-proxy-1.8.0.tgz#fac92da48c852484e4d18693388bf08918b41ef9"
-  integrity sha512-UrKM5hfo7WQAjVBJTspKNjixReVEsge2cVHBs1swcD/0sZlLBQHz7+wNE0YTuTFWOC0cSAKQz0UuKd0769Yciw==
-  dependencies:
-    "@forestadmin/agent-toolkit" "1.2.0"
-    "@forestadmin/datasource-toolkit" "1.53.1"
-    "@langchain/anthropic" "1.3.17"
-    "@langchain/community" "^1.1.19"
-    "@langchain/core" "1.1.15"
-    "@langchain/langgraph" "^1.1.0"
-    "@langchain/mcp-adapters" "1.1.1"
-    "@langchain/openai" "1.2.5"
-    zod "^4.3.5"
-
 "@forestadmin/context@1.37.1":
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/@forestadmin/context/-/context-1.37.1.tgz#301486c456061d43cb653b3e8be60644edb3f71a"


### PR DESCRIPTION
## Summary

- `Runner.fetchRemoteTools()` crashed with `TypeError: configs.map is not a function` on every MCP-typed step. The orchestrator's `GET /liana/mcp-server-configs-with-details` returns `Record<string, ToolConfig>`, but the executor port was typed `Promise<McpConfiguration[]>` and the runner called `.map` on the object.
- Aligns the executor with the wire contract: port now returns `McpServers` (`Record<string, McpServerConfig>`, from `@forestadmin/ai-proxy`), runner wraps the record into `{ configs }` for `loadRemoteTools`, with an empty-Record short-circuit.
- Updates 9 test mock sites (8 `mockResolvedValue([])` plus the `[{ configs: {} }] as never` cast in `runner.test.ts`) to the real Record shape so the contract can't silently regress again. Adds two TDD tests under `MCP lazy loading (via once thunk)` for the non-empty-Record happy path and the empty-Record short-circuit.

## Dependency bumps (heads-up)

`packages/workflow-executor/package.json` bumps:
- `@forestadmin/ai-proxy` 1.8.0 → 1.9.0 — load-bearing for this fix (the `McpServers` type only exists from 1.9.0 onward).
- `@forestadmin/forestadmin-client` 1.39.5 → 1.39.7 — incidental, was already staged in the user's pre-existing main-branch state.

These cannot be split into a separate PR because the workspace-resolved import in `src/ports/workflow-port.ts` would fail to compile against ai-proxy 1.8.0.

## Test plan

- [x] `yarn workspace @forestadmin/workflow-executor jest --runInBand --forceExit --testMatch='**/runner.test.ts'` — 83/83 pass (including 3 new MCP-lazy-loading tests)
- [x] `yarn workspace @forestadmin/workflow-executor jest --runInBand --forceExit` on the 9 changed test files — 361 tests green
- [x] `npx eslint`, `npx prettier --check`, `npx tsc --noEmit` on all 13 changed files — clean
- [x] End-to-end repro against `data-gouv` MCP server on the `executor` dev project — pre-fix run aborted with the generic `"An unexpected error occurred."` (masking the TypeError); post-fix run reports `NoMcpToolsError` cleanly, which is the legitimate downstream behaviour when no tools materialize

Refs: PRD-357

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getMcpServerConfigs` return type to use `McpServers` Record shape in workflow-executor
> - Replaces `McpConfiguration[]` array with `McpServers` (a `Record<string, ToolConfig>` map) as the return type of `getMcpServerConfigs` across [workflow-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1583/files#diff-5d7cbcc8082d4fb62a74fb3912a92940e4a2888aa87ec7fb925f3b747948b3f4), [forest-server-workflow-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1583/files#diff-70b42aec8454fc9dce637bd3559a6e947379c05eea7f496ee4dac1e9323c8c5d), and the public exports in [index.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1583/files#diff-f3276eeb41201a9f098e7daa674ac8c853f6cda66d051427c7c43c5bec3ebb1c).
> - Updates `Runner.fetchRemoteTools` in [runner.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1583/files#diff-53dd42328518d1424983b180f4f92da938c107f6c821327fd03f8f768ffa7e89) to skip calling `aiModelPort.loadRemoteTools` when the config map is empty, and passes `{ configs }` (the Record wrapped in an object) when non-empty.
> - Bumps `@forestadmin/ai-proxy` to 1.9.0 and `@forestadmin/forestadmin-client` to 1.39.7.
> - Behavioral Change: `loadRemoteTools` is no longer called when the orchestrator returns an empty MCP config map; callers relying on the old array format for `getMcpServerConfigs` will need to update to the Record shape.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1583 opened
>
> - Fixed `McpStepExecutor.getFilteredTools` to filter tools by `tool.mcpServerId` instead of `tool.sourceId` when a step specifies `mcpServerId`, and updated `NoMcpToolsError` to include diagnostic context showing the requested `mcpServerId` and list of available `mcpServerIds` when filtering yields no matches [53618a7]
> - Added optional `mcpServerId` property to `RemoteTool` class and threaded it through `ServerRemoteTool` and `McpServerRemoteTool` subclass constructors [53618a7]
> - Modified `McpClient` to extract `id` from each server config entry, store it in an internal `mcpServerIdsByName` map, and populate `mcpServerId` on `McpServerRemoteTool` instances during tool loading, and changed `McpConfiguration.configs` type from `MultiServerMCPClient['config']['mcpServers']` to `Record<string, McpServerConfig>` where `McpServerConfig` includes optional `id?: string` [53618a7]
> - Extended `ForestIntegrationConfig` interface with optional `id?: string` and updated `ForestIntegrationClient.loadTools` to thread this `id` as `mcpServerId` parameter to `getZendeskTools`, `getKolarTools`, and `getSnowflakeTools` factory functions, which were each extended to accept optional `mcpServerId` and pass it to `ServerRemoteTool` constructor [53618a7]
> - Added test coverage for `mcpServerId` propagation across `ForestIntegrationClient`, integration tool factories (`getZendeskTools`, `getKolarTools`, `getSnowflakeTools`), `McpClient`, `McpStepExecutor` filtering behavior, and `NoMcpToolsError` message construction [53618a7]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 480148c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->