### PR TITLE
feat(ai-proxy): export FOREST_INTEGRATION_NAMES as runtime const [PRD-375]

### DIFF
--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -11,7 +11,8 @@ import getZendeskTools, { type ZendeskConfig } from './integrations/zendesk/tool
 import { validateZendeskConfig } from './integrations/zendesk/utils';
 
 export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
-export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
+export const FOREST_INTEGRATION_NAMES = ['Zendesk', 'Kolar', 'Snowflake'] as const;
+export type ForestIntegrationName = (typeof FOREST_INTEGRATION_NAMES)[number];
 
 export interface ForestIntegrationConfig {
   integrationName: ForestIntegrationName;


### PR DESCRIPTION
## Summary

Expose Forest connector integration names as a runtime const so consumers can enumerate them without duplicating the list locally.

## Change

\`\`\`diff
-export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
+export const FOREST_INTEGRATION_NAMES = ['Zendesk', 'Kolar', 'Snowflake'] as const;
+export type ForestIntegrationName = (typeof FOREST_INTEGRATION_NAMES)[number];
\`\`\`

No behavioral change. \`ForestIntegrationName\` still resolves to the same literal union; existing consumers that only import the type are unaffected. New consumers can now \`import { FOREST_INTEGRATION_NAMES }\` to enumerate the names at runtime, with the type derived from the const for guaranteed single-source-of-truth.

## Motivation

forestadmin-server PRD-365 ([forestadmin-server#8249](https://github.com/ForestAdmin/forestadmin-server/pull/8249)) adds a server-side guard rejecting user MCP configs whose \`serverName\` collides with a Forest connector name. Initial implementation mirrored the list locally via a \`Record<ForestIntegrationName, true>\` exhaustiveness trick. Review feedback ([discussion](https://github.com/ForestAdmin/forestadmin-server/pull/8249#discussion_r3272452865)) requested the source of truth move to ai-proxy.

## Test plan

- [x] \`yarn workspace @forestadmin/ai-proxy build\` → tsc clean
- [x] \`yarn workspace @forestadmin/ai-proxy test\` → 355 pass, 0 fail (existing skips unchanged)
- [x] \`npx eslint packages/ai-proxy/src/forest-integration-client.ts\` → clean

## Conflict heads-up

PR #1584 (PRD-362) touches the same file adjacent to this change (\`+id?: string\` on \`ForestIntegrationConfig\`). Conflict expected to be trivial — whichever lands first, the other rebases.

fixes PRD-375
relates to PRD-365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `FOREST_INTEGRATION_NAMES` as a runtime constant array in `ai-proxy`
> Adds an exported `FOREST_INTEGRATION_NAMES` tuple (`['Zendesk', 'Kolar', 'Snowflake'] as const`) to [forest-integration-client.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1588/files#diff-5bc11695132aa6279baadd1b8d87a30c7b4e7f01754a70a1c8fc43b5ba68ee67). The `ForestIntegrationName` type is now derived from this tuple via `(typeof FOREST_INTEGRATION_NAMES)[number]` instead of a manually maintained string-literal union, keeping the type and runtime values in sync.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d8ec9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->