### PR TITLE
refactor(workflow-executor): add stepType to all step execution logs

### DIFF
--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -44,7 +44,7 @@
     "start:watch:inspect": "node --enable-source-maps --async-stack-traces -r ts-node/register --watch --inspect src/serve.ts",
     "test": "jest",
     "db:seed": "ts-node scripts/db-seed.ts",
-    "start:with-executor": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
+    "start:with-executor": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && POLLING_INTERVAL_MS=30000 && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
     "db:executor:up": "cd ../workflow-executor/example && docker compose up -d",
     "db:executor:down": "cd ../workflow-executor/example && docker compose down",
     "db:executor:reset": "cd ../workflow-executor/example && docker compose down -v && docker compose up -d"

--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -44,7 +44,7 @@
     "start:watch:inspect": "node --enable-source-maps --async-stack-traces -r ts-node/register --watch --inspect src/serve.ts",
     "test": "jest",
     "db:seed": "ts-node scripts/db-seed.ts",
-    "start:with-executor": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && POLLING_INTERVAL_MS=30000 && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
+    "start:with-executor": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
     "db:executor:up": "cd ../workflow-executor/example && docker compose up -d",
     "db:executor:down": "cd ../workflow-executor/example && docker compose down",
     "db:executor:reset": "cd ../workflow-executor/example && docker compose down -v && docker compose up -d"

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -10,7 +10,8 @@ export function causeMessage(error: unknown): string | undefined {
 
 // Cascades through err.message → err.parent.message (Sequelize) → err.cause.message → err.name,
 // so wrapped infra errors (SequelizeConnectionRefusedError has an empty .message) don't log as empty.
-export function extractErrorMessage(err: unknown): string {
+export function extractErrorMessage(err?: unknown): string | undefined {
+  if (err === undefined) return undefined;
   if (!(err instanceof Error)) return String(err);
   if (err.message) return err.message;
 

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -325,6 +325,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   private get logCtx() {
     const { runId, stepId, stepIndex, stepDefinition } = this.context;
+
     return { runId, stepId, stepIndex, stepType: stepDefinition.type };
   }
 }

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -41,11 +41,6 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     this.agentPort = context.agentPort;
   }
 
-  private get logCtx() {
-    const { runId, stepId, stepIndex, stepDefinition } = this.context;
-    return { runId, stepId, stepIndex, stepType: stepDefinition.type };
-  }
-
   async execute(): Promise<StepExecutionResult> {
     const { baseRecordRef } = this.context;
 
@@ -326,5 +321,10 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     tool: DynamicStructuredTool,
   ): Promise<T> {
     return (await this.invokeWithTools<T>(messages, [tool])).args;
+  }
+
+  private get logCtx() {
+    const { runId, stepId, stepIndex, stepDefinition } = this.context;
+    return { runId, stepId, stepIndex, stepType: stepDefinition.type };
   }
 }

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -97,7 +97,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       this.context.logger.error('Unexpected error during step execution', {
         ...this.logCtx,
         error: extractErrorMessage(error),
-        cause: errorCause !== undefined ? extractErrorMessage(errorCause) : undefined,
+        cause: extractErrorMessage(errorCause),
         stack: error instanceof Error ? error.stack : undefined,
       });
 

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -43,12 +43,13 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   async execute(): Promise<StepExecutionResult> {
     const { runId, stepId, stepIndex, stepDefinition, baseRecordRef } = this.context;
+    const stepType = stepDefinition.type;
 
     this.context.logger.info('Step execution started', {
       runId,
       stepId,
       stepIndex,
-      stepType: stepDefinition.type,
+      stepType,
       collection: baseRecordRef.collectionName,
     });
 
@@ -62,6 +63,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
           runId,
           stepId,
           stepIndex,
+          stepType,
           status: cached.stepOutcome.status,
         });
 
@@ -74,6 +76,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
         runId,
         stepId,
         stepIndex,
+        stepType,
         status: result.stepOutcome.status,
       });
 
