### PR TITLE
fix(ai-proxy): re-export FOREST_INTEGRATION_NAMES from package index [PRD-375]

### DIFF
--- a/packages/ai-proxy/src/index.ts
+++ b/packages/ai-proxy/src/index.ts
@@ -7,6 +7,7 @@ export { createAiProvider } from './create-ai-provider';
 export { default as ProviderDispatcher } from './provider-dispatcher';
 
 export {
+  FOREST_INTEGRATION_NAMES,
   ForestIntegrationConfig,
   CustomConfig,
   ForestIntegrationName,


### PR DESCRIPTION
## Summary

Follow-up to #1588 (released as ai-proxy@1.10.0). The const `FOREST_INTEGRATION_NAMES` was declared and exported from `forest-integration-client.ts` but the package's `src/index.ts` has a selective named re-export block that did not include it. Consumers importing from `@forestadmin/ai-proxy` get `undefined` at runtime and `any` at the type level — the const is effectively invisible from the package boundary.

## Change

\`\`\`diff
 export {
+  FOREST_INTEGRATION_NAMES,
   ForestIntegrationConfig,
   CustomConfig,
   ForestIntegrationName,
 } from './forest-integration-client';
\`\`\`

## How this slipped through 1.10.0

The original PR added tests inside ai-proxy that touched the file directly, so the internal declaration looked fine. No test asserted the visibility from the package's main entry. Caught only when wiring up the first consumer ([forestadmin-server PR #8249](https://github.com/ForestAdmin/forestadmin-server/pull/8249)) — the `yarn upgrade` to 1.10.0 + the `import { FOREST_INTEGRATION_NAMES }` swap failed lint and typecheck with `any` errors, which surfaced the missing re-export.

## Test plan

- [x] \`yarn workspace @forestadmin/ai-proxy build\` → tsc clean
- [x] \`yarn workspace @forestadmin/ai-proxy test\` → 355 pass, 0 fail
- [x] \`npx eslint packages/ai-proxy/src/index.ts\` → clean
- [x] Verified generated \`dist/index.d.ts\` re-exports the const: \`export { FOREST_INTEGRATION_NAMES, ... }\`
- [x] Verified generated \`dist/index.js\` re-exports the value via \`Object.defineProperty(exports, "FOREST_INTEGRATION_NAMES", ...)\`

## Release

Patch release (1.10.1) appropriate — fixes the export visibility intended in 1.10.0, no behavioral change for consumers already importing the type.

relates to PRD-375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-export `FOREST_INTEGRATION_NAMES` from `ai-proxy` package index
> Adds `FOREST_INTEGRATION_NAMES` to the named exports in [index.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1589/files#diff-abe559cfda8bf8c1a79e55ccdc24072bfa1f8ab2fdb3e61b7dde72ae64f4cf7e), alongside the existing `ForestIntegrationConfig`, `CustomConfig`, and `ForestIntegrationName` exports from `./forest-integration-client`.
>
> #### 🖇️ Linked Issues
> Resolves [PRD-375](ticket:linear/PRD-375).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80f7257.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->