### PR TITLE
feat(workflow-executor): add FORCE_AI_ERROR dev mode

### DIFF
--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -45,6 +45,7 @@
     "test": "jest",
     "db:seed": "ts-node scripts/db-seed.ts",
     "start:with-executor": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
+    "start:with-executor:ai-error": "concurrently --kill-others --names 'agent,executor' \"yarn start\" \"bash -c 'set -a && source .env && AGENT_URL=\\$EXECUTOR_AGENT_URL && DATABASE_URL=\\$EXECUTOR_DATABASE_URL && FORCE_AI_ERROR=true && until curl -s \\$EXECUTOR_AGENT_URL >/dev/null 2>&1; do sleep 1; done && tsx watch ../workflow-executor/src/cli.ts --pretty'\"",
     "db:executor:up": "cd ../workflow-executor/example && docker compose up -d",
     "db:executor:down": "cd ../workflow-executor/example && docker compose down",
     "db:executor:reset": "cd ../workflow-executor/example && docker compose down -v && docker compose up -d"

--- a/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
+++ b/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
@@ -1,0 +1,28 @@
+import type { AiModelPort } from '../ports/ai-model-port';
+import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+
+import { AiModelPortError } from '../errors';
+
+// Dev-only adapter: every AI call throws immediately so devs can reproduce AI error paths
+// without a real AI service. Activated via WORKFLOW_EXECUTOR_FORCE_AI_ERROR=true.
+export default class AlwaysErrorAiModelPort implements AiModelPort {
+  getModel(): BaseChatModel {
+    return {
+      bindTools: () => ({
+        invoke: () =>
+          Promise.reject(
+            new AiModelPortError('invoke', new Error('[dev] AI forced to always error')),
+          ),
+      }),
+    } as unknown as BaseChatModel;
+  }
+
+  loadRemoteTools(_config: McpConfiguration): Promise<RemoteTool[]> {
+    return Promise.resolve([]);
+  }
+
+  closeConnections(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
+++ b/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
@@ -1,11 +1,11 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { RemoteTool } from '@forestadmin/ai-proxy';
+import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AiModelPortError } from '../errors';
 
 // Dev-only adapter: every AI call throws immediately so devs can reproduce AI error paths
-// without a real AI service. Activated via WORKFLOW_EXECUTOR_FORCE_AI_ERROR=true.
+// without a real AI service. Activated via FORCE_AI_ERROR=true.
 export default class AlwaysErrorAiModelPort implements AiModelPort {
   getModel(): BaseChatModel {
     return {
@@ -18,7 +18,8 @@ export default class AlwaysErrorAiModelPort implements AiModelPort {
     } as unknown as BaseChatModel;
   }
 
-  loadRemoteTools(): Promise<RemoteTool[]> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  loadRemoteTools(_config: McpConfiguration): Promise<RemoteTool[]> {
     return Promise.resolve([]);
   }
 

--- a/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
+++ b/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
@@ -1,5 +1,5 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { RemoteTool } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AiModelPortError } from '../errors';
@@ -18,7 +18,7 @@ export default class AlwaysErrorAiModelPort implements AiModelPort {
     } as unknown as BaseChatModel;
   }
 
-  loadRemoteTools(_config: McpConfiguration): Promise<RemoteTool[]> {
+  loadRemoteTools(): Promise<RemoteTool[]> {
     return Promise.resolve([]);
   }
 

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -69,11 +69,15 @@ function buildCommonDependencies(options: ExecutorOptions) {
     );
   }
 
-  const aiModelPort = forceAiError
-    ? new AlwaysErrorAiModelPort()
-    : options.aiConfigurations?.length
-      ? new AiClientAdapter(options.aiConfigurations)
-      : new ServerAiAdapter({ forestServerUrl, envSecret: options.envSecret });
+  let aiModelPort;
+
+  if (forceAiError) {
+    aiModelPort = new AlwaysErrorAiModelPort();
+  } else if (options.aiConfigurations?.length) {
+    aiModelPort = new AiClientAdapter(options.aiConfigurations);
+  } else {
+    aiModelPort = new ServerAiAdapter({ forestServerUrl, envSecret: options.envSecret });
+  }
 
   const schemaCache = new SchemaCache();
 

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -63,7 +63,7 @@ function buildCommonDependencies(options: ExecutorOptions) {
   const forceAiError = options.forceAiError && process.env.NODE_ENV !== 'production';
 
   if (forceAiError) {
-    logger.warn(
+    logger.info(
       'FORCE_AI_ERROR is enabled — AI calls will always fail. Do not use in production.',
       {},
     );

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -8,6 +8,7 @@ import { Sequelize } from 'sequelize';
 
 import AgentClientAgentPort from './adapters/agent-client-agent-port';
 import AiClientAdapter from './adapters/ai-client-adapter';
+import AlwaysErrorAiModelPort from './adapters/always-error-ai-model-port';
 import ConsoleLogger from './adapters/console-logger';
 import ForestServerWorkflowPort from './adapters/forest-server-workflow-port';
 import ForestadminClientActivityLogPortFactory from './adapters/forestadmin-client-activity-log-port-factory';
@@ -42,6 +43,8 @@ export interface ExecutorOptions {
   stepTimeoutMs?: number;
   // Max auto-chained steps per entry (see RunnerConfig.maxChainDepth). 0 disables chaining.
   maxChainDepth?: number;
+  // Dev only: makes every AI call fail immediately so error paths can be exercised locally.
+  forceAiError?: boolean;
 }
 
 export type DatabaseExecutorOptions = ExecutorOptions &
@@ -57,9 +60,20 @@ function buildCommonDependencies(options: ExecutorOptions) {
     logger,
   });
 
-  const aiModelPort = options.aiConfigurations?.length
-    ? new AiClientAdapter(options.aiConfigurations)
-    : new ServerAiAdapter({ forestServerUrl, envSecret: options.envSecret });
+  const { forceAiError } = options;
+
+  if (forceAiError) {
+    logger.warn(
+      'FORCE_AI_ERROR is enabled — AI calls will always fail. Do not use in production.',
+      {},
+    );
+  }
+
+  const aiModelPort = forceAiError
+    ? new AlwaysErrorAiModelPort()
+    : options.aiConfigurations?.length
+      ? new AiClientAdapter(options.aiConfigurations)
+      : new ServerAiAdapter({ forestServerUrl, envSecret: options.envSecret });
 
   const schemaCache = new SchemaCache();
 

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -67,6 +67,8 @@ function buildCommonDependencies(options: ExecutorOptions) {
       'FORCE_AI_ERROR is enabled — AI calls will always fail. Do not use in production.',
       {},
     );
+  } else if (options.forceAiError && process.env.NODE_ENV === 'production') {
+    logger.info('FORCE_AI_ERROR is set but ignored in production.', {});
   }
 
   let aiModelPort;

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -60,7 +60,7 @@ function buildCommonDependencies(options: ExecutorOptions) {
     logger,
   });
 
-  const { forceAiError } = options;
+  const forceAiError = options.forceAiError && process.env.NODE_ENV !== 'production';
 
   if (forceAiError) {
     logger.warn(

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -206,9 +206,15 @@ export function printVersion(): void {
 
 export function logStartup(logger: Logger, config: CliConfig): void {
   const { executorOptions: opts, mode } = config;
-  const aiLabel = opts.aiConfigurations?.length
-    ? `local (${opts.aiConfigurations[0].provider} / ${opts.aiConfigurations[0].model})`
-    : 'server fallback';
+  let aiLabel: string;
+
+  if (opts.forceAiError) {
+    aiLabel = 'forced-error (dev only)';
+  } else if (opts.aiConfigurations?.length) {
+    aiLabel = `local (${opts.aiConfigurations[0].provider} / ${opts.aiConfigurations[0].model})`;
+  } else {
+    aiLabel = 'server fallback';
+  }
 
   logger.info('Workflow executor starting', {
     mode,

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -153,6 +153,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
     stepTimeoutMs: parsePositiveIntEnv('STEP_TIMEOUT_MS', env.STEP_TIMEOUT_MS),
     maxChainDepth: parsePositiveIntEnv('MAX_CHAIN_DEPTH', env.MAX_CHAIN_DEPTH),
     ...(aiConfigurations && { aiConfigurations }),
+    ...(env.FORCE_AI_ERROR === 'true' && { forceAiError: true }),
   };
 
   return {
@@ -188,6 +189,7 @@ Optional environment variables:
   STEP_TIMEOUT_MS        Max duration of a step in ms (default: 300000 = 5 minutes)
   MAX_CHAIN_DEPTH        Max steps auto-executed per run before yielding (default: 50)
   NO_COLOR               Set to any value to disable ANSI colors in pretty logs
+  FORCE_AI_ERROR         Set to "true" to make every AI call fail (dev only, to test error paths)
 
 AI configuration (all-or-nothing — falls back to server AI if any is missing):
   AI_PROVIDER            'anthropic' | 'openai'

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -228,12 +228,12 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId
-      ? this.remoteTools.filter(t => t.mcpServerId === mcpServerId)
+      ? this.remoteTools.filter(t => t.sourceId === mcpServerId)
       : [...this.remoteTools];
 
     if (tools.length === 0) {
       const loadedMcpServerIds = this.remoteTools
-        .map(t => t.mcpServerId)
+        .map(t => t.sourceId)
         .filter((value): value is string => !!value);
       const error = new NoMcpToolsError(mcpServerId, loadedMcpServerIds);
       this.context.logger.error(error.message, {

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -228,12 +228,12 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   private getFilteredTools(): RemoteTool[] {
     const { mcpServerId } = this.context.stepDefinition;
     const tools = mcpServerId
-      ? this.remoteTools.filter(t => t.sourceId === mcpServerId)
+      ? this.remoteTools.filter(t => t.mcpServerId === mcpServerId)
       : [...this.remoteTools];
 
     if (tools.length === 0) {
       const loadedMcpServerIds = this.remoteTools
-        .map(t => t.sourceId)
+        .map(t => t.mcpServerId)
         .filter((value): value is string => !!value);
       const error = new NoMcpToolsError(mcpServerId, loadedMcpServerIds);
       this.context.logger.error(error.message, {

--- a/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
+++ b/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
@@ -1,0 +1,40 @@
+import AlwaysErrorAiModelPort from '../../src/adapters/always-error-ai-model-port';
+import { AiModelPortError } from '../../src/errors';
+
+describe('AlwaysErrorAiModelPort', () => {
+  let port: AlwaysErrorAiModelPort;
+
+  beforeEach(() => {
+    port = new AlwaysErrorAiModelPort();
+  });
+
+  describe('getModel', () => {
+    it('returns a model whose bindTools().invoke() rejects with AiModelPortError', async () => {
+      const model = port.getModel();
+      const bound = model.bindTools([], {});
+
+      await expect(bound.invoke([])).rejects.toBeInstanceOf(AiModelPortError);
+    });
+
+    it('includes the dev error message in the rejection', async () => {
+      const model = port.getModel();
+      const bound = model.bindTools([], {});
+
+      await expect(bound.invoke([])).rejects.toMatchObject({
+        message: expect.stringContaining('AI forced to always error'),
+      });
+    });
+  });
+
+  describe('loadRemoteTools', () => {
+    it('returns an empty array', async () => {
+      await expect(port.loadRemoteTools()).resolves.toEqual([]);
+    });
+  });
+
+  describe('closeConnections', () => {
+    it('resolves without error', async () => {
+      await expect(port.closeConnections()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
+++ b/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
@@ -28,7 +28,7 @@ describe('AlwaysErrorAiModelPort', () => {
 
   describe('loadRemoteTools', () => {
     it('returns an empty array', async () => {
-      await expect(port.loadRemoteTools()).resolves.toEqual([]);
+      await expect(port.loadRemoteTools({} as never)).resolves.toEqual([]);
     });
   });
 

--- a/packages/workflow-executor/test/build-workflow-executor.test.ts
+++ b/packages/workflow-executor/test/build-workflow-executor.test.ts
@@ -12,6 +12,7 @@ jest.mock('../src/adapters/agent-client-agent-port');
 jest.mock('../src/adapters/forest-server-workflow-port');
 jest.mock('../src/http/executor-http-server');
 jest.mock('../src/adapters/ai-client-adapter');
+jest.mock('../src/adapters/always-error-ai-model-port');
 jest.mock('@langchain/openai', () => ({ ChatOpenAI: jest.fn() }));
 jest.mock('../src/adapters/server-ai-adapter');
 jest.mock('sequelize', () => ({
@@ -115,6 +116,30 @@ describe('buildInMemoryExecutor', () => {
       forestServerUrl: 'https://api.forestadmin.com',
       envSecret: BASE_OPTIONS.envSecret,
     });
+  });
+
+  it('creates AlwaysErrorAiModelPort when forceAiError is true', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const AlwaysErrorAiModelPort = require('../src/adapters/always-error-ai-model-port').default;
+
+    buildInMemoryExecutor({ ...BASE_OPTIONS, forceAiError: true });
+
+    expect(AlwaysErrorAiModelPort).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores forceAiError in production (NODE_ENV=production)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const AlwaysErrorAiModelPort = require('../src/adapters/always-error-ai-model-port').default;
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      buildInMemoryExecutor({ ...BASE_OPTIONS, forceAiError: true });
+
+      expect(AlwaysErrorAiModelPort).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = original;
+    }
   });
 
   it('passes pollingIntervalMs with default value of 30000', () => {

--- a/packages/workflow-executor/test/build-workflow-executor.test.ts
+++ b/packages/workflow-executor/test/build-workflow-executor.test.ts
@@ -121,15 +121,20 @@ describe('buildInMemoryExecutor', () => {
   it('creates AlwaysErrorAiModelPort when forceAiError is true', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
     const AlwaysErrorAiModelPort = require('../src/adapters/always-error-ai-model-port').default;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const AiClientAdapter = require('../src/adapters/ai-client-adapter').default;
 
     buildInMemoryExecutor({ ...BASE_OPTIONS, forceAiError: true });
 
     expect(AlwaysErrorAiModelPort).toHaveBeenCalledTimes(1);
+    expect(AiClientAdapter).not.toHaveBeenCalled();
   });
 
   it('ignores forceAiError in production (NODE_ENV=production)', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
     const AlwaysErrorAiModelPort = require('../src/adapters/always-error-ai-model-port').default;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const AiClientAdapter = require('../src/adapters/ai-client-adapter').default;
     const original = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
 
@@ -137,6 +142,7 @@ describe('buildInMemoryExecutor', () => {
       buildInMemoryExecutor({ ...BASE_OPTIONS, forceAiError: true });
 
       expect(AlwaysErrorAiModelPort).not.toHaveBeenCalled();
+      expect(AiClientAdapter).toHaveBeenCalledWith(BASE_OPTIONS.aiConfigurations);
     } finally {
       process.env.NODE_ENV = original;
     }

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -393,6 +393,26 @@ describe('runCli', () => {
     expect(output).toContain('Workflow executor ready');
   });
 
+  it('logs aiConfig as "forced-error (dev only)" when FORCE_AI_ERROR=true', async () => {
+    const { factories } = makeFactories();
+    await runCli(['--json'], { ...baseEnv, FORCE_AI_ERROR: 'true' }, factories);
+
+    const output = infoSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('forced-error (dev only)');
+  });
+
+  it('logs aiConfig with provider/model when aiConfigurations are set', async () => {
+    const { factories } = makeFactories();
+    await runCli(
+      ['--json'],
+      { ...baseEnv, AI_PROVIDER: 'openai', AI_MODEL: 'gpt-4o', AI_API_KEY: 'sk-x' },
+      factories,
+    );
+
+    const output = infoSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('local (openai / gpt-4o)');
+  });
+
   it('logs a structured error when executor.start() fails and rethrows', async () => {
     const failingExecutor = {
       start: jest.fn().mockRejectedValue(new Error('db unreachable')),

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -230,6 +230,12 @@ describe('readEnvConfig', () => {
     expect(config.executorOptions.forceAiError).toBeUndefined();
   });
 
+  it('omits forceAiError when FORCE_AI_ERROR=false', () => {
+    const config = readEnvConfig({ ...baseEnv, FORCE_AI_ERROR: 'false' }, args);
+
+    expect(config.executorOptions.forceAiError).toBeUndefined();
+  });
+
   it('throws when AI config is partially set', () => {
     expect(() =>
       readEnvConfig({ ...baseEnv, AI_PROVIDER: 'anthropic', AI_MODEL: 'claude' }, args),

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -218,6 +218,18 @@ describe('readEnvConfig', () => {
     expect(config.executorOptions.aiConfigurations).toBeUndefined();
   });
 
+  it('sets forceAiError when FORCE_AI_ERROR=true', () => {
+    const config = readEnvConfig({ ...baseEnv, FORCE_AI_ERROR: 'true' }, args);
+
+    expect(config.executorOptions.forceAiError).toBe(true);
+  });
+
+  it('omits forceAiError when FORCE_AI_ERROR is not set', () => {
+    const config = readEnvConfig(baseEnv, args);
+
+    expect(config.executorOptions.forceAiError).toBeUndefined();
+  });
+
   it('throws when AI config is partially set', () => {
     expect(() =>
       readEnvConfig({ ...baseEnv, AI_PROVIDER: 'anthropic', AI_MODEL: 'claude' }, args),


### PR DESCRIPTION
## Summary

- Adds `AlwaysErrorAiModelPort` adapter that makes every AI call fail immediately
- Wired via `FORCE_AI_ERROR=true` env var (parsed in `cli-core.ts`, passed as `forceAiError` option)
- Adds `start:with-executor:ai-error` script in `packages/_example` for one-command local testing

## Usage

```bash
# in packages/_example
yarn start:with-executor:ai-error
```

Or manually:
```bash
FORCE_AI_ERROR=true tsx watch ../workflow-executor/src/cli.ts --pretty
```

Every AI-dependent step returns `status: error` with `"The AI service is unavailable."` — lets you exercise all executionType error paths without a real AI service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `FORCE_AI_ERROR` dev mode to workflow-executor to force AI call failures
> - Adds `AlwaysErrorAiModelPort` in [always-error-ai-model-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1593/files#diff-4a34bbc7cc95597b5e0ece217b164556304ca25c0d847612d4862ab85e628a21), an `AiModelPort` implementation whose `invoke()` always rejects with `AiModelPortError`.
> - Setting `FORCE_AI_ERROR=true` activates this adapter via `buildCommonDependencies` in [build-workflow-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1593/files#diff-9a7b00e34df678f7ad856e6420bb042e4f6e01afc81fdc706055f462da01d493); the flag is silently ignored in production.
> - Startup logs and CLI help text in [cli-core.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1593/files#diff-1605eabb559b21939e3b8d15b4a7a4c933da2a7cd5190022502db6ecaf93b396) reflect forced-error mode when active.
> - Behavioral Change: only available outside `NODE_ENV=production`; in production the flag is ignored and normal AI adapter selection applies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd00427.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->