@@ -81,10 +84,10 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     } catch (error) {
       if (error instanceof StepTimeoutError) {
         this.context.logger.error(error.message, {
-          runId: this.context.runId,
-          stepId: this.context.stepId,
-          stepIndex: this.context.stepIndex,
-          stepType: this.context.stepDefinition.type,
+          runId,
+          stepId,
+          stepIndex,
+          stepType,
           timeoutMs: this.context.stepTimeoutMs,
         });
 
@@ -94,9 +97,10 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       if (error instanceof WorkflowExecutorError) {
         if (error.cause !== undefined) {
           this.context.logger.error(error.message, {
-            runId: this.context.runId,
-            stepId: this.context.stepId,
-            stepIndex: this.context.stepIndex,
+            runId,
+            stepId,
+            stepIndex,
+            stepType,
             cause: error.cause instanceof Error ? error.cause.message : String(error.cause),
             stack: error.cause instanceof Error ? error.cause.stack : undefined,
           });
@@ -107,9 +111,10 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
       const { cause: errorCause } = error as { cause?: unknown };
       this.context.logger.error('Unexpected error during step execution', {
-        runId: this.context.runId,
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
+        runId,
+        stepId,
+        stepIndex,
+        stepType,
         error: extractErrorMessage(error),
         cause: errorCause instanceof Error ? errorCause.message : undefined,
         stack: error instanceof Error ? error.stack : undefined,

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -85,7 +85,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
         if (error.cause !== undefined) {
           this.context.logger.error(error.message, {
             ...this.logCtx,
-            cause: error.cause instanceof Error ? error.cause.message : String(error.cause),
+            cause: extractErrorMessage(error.cause),
             stack: error.cause instanceof Error ? error.cause.stack : undefined,
           });
         }
@@ -97,7 +97,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       this.context.logger.error('Unexpected error during step execution', {
         ...this.logCtx,
         error: extractErrorMessage(error),
-        cause: errorCause instanceof Error ? errorCause.message : undefined,
+        cause: errorCause !== undefined ? extractErrorMessage(errorCause) : undefined,
         stack: error instanceof Error ? error.stack : undefined,
       });
 

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -41,15 +41,16 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     this.agentPort = context.agentPort;
   }
 
+  private get logCtx() {
+    const { runId, stepId, stepIndex, stepDefinition } = this.context;
+    return { runId, stepId, stepIndex, stepType: stepDefinition.type };
+  }
+
   async execute(): Promise<StepExecutionResult> {
-    const { runId, stepId, stepIndex, stepDefinition, baseRecordRef } = this.context;
-    const stepType = stepDefinition.type;
+    const { baseRecordRef } = this.context;
 
     this.context.logger.info('Step execution started', {
-      runId,
-      stepId,
-      stepIndex,
-      stepType,
+      ...this.logCtx,
       collection: baseRecordRef.collectionName,
     });
 
@@ -60,10 +61,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
       if (cached) {
         this.context.logger.info('Step execution completed (replayed from cache)', {
-          runId,
-          stepId,
-          stepIndex,
-          stepType,
+          ...this.logCtx,
           status: cached.stepOutcome.status,
         });
 
@@ -73,10 +71,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       const result = await this.runWithActivityLog();
 
       this.context.logger.info('Step execution completed', {
-        runId,
-        stepId,
-        stepIndex,
-        stepType,
+        ...this.logCtx,
         status: result.stepOutcome.status,
       });
 
@@ -84,10 +79,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     } catch (error) {
       if (error instanceof StepTimeoutError) {
         this.context.logger.error(error.message, {
-          runId,
-          stepId,
-          stepIndex,
-          stepType,
+          ...this.logCtx,
           timeoutMs: this.context.stepTimeoutMs,
         });
 
@@ -97,10 +89,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       if (error instanceof WorkflowExecutorError) {
         if (error.cause !== undefined) {
           this.context.logger.error(error.message, {
-            runId,
-            stepId,
-            stepIndex,
-            stepType,
+            ...this.logCtx,
             cause: error.cause instanceof Error ? error.cause.message : String(error.cause),
             stack: error.cause instanceof Error ? error.cause.stack : undefined,
           });
@@ -111,10 +100,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
       const { cause: errorCause } = error as { cause?: unknown };
       this.context.logger.error('Unexpected error during step execution', {
-        runId,
-        stepId,
-        stepIndex,
-        stepType,
+        ...this.logCtx,
         error: extractErrorMessage(error),
         cause: errorCause instanceof Error ? errorCause.message : undefined,
         stack: error instanceof Error ? error.stack : undefined,
@@ -184,9 +170,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     execPromise.catch(err => {
       if (!hasTimeoutFired) return;
       this.context.logger.info('Step work rejected after timeout — result discarded', {
-        runId: this.context.runId,
-        stepId: this.context.stepId,
-        stepIndex: this.context.stepIndex,
+        ...this.logCtx,
         error: extractErrorMessage(err),
       });
     });

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -47,7 +47,11 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage('plain string')).toBe('plain string');
     expect(extractErrorMessage(42)).toBe('42');
     expect(extractErrorMessage(null)).toBe('null');
-    expect(extractErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('returns undefined when called with undefined', () => {
+    expect(extractErrorMessage(undefined)).toBeUndefined();
+    expect(extractErrorMessage()).toBeUndefined();
   });
 
   it('ignores a non-Error .parent (Sequelize-like shape but wrong type)', () => {

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -256,6 +256,21 @@ describe('BaseStepExecutor', () => {
         );
       });
 
+      it('includes stepType in cache-replay log', async () => {
+        class CachedExecutor extends TestableExecutor {
+          override checkIdempotency() {
+            return Promise.resolve(this.buildOutcomeResult({ status: 'success' }));
+          }
+        }
+        const logger = makeMockLogger();
+        const executor = new CachedExecutor(makeContext({ logger }));
+        await executor.execute();
+        expect(logger.info).toHaveBeenCalledWith(
+          'Step execution completed (replayed from cache)',
+          expect.objectContaining({ stepType: StepType.Condition }),
+        );
+      });
+
       it('includes stack trace in log context', async () => {
         const logger = makeMockLogger();
         const err = new Error('db connection refused');
@@ -285,7 +300,7 @@ describe('BaseStepExecutor', () => {
         );
       });
 
-      it('omits cause from log when error has no cause', async () => {
+      it('sets cause to undefined in log when error has no cause', async () => {
         const logger = makeMockLogger();
         const executor = new TestableExecutor(makeContext({ logger }), new Error('no cause'));
         await executor.execute();
@@ -317,6 +332,7 @@ describe('BaseStepExecutor', () => {
         expect.objectContaining({
           cause: 'db timeout',
           stack: cause.stack,
+          stepType: StepType.Condition,
         }),
       );
     });
@@ -479,6 +495,7 @@ describe('BaseStepExecutor', () => {
           expect.objectContaining({
             runId: 'run-1',
             stepId: 'step-0',
+            stepType: StepType.Condition,
             error: 'late agent failure',
           }),
         );

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -242,6 +242,20 @@ describe('BaseStepExecutor', () => {
         );
       });
 
+      it('includes stepType in info logs for started and completed steps', async () => {
+        const logger = makeMockLogger();
+        const executor = new TestableExecutor(makeContext({ logger }));
+        await executor.execute();
+        expect(logger.info).toHaveBeenCalledWith(
+          'Step execution started',
+          expect.objectContaining({ stepType: StepType.Condition }),
+        );
+        expect(logger.info).toHaveBeenCalledWith(
+          'Step execution completed',
+          expect.objectContaining({ stepType: StepType.Condition }),
+        );
+      });
+
       it('includes stack trace in log context', async () => {
         const logger = makeMockLogger();
         const err = new Error('db connection refused');
@@ -268,6 +282,26 @@ describe('BaseStepExecutor', () => {
         expect(logger.error).toHaveBeenCalledWith(
           'Unexpected error during step execution',
           expect.objectContaining({ cause: 'root cause' }),
+        );
+      });
+
+      it('omits cause from log when error has no cause', async () => {
+        const logger = makeMockLogger();
+        const executor = new TestableExecutor(makeContext({ logger }), new Error('no cause'));
+        await executor.execute();
+        expect(logger.error).toHaveBeenCalledWith(
+          'Unexpected error during step execution',
+          expect.objectContaining({ cause: undefined }),
+        );
+      });
+
+      it('includes stepType in log context', async () => {
+        const logger = makeMockLogger();
+        const executor = new TestableExecutor(makeContext({ logger }), new Error('boom'));
+        await executor.execute();
+        expect(logger.error).toHaveBeenCalledWith(
+          'Unexpected error during step execution',
+          expect.objectContaining({ stepType: StepType.Condition }),
         );
       });
     });


### PR DESCRIPTION
## Summary

- Destructures `stepType` once at the top of `execute()` and uses it uniformly across all log calls (cache hit, success, timeout, `WorkflowExecutorError`, unexpected error) — eliminates the repetition of `this.context.stepDefinition.type` in every catch branch


## Test plan

- [ ] Run `yarn workspace @forestadmin/workflow-executor test` — all tests pass
- [ ] Verify log output includes `stepType` on all execution outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `stepType` to all step execution logs in `BaseStepExecutor`
> - Introduces a `logCtx` private getter on `BaseStepExecutor` that returns `{ runId, stepId, stepIndex, stepType }`, replacing repeated inline context objects across all log calls.
> - Updates error log paths to populate the `cause` field using `extractErrorMessage`, so non-Error causes are stringified and undefined causes remain `undefined`.
> - Updates `extractErrorMessage` in [errors.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1592/files#diff-0109f91a733affdd89e2fae234f7010a44b4b923e1d56be5c84f8014b219cef0) to return `undefined` when called with `undefined`, rather than the string `'undefined'`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1592 opened
>
> - Updated test assertions in `BaseStepExecutor.execute` test suite to verify that `stepType` is included in log contexts [7bfb02c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d030c27.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->