### PR TITLE
fix(workflow-executor): match MCP tools by config id

### DIFF
--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -14,6 +14,7 @@ export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
 export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
 
 export interface ForestIntegrationConfig {
+  id: string;
   integrationName: ForestIntegrationName;
   config: CustomConfig;
   isForestConnector: true;
@@ -39,16 +40,16 @@ export default class ForestIntegrationClient implements ToolProvider {
   async loadTools(): Promise<RemoteTool[]> {
     const tools: RemoteTool[] = [];
 
-    this.configs.forEach(({ integrationName, config }) => {
+    this.configs.forEach(({ id, integrationName, config }) => {
       switch (integrationName) {
         case 'Zendesk':
-          tools.push(...getZendeskTools(config as ZendeskConfig));
+          tools.push(...getZendeskTools(config as ZendeskConfig, id));
           break;
         case 'Kolar':
-          tools.push(...getKolarTools(config as KolarConfig));
+          tools.push(...getKolarTools(config as KolarConfig, id));
           break;
         case 'Snowflake':
-          tools.push(...getSnowflakeTools(config as SnowflakeConfig));
+          tools.push(...getSnowflakeTools(config as SnowflakeConfig, id));
           break;
         default:
           this.logger?.('Warn', `Unsupported integration: ${integrationName}`);

--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -14,7 +14,7 @@ export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
 export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
 
 export interface ForestIntegrationConfig {
-  id: string;
+  id?: string;
   integrationName: ForestIntegrationName;
   config: CustomConfig;
   isForestConnector: true;

--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -40,16 +40,16 @@ export default class ForestIntegrationClient implements ToolProvider {
   async loadTools(): Promise<RemoteTool[]> {
     const tools: RemoteTool[] = [];
 
-    this.configs.forEach(({ id, integrationName, config }) => {
+    this.configs.forEach(({ id: mcpServerId, integrationName, config }) => {
       switch (integrationName) {
         case 'Zendesk':
-          tools.push(...getZendeskTools(config as ZendeskConfig, id));
+          tools.push(...getZendeskTools(config as ZendeskConfig, mcpServerId));
           break;
         case 'Kolar':
-          tools.push(...getKolarTools(config as KolarConfig, id));
+          tools.push(...getKolarTools(config as KolarConfig, mcpServerId));
           break;
         case 'Snowflake':
-          tools.push(...getSnowflakeTools(config as SnowflakeConfig, id));
+          tools.push(...getSnowflakeTools(config as SnowflakeConfig, mcpServerId));
           break;
         default:
           this.logger?.('Warn', `Unsupported integration: ${integrationName}`);

--- a/packages/ai-proxy/src/integrations/kolar/tools.ts
+++ b/packages/ai-proxy/src/integrations/kolar/tools.ts
@@ -11,7 +11,7 @@ export interface KolarConfig {
   apiKey: string;
 }
 
-export default function getKolarTools(config: KolarConfig): RemoteTool[] {
+export default function getKolarTools(config: KolarConfig, id?: string): RemoteTool[] {
   const { baseUrl, headers } = getKolarConfig(config);
 
   return [
@@ -23,6 +23,7 @@ export default function getKolarTools(config: KolarConfig): RemoteTool[] {
     tool =>
       new ServerRemoteTool({
         sourceId: 'kolar',
+        id,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/kolar/tools.ts
+++ b/packages/ai-proxy/src/integrations/kolar/tools.ts
@@ -11,7 +11,7 @@ export interface KolarConfig {
   apiKey: string;
 }
 
-export default function getKolarTools(config: KolarConfig, id?: string): RemoteTool[] {
+export default function getKolarTools(config: KolarConfig, mcpServerId?: string): RemoteTool[] {
   const { baseUrl, headers } = getKolarConfig(config);
 
   return [
@@ -23,7 +23,7 @@ export default function getKolarTools(config: KolarConfig, id?: string): RemoteT
     tool =>
       new ServerRemoteTool({
         sourceId: 'kolar',
-        id,
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/snowflake/tools.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools.ts
@@ -15,7 +15,10 @@ export interface SnowflakeConfig {
   defaultRole?: string;
 }
 
-export default function getSnowflakeTools(config: SnowflakeConfig, id?: string): RemoteTool[] {
+export default function getSnowflakeTools(
+  config: SnowflakeConfig,
+  mcpServerId?: string,
+): RemoteTool[] {
   const headers = getSnowflakeAuthHeaders(config);
   const baseUrl = getSnowflakeBaseUrl(config.accountIdentifier);
 
@@ -27,7 +30,7 @@ export default function getSnowflakeTools(config: SnowflakeConfig, id?: string):
     tool =>
       new ServerRemoteTool({
         sourceId: 'snowflake',
-        id,
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/snowflake/tools.ts
+++ b/packages/ai-proxy/src/integrations/snowflake/tools.ts
@@ -15,7 +15,7 @@ export interface SnowflakeConfig {
   defaultRole?: string;
 }
 
-export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[] {
+export default function getSnowflakeTools(config: SnowflakeConfig, id?: string): RemoteTool[] {
   const headers = getSnowflakeAuthHeaders(config);
   const baseUrl = getSnowflakeBaseUrl(config.accountIdentifier);
 
@@ -27,6 +27,7 @@ export default function getSnowflakeTools(config: SnowflakeConfig): RemoteTool[]
     tool =>
       new ServerRemoteTool({
         sourceId: 'snowflake',
+        id,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/zendesk/tools.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools.ts
@@ -15,7 +15,7 @@ export interface ZendeskConfig {
   apiToken: string;
 }
 
-export default function getZendeskTools(config: ZendeskConfig): RemoteTool[] {
+export default function getZendeskTools(config: ZendeskConfig, id?: string): RemoteTool[] {
   const { baseUrl, headers } = getZendeskConfig(config);
 
   return [
@@ -29,6 +29,7 @@ export default function getZendeskTools(config: ZendeskConfig): RemoteTool[] {
     tool =>
       new ServerRemoteTool({
         sourceId: 'zendesk',
+        id,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/integrations/zendesk/tools.ts
+++ b/packages/ai-proxy/src/integrations/zendesk/tools.ts
@@ -15,7 +15,7 @@ export interface ZendeskConfig {
   apiToken: string;
 }
 
-export default function getZendeskTools(config: ZendeskConfig, id?: string): RemoteTool[] {
+export default function getZendeskTools(config: ZendeskConfig, mcpServerId?: string): RemoteTool[] {
   const { baseUrl, headers } = getZendeskConfig(config);
 
   return [
@@ -29,7 +29,7 @@ export default function getZendeskTools(config: ZendeskConfig, id?: string): Rem
     tool =>
       new ServerRemoteTool({
         sourceId: 'zendesk',
-        id,
+        mcpServerId,
         tool,
       }),
   );

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -8,9 +8,6 @@ import McpServerRemoteTool from './mcp-server-remote-tool';
 
 export type McpServers = MultiServerMCPClient['config']['mcpServers'];
 
-// Base orchestrator entry shape from `@langchain/mcp-adapters`, widened with the optional
-// stable DB `id` exposed by Forest Admin's orchestrator. The id flows down to RemoteTool
-// so the workflow executor can match a step's `mcpServerId` against the config record.
 export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string] & {
   id?: string;
 };

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -45,7 +45,11 @@ export default class McpClient implements ToolProvider {
           const loadedTools = (await client.getTools()) ?? [];
           const extendedTools = loadedTools.map(
             tool =>
-              new McpServerRemoteTool({ tool, sourceId: name, id: this.idsByServerName[name] }),
+              new McpServerRemoteTool({
+                tool,
+                sourceId: name,
+                mcpServerId: this.idsByServerName[name],
+              }),
           );
           tools.push(...extendedTools);
         } catch (error) {

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -18,7 +18,7 @@ export type McpConfiguration = {
 
 export default class McpClient implements ToolProvider {
   private readonly mcpClients: Record<string, MultiServerMCPClient> = {};
-  private readonly idsByServerName: Record<string, string | undefined> = {};
+  private readonly mcpServerIdsByName: Record<string, string | undefined> = {};
   private readonly logger?: Logger;
 
   constructor(config: McpConfiguration, logger?: Logger) {
@@ -26,8 +26,9 @@ export default class McpClient implements ToolProvider {
     // split the config into several clients to be more resilient
     // if a mcp server is down, the others will still work
     Object.entries(config.configs).forEach(([name, serverConfig]) => {
-      const { id, ...rest } = serverConfig as McpServerConfig & Record<string, unknown>;
-      this.idsByServerName[name] = id;
+      const { id: mcpServerId, ...rest } = serverConfig as McpServerConfig &
+        Record<string, unknown>;
+      this.mcpServerIdsByName[name] = mcpServerId;
       this.mcpClients[name] = new MultiServerMCPClient({
         mcpServers: { [name]: rest as McpServerConfig },
         ...config,
@@ -48,7 +49,7 @@ export default class McpClient implements ToolProvider {
               new McpServerRemoteTool({
                 tool,
                 sourceId: name,
-                mcpServerId: this.idsByServerName[name],
+                mcpServerId: this.mcpServerIdsByName[name],
               }),
           );
           tools.push(...extendedTools);

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -8,14 +8,20 @@ import McpServerRemoteTool from './mcp-server-remote-tool';
 
 export type McpServers = MultiServerMCPClient['config']['mcpServers'];
 
-export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string];
+// Base orchestrator entry shape from `@langchain/mcp-adapters`, widened with the optional
+// stable DB `id` exposed by Forest Admin's orchestrator. The id flows down to RemoteTool
+// so the workflow executor can match a step's `mcpServerId` against the config record.
+export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string] & {
+  id?: string;
+};
 
 export type McpConfiguration = {
-  configs: McpServers;
+  configs: Record<string, McpServerConfig>;
 } & Omit<MultiServerMCPClient['config'], 'mcpServers'>;
 
 export default class McpClient implements ToolProvider {
   private readonly mcpClients: Record<string, MultiServerMCPClient> = {};
+  private readonly idsByServerName: Record<string, string | undefined> = {};
   private readonly logger?: Logger;
 
   constructor(config: McpConfiguration, logger?: Logger) {
@@ -23,8 +29,10 @@ export default class McpClient implements ToolProvider {
     // split the config into several clients to be more resilient
     // if a mcp server is down, the others will still work
     Object.entries(config.configs).forEach(([name, serverConfig]) => {
+      const { id, ...rest } = serverConfig as McpServerConfig & Record<string, unknown>;
+      this.idsByServerName[name] = id;
       this.mcpClients[name] = new MultiServerMCPClient({
-        mcpServers: { [name]: serverConfig },
+        mcpServers: { [name]: rest as McpServerConfig },
         ...config,
       });
     });
@@ -39,7 +47,8 @@ export default class McpClient implements ToolProvider {
         try {
           const loadedTools = (await client.getTools()) ?? [];
           const extendedTools = loadedTools.map(
-            tool => new McpServerRemoteTool({ tool, sourceId: name }),
+            tool =>
+              new McpServerRemoteTool({ tool, sourceId: name, id: this.idsByServerName[name] }),
           );
           tools.push(...extendedTools);
         } catch (error) {

--- a/packages/ai-proxy/src/mcp-server-remote-tool.ts
+++ b/packages/ai-proxy/src/mcp-server-remote-tool.ts
@@ -3,7 +3,11 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import RemoteTool from './remote-tool';
 
 export default class McpServerRemoteTool<ToolType = unknown> extends RemoteTool {
-  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+  constructor(options: {
+    tool: StructuredToolInterface<ToolType>;
+    sourceId?: string;
+    id?: string;
+  }) {
     super({ ...options, sourceType: 'mcp-server' });
   }
 }

--- a/packages/ai-proxy/src/mcp-server-remote-tool.ts
+++ b/packages/ai-proxy/src/mcp-server-remote-tool.ts
@@ -6,7 +6,7 @@ export default class McpServerRemoteTool<ToolType = unknown> extends RemoteTool 
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
-    id?: string;
+    mcpServerId?: string;
   }) {
     super({ ...options, sourceType: 'mcp-server' });
   }

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -4,18 +4,18 @@ export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
   sourceType: string;
-  id?: string;
+  mcpServerId?: string;
 
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
     sourceType?: string;
-    id?: string;
+    mcpServerId?: string;
   }) {
     this.base = options.tool;
     this.sourceId = options.sourceId;
     this.sourceType = options.sourceType;
-    this.id = options.id;
+    this.mcpServerId = options.mcpServerId;
   }
 
   get sanitizedName() {

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -4,9 +4,6 @@ export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
   sourceType: string;
-  // Stable DB id of the originating config entry. Distinct from `sourceId`, which is the
-  // human-readable server/integration name. Use `id` for cross-system references (e.g.
-  // matching a workflow step's mcpServerId to its config); use `sourceId` for display.
   id?: string;
 
   constructor(options: {

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -4,6 +4,8 @@ export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
   sourceType: string;
+  // Shared across McpServerRemoteTool and ServerRemoteTool because the orchestrator
+  // stores Forest connectors alongside user MCP servers in the same ai_mcp_configs table.
   mcpServerId?: string;
 
   constructor(options: {

--- a/packages/ai-proxy/src/remote-tool.ts
+++ b/packages/ai-proxy/src/remote-tool.ts
@@ -4,15 +4,21 @@ export default abstract class RemoteTool<ToolType = unknown> {
   base: StructuredToolInterface<ToolType>;
   sourceId: string;
   sourceType: string;
+  // Stable DB id of the originating config entry. Distinct from `sourceId`, which is the
+  // human-readable server/integration name. Use `id` for cross-system references (e.g.
+  // matching a workflow step's mcpServerId to its config); use `sourceId` for display.
+  id?: string;
 
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
     sourceType?: string;
+    id?: string;
   }) {
     this.base = options.tool;
     this.sourceId = options.sourceId;
     this.sourceType = options.sourceType;
+    this.id = options.id;
   }
 
   get sanitizedName() {

--- a/packages/ai-proxy/src/server-remote-tool.ts
+++ b/packages/ai-proxy/src/server-remote-tool.ts
@@ -3,7 +3,11 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import RemoteTool from './remote-tool';
 
 export default class ServerRemoteTool<ToolType = unknown> extends RemoteTool {
-  constructor(options: { tool: StructuredToolInterface<ToolType>; sourceId?: string }) {
+  constructor(options: {
+    tool: StructuredToolInterface<ToolType>;
+    sourceId?: string;
+    id?: string;
+  }) {
     super({ ...options, sourceType: 'server' });
   }
 }

--- a/packages/ai-proxy/src/server-remote-tool.ts
+++ b/packages/ai-proxy/src/server-remote-tool.ts
@@ -6,7 +6,7 @@ export default class ServerRemoteTool<ToolType = unknown> extends RemoteTool {
   constructor(options: {
     tool: StructuredToolInterface<ToolType>;
     sourceId?: string;
-    id?: string;
+    mcpServerId?: string;
   }) {
     super({ ...options, sourceType: 'server' });
   }

--- a/packages/ai-proxy/test/forest-integration-client.test.ts
+++ b/packages/ai-proxy/test/forest-integration-client.test.ts
@@ -1,6 +1,9 @@
 import ForestIntegrationClient from '../src/forest-integration-client';
+import getKolarTools from '../src/integrations/kolar/tools';
 import { validateKolarConfig } from '../src/integrations/kolar/utils';
+import getSnowflakeTools from '../src/integrations/snowflake/tools';
 import { validateSnowflakeConfig } from '../src/integrations/snowflake/utils';
+import getZendeskTools from '../src/integrations/zendesk/tools';
 import { validateZendeskConfig } from '../src/integrations/zendesk/utils';
 
 const mockZendeskTools = [{ name: 'zendesk_get_tickets' }, { name: 'zendesk_get_ticket' }];
@@ -37,6 +40,7 @@ describe('ForestIntegrationClient', () => {
     it('should load zendesk tools when integration is zendesk', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
@@ -52,7 +56,7 @@ describe('ForestIntegrationClient', () => {
       const logger = jest.fn();
       const client = new ForestIntegrationClient(
         // @ts-expect-error Testing unsupported integration
-        [{ integrationName: 'unknown', config: {} as any, isForestConnector: true }],
+        [{ id: '1', integrationName: 'unknown', config: {} as any, isForestConnector: true }],
         logger,
       );
 
@@ -64,6 +68,7 @@ describe('ForestIntegrationClient', () => {
     it('should load kolar tools when integration is Kolar', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Kolar',
           config: { apiKey: 'key' },
           isForestConnector: true,
@@ -78,6 +83,7 @@ describe('ForestIntegrationClient', () => {
     it('should load snowflake tools when integration is Snowflake', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Snowflake',
           config: {
             accountIdentifier: 'a',
@@ -101,11 +107,13 @@ describe('ForestIntegrationClient', () => {
     it('should load tools from multiple configs', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'a', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
         },
         {
+          id: '2',
           integrationName: 'Zendesk',
           config: { subdomain: 'b', email: 'c@d.com', apiToken: 'tok2' },
           isForestConnector: true,
@@ -122,7 +130,7 @@ describe('ForestIntegrationClient', () => {
     it('should call validateZendeskConfig for Zendesk integration', async () => {
       const zendeskConfig = { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Zendesk', config: zendeskConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Zendesk', config: zendeskConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -133,6 +141,7 @@ describe('ForestIntegrationClient', () => {
     it('should return true on success', async () => {
       const client = new ForestIntegrationClient([
         {
+          id: '1',
           integrationName: 'Zendesk',
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
@@ -147,7 +156,7 @@ describe('ForestIntegrationClient', () => {
     it('should call validateKolarConfig for Kolar integration', async () => {
       const kolarConfig = { apiKey: 'key' };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Kolar', config: kolarConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Kolar', config: kolarConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -161,7 +170,7 @@ describe('ForestIntegrationClient', () => {
         programmaticAccessToken: 'tok',
       };
       const client = new ForestIntegrationClient([
-        { integrationName: 'Snowflake', config: snowflakeConfig, isForestConnector: true },
+        { id: '1', integrationName: 'Snowflake', config: snowflakeConfig, isForestConnector: true },
       ]);
 
       await client.checkConnection();
@@ -172,12 +181,10 @@ describe('ForestIntegrationClient', () => {
     it('should throw for unsupported integration', async () => {
       const client = new ForestIntegrationClient([
         // @ts-expect-error Testing unsupported integration
-        { integrationName: 'Unknown', config: {}, isForestConnector: true },
+        { id: '1', integrationName: 'Unknown', config: {}, isForestConnector: true },
       ]);
 
-      await expect(client.checkConnection()).rejects.toThrow(
-        'Unsupported integration: Unknown',
-      );
+      await expect(client.checkConnection()).rejects.toThrow('Unsupported integration: Unknown');
     });
   });
 
@@ -186,6 +193,64 @@ describe('ForestIntegrationClient', () => {
       const client = new ForestIntegrationClient([]);
 
       await expect(client.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('id threaded from ForestIntegrationConfig into integration tool factories', () => {
+    it('passes the config id to getZendeskTools so produced tools can be matched by step.mcpServerId', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-zendesk-42',
+          integrationName: 'Zendesk',
+          config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
+          isForestConnector: true,
+        } as any,
+      ]);
+
+      await client.loadTools();
+
+      // The exact signature shape (positional vs. options bag) is an implementation
+      // detail of the production change; the test pins down that id reaches the factory.
+      expect(getZendeskTools).toHaveBeenCalledWith(
+        expect.objectContaining({ subdomain: 'test' }),
+        'forest-zendesk-42',
+      );
+    });
+
+    it('passes the config id to getKolarTools', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-kolar-7',
+          integrationName: 'Kolar',
+          config: { apiKey: 'key' },
+          isForestConnector: true,
+        } as any,
+      ]);
+
+      await client.loadTools();
+
+      expect(getKolarTools).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'key' }),
+        'forest-kolar-7',
+      );
+    });
+
+    it('passes the config id to getSnowflakeTools', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          id: 'forest-snowflake-99',
+          integrationName: 'Snowflake',
+          config: { accountIdentifier: 'a', programmaticAccessToken: 'tok' },
+          isForestConnector: true,
+        } as any,
+      ]);
+
+      await client.loadTools();
+
+      expect(getSnowflakeTools).toHaveBeenCalledWith(
+        expect.objectContaining({ accountIdentifier: 'a' }),
+        'forest-snowflake-99',
+      );
     });
   });
 });

--- a/packages/ai-proxy/test/forest-integration-client.test.ts
+++ b/packages/ai-proxy/test/forest-integration-client.test.ts
@@ -204,13 +204,11 @@ describe('ForestIntegrationClient', () => {
           integrationName: 'Zendesk',
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
           isForestConnector: true,
-        } as any,
+        },
       ]);
 
       await client.loadTools();
 
-      // The exact signature shape (positional vs. options bag) is an implementation
-      // detail of the production change; the test pins down that id reaches the factory.
       expect(getZendeskTools).toHaveBeenCalledWith(
         expect.objectContaining({ subdomain: 'test' }),
         'forest-zendesk-42',
@@ -224,7 +222,7 @@ describe('ForestIntegrationClient', () => {
           integrationName: 'Kolar',
           config: { apiKey: 'key' },
           isForestConnector: true,
-        } as any,
+        },
       ]);
 
       await client.loadTools();
@@ -242,7 +240,7 @@ describe('ForestIntegrationClient', () => {
           integrationName: 'Snowflake',
           config: { accountIdentifier: 'a', programmaticAccessToken: 'tok' },
           isForestConnector: true,
-        } as any,
+        },
       ]);
 
       await client.loadTools();
@@ -250,6 +248,23 @@ describe('ForestIntegrationClient', () => {
       expect(getSnowflakeTools).toHaveBeenCalledWith(
         expect.objectContaining({ accountIdentifier: 'a' }),
         'forest-snowflake-99',
+      );
+    });
+
+    it('passes undefined to the factory when the config entry has no id', async () => {
+      const client = new ForestIntegrationClient([
+        {
+          integrationName: 'Zendesk',
+          config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
+          isForestConnector: true,
+        },
+      ]);
+
+      await client.loadTools();
+
+      expect(getZendeskTools).toHaveBeenCalledWith(
+        expect.objectContaining({ subdomain: 'test' }),
+        undefined,
       );
     });
   });

--- a/packages/ai-proxy/test/forest-integration-client.test.ts
+++ b/packages/ai-proxy/test/forest-integration-client.test.ts
@@ -196,7 +196,7 @@ describe('ForestIntegrationClient', () => {
     });
   });
 
-  describe('id threaded from ForestIntegrationConfig into integration tool factories', () => {
+  describe('ForestIntegrationConfig.id is threaded as mcpServerId into integration tool factories', () => {
     it('passes the config id to getZendeskTools so produced tools can be matched by step.mcpServerId', async () => {
       const client = new ForestIntegrationClient([
         {

--- a/packages/ai-proxy/test/integrations/kolar/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/kolar/tools.test.ts
@@ -26,4 +26,28 @@ describe('getKolarTools', () => {
       'kolar_get_screening_result',
     ]);
   });
+
+  describe('id propagation', () => {
+    it('sets RemoteTool.id on every produced tool when id is provided', () => {
+      const tools = (
+        getKolarTools as unknown as (
+          cfg: typeof config,
+          id?: string,
+        ) => ReturnType<typeof getKolarTools>
+      )(config, 'forest-kolar-7');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-kolar-7');
+      });
+    });
+
+    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+      const tools = getKolarTools(config);
+
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/integrations/kolar/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/kolar/tools.test.ts
@@ -27,26 +27,21 @@ describe('getKolarTools', () => {
     ]);
   });
 
-  describe('id propagation', () => {
-    it('sets RemoteTool.id on every produced tool when id is provided', () => {
-      const tools = (
-        getKolarTools as unknown as (
-          cfg: typeof config,
-          id?: string,
-        ) => ReturnType<typeof getKolarTools>
-      )(config, 'forest-kolar-7');
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getKolarTools(config, 'forest-kolar-7');
 
       expect(tools).not.toHaveLength(0);
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-kolar-7');
+        expect(tool.mcpServerId).toBe('forest-kolar-7');
       });
     });
 
-    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
       const tools = getKolarTools(config);
 
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+        expect(tool.mcpServerId).toBeUndefined();
       });
     });
   });

--- a/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
@@ -29,26 +29,21 @@ describe('getSnowflakeTools', () => {
     ]);
   });
 
-  describe('id propagation', () => {
-    it('sets RemoteTool.id on every produced tool when id is provided', () => {
-      const tools = (
-        getSnowflakeTools as unknown as (
-          cfg: SnowflakeConfig,
-          id?: string,
-        ) => ReturnType<typeof getSnowflakeTools>
-      )(config, 'forest-snowflake-99');
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getSnowflakeTools(config, 'forest-snowflake-99');
 
       expect(tools).not.toHaveLength(0);
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-snowflake-99');
+        expect(tool.mcpServerId).toBe('forest-snowflake-99');
       });
     });
 
-    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
       const tools = getSnowflakeTools(config);
 
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+        expect(tool.mcpServerId).toBeUndefined();
       });
     });
   });

--- a/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/snowflake/tools.test.ts
@@ -28,4 +28,28 @@ describe('getSnowflakeTools', () => {
       'snowflake_execute_query',
     ]);
   });
+
+  describe('id propagation', () => {
+    it('sets RemoteTool.id on every produced tool when id is provided', () => {
+      const tools = (
+        getSnowflakeTools as unknown as (
+          cfg: SnowflakeConfig,
+          id?: string,
+        ) => ReturnType<typeof getSnowflakeTools>
+      )(config, 'forest-snowflake-99');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-snowflake-99');
+      });
+    });
+
+    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+      const tools = getSnowflakeTools(config);
+
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
@@ -28,4 +28,28 @@ describe('getZendeskTools', () => {
       'zendesk_update_ticket',
     ]);
   });
+
+  describe('id propagation', () => {
+    it('sets RemoteTool.id on every produced tool when id is provided', () => {
+      const tools = (
+        getZendeskTools as unknown as (
+          cfg: typeof config,
+          id?: string,
+        ) => ReturnType<typeof getZendeskTools>
+      )(config, 'forest-zendesk-42');
+
+      expect(tools).not.toHaveLength(0);
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-zendesk-42');
+      });
+    });
+
+    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+      const tools = getZendeskTools(config);
+
+      tools.forEach(tool => {
+        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
+++ b/packages/ai-proxy/test/integrations/zendesk/tools.test.ts
@@ -29,26 +29,21 @@ describe('getZendeskTools', () => {
     ]);
   });
 
-  describe('id propagation', () => {
-    it('sets RemoteTool.id on every produced tool when id is provided', () => {
-      const tools = (
-        getZendeskTools as unknown as (
-          cfg: typeof config,
-          id?: string,
-        ) => ReturnType<typeof getZendeskTools>
-      )(config, 'forest-zendesk-42');
+  describe('mcpServerId propagation', () => {
+    it('sets RemoteTool.mcpServerId on every produced tool when mcpServerId is provided', () => {
+      const tools = getZendeskTools(config, 'forest-zendesk-42');
 
       expect(tools).not.toHaveLength(0);
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBe('forest-zendesk-42');
+        expect(tool.mcpServerId).toBe('forest-zendesk-42');
       });
     });
 
-    it('leaves RemoteTool.id undefined when no id is provided (backwards-compatible call site)', () => {
+    it('leaves RemoteTool.mcpServerId undefined when no mcpServerId is provided', () => {
       const tools = getZendeskTools(config);
 
       tools.forEach(tool => {
-        expect((tool as ServerRemoteTool & { id?: string }).id).toBeUndefined();
+        expect(tool.mcpServerId).toBeUndefined();
       });
     });
   });

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -89,9 +89,6 @@ describe('McpClient', () => {
           schema: undefined,
           responseFormat: 'content',
         });
-        // Each config entry carries the stable DB id surfaced by the orchestrator.
-        // The McpClient must thread that id through to RemoteTool.id so the executor
-        // can match workflow steps against it.
         const configWithId = {
           configs: {
             slack: {

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -1,4 +1,5 @@
 import type { McpConfiguration } from '../src';
+import type RemoteTool from '../src/remote-tool';
 
 import { tool } from '@langchain/core/tools';
 
@@ -77,6 +78,54 @@ describe('McpClient', () => {
         const tools = await mcpClient.loadTools();
 
         expect(tools.length).toEqual(0);
+      });
+    });
+
+    describe('id threaded from config entry into McpServerRemoteTool', () => {
+      it('sets RemoteTool.id from the config entry id alongside sourceId from the map key', async () => {
+        const tool1 = tool(() => {}, {
+          name: 'tool1',
+          description: 'description1',
+          schema: undefined,
+          responseFormat: 'content',
+        });
+        // Each config entry carries the stable DB id surfaced by the orchestrator.
+        // The McpClient must thread that id through to RemoteTool.id so the executor
+        // can match workflow steps against it.
+        const configWithId = {
+          configs: {
+            slack: {
+              transport: 'stdio' as const,
+              command: 'npx',
+              args: ['-y', '@modelcontextprotocol/server-slack'],
+              env: {},
+              id: 'config-id-42',
+            },
+          },
+        } as unknown as McpConfiguration;
+        const mcpClient = new McpClient(configWithId);
+        getToolsMock.mockResolvedValue([tool1]);
+
+        const tools = await mcpClient.loadTools();
+
+        expect(tools).toHaveLength(1);
+        expect(tools[0].sourceId).toBe('slack');
+        expect((tools[0] as RemoteTool & { id?: string }).id).toBe('config-id-42');
+      });
+
+      it('leaves RemoteTool.id undefined when the config entry has no id (legacy / unenriched payload)', async () => {
+        const tool1 = tool(() => {}, {
+          name: 'tool1',
+          description: 'description1',
+          schema: undefined,
+          responseFormat: 'content',
+        });
+        const mcpClient = new McpClient(aConfig);
+        getToolsMock.mockResolvedValue([tool1]);
+
+        const tools = await mcpClient.loadTools();
+
+        expect((tools[0] as RemoteTool & { id?: string }).id).toBeUndefined();
       });
     });
 
@@ -396,6 +445,7 @@ describe('McpClient', () => {
       const configs = {
         server1: { type: 'http' as const, url: 'https://server1.com' },
         zendesk: {
+          id: '1',
           isForestConnector: true as const,
           integrationName: 'Zendesk' as const,
           config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -1,5 +1,4 @@
 import type { McpConfiguration } from '../src';
-import type RemoteTool from '../src/remote-tool';
 
 import { tool } from '@langchain/core/tools';
 
@@ -81,8 +80,8 @@ describe('McpClient', () => {
       });
     });
 
-    describe('id threaded from config entry into McpServerRemoteTool', () => {
-      it('sets RemoteTool.id from the config entry id alongside sourceId from the map key', async () => {
+    describe('mcpServerId threaded from config entry into McpServerRemoteTool', () => {
+      it('sets RemoteTool.mcpServerId from the config entry id alongside sourceId from the map key', async () => {
         const tool1 = tool(() => {}, {
           name: 'tool1',
           description: 'description1',
@@ -107,10 +106,10 @@ describe('McpClient', () => {
 
         expect(tools).toHaveLength(1);
         expect(tools[0].sourceId).toBe('slack');
-        expect((tools[0] as RemoteTool & { id?: string }).id).toBe('config-id-42');
+        expect(tools[0].mcpServerId).toBe('config-id-42');
       });
 
-      it('leaves RemoteTool.id undefined when the config entry has no id (legacy / unenriched payload)', async () => {
+      it('leaves RemoteTool.mcpServerId undefined when the config entry has no id (legacy / unenriched payload)', async () => {
         const tool1 = tool(() => {}, {
           name: 'tool1',
           description: 'description1',
@@ -122,7 +121,7 @@ describe('McpClient', () => {
 
         const tools = await mcpClient.loadTools();
 
-        expect((tools[0] as RemoteTool & { id?: string }).id).toBeUndefined();
+        expect(tools[0].mcpServerId).toBeUndefined();
       });
     });
 

--- a/packages/ai-proxy/test/tool-provider-factory.test.ts
+++ b/packages/ai-proxy/test/tool-provider-factory.test.ts
@@ -35,14 +35,12 @@ describe('createToolProviders', () => {
     const providers = createToolProviders(configs as any);
 
     expect(providers).toHaveLength(1);
-    expect(McpClient).toHaveBeenCalledWith(
-      { configs: { slack: configs.slack } },
-      undefined,
-    );
+    expect(McpClient).toHaveBeenCalledWith({ configs: { slack: configs.slack } }, undefined);
   });
 
   it('should create ForestIntegrationClient for ForestIntegration configs', () => {
     const zendeskConfig = {
+      id: '1',
       isForestConnector: true as const,
       integrationName: 'Zendesk' as const,
       config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
@@ -58,6 +56,7 @@ describe('createToolProviders', () => {
     const configs = {
       slack: { command: 'npx', args: [] },
       zendesk: {
+        id: '1',
         isForestConnector: true as const,
         integrationName: 'Zendesk' as const,
         config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },
@@ -67,10 +66,7 @@ describe('createToolProviders', () => {
     const providers = createToolProviders(configs as any);
 
     expect(providers).toHaveLength(2);
-    expect(McpClient).toHaveBeenCalledWith(
-      { configs: { slack: configs.slack } },
-      undefined,
-    );
+    expect(McpClient).toHaveBeenCalledWith({ configs: { slack: configs.slack } }, undefined);
     expect(ForestIntegrationClient).toHaveBeenCalledWith([configs.zendesk], undefined);
   });
 
@@ -85,6 +81,7 @@ describe('createToolProviders', () => {
     const configs = {
       slack: { command: 'npx', args: [] },
       zendesk: {
+        id: '1',
         isForestConnector: true as const,
         integrationName: 'Zendesk' as const,
         config: { subdomain: 'test', email: 'a@b.com', apiToken: 'tok' },

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -203,10 +203,10 @@ export class StepTimeoutError extends WorkflowExecutorError {
 }
 
 export class NoMcpToolsError extends WorkflowExecutorError {
-  constructor(requestedId?: string, loadedIds?: readonly string[]) {
-    const technical = requestedId
-      ? `No MCP tools available for mcpServerId="${requestedId}". Loaded MCP config ids: [${(
-          loadedIds ?? []
+  constructor(requestedMcpServerId?: string, loadedMcpServerIds?: readonly string[]) {
+    const technical = requestedMcpServerId
+      ? `No MCP tools available for mcpServerId="${requestedMcpServerId}". Loaded MCP server ids: [${(
+          loadedMcpServerIds ?? []
         ).join(', ')}]`
       : 'No MCP tools available';
     super(technical, 'No tools are available to execute this step.');

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -203,8 +203,13 @@ export class StepTimeoutError extends WorkflowExecutorError {
 }
 
 export class NoMcpToolsError extends WorkflowExecutorError {
-  constructor() {
-    super('No MCP tools available', 'No tools are available to execute this step.');
+  constructor(requestedId?: string, loadedIds?: readonly string[]) {
+    const technical = requestedId
+      ? `No MCP tools available for mcpServerId="${requestedId}". Loaded MCP config ids: [${(
+          loadedIds ?? []
+        ).join(', ')}]`
+      : 'No MCP tools available';
+    super(technical, 'No tools are available to execute this step.');
   }
 }
 

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -227,18 +227,20 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId
-      ? this.remoteTools.filter(t => t.id === mcpServerId)
+      ? this.remoteTools.filter(t => t.mcpServerId === mcpServerId)
       : [...this.remoteTools];
 
     if (tools.length === 0) {
-      const loadedIds = this.remoteTools.map(t => t.id).filter((value): value is string => !!value);
-      const error = new NoMcpToolsError(mcpServerId, loadedIds);
+      const loadedMcpServerIds = this.remoteTools
+        .map(t => t.mcpServerId)
+        .filter((value): value is string => !!value);
+      const error = new NoMcpToolsError(mcpServerId, loadedMcpServerIds);
       this.context.logger.error(error.message, {
         runId: this.context.runId,
         stepId: this.context.stepId,
         stepIndex: this.context.stepIndex,
         requestedMcpServerId: mcpServerId,
-        loadedIds,
+        loadedMcpServerIds,
       });
       throw error;
     }

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -224,9 +224,6 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     );
   }
 
-  // Match the workflow step's mcpServerId against the stable DB id carried on each tool —
-  // not the display-oriented sourceId — so server-name collisions cannot leak tools across
-  // configs and the same id selects both regular MCP entries and Forest-connector entries.
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -235,7 +235,15 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
 
     if (tools.length === 0) {
       const loadedIds = this.remoteTools.map(t => t.id).filter((value): value is string => !!value);
-      throw new NoMcpToolsError(mcpServerId, loadedIds);
+      const error = new NoMcpToolsError(mcpServerId, loadedIds);
+      this.context.logger.error(error.message, {
+        runId: this.context.runId,
+        stepId: this.context.stepId,
+        stepIndex: this.context.stepIndex,
+        requestedMcpServerId: mcpServerId,
+        loadedIds,
+      });
+      throw error;
     }
 
     return tools;

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -224,13 +224,19 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     );
   }
 
-  /** Returns tools filtered by mcpServerId (if specified). Throws NoMcpToolsError if empty. */
+  // Match the workflow step's mcpServerId against the stable DB id carried on each tool —
+  // not the display-oriented sourceId — so server-name collisions cannot leak tools across
+  // configs and the same id selects both regular MCP entries and Forest-connector entries.
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId
-      ? this.remoteTools.filter(t => t.sourceId === mcpServerId)
+      ? this.remoteTools.filter(t => t.id === mcpServerId)
       : [...this.remoteTools];
-    if (tools.length === 0) throw new NoMcpToolsError();
+
+    if (tools.length === 0) {
+      const loadedIds = this.remoteTools.map(t => t.id).filter((value): value is string => !!value);
+      throw new NoMcpToolsError(mcpServerId, loadedIds);
+    }
 
     return tools;
   }

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -60,40 +60,35 @@ describe('extractErrorMessage', () => {
 });
 
 describe('NoMcpToolsError', () => {
-  const Ctor = NoMcpToolsError as unknown as new (
-    requestedId?: string,
-    loadedIds?: readonly string[],
-  ) => NoMcpToolsError;
-
-  it('produces a fully generic technical message when no id was requested (no filter case)', () => {
-    const err = new Ctor();
+  it('produces a fully generic technical message when no mcpServerId was requested (no filter case)', () => {
+    const err = new NoMcpToolsError();
 
     expect(err.message).toBe('No MCP tools available');
     expect(err.userMessage).toBe('No tools are available to execute this step.');
   });
 
   it('includes the requested mcpServerId in the technical message when a filter was active', () => {
-    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
 
     expect(err.message).toMatch(/id-missing/);
   });
 
-  it('lists the loaded MCP config ids in the technical message so misconfigurations are diagnosable', () => {
-    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+  it('lists the loaded mcpServerIds in the technical message so misconfigurations are diagnosable', () => {
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
 
     expect(err.message).toMatch(/id-A/);
     expect(err.message).toMatch(/id-B/);
   });
 
   it('handles an empty loaded-id list without producing a malformed message', () => {
-    const err = new Ctor('id-missing', []);
+    const err = new NoMcpToolsError('id-missing', []);
 
     expect(err.message).toMatch(/id-missing/);
     expect(err.message).not.toMatch(/undefined|null|\[object/i);
   });
 
   it('keeps the user-facing message generic — no internal ids must leak', () => {
-    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+    const err = new NoMcpToolsError('id-missing', ['id-A', 'id-B']);
 
     expect(err.userMessage).toBe('No tools are available to execute this step.');
     expect(err.userMessage).not.toMatch(/id-missing|id-A|id-B/);

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -89,7 +89,6 @@ describe('NoMcpToolsError', () => {
     const err = new Ctor('id-missing', []);
 
     expect(err.message).toMatch(/id-missing/);
-    // Should not produce undefined/null/[object Object] artefacts in the message.
     expect(err.message).not.toMatch(/undefined|null|\[object/i);
   });
 

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -1,4 +1,4 @@
-import { extractErrorMessage } from '../src/errors';
+import { NoMcpToolsError, extractErrorMessage } from '../src/errors';
 
 describe('extractErrorMessage', () => {
   it('returns err.message when non-empty', () => {
@@ -56,5 +56,47 @@ describe('extractErrorMessage', () => {
     (err as Error & { cause?: unknown }).cause = new Error('from cause');
 
     expect(extractErrorMessage(err)).toBe('from cause');
+  });
+});
+
+describe('NoMcpToolsError', () => {
+  const Ctor = NoMcpToolsError as unknown as new (
+    requestedId?: string,
+    loadedIds?: readonly string[],
+  ) => NoMcpToolsError;
+
+  it('produces a fully generic technical message when no id was requested (no filter case)', () => {
+    const err = new Ctor();
+
+    expect(err.message).toBe('No MCP tools available');
+    expect(err.userMessage).toBe('No tools are available to execute this step.');
+  });
+
+  it('includes the requested mcpServerId in the technical message when a filter was active', () => {
+    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+
+    expect(err.message).toMatch(/id-missing/);
+  });
+
+  it('lists the loaded MCP config ids in the technical message so misconfigurations are diagnosable', () => {
+    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+
+    expect(err.message).toMatch(/id-A/);
+    expect(err.message).toMatch(/id-B/);
+  });
+
+  it('handles an empty loaded-id list without producing a malformed message', () => {
+    const err = new Ctor('id-missing', []);
+
+    expect(err.message).toMatch(/id-missing/);
+    // Should not produce undefined/null/[object Object] artefacts in the message.
+    expect(err.message).not.toMatch(/undefined|null|\[object/i);
+  });
+
+  it('keeps the user-facing message generic — no internal ids must leak', () => {
+    const err = new Ctor('id-missing', ['id-A', 'id-B']);
+
+    expect(err.userMessage).toBe('No tools are available to execute this step.');
+    expect(err.userMessage).not.toMatch(/id-missing|id-A|id-B/);
   });
 });

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -442,8 +442,6 @@ describe('McpStepExecutor', () => {
 
   describe('mcpServerId filter (matches by tool.id, not tool.sourceId)', () => {
     it('passes only tools whose id matches step.mcpServerId to the AI', async () => {
-      // Both tools share sourceId='zendesk' (e.g. same integration server name) but carry
-      // distinct stable DB ids — proves the filter goes through id, not sourceId.
       const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'zendesk', id: 'id-A' });
       const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'zendesk', id: 'id-B' });
       const invokeFn = jest.fn().mockResolvedValue('ok');
@@ -473,8 +471,6 @@ describe('McpStepExecutor', () => {
     });
 
     it('does not match by sourceId — server-name collisions must not leak tools across configs', async () => {
-      // mcpServerId='server-B' should NOT match a tool that merely has sourceId='server-B' but
-      // a different DB id; only tool.id is authoritative.
       const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-B', id: 'id-99' });
       const context = makeContext({
         stepDefinition: makeStep({ mcpServerId: 'server-B' }),
@@ -505,8 +501,6 @@ describe('McpStepExecutor', () => {
     });
 
     it('resolves a Forest-connector-backed tool when its id is threaded through', async () => {
-      // Simulates a Forest connector entry (e.g. Zendesk) where ForestIntegrationConfig.id
-      // has been propagated all the way to RemoteTool.id by the ai-proxy construction site.
       const invokeFn = jest.fn().mockResolvedValue('done');
       const forestTool = new MockRemoteTool({
         name: 'zendesk_get_tickets',

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -16,7 +16,12 @@ import { StepType } from '../../src/types/validated/step-definition';
 // ---------------------------------------------------------------------------
 
 class MockRemoteTool extends RemoteTool {
-  constructor(options: { name: string; sourceId?: string; id?: string; invoke?: jest.Mock }) {
+  constructor(options: {
+    name: string;
+    sourceId?: string;
+    mcpServerId?: string;
+    invoke?: jest.Mock;
+  }) {
     const invokeFn = options.invoke ?? jest.fn().mockResolvedValue('tool-result');
     super({
       tool: {
@@ -27,8 +32,8 @@ class MockRemoteTool extends RemoteTool {
       } as unknown as RemoteTool['base'],
       sourceId: options.sourceId ?? 'mcp-server-1',
       sourceType: 'mcp',
-      id: options.id,
-    } as ConstructorParameters<typeof RemoteTool>[0] & { id?: string });
+      mcpServerId: options.mcpServerId,
+    });
   }
 }
 
@@ -440,15 +445,23 @@ describe('McpStepExecutor', () => {
     });
   });
 
-  describe('mcpServerId filter (matches by tool.id, not tool.sourceId)', () => {
-    it('passes only tools whose id matches step.mcpServerId to the AI', async () => {
-      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'zendesk', id: 'id-A' });
-      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'zendesk', id: 'id-B' });
+  describe('mcpServerId filter (matches by tool.mcpServerId, not tool.sourceId)', () => {
+    it('passes only tools whose mcpServerId matches step.mcpServerId to the AI', async () => {
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'zendesk',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'zendesk',
+        mcpServerId: 'id-B',
+      });
       const invokeFn = jest.fn().mockResolvedValue('ok');
       const toolB2 = new MockRemoteTool({
         name: 'tool_b2',
         sourceId: 'zendesk',
-        id: 'id-B',
+        mcpServerId: 'id-B',
         invoke: invokeFn,
       });
 
@@ -471,7 +484,11 @@ describe('McpStepExecutor', () => {
     });
 
     it('does not match by sourceId — server-name collisions must not leak tools across configs', async () => {
-      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-B', id: 'id-99' });
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-B',
+        mcpServerId: 'id-99',
+      });
       const context = makeContext({
         stepDefinition: makeStep({ mcpServerId: 'server-B' }),
       });
@@ -484,8 +501,16 @@ describe('McpStepExecutor', () => {
     });
 
     it('returns all tools (no filter) when step.mcpServerId is absent', async () => {
-      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
-      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B', id: 'id-B' });
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'server-B',
+        mcpServerId: 'id-B',
+      });
       const { model, bindTools } = makeMockModel('tool_a', {});
       const context = makeContext({
         model,
@@ -500,12 +525,12 @@ describe('McpStepExecutor', () => {
       expect(boundNames).toEqual(expect.arrayContaining(['tool_a', 'tool_b']));
     });
 
-    it('resolves a Forest-connector-backed tool when its id is threaded through', async () => {
+    it('resolves a Forest-connector-backed tool when its mcpServerId is threaded through', async () => {
       const invokeFn = jest.fn().mockResolvedValue('done');
       const forestTool = new MockRemoteTool({
         name: 'zendesk_get_tickets',
         sourceId: 'zendesk',
-        id: 'forest-connector-42',
+        mcpServerId: 'forest-connector-42',
         invoke: invokeFn,
       });
       const { model, bindTools } = makeMockModel('zendesk_get_tickets', {});
@@ -539,7 +564,11 @@ describe('McpStepExecutor', () => {
     });
 
     it('returns error when mcpServerId filter yields no tools', async () => {
-      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
       const context = makeContext({
         stepDefinition: makeStep({ mcpServerId: 'id-B' }),
       });
@@ -551,8 +580,12 @@ describe('McpStepExecutor', () => {
       expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
     });
 
-    it('keeps the user-facing error message generic regardless of the misconfigured id', async () => {
-      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
+    it('keeps the user-facing error message generic regardless of the misconfigured mcpServerId', async () => {
+      const tool = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
       const context = makeContext({ stepDefinition: makeStep({ mcpServerId: 'id-B' }) });
       const executor = new McpStepExecutor(context, [tool]);
 
@@ -562,10 +595,18 @@ describe('McpStepExecutor', () => {
       expect(result.stepOutcome.error).not.toMatch(/id-B/);
     });
 
-    it('logs the technical message with the requested id and loaded ids when filter misses', async () => {
+    it('logs the technical message with the requested mcpServerId and loaded mcpServerIds when filter misses', async () => {
       const logger = { info: jest.fn(), error: jest.fn() };
-      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
-      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B', id: 'id-B' });
+      const toolA = new MockRemoteTool({
+        name: 'tool_a',
+        sourceId: 'server-A',
+        mcpServerId: 'id-A',
+      });
+      const toolB = new MockRemoteTool({
+        name: 'tool_b',
+        sourceId: 'server-B',
+        mcpServerId: 'id-B',
+      });
       const context = makeContext({
         logger,
         stepDefinition: makeStep({ mcpServerId: 'id-missing' }),
@@ -578,7 +619,7 @@ describe('McpStepExecutor', () => {
         expect.stringMatching(/id-missing/),
         expect.objectContaining({
           requestedMcpServerId: 'id-missing',
-          loadedIds: expect.arrayContaining(['id-A', 'id-B']),
+          loadedMcpServerIds: expect.arrayContaining(['id-A', 'id-B']),
         }),
       );
     });

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -558,9 +558,6 @@ describe('McpStepExecutor', () => {
     });
 
     it('keeps the user-facing error message generic regardless of the misconfigured id', async () => {
-      // Technical-message enrichment is covered in errors.test.ts by exercising the
-      // NoMcpToolsError constructor directly; here we lock down the dual-message
-      // contract: no internal id leaks into the user-facing message.
       const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
       const context = makeContext({ stepDefinition: makeStep({ mcpServerId: 'id-B' }) });
       const executor = new McpStepExecutor(context, [tool]);
@@ -569,6 +566,27 @@ describe('McpStepExecutor', () => {
 
       expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
       expect(result.stepOutcome.error).not.toMatch(/id-B/);
+    });
+
+    it('logs the technical message with the requested id and loaded ids when filter misses', async () => {
+      const logger = { info: jest.fn(), error: jest.fn() };
+      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
+      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B', id: 'id-B' });
+      const context = makeContext({
+        logger,
+        stepDefinition: makeStep({ mcpServerId: 'id-missing' }),
+      });
+      const executor = new McpStepExecutor(context, [toolA, toolB]);
+
+      await executor.execute();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringMatching(/id-missing/),
+        expect.objectContaining({
+          requestedMcpServerId: 'id-missing',
+          loadedIds: expect.arrayContaining(['id-A', 'id-B']),
+        }),
+      );
     });
   });
 

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -16,7 +16,7 @@ import { StepType } from '../../src/types/validated/step-definition';
 // ---------------------------------------------------------------------------
 
 class MockRemoteTool extends RemoteTool {
-  constructor(options: { name: string; sourceId?: string; invoke?: jest.Mock }) {
+  constructor(options: { name: string; sourceId?: string; id?: string; invoke?: jest.Mock }) {
     const invokeFn = options.invoke ?? jest.fn().mockResolvedValue('tool-result');
     super({
       tool: {
@@ -27,7 +27,8 @@ class MockRemoteTool extends RemoteTool {
       } as unknown as RemoteTool['base'],
       sourceId: options.sourceId ?? 'mcp-server-1',
       sourceType: 'mcp',
-    });
+      id: options.id,
+    } as ConstructorParameters<typeof RemoteTool>[0] & { id?: string });
   }
 }
 
@@ -439,14 +440,17 @@ describe('McpStepExecutor', () => {
     });
   });
 
-  describe('mcpServerId filter', () => {
-    it('passes only tools from the specified server to the AI', async () => {
-      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A' });
-      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B' });
+  describe('mcpServerId filter (matches by tool.id, not tool.sourceId)', () => {
+    it('passes only tools whose id matches step.mcpServerId to the AI', async () => {
+      // Both tools share sourceId='zendesk' (e.g. same integration server name) but carry
+      // distinct stable DB ids — proves the filter goes through id, not sourceId.
+      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'zendesk', id: 'id-A' });
+      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'zendesk', id: 'id-B' });
       const invokeFn = jest.fn().mockResolvedValue('ok');
       const toolB2 = new MockRemoteTool({
         name: 'tool_b2',
-        sourceId: 'server-B',
+        sourceId: 'zendesk',
+        id: 'id-B',
         invoke: invokeFn,
       });
 
@@ -455,18 +459,77 @@ describe('McpStepExecutor', () => {
       const context = makeContext({
         model,
         runStore,
-        stepDefinition: makeStep({ mcpServerId: 'server-B', automaticExecution: true }),
+        stepDefinition: makeStep({ mcpServerId: 'id-B', automaticExecution: true }),
       });
       const executor = new McpStepExecutor(context, [toolA, toolB, toolB2]);
 
       await executor.execute();
 
-      // bindTools should only receive server-B tools
       const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
       const boundNames = boundTools.map(t => t.name);
       expect(boundNames).not.toContain('tool_a');
       expect(boundNames).toContain('tool_b');
       expect(boundNames).toContain('tool_b2');
+    });
+
+    it('does not match by sourceId — server-name collisions must not leak tools across configs', async () => {
+      // mcpServerId='server-B' should NOT match a tool that merely has sourceId='server-B' but
+      // a different DB id; only tool.id is authoritative.
+      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-B', id: 'id-99' });
+      const context = makeContext({
+        stepDefinition: makeStep({ mcpServerId: 'server-B' }),
+      });
+      const executor = new McpStepExecutor(context, [tool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+    });
+
+    it('returns all tools (no filter) when step.mcpServerId is absent', async () => {
+      const toolA = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
+      const toolB = new MockRemoteTool({ name: 'tool_b', sourceId: 'server-B', id: 'id-B' });
+      const { model, bindTools } = makeMockModel('tool_a', {});
+      const context = makeContext({
+        model,
+        stepDefinition: makeStep({ automaticExecution: true }),
+      });
+      const executor = new McpStepExecutor(context, [toolA, toolB]);
+
+      await executor.execute();
+
+      const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
+      const boundNames = boundTools.map(t => t.name);
+      expect(boundNames).toEqual(expect.arrayContaining(['tool_a', 'tool_b']));
+    });
+
+    it('resolves a Forest-connector-backed tool when its id is threaded through', async () => {
+      // Simulates a Forest connector entry (e.g. Zendesk) where ForestIntegrationConfig.id
+      // has been propagated all the way to RemoteTool.id by the ai-proxy construction site.
+      const invokeFn = jest.fn().mockResolvedValue('done');
+      const forestTool = new MockRemoteTool({
+        name: 'zendesk_get_tickets',
+        sourceId: 'zendesk',
+        id: 'forest-connector-42',
+        invoke: invokeFn,
+      });
+      const { model, bindTools } = makeMockModel('zendesk_get_tickets', {});
+      const context = makeContext({
+        model,
+        stepDefinition: makeStep({
+          mcpServerId: 'forest-connector-42',
+          automaticExecution: true,
+        }),
+      });
+      const executor = new McpStepExecutor(context, [forestTool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      const boundTools = bindTools.mock.calls[0][0] as Array<{ name: string }>;
+      expect(boundTools.map(t => t.name)).toEqual(['zendesk_get_tickets']);
+      expect(invokeFn).toHaveBeenCalled();
     });
   });
 
@@ -482,9 +545,9 @@ describe('McpStepExecutor', () => {
     });
 
     it('returns error when mcpServerId filter yields no tools', async () => {
-      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A' });
+      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
       const context = makeContext({
-        stepDefinition: makeStep({ mcpServerId: 'server-B' }),
+        stepDefinition: makeStep({ mcpServerId: 'id-B' }),
       });
       const executor = new McpStepExecutor(context, [tool]);
 
@@ -492,6 +555,20 @@ describe('McpStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('error');
       expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+    });
+
+    it('keeps the user-facing error message generic regardless of the misconfigured id', async () => {
+      // Technical-message enrichment is covered in errors.test.ts by exercising the
+      // NoMcpToolsError constructor directly; here we lock down the dual-message
+      // contract: no internal id leaks into the user-facing message.
+      const tool = new MockRemoteTool({ name: 'tool_a', sourceId: 'server-A', id: 'id-A' });
+      const context = makeContext({ stepDefinition: makeStep({ mcpServerId: 'id-B' }) });
+      const executor = new McpStepExecutor(context, [tool]);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.error).toBe('No tools are available to execute this step.');
+      expect(result.stepOutcome.error).not.toMatch(/id-B/);
     });
   });
 


### PR DESCRIPTION
## Summary

- ai-proxy: threads a stable DB `id` from each `ToolConfig` entry through `McpClient`, `ForestIntegrationClient` and the integration tool factories (`getZendeskTools`, `getKolarTools`, `getSnowflakeTools`) onto `RemoteTool.id`
- workflow-executor: `McpStepExecutor.getFilteredTools` now matches `tool.id === step.mcpServerId` (was `tool.sourceId`), so workflows targeting a specific MCP server actually resolve their tools instead of always hitting `NoMcpToolsError`
- workflow-executor: `NoMcpToolsError` carries the misconfigured `mcpServerId` and the list of loaded config ids in its technical message; user-facing message stays generic per the dual-message convention

fixes PRD-362

## Stacked on

Targets `fix/prd-357-fetchremotetools-record-shape` (#1583). PR #1583 introduces the `Record<string, ToolConfig>` shape this change consumes. Once #1583 merges into `feat/prd-214-server-step-mapper`, rebase this onto the same base.

## Prerequisite

End-to-end resolution also depends on the orchestrator (forestadmin-server, PRD-360) exposing the DB `id` on each `Record<string, ToolConfig>` entry, including Forest-connector entries. Until that lands, the executor still fires `NoMcpToolsError` with an enriched diagnostic message — which is now actionable from the activity log.

## Test plan

- [ ] CI passes (ai-proxy + workflow-executor)
- [ ] Manual: run a workflow whose MCP step targets a specific MCP server config id — tool resolves and runs
- [ ] Manual: run a workflow whose MCP step targets a Forest-connector-backed config (Zendesk/Kolar/Snowflake) — tool resolves and runs
- [ ] Manual: deliberately set `mcpServerId` to a non-existent id and check the activity log carries the requested id + loaded id list

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP tool filtering in `McpStepExecutor` to match by config `id` instead of `sourceId`
> - Adds an optional `id` field to `McpServerConfig` and `ForestIntegrationConfig`, which is threaded through tool construction so each `RemoteTool` instance carries a matching `mcpServerId` property.
> - Updates `McpStepExecutor.getFilteredTools` to filter tools by `tool.mcpServerId` instead of `sourceId`, fixing cross-config tool leakage.
> - Improves `NoMcpToolsError` to include the requested `mcpServerId` and list of loaded IDs in its technical message for easier diagnostics.
> - Behavioral Change: steps that previously matched tools by `sourceId` will now only match tools whose `mcpServerId` aligns with the step's `mcpServerId`; steps relying on the old `sourceId` matching will no longer find tools.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1584 opened
>
> - Renamed MCP server ID variables and map properties to explicitly indicate they store MCP server identifiers [ceacd35]
> - Added explanatory comment to `mcpServerId` property in `RemoteTool` class documenting shared usage across `McpServerRemoteTool` and `ServerRemoteTool` [095113b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4edc2e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->