### PR TITLE
chore(security): patch Dependabot alerts (2026-05-21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,13 @@
     "semantic-release": "^25.0.0",
     "qs": ">=6.14.1",
     "@hono/node-server": "^1.19.13",
-    "langsmith": "^0.5.18",
+    "langsmith": "^0.6.0",
     "lodash": "^4.18.0",
     "**/@langchain/langgraph-sdk/uuid": "^13.0.1",
     "**/socks/ip-address": "^10.1.1",
     "**/express-rate-limit/ip-address": "^10.1.1",
-    "**/@aws-sdk/xml-builder/fast-xml-parser": "^5.7.0"
+    "**/@aws-sdk/xml-builder/fast-xml-parser": "^5.7.0",
+    "**/@modelcontextprotocol/sdk/hono": "^4.12.18",
+    "**/ajv/fast-uri": "^3.1.2"
   }
 }

--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -24,7 +24,7 @@
     "fastify4": "npm:fastify@^4.29.0",
     "koa": "^3.0.1",
     "mariadb": "^3.0.2",
-    "mongoose": "8.21.0",
+    "mongoose": "8.22.1",
     "mysql2": "^3.0.1",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",

--- a/packages/datasource-mongo/package.json
+++ b/packages/datasource-mongo/package.json
@@ -15,7 +15,7 @@
     "@forestadmin/datasource-mongoose": "1.13.4",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "json-stringify-pretty-compact": "^3.0.0",
