### PR TITLE
fix(workflow-executor): tolerate LLM field name variations in findField

### DIFF
--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -84,12 +84,18 @@ export default abstract class RecordStepExecutor<
     const normalizeFieldName = (s: string) => s.toLowerCase().replace(/[\s_-]/g, '');
     const normalized = normalizeFieldName(name);
 
-    return (
+    const exact =
       schema.fields.find(f => f.displayName === name) ??
-      schema.fields.find(f => f.fieldName === name) ??
-      schema.fields.find(f => normalizeFieldName(f.displayName) === normalized) ??
-      schema.fields.find(f => normalizeFieldName(f.fieldName) === normalized)
+      schema.fields.find(f => f.fieldName === name);
+    if (exact) return exact;
+
+    const fuzzy = schema.fields.filter(
+      f =>
+        normalizeFieldName(f.displayName) === normalized ||
+        normalizeFieldName(f.fieldName) === normalized,
     );
+
+    return fuzzy.length === 1 ? fuzzy[0] : undefined;
   }
 
   private async toRecordIdentifier(record: RecordRef): Promise<string> {

--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -77,11 +77,10 @@ export default abstract class RecordStepExecutor<
   }
 
   protected findField(schema: CollectionSchema, name: string): FieldSchema | undefined {
-    // The tool definition sent to the LLM is built from z.literal(displayName) — the JSON
-    // Schema does constrain fieldName to exact values. However, invokeWithTool returns
-    // toolCall.args as-is without re-running Zod validation on the response, so the LLM can
-    // silently ignore the constraint and return a formatting variation (e.g. "first_name"
-    // instead of "firstname"). The normalized fallback catches these cosmetic mismatches.
+    // LLMs occasionally return formatting variants of field names (e.g. "first_name" for
+    // "firstname", "full-name" for "Full Name") even though the tool schema declares them
+    // as literals. Fall back to a normalized comparison so a cosmetic variation doesn't
+    // fail an otherwise correct step.
     const normalizeFieldName = (s: string) => s.toLowerCase().replace(/[\s_-]/g, '');
     const normalized = normalizeFieldName(name);
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -499,6 +499,37 @@ describe('UpdateRecordStepExecutor', () => {
     });
   });
 
+  describe('resolveFieldName fuzzy matching', () => {
+    it.each([
+      ['snake_case variant', 'full_name', 'Full Name', 'name'],
+      ['camelCase variant', 'fullName', 'Full Name', 'name'],
+      ['lowercase no separator', 'fullname', 'Full Name', 'name'],
+      ['hyphen variant', 'full-name', 'Full Name', 'name'],
+    ])(
+      'resolves field when LLM returns %s (%s)',
+      async (_label, aiReturnedName, _displayName, expectedFieldName) => {
+        const agentPort = makeMockAgentPort();
+        const mockModel = makeMockModel({
+          input: { fieldName: aiReturnedName, value: 'John Doe', reasoning: 'test' },
+        });
+        const context = makeContext({
+          model: mockModel.model,
+          agentPort,
+          stepDefinition: makeStep({ automaticExecution: true }),
+        });
+        const executor = new UpdateRecordStepExecutor(context);
+
+        const result = await executor.execute();
+
+        expect(result.stepOutcome.status).toBe('success');
+        expect(agentPort.updateRecord).toHaveBeenCalledWith(
+          expect.objectContaining({ values: { [expectedFieldName]: 'John Doe' } }),
+          expect.anything(),
+        );
+      },
+    );
+  });
+
   describe('relationship fields excluded from update tool', () => {
     it('excludes relationship fields from the tool schema', async () => {
       const mockModel = makeMockModel({

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -528,6 +528,31 @@ describe('UpdateRecordStepExecutor', () => {
         );
       },
     );
+
+    it('returns undefined (field not found) when two fields normalize to the same string', async () => {
+      // { displayName: "Full Name", fieldName: "fullname" } and
+      // { displayName: "FullName", fieldName: "full_name" } both normalize to "fullname".
+      // Returning either one would be a silent wrong pick — undefined is safer.
+      const ambiguousSchema = makeCollectionSchema({
+        fields: [
+          { fieldName: 'fullname', displayName: 'Full Name', isRelationship: false, type: 'String' },
+          { fieldName: 'full_name', displayName: 'FullName', isRelationship: false, type: 'String' },
+        ],
+      });
+      const mockModel = makeMockModel({
+        input: { fieldName: 'Full-Name', value: 'John', reasoning: 'test' },
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        workflowPort: makeMockWorkflowPort({ customers: ambiguousSchema }),
+        stepDefinition: makeStep({ automaticExecution: true }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+    });
   });
 
   describe('relationship fields excluded from update tool', () => {

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -535,8 +535,18 @@ describe('UpdateRecordStepExecutor', () => {
       // Returning either one would be a silent wrong pick — undefined is safer.
       const ambiguousSchema = makeCollectionSchema({
         fields: [
-          { fieldName: 'fullname', displayName: 'Full Name', isRelationship: false, type: 'String' },
-          { fieldName: 'full_name', displayName: 'FullName', isRelationship: false, type: 'String' },
+          {
+            fieldName: 'fullname',
+            displayName: 'Full Name',
+            isRelationship: false,
+            type: 'String',
+          },
+          {
+            fieldName: 'full_name',
+            displayName: 'FullName',
+            isRelationship: false,
+            type: 'String',
+          },
         ],
       });
       const mockModel = makeMockModel({


### PR DESCRIPTION
## Summary

- `findField` previously did exact string matching (`===`) on `displayName` and `fieldName`
- LLMs sometimes return snake_case variants of field names (e.g. `first_name` instead of `firstname`) even when the tool schema constrains the value via `z.literal`
- This adds a normalized fallback that strips separators (`_`, `-`, spaces) and lowercases before matching, so a hallucinated variation no longer kills an otherwise correct step

## Root cause

`invokeWithTool` returns `toolCall.args` directly without re-validating against the Zod schema. The `z.literal` constraint is only used to generate the tool definition sent to the LLM — it is not enforced on the response.

## Test plan
- [ ] Existing `update-record` / `read-record` / `load-related-record` tests pass
- [ ] Manually verify: a workflow with an `account.firstname` field no longer fails when the LLM outputs `first_name`

fixes PRD-214

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `findField` in `RecordStepExecutor` to tolerate LLM field name variants
> LLMs may return field names in snake_case, camelCase, lowercase, or hyphenated forms. The `findField` method in [record-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1585/files#diff-8a51c158f5f5c6df99cb9483d4d66d54f51671a37f114fafce10ea8b1e51e29c) already uses normalized comparison to handle these cosmetic variants; this PR clarifies the inline comment and adds a parameterized test suite in [update-record-step-executor.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1585/files#diff-35ae2d31d3b452c2ac498df9293b2a6209e5a81d3dc793cfdb911260817a6c54) to verify each variant resolves to the correct normalized field name.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1585 opened
>
> - Modified `RecordStepExecutor.findField` method in `workflow-executor` to implement two-phase field resolution: first attempting exact match on `displayName` or `fieldName`, then computing fuzzy matches using normalized names (lowercased with spaces, underscores, and hyphens removed), returning a field only if exactly one fuzzy match exists, otherwise returning undefined instead of the first fuzzy match [065d4b0]
> - Added test case to `update-record-step-executor.test.ts` in `workflow-executor` under the 'automaticExecution: update direct (Branch B)' suite that constructs a schema with two fields normalizing to the same string and asserts the executor returns an error status [065d4b0]
> - Reformatted field object literals in `update-record-step-executor.test.ts` [e3f8e58]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3496f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->