### PR TITLE
fix(workflow-executor): retry 404 in markSucceeded/markFailed (PRD-392)

### DIFF
--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -63,10 +63,10 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'completed',
             }),
-          { logger: this.logger },
+          { logger: this.logger, retry404: true },
         );
       } catch (err) {
-        this.logger.error('Activity log markSucceeded failed after retries', {
+        this.logger.error('Activity log markSucceeded failed', {
           handleId: handle.id,
           error: extractErrorMessage(err),
         });
@@ -85,10 +85,10 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'failed',
             }),
-          { logger: this.logger },
+          { logger: this.logger, retry404: true },
         );
       } catch (err) {
-        this.logger.error('Activity log markFailed failed after retries', {
+        this.logger.error('Activity log markFailed failed', {
           handleId: handle.id,
           stepErrorMessage: errorMessage,
           error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -63,7 +63,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'completed',
             }),
-          { logger: this.logger, retry404: true },
+          { logger: this.logger },
         );
       } catch (err) {
         this.logger.error('Activity log markSucceeded failed', {
@@ -85,7 +85,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'failed',
             }),
-          { logger: this.logger, retry404: true },
+          { logger: this.logger },
         );
       } catch (err) {
         this.logger.error('Activity log markFailed failed', {

--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -63,7 +63,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'completed',
             }),
-          { logger: this.logger },
+          { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
         this.logger.error('Failed to mark activity log as succeeded', {
@@ -85,7 +85,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
               activityLog: { id: handle.id, attributes: { index: handle.index } },
               status: 'failed',
             }),
-          { logger: this.logger },
+          { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
         this.logger.error('Failed to mark activity log as failed', {

--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -42,7 +42,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
 
       return { id: response.id, index: response.attributes.index };
     } catch (cause) {
-      this.logger.error('Activity log creation failed', {
+      this.logger.error('Failed to create activity log', {
         action: args.action,
         collectionId: args.collectionId,
         status: (cause as { status?: number }).status,

--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -66,7 +66,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           { logger: this.logger },
         );
       } catch (err) {
-        this.logger.error('Activity log markSucceeded failed', {
+        this.logger.error('Failed to mark activity log as succeeded', {
           handleId: handle.id,
           error: extractErrorMessage(err),
         });
@@ -88,7 +88,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           { logger: this.logger },
         );
       } catch (err) {
-        this.logger.error('Activity log markFailed failed', {
+        this.logger.error('Failed to mark activity log as failed', {
           handleId: handle.id,
           stepErrorMessage: errorMessage,
           error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -11,16 +11,18 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function isRetryable(err: unknown): boolean {
+function isRetryable(err: unknown, retry404: boolean): boolean {
   const { status } = err as { status?: number };
+  if (typeof status !== 'number') return false;
+  if (retry404 && status === 404) return true;
 
-  return typeof status === 'number' && RETRYABLE_STATUS.has(status);
+  return RETRYABLE_STATUS.has(status);
 }
 
 export default async function withRetry<T>(
   label: string,
   fn: () => Promise<T>,
-  { logger }: { logger: Logger },
+  { logger, retry404 = false }: { logger: Logger; retry404?: boolean },
 ): Promise<T> {
   let lastError: unknown;
 
@@ -30,7 +32,7 @@ export default async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastError = err;
-      if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
+      if (!isRetryable(err, retry404) || attempt === RETRY_DELAYS_MS.length) throw err;
       logger.info(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
         error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -31,7 +31,7 @@ export default async function withRetry<T>(
     } catch (err) {
       lastError = err;
       if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
-      logger.info(`"${label}" failed, retrying`, {
+      logger.error(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
         status: (err as { status?: number }).status,
         error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -31,7 +31,7 @@ export default async function withRetry<T>(
     } catch (err) {
       lastError = err;
       if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
-      logger.error(`"${label}" failed, retrying`, {
+      logger.warn(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
         status: (err as { status?: number }).status,
         error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -3,7 +3,7 @@ import type { Logger } from '../ports/logger-port';
 import { extractErrorMessage } from '../errors';
 
 const RETRY_DELAYS_MS = [100, 500, 2_000];
-const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+const RETRYABLE_STATUS = new Set([404, 408, 429, 500, 502, 503, 504]);
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => {
@@ -11,18 +11,16 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function isRetryable(err: unknown, retry404: boolean): boolean {
+function isRetryable(err: unknown): boolean {
   const { status } = err as { status?: number };
-  if (typeof status !== 'number') return false;
-  if (retry404 && status === 404) return true;
 
-  return RETRYABLE_STATUS.has(status);
+  return typeof status === 'number' && RETRYABLE_STATUS.has(status);
 }
 
 export default async function withRetry<T>(
   label: string,
   fn: () => Promise<T>,
-  { logger, retry404 = false }: { logger: Logger; retry404?: boolean },
+  { logger }: { logger: Logger },
 ): Promise<T> {
   let lastError: unknown;
 
@@ -32,7 +30,7 @@ export default async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastError = err;
-      if (!isRetryable(err, retry404) || attempt === RETRY_DELAYS_MS.length) throw err;
+      if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
       logger.info(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
         error: extractErrorMessage(err),

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -3,7 +3,7 @@ import type { Logger } from '../ports/logger-port';
 import { extractErrorMessage } from '../errors';
 
 const RETRY_DELAYS_MS = [100, 500, 2_000];
-const RETRYABLE_STATUS = new Set([404, 408, 429, 500, 502, 503, 504]);
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => {
@@ -11,16 +11,17 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function isRetryable(err: unknown): boolean {
+function isRetryable(err: unknown, extra: number[]): boolean {
   const { status } = err as { status?: number };
+  if (typeof status !== 'number') return false;
 
-  return typeof status === 'number' && RETRYABLE_STATUS.has(status);
+  return RETRYABLE_STATUS.has(status) || extra.includes(status);
 }
 
 export default async function withRetry<T>(
   label: string,
   fn: () => Promise<T>,
-  { logger }: { logger: Logger },
+  { logger, extraRetryStatuses = [] }: { logger: Logger; extraRetryStatuses?: number[] },
 ): Promise<T> {
   let lastError: unknown;
 
@@ -30,7 +31,7 @@ export default async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastError = err;
-      if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
+      if (!isRetryable(err, extraRetryStatuses) || attempt === RETRY_DELAYS_MS.length) throw err;
       logger.warn(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
         status: (err as { status?: number }).status,

--- a/packages/workflow-executor/src/adapters/with-retry.ts
+++ b/packages/workflow-executor/src/adapters/with-retry.ts
@@ -33,6 +33,7 @@ export default async function withRetry<T>(
       if (!isRetryable(err) || attempt === RETRY_DELAYS_MS.length) throw err;
       logger.info(`"${label}" failed, retrying`, {
         attempt: attempt + 1,
+        status: (err as { status?: number }).status,
         error: extractErrorMessage(err),
       });
       // eslint-disable-next-line no-await-in-loop

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -183,9 +183,22 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('markSucceeded failed'),
+        'Activity log markSucceeded failed',
         expect.objectContaining({ handleId: 'log-1' }),
       );
+    });
+
+    it('retries on 404 — eventual consistency: record may not be visible yet on the read path', async () => {
+      const service = makeService();
+      service.updateActivityLogStatus
+        .mockRejectedValueOnce(makeHttpError(404))
+        .mockResolvedValueOnce(undefined);
+      const port = makePort(service);
+
+      const promise = port.markSucceeded({ id: 'log-1', index: '0' });
+      await jest.advanceTimersByTimeAsync(100);
+      await expect(promise).resolves.toBeUndefined();
+      expect(service.updateActivityLogStatus).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -222,12 +235,25 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('markFailed failed'),
+        'Activity log markFailed failed',
         expect.objectContaining({
           handleId: 'log-1',
           stepErrorMessage: 'step-error-msg',
         }),
       );
+    });
+
+    it('retries on 404 — eventual consistency: record may not be visible yet on the read path', async () => {
+      const service = makeService();
+      service.updateActivityLogStatus
+        .mockRejectedValueOnce(makeHttpError(404))
+        .mockResolvedValueOnce(undefined);
+      const port = makePort(service);
+
+      const promise = port.markFailed({ id: 'log-1', index: '0' }, 'boom');
+      await jest.advanceTimersByTimeAsync(100);
+      await expect(promise).resolves.toBeUndefined();
+      expect(service.updateActivityLogStatus).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -77,7 +77,7 @@ describe('ForestadminClientActivityLogPort', () => {
 
       expect(handle).toEqual({ id: 'log-2', index: '1' });
       expect(service.createActivityLog).toHaveBeenCalledTimes(2);
-      expect(logger.error).toHaveBeenCalledWith(
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('createPending'),
         expect.objectContaining({ attempt: 1 }),
       );

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -97,6 +97,19 @@ describe('ForestadminClientActivityLogPort', () => {
       expect(service.createActivityLog).toHaveBeenCalledTimes(4);
     });
 
+    it('retries on 404 — same global policy as markSucceeded/markFailed, accepted tradeoff for simplicity', async () => {
+      const service = makeService();
+      service.createActivityLog
+        .mockRejectedValueOnce(makeHttpError(404))
+        .mockResolvedValueOnce({ id: 'log-404', attributes: { index: '0' } });
+      const port = makePort(service);
+
+      const promise = port.createPending({ renderingId: 5, action: 'update', type: 'write' });
+      await jest.advanceTimersByTimeAsync(100);
+      await expect(promise).resolves.toEqual({ id: 'log-404', index: '0' });
+      expect(service.createActivityLog).toHaveBeenCalledTimes(2);
+    });
+
     it('does not retry on 401 (not a transient error)', async () => {
       const service = makeService();
       service.createActivityLog.mockRejectedValue(makeHttpError(401));

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -97,17 +97,15 @@ describe('ForestadminClientActivityLogPort', () => {
       expect(service.createActivityLog).toHaveBeenCalledTimes(4);
     });
 
-    it('retries on 404 — same global policy as markSucceeded/markFailed, accepted tradeoff for simplicity', async () => {
+    it('throws immediately on 404 — not retriable for createPending (unlike markSucceeded/markFailed)', async () => {
       const service = makeService();
-      service.createActivityLog
-        .mockRejectedValueOnce(makeHttpError(404))
-        .mockResolvedValueOnce({ id: 'log-404', attributes: { index: '0' } });
+      service.createActivityLog.mockRejectedValueOnce(makeHttpError(404));
       const port = makePort(service);
 
-      const promise = port.createPending({ renderingId: 5, action: 'update', type: 'write' });
-      await jest.advanceTimersByTimeAsync(100);
-      await expect(promise).resolves.toEqual({ id: 'log-404', index: '0' });
-      expect(service.createActivityLog).toHaveBeenCalledTimes(2);
+      await expect(
+        port.createPending({ renderingId: 5, action: 'update', type: 'write' }),
+      ).rejects.toBeInstanceOf(ActivityLogCreationError);
+      expect(service.createActivityLog).toHaveBeenCalledTimes(1);
     });
 
     it('does not retry on 401 (not a transient error)', async () => {

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -77,7 +77,7 @@ describe('ForestadminClientActivityLogPort', () => {
 
       expect(handle).toEqual({ id: 'log-2', index: '1' });
       expect(service.createActivityLog).toHaveBeenCalledTimes(2);
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('createPending'),
         expect.objectContaining({ attempt: 1 }),
       );

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -183,7 +183,7 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        'Activity log markSucceeded failed',
+        'Failed to mark activity log as succeeded',
         expect.objectContaining({ handleId: 'log-1' }),
       );
     });
@@ -235,7 +235,7 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        'Activity log markFailed failed',
+        'Failed to mark activity log as failed',
         expect.objectContaining({
           handleId: 'log-1',
           stepErrorMessage: 'step-error-msg',

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -130,4 +130,45 @@ describe('withRetry', () => {
     await expect(withRetry('test', fn, { logger })).rejects.toThrow('plain error');
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it('throws immediately on 404 without retry404 flag', async () => {
+    const logger = makeLogger();
+    const fn = jest.fn().mockRejectedValue(makeHttpError(404));
+
+    await expect(withRetry('test', fn, { logger })).rejects.toMatchObject({ status: 404 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('retries on 404 when retry404: true', async () => {
+    const logger = makeLogger();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(makeHttpError(404))
+      .mockRejectedValueOnce(makeHttpError(404))
+      .mockRejectedValueOnce(makeHttpError(404))
+      .mockRejectedValueOnce(makeHttpError(404));
+
+    let caught: unknown;
+    const promise = withRetry('test', fn, { logger, retry404: true }).catch(err => {
+      caught = err;
+    });
+    await jest.advanceTimersByTimeAsync(100 + 500 + 2000);
+    await promise;
+
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect((caught as { status: number }).status).toBe(404);
+    expect(logger.info).toHaveBeenCalledTimes(3);
+  });
+
+  it('succeeds on 2nd attempt when retry404: true', async () => {
+    const logger = makeLogger();
+    const fn = jest.fn().mockRejectedValueOnce(makeHttpError(404)).mockResolvedValueOnce('ok');
+
+    const promise = withRetry('test', fn, { logger, retry404: true });
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -114,6 +114,17 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(4);
   });
 
+  it('retries on status 404 (eventual consistency)', async () => {
+    const logger = makeLogger();
+    const fn = jest.fn().mockRejectedValueOnce(makeHttpError(404)).mockResolvedValueOnce('ok');
+
+    const promise = withRetry('test', fn, { logger });
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
   it('throws immediately on non-retryable errors (4xx)', async () => {
     const logger = makeLogger();
     const fn = jest.fn().mockRejectedValue(makeHttpError(400));
@@ -129,46 +140,5 @@ describe('withRetry', () => {
 
     await expect(withRetry('test', fn, { logger })).rejects.toThrow('plain error');
     expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it('throws immediately on 404 without retry404 flag', async () => {
-    const logger = makeLogger();
-    const fn = jest.fn().mockRejectedValue(makeHttpError(404));
-
-    await expect(withRetry('test', fn, { logger })).rejects.toMatchObject({ status: 404 });
-    expect(fn).toHaveBeenCalledTimes(1);
-    expect(logger.info).not.toHaveBeenCalled();
-  });
-
-  it('retries on 404 when retry404: true', async () => {
-    const logger = makeLogger();
-    const fn = jest
-      .fn()
-      .mockRejectedValueOnce(makeHttpError(404))
-      .mockRejectedValueOnce(makeHttpError(404))
-      .mockRejectedValueOnce(makeHttpError(404))
-      .mockRejectedValueOnce(makeHttpError(404));
-
-    let caught: unknown;
-    const promise = withRetry('test', fn, { logger, retry404: true }).catch(err => {
-      caught = err;
-    });
-    await jest.advanceTimersByTimeAsync(100 + 500 + 2000);
-    await promise;
-
-    expect(fn).toHaveBeenCalledTimes(4);
-    expect((caught as { status: number }).status).toBe(404);
-    expect(logger.info).toHaveBeenCalledTimes(3);
-  });
-
-  it('succeeds on 2nd attempt when retry404: true', async () => {
-    const logger = makeLogger();
-    const fn = jest.fn().mockRejectedValueOnce(makeHttpError(404)).mockResolvedValueOnce('ok');
-
-    const promise = withRetry('test', fn, { logger, retry404: true });
-    await jest.advanceTimersByTimeAsync(100);
-
-    await expect(promise).resolves.toBe('ok');
-    expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -123,6 +123,10 @@ describe('withRetry', () => {
 
     await expect(promise).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(
+      '"test" failed, retrying',
+      expect.objectContaining({ attempt: 1, status: 404 }),
+    );
   });
 
   it('throws immediately on non-retryable errors (4xx)', async () => {

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -114,11 +114,11 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(4);
   });
 
-  it('retries on status 404 (eventual consistency)', async () => {
+  it('retries on status 404 when extraRetryStatuses includes 404', async () => {
     const logger = makeLogger();
     const fn = jest.fn().mockRejectedValueOnce(makeHttpError(404)).mockResolvedValueOnce('ok');
 
-    const promise = withRetry('test', fn, { logger });
+    const promise = withRetry('test', fn, { logger, extraRetryStatuses: [404] });
     await jest.advanceTimersByTimeAsync(100);
 
     await expect(promise).resolves.toBe('ok');
@@ -127,6 +127,15 @@ describe('withRetry', () => {
       '"test" failed, retrying',
       expect.objectContaining({ attempt: 1, status: 404 }),
     );
+  });
+
+  it('throws immediately on 404 without extraRetryStatuses', async () => {
+    const logger = makeLogger();
+    const fn = jest.fn().mockRejectedValue(makeHttpError(404));
+
+    await expect(withRetry('test', fn, { logger })).rejects.toMatchObject({ status: 404 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('throws immediately on non-retryable errors (4xx)', async () => {

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -32,7 +32,7 @@ describe('withRetry', () => {
 
     expect(result).toBe('ok');
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it('retries on retryable HTTP status codes (503)', async () => {
@@ -44,7 +44,7 @@ describe('withRetry', () => {
 
     await expect(promise).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       '"test" failed, retrying',
       expect.objectContaining({ attempt: 1 }),
     );
@@ -123,7 +123,7 @@ describe('withRetry', () => {
 
     await expect(promise).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.error).toHaveBeenCalledWith(
       '"test" failed, retrying',
       expect.objectContaining({ attempt: 1, status: 404 }),
     );
@@ -135,7 +135,7 @@ describe('withRetry', () => {
 
     await expect(withRetry('test', fn, { logger })).rejects.toMatchObject({ status: 400 });
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it('throws immediately on errors with no status', async () => {

--- a/packages/workflow-executor/test/adapters/with-retry.test.ts
+++ b/packages/workflow-executor/test/adapters/with-retry.test.ts
@@ -32,7 +32,7 @@ describe('withRetry', () => {
 
     expect(result).toBe('ok');
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('retries on retryable HTTP status codes (503)', async () => {
@@ -44,7 +44,7 @@ describe('withRetry', () => {
 
     await expect(promise).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       '"test" failed, retrying',
       expect.objectContaining({ attempt: 1 }),
     );
@@ -123,7 +123,7 @@ describe('withRetry', () => {
 
     await expect(promise).resolves.toBe('ok');
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(logger.warn).toHaveBeenCalledWith(
       '"test" failed, retrying',
       expect.objectContaining({ attempt: 1, status: 404 }),
     );
@@ -135,7 +135,7 @@ describe('withRetry', () => {
 
     await expect(withRetry('test', fn, { logger })).rejects.toMatchObject({ status: 400 });
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('throws immediately on errors with no status', async () => {


### PR DESCRIPTION
## Summary

- `withRetry` gains an optional `retry404` flag (default `false`) — when true, 404 responses are treated as transient and retried with the existing 100/500/2000 ms backoff
- `markSucceeded` and `markFailed` pass `retry404: true` to absorb eventual-consistency 404s on `updateActivityLogStatus`
- Error log labels lose the misleading "after retries" suffix (was "failed after retries", now just "failed")

## Why

When a step completes very quickly (condition, guidance), `markSucceeded`/`markFailed` can fire a few ms after `createActivityLog`. The server returns 404 if the record isn't yet visible on the read path. `withRetry` didn't retry 404s, so the call failed silently with a misleading log. `createPending` is intentionally left unchanged — a 404 there is a genuine error.

## Test plan

- [ ] `with-retry.test.ts`: 404 without flag → immediate throw; 404 with flag → full backoff; 404 with flag → success on 2nd attempt
- [ ] `forestadmin-client-activity-log-port.test.ts`: `markSucceeded` and `markFailed` retry on 404; log message is `"Activity log mark* failed"` (no "after retries")

fixes PRD-392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry 404 responses in `markSucceeded` and `markFailed` activity log calls
> - Adds HTTP 404 to the `RETRYABLE_STATUS` set in [`with-retry.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1595/files#diff-8b8d1cf1c1f54e0df01f68854a9322bdd391d8e59fc0ab2ca734be57f4a15a55), so transient 404s from the Forest Admin API are retried alongside 408, 429, 5xx errors.
> - Retry log entries now include the HTTP status code of the triggering error.
> - Updates error log message text in [`forestadmin-client-activity-log-port.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1595/files#diff-befcfa281e5c580e817f1691a20746423774e64a7e602888780c4deacbae09f5) for consistency across `createPending`, `markSucceeded`, and `markFailed`.
> - Behavioral Change: 404 responses in any `withRetry`-wrapped call are now retried up to the configured retry limit instead of failing immediately.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1595 opened
>
> - Removed HTTP 404 from the default set of retryable statuses in `withRetry` and added an `extraRetryStatuses` parameter to allow callers to opt-in to retrying additional HTTP status codes including 404 [a9faf2d]
> - Added HTTP 404 to `extraRetryStatuses` in `ForestadminClientActivityLogPort.markSucceeded` and `ForestadminClientActivityLogPort.markFailed` methods to retry when `updateActivityLogStatus` returns 404 [a9faf2d]
> - Changed retry logging level from `logger.info` to `logger.warn` in the `withRetry` function [a9faf2d]
> - Updated test expectations to reflect that HTTP 404 errors are no longer retried by default and that retry logs are emitted at warn level instead of info level [a9faf2d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d0c033.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->