-    "mongoose": "8.21.0",
+    "mongoose": "8.22.1",
     "tunnel-ssh": "^5.2.0"
   },
   "files": [

--- a/packages/datasource-mongoose/package.json
+++ b/packages/datasource-mongoose/package.json
@@ -20,7 +20,7 @@
     "luxon": "^3.2.1"
   },
   "devDependencies": {
-    "mongoose": "8.21.0"
+    "mongoose": "8.22.1"
   },
   "peerDependencies": {
     "mongoose": "6.x || 7.x || 8.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8342,10 +8342,10 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.3.0.tgz#bdae493942483d299e7285dcb4627767d42e2793"
   integrity sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@^3.0.1, fast-uri@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-xml-builder@^1.2.0:
   version "1.2.0"
@@ -9409,10 +9409,10 @@ highlight.js@^10.7.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hono@^4.11.4:
-  version "4.12.14"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
-  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
+hono@^4.11.4, hono@^4.12.18:
+  version "4.12.21"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.21.tgz#f11846462095d365b9a8b4859b37c02cb0981df3"
+  integrity sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==
 
 hook-std@^4.0.0:
   version "4.0.0"
@@ -11319,13 +11319,12 @@ koa@^3.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-"langsmith@>=0.4.0 <1.0.0", langsmith@^0.5.18:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.21.tgz#2f4cd30dafc22922e423cf0f151ead5f636e76b0"
-  integrity sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==
+"langsmith@>=0.4.0 <1.0.0", langsmith@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.6.3.tgz#a3d8ad58d66a47d3697e3c69b2be3f6df5233190"
+  integrity sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==
   dependencies:
     p-queue "6.6.2"
-    uuid "10.0.0"
 
 lerna@^8.2.3:
   version "8.2.3"
@@ -12682,10 +12681,10 @@ mongodb@~6.20.0:
     bson "^6.10.4"
     mongodb-connection-string-url "^3.0.2"
 
-mongoose@8.21.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.21.0.tgz#e4b940a6b22c2fc176916667766f34656e352906"
-  integrity sha512-dW2U01gN8EVQT5KAO5AkzjbqWc8A/CsEq15jOzq/M9ISpy8jw3iq7W9ZP135h9zykFOMt3AMxq4+anvt2YNJgw==
+mongoose@8.22.1:
+  version "8.22.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.22.1.tgz#6b873d88b883c9b283e2a3b94cdc541d108ea94a"
+  integrity sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==
   dependencies:
     bson "^6.10.4"
     kareem "2.6.3"
@@ -17323,11 +17322,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@10.0.0, uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
 uuid@11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
@@ -17337,6 +17331,11 @@ uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^13.0.0, uuid@^13.0.1:
   version "13.0.2"


### PR DESCRIPTION
## Summary
12 fixed, 1 ignored, 1 deferred, 2 resolutions added, 0 resolutions removed. | label: :lock: security applied

## Fixed
| Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|-------|---------|-----------|-----------|----------|-----------------|
| #350 | mongoose | npm | 8.21.0 → 8.22.1 | high | direct dep in `packages/datasource-mongo/package.json` |
| #351 | mongoose | npm | 8.21.0 → 8.22.1 | high | direct dep in `packages/datasource-mongoose/package.json` |
| #352 | mongoose | npm | 8.21.0 → 8.22.1 | high | direct dep in `packages/_example/package.json` |
| #353 | mongoose | npm | 8.21.0 → 8.22.1 | high | lock-file alert closed by the three direct bumps above |
| #354 | hono | npm | 4.12.14 → 4.12.21 | medium | scoped resolution `**/@modelcontextprotocol/sdk/hono` (transitive via MCP SDK) |
| #355 | hono | npm | 4.12.14 → 4.12.21 | medium | same as #354 |
| #357 | fast-uri | npm | 3.1.0 → 3.1.2 | high | scoped resolution `**/ajv/fast-uri` (transitive via ajv) |
| #358 | fast-uri | npm | 3.1.0 → 3.1.2 | high | same as #357 |
| #359 | hono | npm | 4.12.14 → 4.12.21 | medium | same as #354 |
| #360 | hono | npm | 4.12.14 → 4.12.21 | low | same as #354 |
| #361 | hono | npm | 4.12.14 → 4.12.21 | medium | same as #354 |
| #362 | langsmith | npm | 0.5.21 → 0.6.3 | high | existing root resolution `langsmith` updated from `^0.5.18` to `^0.6.0` |

## Ignored
- **#349 ip-address (XSS in `Address6` HTML-emitting methods)** — *Vulnerable code path is unreachable from our code.* The only chain to a vulnerable `ip-address@5.9.4` is `@forestadmin/agent → forest-ip-utils@1.0.1 → ip-address ^5.8.9`. `forest-ip-utils` only consumes `new Address6(ipv6).bigInteger()` (for numeric comparison in IP-whitelist matching) and never returns/exposes the vulnerable methods `Address6.group()`, `Address6.link()`, or `AddressError.parseMessage` to callers. Forest Admin uses `forest-ip-utils.isIpMatchesRule` in `packages/agent/src/routes/security/ip-whitelist.ts` to validate request IPs server-side — no HTML rendering of any `Address6`-derived value happens anywhere in the codebase (verified with `grep -rn '\.group(\|\.link(\|parseMessage'` — no hits land on `ip-address`). `forest-ip-utils@1.0.1` is the latest published version and is the only `ip-address ^5.x` consumer (other ip-address chains already pin to `^10.1.1` via existing resolutions). Forcing `ip-address@10.x` here would risk breaking `forest-ip-utils` (its `Address6.bigInteger()` call was renamed in newer majors of `ip-address`) for no reachable-vulnerability benefit.

## Deferred
- **#364 ws** — opened 2026-05-20, ~1 day old. Skipped by the 7-day age gate; will be picked up by the next run.

## Resolutions added
- **#354/#355/#359/#360/#361 hono `^4.12.18`** — parent chain `@modelcontextprotocol/sdk → hono`. Parent bump not viable: even the latest `@modelcontextprotocol/sdk@1.29.0` still depends on `hono: ^4.11.4`, so bumping the parent does not move hono off the vulnerable line. Placed in root `package.json` as parent-scoped form `**/@modelcontextprotocol/sdk/hono` — the only chain to hono in the tree is via MCP SDK (used by `mcp-server` and indirectly by `ai-proxy` via `@langchain/mcp-adapters`); the scoped key keeps the pin contained to that chain.
- **#357/#358 fast-uri `^3.1.2`** — parent chain `ajv@^8 → fast-uri`. Parent bump not viable: ajv@^8.17.1 (latest 8.x) already accepts fast-uri ^3.x and naturally pulled the vulnerable 3.1.0; no ajv release bumps the lower bound past 3.1.1. Placed in root `package.json` as parent-scoped form `**/ajv/fast-uri` — the only `fast-uri ^3` consumer in the tree is ajv (the `fast-uri ^2` chain via fastify@3/`fast-json-stringify` was not flagged by Dependabot and resolves to 2.3.0, which the advisory's npm-range does not cover).

The existing top-level `langsmith` pin was edited in place (range bump `^0.5.18` → `^0.6.0`), not added — counted as the resolution-update path to fix #362 rather than a new entry.

## Resolutions removed
None. All 11 existing entries in the root `resolutions` block were swept; each pinned package is still present in the resolved tree (none stale), and each parent chain still requests a range whose natural resolution would fall back below the pin (e.g. `tar`: many parents request `^6.x` and would re-introduce tar 6.x; `qs`: `body-parser@1.20.3` and `express@4.21.2` pin `qs 6.13.0` exactly; `**/socks/ip-address` and `**/express-rate-limit/ip-address` still required because the only other ip-address chain — `forest-ip-utils` — is the ignored alert #349 above). Nothing was redundant.

## Risks
- **mongoose 8.21.0 → 8.22.1** — patch release. CHANGELOG between 8.21 and 8.22.1 is bugfix-only (no API changes touching Forest Admin's usage patterns: model/schema definition, `find/findOne/aggregate`, hooks). No peer-dep bump.
- **hono 4.12.14 → 4.12.21** — patch line, used only inside MCP SDK internals (not surfaced to Forest Admin code). Behavior change is the patched header-handling fix; no API touched.
- **fast-uri 3.1.0 → 3.1.2** — pure security patch. Used only inside ajv schema URI resolution.
- **langsmith 0.5.21 → 0.6.3** — minor bump. Consumed transitively by `@langchain/core@1.1.15` and `@langchain/community → @langchain/classic`, both of which declare `langsmith@>=0.4.0 <1.0.0`, so the peer range is satisfied. No Forest Admin code imports langsmith directly. Risk surface: tracing/observability behavior in `ai-proxy` runtime; covered by CI.

## Manual testing
Covered by CI.

## Validation
✅ CI green


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch Dependabot security alerts by bumping langsmith, mongoose, and resolution overrides
> - Bumps `langsmith` from `^0.5.18` to `^0.6.0` in the root [package.json](https://github.com/ForestAdmin/agent-nodejs/pull/1591/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
> - Adds resolution overrides for `**/@modelcontextprotocol/sdk/hono` (`^4.12.18`) and `**/ajv/fast-uri` (`^3.1.2`) to force secure transitive dependency versions.
> - Updates `mongoose` from `8.21.0` to `8.22.1` across the mongo and mongoose datasource packages and the example package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a38351b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->