### PR TITLE
fix(workflow-executor): single source of truth for CLI defaults

### DIFF
--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -13,15 +13,17 @@ import ConsoleLogger from './adapters/console-logger';
 import ForestServerWorkflowPort from './adapters/forest-server-workflow-port';
 import ForestadminClientActivityLogPortFactory from './adapters/forestadmin-client-activity-log-port-factory';
 import ServerAiAdapter from './adapters/server-ai-adapter';
+import {
+  DEFAULT_FOREST_SERVER_URL,
+  DEFAULT_POLLING_INTERVAL_MS,
+  DEFAULT_STEP_TIMEOUT_MS,
+} from './defaults';
 import ExecutorHttpServer from './http/executor-http-server';
 import Runner from './runner';
 import SchemaCache from './schema-cache';
 import DatabaseStore from './stores/database-store';
 import InMemoryStore from './stores/in-memory-store';
 
-const DEFAULT_FOREST_SERVER_URL = 'https://api.forestadmin.com';
-export const DEFAULT_POLLING_INTERVAL_MS = 30000;
-const DEFAULT_STEP_TIMEOUT_MS = 5 * 60_000;
 const FORCE_EXIT_DELAY_MS = 5000;
 
 export interface WorkflowExecutor {

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -8,11 +8,18 @@ import { z } from 'zod';
 import ConsoleLogger from './adapters/console-logger';
 import PrettyLogger from './adapters/pretty-logger';
 import {
-  DEFAULT_POLLING_INTERVAL_MS,
   type DatabaseExecutorOptions,
   type ExecutorOptions,
   type WorkflowExecutor,
 } from './build-workflow-executor';
+import {
+  DEFAULT_FOREST_SERVER_URL,
+  DEFAULT_HTTP_PORT,
+  DEFAULT_MAX_CHAIN_DEPTH,
+  DEFAULT_POLLING_INTERVAL_MS,
+  DEFAULT_STEP_TIMEOUT_MS,
+  DEFAULT_STOP_TIMEOUT_MS,
+} from './defaults';
 import { ConfigurationError, extractErrorMessage } from './errors';
 
 const POSITIVE_INT = z.coerce.number().int().positive();
@@ -146,7 +153,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
     envSecret: env.FOREST_ENV_SECRET as string,
     authSecret: env.FOREST_AUTH_SECRET as string,
     agentUrl: env.AGENT_URL as string,
-    httpPort: parsePositiveIntEnv('HTTP_PORT', env.HTTP_PORT) ?? 3400,
+    httpPort: parsePositiveIntEnv('HTTP_PORT', env.HTTP_PORT) ?? DEFAULT_HTTP_PORT,
     forestServerUrl: env.FOREST_SERVER_URL,
     pollingIntervalMs: parsePositiveIntEnv('POLLING_INTERVAL_MS', env.POLLING_INTERVAL_MS),
     stopTimeoutMs: parsePositiveIntEnv('STOP_TIMEOUT_MS', env.STOP_TIMEOUT_MS),
@@ -182,12 +189,12 @@ Required environment variables:
   DATABASE_URL        Postgres connection string (not needed with --in-memory)
 
 Optional environment variables:
-  HTTP_PORT              Default: 3400
-  FOREST_SERVER_URL      Default: https://api.forestadmin.com
+  HTTP_PORT              Default: ${DEFAULT_HTTP_PORT}
+  FOREST_SERVER_URL      Default: ${DEFAULT_FOREST_SERVER_URL}
   POLLING_INTERVAL_MS    Default: ${DEFAULT_POLLING_INTERVAL_MS}
-  STOP_TIMEOUT_MS        Default: 30000
-  STEP_TIMEOUT_MS        Max duration of a step in ms (default: 300000 = 5 minutes)
-  MAX_CHAIN_DEPTH        Max steps auto-executed per run before yielding (default: 50)
+  STOP_TIMEOUT_MS        Default: ${DEFAULT_STOP_TIMEOUT_MS}
+  STEP_TIMEOUT_MS        Max duration of a step in ms (default: ${DEFAULT_STEP_TIMEOUT_MS})
+  MAX_CHAIN_DEPTH        Max steps auto-executed per run before yielding (default: ${DEFAULT_MAX_CHAIN_DEPTH})
   NO_COLOR               Set to any value to disable ANSI colors in pretty logs
   FORCE_AI_ERROR         Set to "true" to make every AI call fail (dev only, to test error paths)
 
@@ -218,10 +225,10 @@ export function logStartup(logger: Logger, config: CliConfig): void {
 
   logger.info('Workflow executor starting', {
     mode,
-    forestServerUrl: opts.forestServerUrl ?? 'https://api.forestadmin.com',
+    forestServerUrl: opts.forestServerUrl ?? DEFAULT_FOREST_SERVER_URL,
     agentUrl: opts.agentUrl,
     httpPort: opts.httpPort,
-    pollingIntervalMs: opts.pollingIntervalMs,
+    pollingIntervalMs: opts.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS,
     aiConfig: aiLabel,
   });
 }

--- a/packages/workflow-executor/src/defaults.ts
+++ b/packages/workflow-executor/src/defaults.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_HTTP_PORT = 3400;
+export const DEFAULT_FOREST_SERVER_URL = 'https://api.forestadmin.com';
+export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
+export const DEFAULT_STEP_TIMEOUT_MS = 5 * 60_000;
+export const DEFAULT_STOP_TIMEOUT_MS = 30_000;
+export const DEFAULT_MAX_CHAIN_DEPTH = 50;

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -12,6 +12,7 @@ import type { StepOutcome } from './types/validated/step-outcome';
 import type { RemoteTool } from '@forestadmin/ai-proxy';
 
 import ConsoleLogger from './adapters/console-logger';
+import { DEFAULT_MAX_CHAIN_DEPTH, DEFAULT_STOP_TIMEOUT_MS } from './defaults';
 import {
   MalformedRunError,
   RunNotFoundError,
@@ -25,11 +26,6 @@ import { stepTypeToOutcomeType } from './types/validated/step-outcome';
 import validateSecrets from './validate-secrets';
 
 export type RunnerState = 'idle' | 'running' | 'draining' | 'stopped';
-
-// Default cap on auto-chained steps per entry (initial step + chained). High enough to cover
-// realistic auto workflows; low enough to fail loud if a workflow misbehaves.
-const DEFAULT_MAX_CHAIN_DEPTH = 50;
-const DEFAULT_STOP_TIMEOUT_MS = 30_000;
 
 export interface RunnerConfig {
   agentPort: AgentPort;

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -4,6 +4,7 @@ import type { CliFactories } from '../src/cli-core';
 import ConsoleLogger from '../src/adapters/console-logger';
 import PrettyLogger from '../src/adapters/pretty-logger';
 import {
+  logStartup,
   parseArgs,
   pickLogger,
   printHelp,
@@ -11,6 +12,14 @@ import {
   readEnvConfig,
   runCli,
 } from '../src/cli-core';
+import {
+  DEFAULT_FOREST_SERVER_URL,
+  DEFAULT_HTTP_PORT,
+  DEFAULT_MAX_CHAIN_DEPTH,
+  DEFAULT_POLLING_INTERVAL_MS,
+  DEFAULT_STEP_TIMEOUT_MS,
+  DEFAULT_STOP_TIMEOUT_MS,
+} from '../src/defaults';
 
 const baseEnv: NodeJS.ProcessEnv = {
   FOREST_ENV_SECRET: 'env-secret',
@@ -118,7 +127,7 @@ describe('readEnvConfig', () => {
         envSecret: 'env-secret',
         authSecret: 'auth-secret',
         agentUrl: 'http://localhost:3351',
-        httpPort: 3400,
+        httpPort: DEFAULT_HTTP_PORT,
       }),
     );
   });
@@ -273,11 +282,51 @@ describe('printHelp / printVersion', () => {
     expect(output).toContain('SIGTERM');
   });
 
+  it('printHelp prints every default value from defaults.ts', () => {
+    printHelp();
+    const output = logSpy.mock.calls.map(call => call[0]).join('\n');
+
+    expect(output).toContain(`Default: ${DEFAULT_HTTP_PORT}`);
+    expect(output).toContain(`Default: ${DEFAULT_FOREST_SERVER_URL}`);
+    expect(output).toContain(`Default: ${DEFAULT_POLLING_INTERVAL_MS}`);
+    expect(output).toContain(`Default: ${DEFAULT_STOP_TIMEOUT_MS}`);
+    expect(output).toContain(`default: ${DEFAULT_STEP_TIMEOUT_MS}`);
+    expect(output).toContain(`default: ${DEFAULT_MAX_CHAIN_DEPTH}`);
+  });
+
   it('printVersion prints a version string', () => {
     printVersion();
 
     expect(logSpy).toHaveBeenCalled();
     expect(logSpy.mock.calls[0][0]).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('logStartup', () => {
+  function makeLogger() {
+    return { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+  }
+
+  it('logs resolved defaults when env-derived options are undefined', () => {
+    const logger = makeLogger();
+
+    logStartup(logger as never, {
+      mode: 'database',
+      executorOptions: {
+        envSecret: 'e',
+        authSecret: 'a',
+        agentUrl: 'http://agent',
+        httpPort: DEFAULT_HTTP_PORT,
+      },
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Workflow executor starting',
+      expect.objectContaining({
+        forestServerUrl: DEFAULT_FOREST_SERVER_URL,
+        pollingIntervalMs: DEFAULT_POLLING_INTERVAL_MS,
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Created `src/defaults.ts` exporting all 6 CLI-visible defaults (`DEFAULT_HTTP_PORT`, `DEFAULT_FOREST_SERVER_URL`, `DEFAULT_POLLING_INTERVAL_MS`, `DEFAULT_STEP_TIMEOUT_MS`, `DEFAULT_STOP_TIMEOUT_MS`, `DEFAULT_MAX_CHAIN_DEPTH`).
- `build-workflow-executor.ts`, `runner.ts`, and `cli-core.ts` now import from `defaults.ts` instead of duplicating constants.
- `logStartup` now resolves `forestServerUrl`/`pollingIntervalMs` against the defaults so logged values match runtime behavior (previously logged `undefined` when env vars were unset).

fixes PRD-394

## Test plan

- [x] `yarn workspace @forestadmin/workflow-executor test` (774 passing)
- [x] `yarn workspace @forestadmin/workflow-executor lint` (no new warnings)
- [x] `yarn workspace @forestadmin/workflow-executor build`
- [x] New test asserts `printHelp` output contains every default value
- [x] New test asserts `logStartup` logs resolved defaults when env-derived options are undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize CLI default constants in workflow-executor into a single `defaults` module
> - Introduces [defaults.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1596/files#diff-1766dc2654e9359f823371f8f5f5fb6d2d0af2f79d9b9f26542364d967287f95) as the single source of truth for `DEFAULT_HTTP_PORT`, `DEFAULT_FOREST_SERVER_URL`, `DEFAULT_POLLING_INTERVAL_MS`, `DEFAULT_STEP_TIMEOUT_MS`, `DEFAULT_STOP_TIMEOUT_MS`, and `DEFAULT_MAX_CHAIN_DEPTH`.
> - Updates [cli-core.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1596/files#diff-1605eabb559b21939e3b8d15b4a7a4c933da2a7cd5190022502db6ecaf93b396), [build-workflow-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1596/files#diff-9a7b00e34df678f7ad856e6420bb042e4f6e01afc81fdc706055f462da01d493), and [runner.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1596/files#diff-53dd42328518d1424983b180f4f92da938c107f6c821327fd03f8f768ffa7e89) to import from `./defaults` instead of defining constants locally.
> - `logStartup` now logs the default `pollingIntervalMs` value when none is provided, closing a gap in startup output.
> - Behavioral Change: `DEFAULT_POLLING_INTERVAL_MS` is no longer exported from `build-workflow-executor`; consumers must import it from `./defaults`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 729eacb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->