### PR TITLE
fix(workflow-executor): preserve AI suggestion in pending data

### DIFF
--- a/WORKFLOW-EXECUTOR-CONTRACT.md
+++ b/WORKFLOW-EXECUTOR-CONTRACT.md
@@ -306,8 +306,8 @@ interface LoadRelatedRecordPendingData {
 {
   userConfirmed:      boolean;
   name?:              string;                 // override relation
-  displayName?:       string;
   selectedRecordId?:  Array<string | number>; // min 1 element
+  // displayName is NOT accepted — derived from FieldSchema after resolving name.
 }
 ```
 

--- a/WORKFLOW-EXECUTOR-CONTRACT.md
+++ b/WORKFLOW-EXECUTOR-CONTRACT.md
@@ -263,50 +263,63 @@ Request body:
 { pendingData?: unknown }
 ```
 
-On re-execution, the executor reads `pendingData` from the RunStore and checks `userConfirmed`:
-- `undefined` → returns `awaiting-input` again (step not yet actionable)
+> Note: the HTTP body key is `pendingData` for historical reasons, but the validated payload is
+> stored separately as `execution.userConfirmation` in the RunStore — it does **not** overwrite
+> the AI suggestion in `execution.pendingData`.
+
+On re-execution, the executor reads `userConfirmation` from the RunStore and checks `userConfirmed`:
+- `undefined` → returns `awaiting-input` again (POST not yet called)
 - `true` → executes the confirmed action
 - `false` → skips the step (marks as success)
 
 ### update-record
 
 ```typescript
-// Stored in RunStore (pendingData written by executor):
+// Stored in RunStore (pendingData written by executor — AI suggestion, never overwritten):
 interface UpdateRecordPendingData {
-  name:           string;   // technical field name
-  displayName:    string;   // label shown in UI
-  value:          string;   // AI-proposed value; overridable by frontend
-  userConfirmed?: boolean;
+  name:        string;   // technical field name
+  displayName: string;   // label shown in UI
+  value:       unknown;  // AI-proposed value
 }
 
-// pendingData field of POST /runs/:runId/trigger body:
+// userConfirmation payload of POST /runs/:runId/trigger body:
 { userConfirmed: boolean; value?: string; }
+// value overrides the AI-proposed value when provided
 ```
 
-### trigger-action & mcp
+### trigger-action
 
 ```typescript
-// pendingData field of POST /runs/:runId/trigger body:
+// userConfirmation payload of POST /runs/:runId/trigger body:
+{
+  userConfirmed: boolean;
+  actionResult?: unknown; // required when userConfirmed=true (frontend executes the action itself)
+}
+```
+
+### mcp
+
+```typescript
+// userConfirmation payload of POST /runs/:runId/trigger body:
 { userConfirmed: boolean; }
 ```
 
 ### load-related-record
 
 ```typescript
-// Stored in RunStore (pendingData written by executor):
+// Stored in RunStore (pendingData written by executor — AI suggestion, never overwritten):
 interface LoadRelatedRecordPendingData {
-  name:              string;
-  displayName:       string;
-  suggestedFields?:  string[];
-  selectedRecordId:  Array<string | number>;
-  userConfirmed?:    boolean;
+  name:             string;
+  displayName:      string;
+  suggestedFields?: string[];
+  selectedRecordId: Array<string | number>;
 }
 
-// pendingData field of POST /runs/:runId/trigger body:
+// userConfirmation payload of POST /runs/:runId/trigger body:
 {
-  userConfirmed:      boolean;
-  name?:              string;                 // override relation
-  selectedRecordId?:  Array<string | number>; // min 1 element
+  userConfirmed:     boolean;
+  name?:             string;                 // override relation (requires selectedRecordId)
+  selectedRecordId?: Array<string | number>; // min 1 element; required when name is provided
 }
 ```
 

--- a/WORKFLOW-EXECUTOR-CONTRACT.md
+++ b/WORKFLOW-EXECUTOR-CONTRACT.md
@@ -307,7 +307,6 @@ interface LoadRelatedRecordPendingData {
   userConfirmed:      boolean;
   name?:              string;                 // override relation
   selectedRecordId?:  Array<string | number>; // min 1 element
-  // displayName is NOT accepted — derived from FieldSchema after resolving name.
 }
 ```
 

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -213,7 +213,7 @@ export function logStartup(logger: Logger, config: CliConfig): void {
     forestServerUrl: opts.forestServerUrl ?? 'https://api.forestadmin.com',
     agentUrl: opts.agentUrl,
     httpPort: opts.httpPort,
-    pollingIntervalMs: opts.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS,
+    pollingIntervalMs: opts.pollingIntervalMs,
     aiConfig: aiLabel,
   });
 }

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -213,7 +213,7 @@ export function logStartup(logger: Logger, config: CliConfig): void {
     forestServerUrl: opts.forestServerUrl ?? 'https://api.forestadmin.com',
     agentUrl: opts.agentUrl,
     httpPort: opts.httpPort,
-    pollingIntervalMs: opts.pollingIntervalMs,
+    pollingIntervalMs: opts.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS,
     aiConfig: aiLabel,
   });
 }

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -5,7 +5,10 @@ import type {
   IStepExecutor,
   StepExecutionResult,
 } from '../types/execution-context';
-import type { StepExecutionData, WithUserConfirmation } from '../types/step-execution-data';
+import type {
+  ConfirmableStepExecutionData,
+  StepExecutionData,
+} from '../types/step-execution-data';
 import type { StepDefinition } from '../types/validated/step-definition';
 import type { StepStatus } from '../types/validated/step-outcome';
 import type {
@@ -26,10 +29,6 @@ import {
 } from '../errors';
 import patchBodySchemas from '../http/pending-data-validators';
 import StepSummaryBuilder from './summary/step-summary-builder';
-
-type WithPendingData = StepExecutionData & { pendingData?: object } & WithUserConfirmation;
-
-type PatchBody = Record<string, unknown> & { userConfirmed?: boolean };
 
 export default abstract class BaseStepExecutor<TStep extends StepDefinition = StepDefinition>
   implements IStepExecutor
@@ -193,7 +192,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     error?: string;
   }): StepExecutionResult;
 
-  protected async findPendingExecution<TExec extends WithPendingData>(
+  protected async findPendingExecution<TExec extends ConfirmableStepExecutionData>(
     type: string,
   ): Promise<TExec | undefined> {
     const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
@@ -205,7 +204,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   // Preserves the AI suggestion in pendingData: only userConfirmed is mirrored there because
   // handleConfirmationFlow gates on it. The full parsed PATCH body is stored in userConfirmation.
-  protected async patchAndReloadPendingData<TExec extends WithPendingData>(
+  protected async patchAndReloadPendingData<TExec extends ConfirmableStepExecutionData>(
     pendingData?: unknown,
   ): Promise<TExec | undefined> {
     const { type } = this.context.stepDefinition;
@@ -231,18 +230,18 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       );
     }
 
-    const patchBody = parsed.data as PatchBody;
+    const userConfirmation = parsed.data as TExec['userConfirmation'];
 
     // Last-write-wins: spread-merging would leak stale keys from prior PATCHes.
     const updated: TExec = {
       ...execution,
       pendingData: {
         ...execution.pendingData,
-        ...(patchBody.userConfirmed !== undefined
-          ? { userConfirmed: patchBody.userConfirmed }
+        ...(userConfirmation?.userConfirmed !== undefined
+          ? { userConfirmed: userConfirmation.userConfirmed }
           : {}),
       },
-      userConfirmation: patchBody as TExec['userConfirmation'],
+      userConfirmation,
     };
 
     await this.context.runStore.saveStepExecution(this.context.runId, updated);
@@ -252,7 +251,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   // userConfirmed branches: undefined → re-emit awaiting-input (PATCH not yet called);
   // false → save as skipped + success outcome; true → resolveAndExecute.
-  protected async handleConfirmationFlow<TExec extends WithPendingData>(
+  protected async handleConfirmationFlow<TExec extends ConfirmableStepExecutionData>(
     execution: TExec,
     resolveAndExecute: (execution: TExec) => Promise<StepExecutionResult>,
   ): Promise<StepExecutionResult> {

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -199,8 +199,6 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     );
   }
 
-  // Preserves the AI suggestion in pendingData: only userConfirmed is mirrored there because
-  // handleConfirmationFlow gates on it. The full parsed PATCH body is stored in userConfirmation.
   protected async patchAndReloadPendingData<TExec extends ConfirmableStepExecutionData>(
     pendingData?: unknown,
   ): Promise<TExec | undefined> {
@@ -229,15 +227,8 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
     const userConfirmation = parsed.data as TExec['userConfirmation'];
 
-    // Last-write-wins: spread-merging would leak stale keys from prior PATCHes.
     const updated: TExec = {
       ...execution,
-      pendingData: {
-        ...execution.pendingData,
-        ...(userConfirmation?.userConfirmed !== undefined
-          ? { userConfirmed: userConfirmation.userConfirmed }
-          : {}),
-      },
       userConfirmation,
     };
 
@@ -256,7 +247,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       throw new StepStateError(`Step at index ${this.context.stepIndex} has no pending data`);
     }
 
-    const { userConfirmed } = execution.pendingData as { userConfirmed?: boolean };
+    const { userConfirmed } = execution.userConfirmation ?? {};
 
     if (userConfirmed === undefined) {
       return this.buildOutcomeResult({ status: 'awaiting-input' });

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -203,8 +203,8 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     );
   }
 
-  // Keeps `pendingData` immutable; mirrors `userConfirmed` only because
-  // `handleConfirmationFlow` reads the gate from there.
+  // Preserves the AI suggestion in pendingData: only userConfirmed is mirrored there because
+  // handleConfirmationFlow gates on it. The full parsed PATCH body is stored in userConfirmation.
   protected async patchAndReloadPendingData<TExec extends WithPendingData>(
     pendingData?: unknown,
   ): Promise<TExec | undefined> {
@@ -235,7 +235,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
           ? { userConfirmed: patchBody.userConfirmed }
           : {}),
       },
-      userConfirmation: patchBody,
+      userConfirmation: patchBody as TExec['userConfirmation'],
     };
 
     await this.context.runStore.saveStepExecution(this.context.runId, updated);

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -237,7 +237,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     return updated;
   }
 
-  // userConfirmed branches: undefined → re-emit awaiting-input (PATCH not yet called);
+  // userConfirmed branches: undefined → re-emit awaiting-input (POST not yet called);
   // false → save as skipped + success outcome; true → resolveAndExecute.
   protected async handleConfirmationFlow<TExec extends ConfirmableStepExecutionData>(
     execution: TExec,

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -5,10 +5,7 @@ import type {
   IStepExecutor,
   StepExecutionResult,
 } from '../types/execution-context';
-import type {
-  ConfirmableStepExecutionData,
-  StepExecutionData,
-} from '../types/step-execution-data';
+import type { ConfirmableStepExecutionData, StepExecutionData } from '../types/step-execution-data';
 import type { StepDefinition } from '../types/validated/step-definition';
 import type { StepStatus } from '../types/validated/step-outcome';
 import type {

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -5,7 +5,7 @@ import type {
   IStepExecutor,
   StepExecutionResult,
 } from '../types/execution-context';
-import type { StepExecutionData } from '../types/step-execution-data';
+import type { StepExecutionData, WithUserConfirmation } from '../types/step-execution-data';
 import type { StepDefinition } from '../types/validated/step-definition';
 import type { StepStatus } from '../types/validated/step-outcome';
 import type {
@@ -27,7 +27,9 @@ import {
 import patchBodySchemas from '../http/pending-data-validators';
 import StepSummaryBuilder from './summary/step-summary-builder';
 
-type WithPendingData = StepExecutionData & { pendingData?: object };
+type WithPendingData = StepExecutionData & { pendingData?: object } & WithUserConfirmation;
+
+type PatchBody = Record<string, unknown> & { userConfirmed?: boolean };
 
 export default abstract class BaseStepExecutor<TStep extends StepDefinition = StepDefinition>
   implements IStepExecutor
@@ -201,36 +203,44 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     );
   }
 
+  // Keeps `pendingData` immutable; mirrors `userConfirmed` only because
+  // `handleConfirmationFlow` reads the gate from there.
   protected async patchAndReloadPendingData<TExec extends WithPendingData>(
     pendingData?: unknown,
   ): Promise<TExec | undefined> {
     const { type } = this.context.stepDefinition;
     const execution = await this.findPendingExecution<TExec>(type);
 
-    if (pendingData !== undefined && execution) {
-      const schema = patchBodySchemas[execution.type]!;
-      const parsed = schema.safeParse(pendingData);
+    if (!execution) return undefined;
 
-      if (!parsed.success) {
-        throw new StepStateError(
-          `Invalid pending data: ${parsed.error.issues.map(i => i.message).join(', ')}`,
-        );
-      }
+    if (pendingData === undefined) return execution;
 
-      const updated = {
-        ...execution,
-        pendingData: { ...(execution.pendingData as object), ...(parsed.data as object) },
-      } as TExec;
+    const schema = patchBodySchemas[execution.type]!;
+    const parsed = schema.safeParse(pendingData);
 
-      await this.context.runStore.saveStepExecution(
-        this.context.runId,
-        updated as StepExecutionData,
+    if (!parsed.success) {
+      throw new StepStateError(
+        `Invalid pending data: ${parsed.error.issues.map(i => i.message).join(', ')}`,
       );
-
-      return updated;
     }
 
-    return execution;
+    const patchBody = parsed.data as PatchBody;
+
+    // Last-write-wins: spread-merging would leak stale keys from prior PATCHes.
+    const updated: TExec = {
+      ...execution,
+      pendingData: {
+        ...execution.pendingData,
+        ...(patchBody.userConfirmed !== undefined
+          ? { userConfirmed: patchBody.userConfirmed }
+          : {}),
+      },
+      userConfirmation: patchBody,
+    };
+
+    await this.context.runStore.saveStepExecution(this.context.runId, updated);
+
+    return updated;
   }
 
   // userConfirmed branches: undefined → re-emit awaiting-input (PATCH not yet called);

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -167,7 +167,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
     execPromise.catch(err => {
       if (!hasTimeoutFired) return;
-      this.context.logger.info('Step work rejected after timeout — result discarded', {
+      this.context.logger.warn('Step work rejected after timeout — result discarded', {
         ...this.logCtx,
         error: extractErrorMessage(err),
       });
@@ -215,7 +215,14 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
     if (pendingData === undefined) return execution;
 
-    const schema = patchBodySchemas[execution.type]!;
+    const schema = patchBodySchemas[execution.type];
+
+    if (!schema) {
+      throw new StepStateError(
+        `No pending-data validator registered for step type "${execution.type}"`,
+      );
+    }
+
     const parsed = schema.safeParse(pendingData);
 
     if (!parsed.success) {

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -149,28 +149,20 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       throw new StepStateError(`Step at index ${this.context.stepIndex} has no pending data`);
     }
 
-    const isString = (v: unknown): v is string => typeof v === 'string';
-    const isRecordId = (v: unknown): v is Array<string | number> =>
-      Array.isArray(v) && v.every(e => typeof e === 'string' || typeof e === 'number');
+    const name = userConfirmation?.name ?? pendingData.name;
+    const selectedRecordId = userConfirmation?.selectedRecordId ?? pendingData.selectedRecordId;
 
-    const name = isString(userConfirmation?.name) ? userConfirmation.name : pendingData.name;
-    const displayName = isString(userConfirmation?.displayName)
-      ? userConfirmation.displayName
-      : pendingData.displayName;
-    const selectedRecordId = isRecordId(userConfirmation?.selectedRecordId)
-      ? userConfirmation.selectedRecordId
-      : pendingData.selectedRecordId;
-
-    // Re-derive relatedCollectionName because the user may have swapped the relation.
+    // Re-derive relatedCollectionName and displayName because the user may have swapped the relation.
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const field = schema.fields.find(f => f.fieldName === name);
-    const relatedCollectionName = field?.relatedCollectionName;
 
-    if (!relatedCollectionName) {
+    if (!field?.relatedCollectionName) {
       throw new StepStateError(
         `Step at index ${this.context.stepIndex} could not resolve relatedCollectionName for relation "${name}"`,
       );
     }
+
+    const { displayName, relatedCollectionName } = field;
 
     const record: RecordRef = {
       collectionName: relatedCollectionName,

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -139,21 +139,29 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     return this.persistAndReturn(record, target, undefined);
   }
 
-  // Branch A: builds RecordRef from pendingData.selectedRecordId without a new getRelatedData call.
-  // Re-derives relatedCollectionName so a user-overridden relation name is handled correctly.
+  // Branch A: builds RecordRef from the user-confirmed selection without a new getRelatedData call.
   private async resolveFromSelection(
     execution: LoadRelatedRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
-    const { selectedRecordRef, pendingData } = execution;
+    const { selectedRecordRef, pendingData, userConfirmation } = execution;
 
     if (!pendingData) {
       throw new StepStateError(`Step at index ${this.context.stepIndex} has no pending data`);
     }
 
-    const { name, displayName, selectedRecordId } = pendingData;
+    const isString = (v: unknown): v is string => typeof v === 'string';
+    const isRecordId = (v: unknown): v is Array<string | number> =>
+      Array.isArray(v) && v.every(e => typeof e === 'string' || typeof e === 'number');
 
-    // Re-derive relatedCollectionName from schema using the (possibly updated) relation name.
-    // `name` is always a fieldName (set from field.fieldName in buildTarget) — search directly.
+    const name = isString(userConfirmation?.name) ? userConfirmation.name : pendingData.name;
+    const displayName = isString(userConfirmation?.displayName)
+      ? userConfirmation.displayName
+      : pendingData.displayName;
+    const selectedRecordId = isRecordId(userConfirmation?.selectedRecordId)
+      ? userConfirmation.selectedRecordId
+      : pendingData.selectedRecordId;
+
+    // Re-derive relatedCollectionName because the user may have swapped the relation.
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const field = schema.fields.find(f => f.fieldName === name);
     const relatedCollectionName = field?.relatedCollectionName;

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -71,11 +71,11 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       return this.handleConfirmationFlow<TriggerRecordActionStepExecutionData>(
         pending,
         async exec => {
-          const { selectedRecordRef, pendingData } = exec;
+          const { selectedRecordRef, pendingData, userConfirmation } = exec;
 
           // The frontend executes the action itself and posts the result back.
           // A confirmed step without actionResult is a broken frontend contract.
-          if (!pendingData || !('actionResult' in pendingData)) {
+          if (!pendingData || !userConfirmation || !('actionResult' in userConfirmation)) {
             throw new StepStateError(
               `Frontend confirmed action but did not provide actionResult ` +
                 `(run "${this.context.runId}", step ${this.context.stepIndex})`,
@@ -88,7 +88,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
             name: pendingData.name,
           };
 
-          return this.saveFrontendResult(target, pendingData.actionResult, exec);
+          return this.saveFrontendResult(target, userConfirmation.actionResult, exec);
         },
       );
     }

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,6 +1,6 @@
 import type { CreateActivityLogArgs } from '../ports/activity-log-port';
 import type { StepExecutionResult } from '../types/execution-context';
-import type { FieldRef, UpdateRecordStepExecutionData } from '../types/step-execution-data';
+import type { FieldWithValue, UpdateRecordStepExecutionData } from '../types/step-execution-data';
 import type { CollectionSchema, FieldSchema, RecordRef } from '../types/validated/collection';
 import type { UpdateRecordStepDefinition } from '../types/validated/step-definition';
 
@@ -91,9 +91,8 @@ function buildZodSchemaForField(field: FieldSchema): z.ZodTypeAny {
   return buildZodSchemaForPrimitive(type as string, enumValues);
 }
 
-interface UpdateTarget extends FieldRef {
+interface UpdateTarget extends FieldWithValue {
   selectedRecordRef: RecordRef;
-  value: unknown;
 }
 
 export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateRecordStepDefinition> {

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -131,10 +131,15 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
 
     if (pending) {
       return this.handleConfirmationFlow<UpdateRecordStepExecutionData>(pending, async exec => {
-        const { selectedRecordRef, pendingData } = exec;
+        const { selectedRecordRef, pendingData, userConfirmation } = exec;
+        const userValue =
+          userConfirmation && 'value' in userConfirmation
+            ? userConfirmation.value
+            : (pendingData as { value: unknown })?.value;
         const target: UpdateTarget = {
           selectedRecordRef,
-          ...(pendingData as FieldRef & { value: unknown }),
+          ...(pendingData as FieldRef),
+          value: userValue,
         };
 
         return this.resolveAndUpdate(target, exec);

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -132,14 +132,10 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     if (pending) {
       return this.handleConfirmationFlow<UpdateRecordStepExecutionData>(pending, async exec => {
         const { selectedRecordRef, pendingData, userConfirmation } = exec;
-        const userValue =
-          userConfirmation && 'value' in userConfirmation
-            ? userConfirmation.value
-            : (pendingData as { value: unknown })?.value;
         const target: UpdateTarget = {
           selectedRecordRef,
-          ...(pendingData as FieldRef),
-          value: userValue,
+          ...pendingData!,
+          value: userConfirmation?.value ?? pendingData!.value,
         };
 
         return this.resolveAndUpdate(target, exec);

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -1,53 +1,67 @@
-import type { StepExecutionData } from '../types/step-execution-data';
-
 import { z } from 'zod';
 
 // Per-step-type schemas for the `pendingData` payload sent by the front via
 // POST /runs/:runId/trigger. Consumed by step executors to validate `incomingPendingData`
 // before applying user confirmation or override. Schemas use .strict() to reject unknown fields.
-const patchBodySchemas: Partial<Record<StepExecutionData['type'], z.ZodTypeAny>> = {
-  'update-record': z
-    .object({
-      userConfirmed: z.boolean(),
-      value: z.string().optional(), // user may override the AI-proposed value
-    })
-    .strict(),
 
-  'trigger-action': z
-    .object({
-      userConfirmed: z.boolean(),
-      // Opaque action result from the frontend. Required when userConfirmed=true; the
-      // presence check lives in the step-executor so a descriptive StepStateError can
-      // name the runId/stepIndex — not achievable from inside a zod schema.
-      actionResult: z.unknown().optional(),
-    })
-    .strict(),
+const updateRecordPatchSchema = z
+  .object({
+    userConfirmed: z.boolean(),
+    value: z.string().optional(), // user may override the AI-proposed value
+  })
+  .strict();
 
-  mcp: z.object({ userConfirmed: z.boolean() }).strict(),
+const triggerActionPatchSchema = z
+  .object({
+    userConfirmed: z.boolean(),
+    // Opaque action result from the frontend. Required when userConfirmed=true; the
+    // presence check lives in the step-executor so a descriptive StepStateError can
+    // name the runId/stepIndex — not achievable from inside a zod schema.
+    actionResult: z.unknown().optional(),
+  })
+  .strict();
 
-  'load-related-record': z
-    .object({
-      userConfirmed: z.boolean(),
-      // User may intentionally switch to a different relation than the one the AI selected.
-      // The executor re-derives relatedCollectionName from FieldSchema when processing the confirmation.
-      name: z.string().optional(),
-      displayName: z.string().optional(),
-      // User may override the AI-selected record; must be non-empty when provided.
-      selectedRecordId: z
-        .array(z.union([z.string(), z.number()]))
-        .min(1)
-        .optional(),
-    })
-    .strict(),
-  // relatedCollectionName and suggestedFields are NOT accepted — internal executor data.
+const mcpPatchSchema = z.object({ userConfirmed: z.boolean() }).strict();
 
-  guidance: z
-    .object({
-      userInput: z.string().optional(),
-    })
-    .strict(),
+const loadRelatedRecordPatchSchema = z
+  .object({
+    userConfirmed: z.boolean(),
+    // User may intentionally switch to a different relation than the one the AI selected.
+    // The executor re-derives relatedCollectionName and displayName from FieldSchema when
+    // processing the confirmation.
+    name: z.string().optional(),
+    // User may override the AI-selected record; must be non-empty when provided.
+    selectedRecordId: z
+      .array(z.union([z.string(), z.number()]))
+      .min(1)
+      .optional(),
+  })
+  .strict();
+// relatedCollectionName, displayName and suggestedFields are NOT accepted — internal executor data.
 
-  condition: z.object({ selectedOption: z.string() }).strict(),
+const guidancePatchSchema = z
+  .object({
+    userInput: z.string().optional(),
+  })
+  .strict();
+
+const conditionPatchSchema = z.object({ selectedOption: z.string() }).strict();
+
+// Inferred types — consumed by step-execution-data.ts to type `userConfirmation` precisely,
+// removing the need for runtime type guards in executors.
+export type UpdateRecordConfirmation = z.infer<typeof updateRecordPatchSchema>;
+export type TriggerActionConfirmation = z.infer<typeof triggerActionPatchSchema>;
+export type McpConfirmation = z.infer<typeof mcpPatchSchema>;
+export type LoadRelatedRecordConfirmation = z.infer<typeof loadRelatedRecordPatchSchema>;
+export type GuidanceConfirmation = z.infer<typeof guidancePatchSchema>;
+
+const patchBodySchemas: Partial<Record<string, z.ZodTypeAny>> = {
+  'update-record': updateRecordPatchSchema,
+  'trigger-action': triggerActionPatchSchema,
+  mcp: mcpPatchSchema,
+  'load-related-record': loadRelatedRecordPatchSchema,
+  guidance: guidancePatchSchema,
+  condition: conditionPatchSchema,
 };
 
 export default patchBodySchemas;

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -42,8 +42,6 @@ const loadRelatedRecordPatchSchema = z
   .refine(data => data.name === undefined || data.selectedRecordId !== undefined, {
     message: 'selectedRecordId is required when overriding the relation name',
   });
-// relatedCollectionName, displayName and suggestedFields are NOT accepted — internal executor data.
-
 const guidancePatchSchema = z
   .object({
     userInput: z.string().optional(),

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -29,7 +29,7 @@ const loadRelatedRecordPatchSchema = z
     // User may intentionally switch to a different relation than the one the AI selected.
     // The executor re-derives relatedCollectionName and displayName from FieldSchema when
     // processing the confirmation.
-    name: z.string().optional(),
+    name: z.string().min(1).optional(),
     // User may override the AI-selected record; must be non-empty when provided.
     // Required when overriding the relation name — the original record ID belongs to a
     // different collection and cannot be reused for the new relation.
@@ -39,7 +39,7 @@ const loadRelatedRecordPatchSchema = z
       .optional(),
   })
   .strict()
-  .refine(data => !data.name || data.selectedRecordId !== undefined, {
+  .refine(data => data.name === undefined || data.selectedRecordId !== undefined, {
     message: 'selectedRecordId is required when overriding the relation name',
   });
 // relatedCollectionName, displayName and suggestedFields are NOT accepted — internal executor data.

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -31,12 +31,17 @@ const loadRelatedRecordPatchSchema = z
     // processing the confirmation.
     name: z.string().optional(),
     // User may override the AI-selected record; must be non-empty when provided.
+    // Required when overriding the relation name — the original record ID belongs to a
+    // different collection and cannot be reused for the new relation.
     selectedRecordId: z
       .array(z.union([z.string(), z.number()]))
       .min(1)
       .optional(),
   })
-  .strict();
+  .strict()
+  .refine(data => !data.name || data.selectedRecordId !== undefined, {
+    message: 'selectedRecordId is required when overriding the relation name',
+  });
 // relatedCollectionName, displayName and suggestedFields are NOT accepted — internal executor data.
 
 const guidancePatchSchema = z

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-// Per-step-type schemas for the `pendingData` payload sent by the front via
-// POST /runs/:runId/trigger. Consumed by step executors to validate `incomingPendingData`
-// before applying user confirmation or override. Schemas use .strict() to reject unknown fields.
+// Per-step-type schemas for the userConfirmation payload sent by the front via
+// POST /runs/:runId/trigger. Validated into `execution.userConfirmation`; schemas
+// use .strict() to reject unknown fields.
 
 const updateRecordPatchSchema = z
   .object({

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -56,9 +56,16 @@ export type UpdateRecordConfirmation = z.infer<typeof updateRecordPatchSchema>;
 export type TriggerActionConfirmation = z.infer<typeof triggerActionPatchSchema>;
 export type McpConfirmation = z.infer<typeof mcpPatchSchema>;
 export type LoadRelatedRecordConfirmation = z.infer<typeof loadRelatedRecordPatchSchema>;
-export type GuidanceConfirmation = z.infer<typeof guidancePatchSchema>;
 
-const patchBodySchemas: Partial<Record<string, z.ZodTypeAny>> = {
+type PatchableStepType =
+  | 'update-record'
+  | 'trigger-action'
+  | 'mcp'
+  | 'load-related-record'
+  | 'guidance'
+  | 'condition';
+
+const patchBodySchemas: Partial<Record<PatchableStepType, z.ZodTypeAny>> = {
   'update-record': updateRecordPatchSchema,
   'trigger-action': triggerActionPatchSchema,
   mcp: mcpPatchSchema,

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -41,6 +41,8 @@ export interface FieldRef {
   displayName: string;
 }
 
+export type FieldWithValue = FieldRef & { value: unknown };
+
 // -- Read Record --
 
 export interface FieldReadSuccess extends FieldRef {
@@ -66,10 +68,10 @@ export interface UpdateRecordStepExecutionData
   extends MutatingStepExecutionData,
     WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
-  executionParams?: FieldRef & { value: unknown };
+  executionParams?: FieldWithValue;
   // User confirmed → values returned by updateRecord. User rejected → skipped.
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
-  pendingData?: FieldRef & { value: unknown };
+  pendingData?: FieldWithValue;
   selectedRecordRef: RecordRef;
 }
 

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -20,8 +20,8 @@ interface MutatingStepExecutionData extends BaseStepExecutionData {
   idempotencyPhase?: 'executing' | 'done';
 }
 
-// Parsed PATCH body kept beside `pendingData` so executors can read the user's
-// final input without overwriting the AI suggestion.
+// Validated PATCH body stored alongside `pendingData` (AI suggestion) so executors
+// can read user input without overwriting the AI suggestion.
 export interface WithUserConfirmation<T extends Record<string, unknown> = Record<string, unknown>> {
   userConfirmation?: T;
 }
@@ -134,7 +134,7 @@ export interface RecordStepExecutionData extends BaseStepExecutionData {
 export interface LoadRelatedRecordPendingData extends RelationRef {
   // undefined when not computed (record has no non-relation fields).
   suggestedFields?: string[];
-  // AI-selected initially; can be overridden by the frontend via PATCH .../pending-data.
+  // AI-selected initially; frontend can override via userConfirmation.selectedRecordId.
   selectedRecordId: Array<string | number>;
 }
 

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -109,7 +109,9 @@ export interface McpToolCall extends McpToolRef {
   input: Record<string, unknown>;
 }
 
-export interface McpStepExecutionData extends MutatingStepExecutionData, WithUserConfirmation<McpConfirmation> {
+export interface McpStepExecutionData
+  extends MutatingStepExecutionData,
+    WithUserConfirmation<McpConfirmation> {
   type: 'mcp';
   executionParams?: McpToolCall;
   executionResult?:

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -1,6 +1,12 @@
 /** @draft Types derived from the workflow-executor spec -- subject to change. */
 
 import type { RecordRef } from './validated/collection';
+import type {
+  LoadRelatedRecordConfirmation,
+  McpConfirmation,
+  TriggerActionConfirmation,
+  UpdateRecordConfirmation,
+} from '../http/pending-data-validators';
 
 // -- Base --
 
@@ -16,8 +22,8 @@ interface MutatingStepExecutionData extends BaseStepExecutionData {
 
 // Parsed PATCH body kept beside `pendingData` so executors can read the user's
 // final input without overwriting the AI suggestion.
-export interface WithUserConfirmation {
-  userConfirmation?: Record<string, unknown>;
+export interface WithUserConfirmation<T extends Record<string, unknown> = Record<string, unknown>> {
+  userConfirmation?: T;
 }
 
 // -- Condition --
@@ -58,7 +64,7 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 
 export interface UpdateRecordStepExecutionData
   extends MutatingStepExecutionData,
-    WithUserConfirmation {
+    WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
   executionParams?: FieldRef & { value: unknown };
   // User confirmed → values returned by updateRecord. User rejected → skipped.
@@ -83,7 +89,7 @@ export interface RelationRef {
 
 export interface TriggerRecordActionStepExecutionData
   extends MutatingStepExecutionData,
-    WithUserConfirmation {
+    WithUserConfirmation<TriggerActionConfirmation> {
   type: 'trigger-action';
   executionParams?: ActionRef;
   executionResult?: { success: true; actionResult: unknown } | { skipped: true };
@@ -103,7 +109,7 @@ export interface McpToolCall extends McpToolRef {
   input: Record<string, unknown>;
 }
 
-export interface McpStepExecutionData extends MutatingStepExecutionData {
+export interface McpStepExecutionData extends MutatingStepExecutionData, WithUserConfirmation<McpConfirmation> {
   type: 'mcp';
   executionParams?: McpToolCall;
   executionResult?:
@@ -133,7 +139,7 @@ export interface LoadRelatedRecordPendingData extends RelationRef {
 
 export interface LoadRelatedRecordStepExecutionData
   extends BaseStepExecutionData,
-    WithUserConfirmation {
+    WithUserConfirmation<LoadRelatedRecordConfirmation> {
   type: 'load-related-record';
   pendingData?: LoadRelatedRecordPendingData;
   selectedRecordRef: RecordRef;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -158,7 +158,13 @@ export interface GuidanceStepExecutionData extends BaseStepExecutionData {
   executionResult?: { userInput?: string };
 }
 
-// -- Union --
+// -- Unions --
+
+export type ConfirmableStepExecutionData =
+  | UpdateRecordStepExecutionData
+  | TriggerRecordActionStepExecutionData
+  | McpStepExecutionData
+  | LoadRelatedRecordStepExecutionData;
 
 export type StepExecutionData =
   | ConditionStepExecutionData

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -69,7 +69,7 @@ export interface UpdateRecordStepExecutionData
   executionParams?: FieldRef & { value: unknown };
   // User confirmed → values returned by updateRecord. User rejected → skipped.
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
-  pendingData?: FieldRef & { value: unknown; userConfirmed?: boolean };
+  pendingData?: FieldRef & { value: unknown };
   selectedRecordRef: RecordRef;
 }
 
@@ -93,7 +93,7 @@ export interface TriggerRecordActionStepExecutionData
   type: 'trigger-action';
   executionParams?: ActionRef;
   executionResult?: { success: true; actionResult: unknown } | { skipped: true };
-  pendingData?: ActionRef & { userConfirmed?: boolean };
+  pendingData?: ActionRef;
   selectedRecordRef: RecordRef;
 }
 
@@ -117,7 +117,7 @@ export interface McpStepExecutionData
   executionResult?:
     | { success: true; toolResult: unknown; formattedResponse?: string }
     | { skipped: true };
-  pendingData?: McpToolCall & { userConfirmed?: boolean };
+  pendingData?: McpToolCall;
 }
 
 // -- Generic AI Task (fallback for untyped steps) --
@@ -136,7 +136,6 @@ export interface LoadRelatedRecordPendingData extends RelationRef {
   suggestedFields?: string[];
   // AI-selected initially; can be overridden by the frontend via PATCH .../pending-data.
   selectedRecordId: Array<string | number>;
-  userConfirmed?: boolean;
 }
 
 export interface LoadRelatedRecordStepExecutionData

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -14,6 +14,12 @@ interface MutatingStepExecutionData extends BaseStepExecutionData {
   idempotencyPhase?: 'executing' | 'done';
 }
 
+// Parsed PATCH body kept beside `pendingData` so executors can read the user's
+// final input without overwriting the AI suggestion.
+export interface WithUserConfirmation {
+  userConfirmation?: Record<string, unknown>;
+}
+
 // -- Condition --
 
 export interface ConditionStepExecutionData extends BaseStepExecutionData {
@@ -50,7 +56,9 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 
 // -- Update Record --
 
-export interface UpdateRecordStepExecutionData extends MutatingStepExecutionData {
+export interface UpdateRecordStepExecutionData
+  extends MutatingStepExecutionData,
+    WithUserConfirmation {
   type: 'update-record';
   executionParams?: FieldRef & { value: unknown };
   // User confirmed → values returned by updateRecord. User rejected → skipped.
@@ -73,13 +81,13 @@ export interface RelationRef {
   displayName: string;
 }
 
-export interface TriggerRecordActionStepExecutionData extends MutatingStepExecutionData {
+export interface TriggerRecordActionStepExecutionData
+  extends MutatingStepExecutionData,
+    WithUserConfirmation {
   type: 'trigger-action';
   executionParams?: ActionRef;
   executionResult?: { success: true; actionResult: unknown } | { skipped: true };
-  // When userConfirmed=true, actionResult is required: the frontend executes the action and
-  // posts the result back (the executor never re-executes on confirmation).
-  pendingData?: ActionRef & { userConfirmed?: boolean; actionResult?: unknown };
+  pendingData?: ActionRef & { userConfirmed?: boolean };
   selectedRecordRef: RecordRef;
 }
 
@@ -123,7 +131,9 @@ export interface LoadRelatedRecordPendingData extends RelationRef {
   userConfirmed?: boolean;
 }
 
-export interface LoadRelatedRecordStepExecutionData extends BaseStepExecutionData {
+export interface LoadRelatedRecordStepExecutionData
+  extends BaseStepExecutionData,
+    WithUserConfirmation {
   type: 'load-related-record';
   pendingData?: LoadRelatedRecordPendingData;
   selectedRecordRef: RecordRef;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -20,7 +20,7 @@ interface MutatingStepExecutionData extends BaseStepExecutionData {
   idempotencyPhase?: 'executing' | 'done';
 }
 
-// Validated PATCH body stored alongside `pendingData` (AI suggestion) so executors
+// Validated POST body stored alongside `pendingData` (AI suggestion) so executors
 // can read user input without overwriting the AI suggestion.
 export interface WithUserConfirmation<T extends Record<string, unknown> = Record<string, unknown>> {
   userConfirmation?: T;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -158,8 +158,6 @@ export interface GuidanceStepExecutionData extends BaseStepExecutionData {
   executionResult?: { userInput?: string };
 }
 
-// -- Unions --
-
 export type ConfirmableStepExecutionData =
   | UpdateRecordStepExecutionData
   | TriggerRecordActionStepExecutionData

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -492,7 +492,7 @@ describe('BaseStepExecutor', () => {
           setTimeout(resolve, 1_100);
         });
 
-        expect(logger.info).toHaveBeenCalledWith(
+        expect(logger.warn).toHaveBeenCalledWith(
           'Step work rejected after timeout — result discarded',
           expect.objectContaining({
             runId: 'run-1',
@@ -516,7 +516,7 @@ describe('BaseStepExecutor', () => {
 
       await executor.execute();
 
-      expect(logger.info).not.toHaveBeenCalledWith(
+      expect(logger.warn).not.toHaveBeenCalledWith(
         'Step work rejected after timeout — result discarded',
         expect.anything(),
       );

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -788,14 +788,19 @@ describe('BaseStepExecutor', () => {
   describe('patchAndReloadPendingData', () => {
     class PatchingExecutor extends BaseStepExecutor {
       async callPatchAndReload(pendingData?: unknown) {
-        return (this as unknown as { patchAndReloadPendingData(d?: unknown): Promise<unknown> }).patchAndReloadPendingData(pendingData);
+        return (
+          this as unknown as { patchAndReloadPendingData(d?: unknown): Promise<unknown> }
+        ).patchAndReloadPendingData(pendingData);
       }
 
       protected async doExecute(): Promise<StepExecutionResult> {
         return this.buildOutcomeResult({ status: 'success' });
       }
 
-      protected buildOutcomeResult(outcome: { status: BaseStepStatus; error?: string }): StepExecutionResult {
+      protected buildOutcomeResult(outcome: {
+        status: BaseStepStatus;
+        error?: string;
+      }): StepExecutionResult {
         return {
           stepOutcome: {
             type: 'record',

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -15,6 +15,7 @@ import {
   MissingToolCallError,
   NoRecordsError,
   RunStorePortError,
+  StepStateError,
   WorkflowExecutorError,
 } from '../../src/errors';
 import BaseStepExecutor from '../../src/executors/base-step-executor';
@@ -780,6 +781,49 @@ describe('BaseStepExecutor', () => {
       );
       await expect(executor.invokeWithTool(dummyMessages, dummyTool)).rejects.toThrow(
         'AI returned a malformed tool call for "unknown": Something broke',
+      );
+    });
+  });
+
+  describe('patchAndReloadPendingData', () => {
+    class PatchingExecutor extends BaseStepExecutor {
+      async callPatchAndReload(pendingData?: unknown) {
+        return (this as unknown as { patchAndReloadPendingData(d?: unknown): Promise<unknown> }).patchAndReloadPendingData(pendingData);
+      }
+
+      protected async doExecute(): Promise<StepExecutionResult> {
+        return this.buildOutcomeResult({ status: 'success' });
+      }
+
+      protected buildOutcomeResult(outcome: { status: BaseStepStatus; error?: string }): StepExecutionResult {
+        return {
+          stepOutcome: {
+            type: 'record',
+            stepId: this.context.stepId,
+            stepIndex: this.context.stepIndex,
+            status: outcome.status,
+          },
+        };
+      }
+    }
+
+    it('throws StepStateError when no schema is registered for the step type', async () => {
+      const runStore = makeMockRunStore([
+        { type: 'read-record', stepIndex: 0 } as unknown as StepExecutionData,
+      ]);
+      const executor = new PatchingExecutor(
+        makeContext({
+          runStore,
+          stepDefinition: {
+            type: StepType.ReadRecord,
+            executionType: StepExecutionMode.FullyAutomated,
+          },
+        }),
+      );
+
+      await expect(executor.callPatchAndReload({ someField: 'x' })).rejects.toThrow(StepStateError);
+      await expect(executor.callPatchAndReload({ someField: 'x' })).rejects.toThrow(
+        'No pending-data validator registered for step type "read-record"',
       );
     });
   });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -894,7 +894,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
         incomingPendingData: {
           userConfirmed: true,
           name: 'address',
-          displayName: 'Address',
           selectedRecordId: [7],
         },
       });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -766,8 +766,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: ['status', 'amount'],
           selectedRecordId: [99],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -804,8 +804,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: ['status', 'amount'],
           selectedRecordId: [42],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -865,7 +865,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
             displayName: 'Order',
             name: 'order',
             selectedRecordId: [99], // AI suggestion preserved
-            userConfirmed: true,
           }),
           executionResult: expect.objectContaining({
             record: expect.objectContaining({ collectionName: 'orders', recordId: [42] }),
@@ -941,8 +940,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: [],
           selectedRecordId: [99],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -982,8 +981,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: [],
           selectedRecordId: [99],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -1027,8 +1026,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'address',
           suggestedFields: [],
           selectedRecordId: [77],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -1058,8 +1057,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: [],
           selectedRecordId: [99],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -1086,8 +1085,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: ['status', 'amount'],
           selectedRecordId: [99],
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -1110,9 +1109,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
   });
 
   describe('trigger before PATCH (Branch A)', () => {
-    it('re-emits awaiting-input when userConfirmed is not yet set in pendingData', async () => {
+    it('re-emits awaiting-input when userConfirmation is not yet set', async () => {
       const agentPort = makeMockAgentPort();
-      const execution = makePendingExecution(); // pendingData has no userConfirmed
+      const execution = makePendingExecution(); // userConfirmation not yet set
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
       });
@@ -1274,8 +1273,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: ['status', 'amount'],
           selectedRecordId: [99],
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -1645,8 +1644,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           name: 'order',
           suggestedFields: ['status', 'amount'],
           selectedRecordId: [99],
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
       });
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -828,6 +828,101 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
+  describe('confirmation with user override of selectedRecordId (Branch A)', () => {
+    it('preserves AI suggestion in pendingData and writes user choice to executionParams', async () => {
+      // Persisted state: AI suggested record [99], awaiting confirmation.
+      const execution = makePendingExecution({
+        pendingData: {
+          displayName: 'Order',
+          name: 'order',
+          selectedRecordId: [99],
+          suggestedFields: ['status', 'amount'],
+        },
+      });
+      const agentPort = makeMockAgentPort();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      // User confirms with a different record id: [42].
+      const context = makeContext({
+        agentPort,
+        runStore,
+        incomingPendingData: { userConfirmed: true, selectedRecordId: [42] },
+      });
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+
+      // Final persisted execution must keep AI suggestion in pendingData
+      // and use the user-overridden record id in executionResult.
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave).toEqual(
+        expect.objectContaining({
+          type: 'load-related-record',
+          pendingData: expect.objectContaining({
+            displayName: 'Order',
+            name: 'order',
+            selectedRecordId: [99], // AI suggestion preserved
+            userConfirmed: true,
+          }),
+          executionResult: expect.objectContaining({
+            record: expect.objectContaining({ collectionName: 'orders', recordId: [42] }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('confirmation with user override of relation name (Branch A)', () => {
+    it('re-derives relatedCollectionName when the user switches to a different relation', async () => {
+      // AI suggested "order" (→ orders collection). User switches to "address" (→ addresses).
+      const execution = makePendingExecution({
+        pendingData: {
+          displayName: 'Order',
+          name: 'order',
+          selectedRecordId: [99],
+          suggestedFields: [],
+        },
+      });
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      const context = makeContext({
+        runStore,
+        incomingPendingData: {
+          userConfirmed: true,
+          name: 'address',
+          displayName: 'Address',
+          selectedRecordId: [7],
+        },
+      });
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave).toEqual(
+        expect.objectContaining({
+          // AI suggestion preserved on pendingData
+          pendingData: expect.objectContaining({
+            name: 'order',
+            displayName: 'Order',
+            selectedRecordId: [99],
+          }),
+          // User-overridden relation resolves to the addresses collection
+          executionParams: { name: 'address', displayName: 'Address' },
+          executionResult: expect.objectContaining({
+            relation: { name: 'address', displayName: 'Address' },
+            record: expect.objectContaining({ collectionName: 'addresses', recordId: [7] }),
+          }),
+        }),
+      );
+    });
+  });
+
   describe('resolveFromSelection — relatedCollectionName resolution (Branch A)', () => {
     it('derives relatedCollectionName from schema when confirmed', async () => {
       const schema = makeCollectionSchema({

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -369,8 +369,8 @@ describe('McpStepExecutor', () => {
           name: 'send_notification',
           sourceId: 'mcp-server-1',
           input: { message: 'Hello' },
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       };
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -396,7 +396,6 @@ describe('McpStepExecutor', () => {
             name: 'send_notification',
             sourceId: 'mcp-server-1',
             input: { message: 'Hello' },
-            userConfirmed: true,
           },
         }),
       );
@@ -418,8 +417,8 @@ describe('McpStepExecutor', () => {
           name: 'send_notification',
           sourceId: 'mcp-server-1',
           input: { message: 'Hello' },
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
       };
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([execution]),
@@ -439,7 +438,6 @@ describe('McpStepExecutor', () => {
             name: 'send_notification',
             sourceId: 'mcp-server-1',
             input: { message: 'Hello' },
-            userConfirmed: false,
           },
         }),
       );
@@ -638,8 +636,8 @@ describe('McpStepExecutor', () => {
           name: 'deleted_tool',
           sourceId: 'mcp-server-1',
           input: {},
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       };
       const tool = new MockRemoteTool({ name: 'other_tool', sourceId: 'mcp-server-1' });
       const runStore = makeMockRunStore({
@@ -705,8 +703,8 @@ describe('McpStepExecutor', () => {
           name: 'send_notification',
           sourceId: 'mcp-server-1',
           input: { message: 'Hello' },
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
       };
       const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
       const runStore = makeMockRunStore({

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -251,7 +251,6 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: true,
         },
         userConfirmation: {
           userConfirmed: true,
@@ -285,7 +284,6 @@ describe('TriggerRecordActionStepExecutor', () => {
           pendingData: {
             displayName: 'Send Welcome Email',
             name: 'send-welcome-email',
-            userConfirmed: true,
           },
         }),
       );
@@ -299,7 +297,6 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: true,
         },
         userConfirmation: {
           userConfirmed: true,
@@ -333,8 +330,8 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -363,8 +360,8 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -384,7 +381,6 @@ describe('TriggerRecordActionStepExecutor', () => {
           pendingData: {
             displayName: 'Send Welcome Email',
             name: 'send-welcome-email',
-            userConfirmed: false,
           },
         }),
       );
@@ -904,8 +900,8 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -955,7 +951,6 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
-          userConfirmed: true,
         },
         userConfirmation: {
           userConfirmed: true,

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -252,6 +252,9 @@ describe('TriggerRecordActionStepExecutor', () => {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
           userConfirmed: true,
+        },
+        userConfirmation: {
+          userConfirmed: true,
           actionResult: { success: 'ok', html: '<p>Email queued</p>' },
         },
         selectedRecordRef: makeRecordRef(),
@@ -283,7 +286,6 @@ describe('TriggerRecordActionStepExecutor', () => {
             displayName: 'Send Welcome Email',
             name: 'send-welcome-email',
             userConfirmed: true,
-            actionResult: { success: 'ok', html: '<p>Email queued</p>' },
           },
         }),
       );
@@ -297,6 +299,9 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
+          userConfirmed: true,
+        },
+        userConfirmation: {
           userConfirmed: true,
           actionResult: null,
         },
@@ -950,6 +955,9 @@ describe('TriggerRecordActionStepExecutor', () => {
         pendingData: {
           displayName: 'Send Welcome Email',
           name: 'send-welcome-email',
+          userConfirmed: true,
+        },
+        userConfirmation: {
           userConfirmed: true,
           actionResult: { success: 'ok' },
         },

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -222,8 +222,8 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -249,7 +249,6 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Status',
             name: 'status',
             value: 'active',
-            userConfirmed: true,
           },
         }),
       );
@@ -300,7 +299,6 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Status',
             name: 'status',
             value: 'inactive', // AI suggestion preserved
-            userConfirmed: true,
           }),
           executionParams: { displayName: 'Status', name: 'status', value: 'active' },
           executionResult: { updatedValues },
@@ -374,7 +372,6 @@ describe('UpdateRecordStepExecutor', () => {
           executionResult: { skipped: true },
           pendingData: expect.objectContaining({
             value: 'inactive',
-            userConfirmed: false,
           }),
         }),
       );
@@ -391,8 +388,8 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -413,7 +410,6 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Status',
             name: 'status',
             value: 'active',
-            userConfirmed: false,
           },
         }),
       );
@@ -814,8 +810,8 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -864,8 +860,8 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
-          userConfirmed: true,
         },
+        userConfirmation: { userConfirmed: true },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({
@@ -986,8 +982,8 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
-          userConfirmed: false,
         },
+        userConfirmation: { userConfirmed: false },
         selectedRecordRef: makeRecordRef(),
       };
       const runStore = makeMockRunStore({

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -256,6 +256,131 @@ describe('UpdateRecordStepExecutor', () => {
     });
   });
 
+  describe('confirmation with user override (Branch A)', () => {
+    it('preserves AI suggestion in pendingData and writes user value to executionParams', async () => {
+      // Persisted state: AI proposed 'inactive', awaiting confirmation.
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingData: {
+          displayName: 'Status',
+          name: 'status',
+          value: 'inactive',
+        },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const updatedValues = { status: 'active' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      // User confirms with a different value: 'active'.
+      const context = makeContext({
+        agentPort,
+        runStore,
+        incomingPendingData: { userConfirmed: true, value: 'active' },
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      // updateRecord must be called with the user-confirmed value.
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        { collection: 'customers', id: [42], values: { status: 'active' } },
+        expect.objectContaining({ id: 1 }),
+      );
+
+      // Final persisted execution must keep AI suggestion in pendingData
+      // and the user value in executionParams.
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave).toEqual(
+        expect.objectContaining({
+          type: 'update-record',
+          pendingData: expect.objectContaining({
+            displayName: 'Status',
+            name: 'status',
+            value: 'inactive', // AI suggestion preserved
+            userConfirmed: true,
+          }),
+          executionParams: { displayName: 'Status', name: 'status', value: 'active' },
+          executionResult: { updatedValues },
+        }),
+      );
+    });
+  });
+
+  describe('accept-via-PATCH without value override (Branch A)', () => {
+    it('falls back to pendingData.value when userConfirmation has no value key', async () => {
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingData: { displayName: 'Status', name: 'status', value: 'active' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const updatedValues = { status: 'active' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      const context = makeContext({
+        agentPort,
+        runStore,
+        incomingPendingData: { userConfirmed: true },
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        { collection: 'customers', id: [42], values: { status: 'active' } },
+        expect.objectContaining({ id: 1 }),
+      );
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave).toEqual(
+        expect.objectContaining({
+          executionParams: { displayName: 'Status', name: 'status', value: 'active' },
+          userConfirmation: { userConfirmed: true },
+        }),
+      );
+    });
+  });
+
+  describe('rejection via PATCH with userConfirmation set (Branch A)', () => {
+    it('skips the update and ignores any value in userConfirmation', async () => {
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingData: { displayName: 'Status', name: 'status', value: 'inactive' },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const agentPort = makeMockAgentPort();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      const context = makeContext({
+        agentPort,
+        runStore,
+        incomingPendingData: { userConfirmed: false, value: 'active' },
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).not.toHaveBeenCalled();
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave).toEqual(
+        expect.objectContaining({
+          executionResult: { skipped: true },
+          pendingData: expect.objectContaining({
+            value: 'inactive',
+            userConfirmed: false,
+          }),
+        }),
+      );
+    });
+  });
+
   describe('confirmation rejected (Branch A)', () => {
     it('skips the update when user rejects', async () => {
       const agentPort = makeMockAgentPort();

--- a/packages/workflow-executor/test/http/pending-data-validators.test.ts
+++ b/packages/workflow-executor/test/http/pending-data-validators.test.ts
@@ -92,6 +92,10 @@ describe('patchBodySchemas', () => {
       );
     });
 
+    it('rejects empty string name — empty string is not a valid relation name', () => {
+      expect(() => schema.parse({ userConfirmed: true, name: '' })).toThrow();
+    });
+
     it('rejects unknown fields (strict schema)', () => {
       expect(() => schema.parse({ userConfirmed: true, extra: 'leak' })).toThrow();
     });

--- a/packages/workflow-executor/test/http/pending-data-validators.test.ts
+++ b/packages/workflow-executor/test/http/pending-data-validators.test.ts
@@ -81,9 +81,9 @@ describe('patchBodySchemas', () => {
     });
 
     it('accepts confirmation with both name and selectedRecordId (relation override)', () => {
-      expect(
-        schema.parse({ userConfirmed: true, name: 'address', selectedRecordId: [7] }),
-      ).toEqual({ userConfirmed: true, name: 'address', selectedRecordId: [7] });
+      expect(schema.parse({ userConfirmed: true, name: 'address', selectedRecordId: [7] })).toEqual(
+        { userConfirmed: true, name: 'address', selectedRecordId: [7] },
+      );
     });
 
     it('rejects name override without selectedRecordId — original record ID belongs to a different collection', () => {

--- a/packages/workflow-executor/test/http/pending-data-validators.test.ts
+++ b/packages/workflow-executor/test/http/pending-data-validators.test.ts
@@ -64,4 +64,36 @@ describe('patchBodySchemas', () => {
       expect(() => schema.parse({ userConfirmed: 'yes' })).toThrow();
     });
   });
+
+  describe('load-related-record', () => {
+    const schema = patchBodySchemas['load-related-record'];
+    if (!schema) throw new Error('load-related-record schema not registered');
+
+    it('accepts confirmation with no overrides', () => {
+      expect(schema.parse({ userConfirmed: true })).toEqual({ userConfirmed: true });
+    });
+
+    it('accepts confirmation with selectedRecordId override only', () => {
+      expect(schema.parse({ userConfirmed: true, selectedRecordId: [42] })).toEqual({
+        userConfirmed: true,
+        selectedRecordId: [42],
+      });
+    });
+
+    it('accepts confirmation with both name and selectedRecordId (relation override)', () => {
+      expect(
+        schema.parse({ userConfirmed: true, name: 'address', selectedRecordId: [7] }),
+      ).toEqual({ userConfirmed: true, name: 'address', selectedRecordId: [7] });
+    });
+
+    it('rejects name override without selectedRecordId — original record ID belongs to a different collection', () => {
+      expect(() => schema.parse({ userConfirmed: true, name: 'address' })).toThrow(
+        'selectedRecordId is required when overriding the relation name',
+      );
+    });
+
+    it('rejects unknown fields (strict schema)', () => {
+      expect(() => schema.parse({ userConfirmed: true, extra: 'leak' })).toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Keeps `pendingData` immutable so the AI proposal can be diffed against the user's final choice. User overrides now land in a sibling `userConfirmation: Record<string, unknown>` populated by `patchAndReloadPendingData` from the validated PATCH body.
- `update-record`, `trigger-action` and `load-related-record` executors read user-confirmed values (`value`, `actionResult`, `name`/`displayName`/`selectedRecordId`) from `userConfirmation` with fallback to the AI suggestion in `pendingData`.
- `userConfirmation` is replaced last-write-wins (no spread-merge) to avoid stale keys bleeding across sequential PATCHes.

## Test plan

- [x] `yarn workspace @forestadmin/workflow-executor build`
- [x] `yarn workspace @forestadmin/workflow-executor test` (726 tests pass)
- [x] `yarn workspace @forestadmin/workflow-executor lint`
- [x] Regression tests added: AI suggestion preserved with user-override of `value` / `selectedRecordId` / relation `name`+`displayName`, accept-via-PATCH without override (fallback), rejection via PATCH with `userConfirmation` set.