### PR TITLE
refactor(workflow-executor): suppress spurious timeout log when step fails before timeout

### DIFF
--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -173,9 +173,14 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     if (!timeoutMs || timeoutMs <= 0) return this.doExecute();
 
     let timer: NodeJS.Timeout | undefined;
+    let timeoutFired = false;
     const execPromise = this.doExecute();
 
+    // .catch() prevents UnhandledPromiseRejection when execPromise rejects after the timeout has
+    // already won the race. Only log when timeoutFired — a rejection before the timeout propagates
+    // normally through the race and needs no log here.
     execPromise.catch(err => {
+      if (!timeoutFired) return;
       this.context.logger.info('Step work rejected after timeout — result discarded', {
         runId: this.context.runId,
         stepId: this.context.stepId,
@@ -188,7 +193,10 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       return await Promise.race([
         execPromise,
         new Promise<never>((_, reject) => {
-          timer = setTimeout(() => reject(new StepTimeoutError(timeoutMs)), timeoutMs);
+          timer = setTimeout(() => {
+            timeoutFired = true;
+            reject(new StepTimeoutError(timeoutMs));
+          }, timeoutMs);
         }),
       ]);
     } finally {

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -173,14 +173,11 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     if (!timeoutMs || timeoutMs <= 0) return this.doExecute();
 
     let timer: NodeJS.Timeout | undefined;
-    let timeoutFired = false;
+    let hasTimeoutFired = false;
     const execPromise = this.doExecute();
 
-    // .catch() prevents UnhandledPromiseRejection when execPromise rejects after the timeout has
-    // already won the race. Only log when timeoutFired — a rejection before the timeout propagates
-    // normally through the race and needs no log here.
     execPromise.catch(err => {
-      if (!timeoutFired) return;
+      if (!hasTimeoutFired) return;
       this.context.logger.info('Step work rejected after timeout — result discarded', {
         runId: this.context.runId,
         stepId: this.context.stepId,
@@ -194,7 +191,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
         execPromise,
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => {
-            timeoutFired = true;
+            hasTimeoutFired = true;
             reject(new StepTimeoutError(timeoutMs));
           }, timeoutMs);
         }),

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -454,7 +454,7 @@ describe('BaseStepExecutor', () => {
       }
     }, 5_000);
 
-    it('does not log when execPromise rejects before the timeout fires', async () => {
+    it('does not log discard message when step rejects before timeout', async () => {
       const logger = makeMockLogger();
       const executor = new TestableExecutor(
         makeContext({ stepTimeoutMs: 5_000, logger }),

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -453,6 +453,39 @@ describe('BaseStepExecutor', () => {
         process.off('unhandledRejection', unhandled);
       }
     }, 5_000);
+
+    it('does not log when execPromise rejects before the timeout fires', async () => {
+      class ImmediateFailExecutor extends BaseStepExecutor {
+        protected async doExecute(): Promise<StepExecutionResult> {
+          throw new Error('normal step error');
+        }
+
+        protected buildOutcomeResult(outcome: {
+          status: BaseStepStatus;
+          error?: string;
+        }): StepExecutionResult {
+          return {
+            stepOutcome: {
+              type: 'record',
+              stepId: this.context.stepId,
+              stepIndex: this.context.stepIndex,
+              status: outcome.status,
+              ...(outcome.error !== undefined && { error: outcome.error }),
+            },
+          };
+        }
+      }
+
+      const logger = makeMockLogger();
+      const executor = new ImmediateFailExecutor(makeContext({ stepTimeoutMs: 5_000, logger }));
+
+      await executor.execute();
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        'Step work rejected after timeout — result discarded',
+        expect.anything(),
+      );
+    });
   });
 
   describe('activity log lifecycle', () => {

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -455,29 +455,11 @@ describe('BaseStepExecutor', () => {
     }, 5_000);
 
     it('does not log when execPromise rejects before the timeout fires', async () => {
-      class ImmediateFailExecutor extends BaseStepExecutor {
-        protected async doExecute(): Promise<StepExecutionResult> {
-          throw new Error('normal step error');
-        }
-
-        protected buildOutcomeResult(outcome: {
-          status: BaseStepStatus;
-          error?: string;
-        }): StepExecutionResult {
-          return {
-            stepOutcome: {
-              type: 'record',
-              stepId: this.context.stepId,
-              stepIndex: this.context.stepIndex,
-              status: outcome.status,
-              ...(outcome.error !== undefined && { error: outcome.error }),
-            },
-          };
-        }
-      }
-
       const logger = makeMockLogger();
-      const executor = new ImmediateFailExecutor(makeContext({ stepTimeoutMs: 5_000, logger }));
+      const executor = new TestableExecutor(
+        makeContext({ stepTimeoutMs: 5_000, logger }),
+        new Error('normal step error'),
+      );
 
       await executor.execute();
 


### PR DESCRIPTION
## Summary

- `runWithTimeout()` attached a `.catch()` on `execPromise` before `Promise.race` to prevent `UnhandledPromiseRejection` on late rejections. It always logged `"Step work rejected after timeout — result discarded"` — even when the step failed before the timeout fired, producing a misleading log for any normal step error.
- Added a `timeoutFired` boolean flag set to `true` only inside the `setTimeout` callback. The `.catch()` now skips the log when `timeoutFired` is false (rejection propagates normally through the race; no log needed).
- Added a regression test: verifies the log is NOT emitted when `execPromise` rejects before the timeout.

## Test plan

- [ ] `yarn workspace @forestadmin/workflow-executor test --testPathPattern="base-step-executor"` — all 30 tests green including the new one
- [ ] Existing test `'logs a late rejection of the losing promise as info'` still passes (real timeout case unchanged)
- [ ] New test `'does not log when execPromise rejects before the timeout fires'` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spurious 'result discarded' log in `BaseStepExecutor.runWithTimeout` when step fails before timeout
> Adds a `timeoutFired` boolean flag in `runWithTimeout` to distinguish between a step rejection caused by the timeout branch versus a normal pre-timeout failure. The 'Step work rejected after timeout — result discarded' log is now only emitted when the timeout actually fires, not on every rejection. A new test in [base-step-executor.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1587/files#diff-d7ab010aad83f0a668d49bd1f5f4eb531ed5ac54ae0068f40e42479a3b7a7cb9) asserts that pre-timeout rejections do not produce this log.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1587 opened
>
> - Renamed internal timeout tracking flag and updated rejection logging conditions [d0a5054]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 191ddf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->