### PR TITLE
chore: merge main into feat/prd-214-server-step-mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,13 @@
     "semantic-release": "^25.0.0",
     "qs": ">=6.14.1",
     "@hono/node-server": "^1.19.13",
-    "langsmith": "^0.5.18",
+    "langsmith": "^0.6.0",
     "lodash": "^4.18.0",
     "**/@langchain/langgraph-sdk/uuid": "^13.0.1",
     "**/socks/ip-address": "^10.1.1",
     "**/express-rate-limit/ip-address": "^10.1.1",
-    "**/@aws-sdk/xml-builder/fast-xml-parser": "^5.7.0"
+    "**/@aws-sdk/xml-builder/fast-xml-parser": "^5.7.0",
+    "**/@modelcontextprotocol/sdk/hono": "^4.12.18",
+    "**/ajv/fast-uri": "^3.1.2"
   }
 }

--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -24,7 +24,7 @@
     "fastify4": "npm:fastify@^4.29.0",
     "koa": "^3.0.1",
     "mariadb": "^3.0.2",
-    "mongoose": "8.21.0",
+    "mongoose": "8.22.1",
     "mysql2": "^3.0.1",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",

--- a/packages/agent-client/CHANGELOG.md
+++ b/packages/agent-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/agent-client [1.5.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-client@1.5.8...@forestadmin/agent-client@1.5.9) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.8
+
 ## @forestadmin/agent-client [1.5.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-client@1.5.7...@forestadmin/agent-client@1.5.8) (2026-05-11)
 
 

--- a/packages/agent-client/CHANGELOG.md
+++ b/packages/agent-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/agent-client [1.5.10](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-client@1.5.9...@forestadmin/agent-client@1.5.10) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.9
+
 ## @forestadmin/agent-client [1.5.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-client@1.5.8...@forestadmin/agent-client@1.5.9) (2026-05-20)
 
 

--- a/packages/agent-client/package.json
+++ b/packages/agent-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-client",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.8",
+    "@forestadmin/forestadmin-client": "1.39.9",
     "jsonapi-serializer": "^3.6.9",
     "superagent": "^10.3.0"
   },

--- a/packages/agent-client/package.json
+++ b/packages/agent-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-client",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.7",
+    "@forestadmin/forestadmin-client": "1.39.8",
     "jsonapi-serializer": "^3.6.9",
     "superagent": "^10.3.0"
   },

--- a/packages/agent-testing/CHANGELOG.md
+++ b/packages/agent-testing/CHANGELOG.md
@@ -1,3 +1,15 @@
+## @forestadmin/agent-testing [1.1.23](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.22...@forestadmin/agent-testing@1.1.23) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent-client:** upgraded to 1.5.10
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.9
+* **@forestadmin/agent:** upgraded to 1.78.13
+
 ## @forestadmin/agent-testing [1.1.22](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.21...@forestadmin/agent-testing@1.1.22) (2026-05-20)
 
 

--- a/packages/agent-testing/CHANGELOG.md
+++ b/packages/agent-testing/CHANGELOG.md
@@ -1,3 +1,15 @@
+## @forestadmin/agent-testing [1.1.22](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.21...@forestadmin/agent-testing@1.1.22) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent-client:** upgraded to 1.5.9
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.8
+* **@forestadmin/agent:** upgraded to 1.78.12
+
 ## @forestadmin/agent-testing [1.1.21](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent-testing@1.1.20...@forestadmin/agent-testing@1.1.21) (2026-05-11)
 
 

--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-testing",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "description": "Testing utilities for Forest Admin agent",
   "author": "Vincent Molinié <vincent.m@forestadmin.com>",
   "homepage": "https://github.com/ForestAdmin/agent-nodejs#readme",
@@ -26,16 +26,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@forestadmin/agent-client": "1.5.9",
+    "@forestadmin/agent-client": "1.5.10",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.8",
+    "@forestadmin/forestadmin-client": "1.39.9",
     "jsonapi-serializer": "^3.6.9",
     "jsonwebtoken": "^9.0.3",
     "superagent": "^10.3.0"
   },
   "peerDependencies": {
-    "@forestadmin/agent": "1.78.12"
+    "@forestadmin/agent": "1.78.13"
   },
   "peerDependenciesMeta": {
     "@forestadmin/agent": {
@@ -43,7 +43,7 @@
     }
   },
   "devDependencies": {
-    "@forestadmin/agent": "1.78.12",
+    "@forestadmin/agent": "1.78.13",
     "@forestadmin/datasource-sql": "1.17.10",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/superagent": "^8.1.9",

--- a/packages/agent-testing/package.json
+++ b/packages/agent-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent-testing",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "Testing utilities for Forest Admin agent",
   "author": "Vincent Molinié <vincent.m@forestadmin.com>",
   "homepage": "https://github.com/ForestAdmin/agent-nodejs#readme",
@@ -26,16 +26,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@forestadmin/agent-client": "1.5.8",
+    "@forestadmin/agent-client": "1.5.9",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.7",
+    "@forestadmin/forestadmin-client": "1.39.8",
     "jsonapi-serializer": "^3.6.9",
     "jsonwebtoken": "^9.0.3",
     "superagent": "^10.3.0"
   },
   "peerDependencies": {
-    "@forestadmin/agent": "1.78.11"
+    "@forestadmin/agent": "1.78.12"
   },
   "peerDependenciesMeta": {
     "@forestadmin/agent": {
@@ -43,7 +43,7 @@
     }
   },
   "devDependencies": {
-    "@forestadmin/agent": "1.78.11",
+    "@forestadmin/agent": "1.78.12",
     "@forestadmin/datasource-sql": "1.17.10",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/superagent": "^8.1.9",

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/agent [1.78.12](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.78.11...@forestadmin/agent@1.78.12) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.8
+* **@forestadmin/mcp-server:** upgraded to 1.11.10
+
 ## @forestadmin/agent [1.78.11](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.78.10...@forestadmin/agent@1.78.11) (2026-05-11)
 
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/agent [1.78.13](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.78.12...@forestadmin/agent@1.78.13) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.9
+* **@forestadmin/mcp-server:** upgraded to 1.11.11
+
 ## @forestadmin/agent [1.78.12](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/agent@1.78.11...@forestadmin/agent@1.78.12) (2026-05-20)
 
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent",
-  "version": "1.78.12",
+  "version": "1.78.13",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -16,8 +16,8 @@
     "@forestadmin/agent-toolkit": "1.2.0",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.8",
-    "@forestadmin/mcp-server": "1.11.10",
+    "@forestadmin/forestadmin-client": "1.39.9",
+    "@forestadmin/mcp-server": "1.11.11",
     "@koa/bodyparser": "^6.0.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^13.1.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/agent",
-  "version": "1.78.11",
+  "version": "1.78.12",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -16,8 +16,8 @@
     "@forestadmin/agent-toolkit": "1.2.0",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-toolkit": "1.53.1",
-    "@forestadmin/forestadmin-client": "1.39.7",
-    "@forestadmin/mcp-server": "1.11.9",
+    "@forestadmin/forestadmin-client": "1.39.8",
+    "@forestadmin/mcp-server": "1.11.10",
     "@koa/bodyparser": "^6.0.0",
     "@koa/cors": "^5.0.0",
     "@koa/router": "^13.1.0",

--- a/packages/ai-proxy/CHANGELOG.md
+++ b/packages/ai-proxy/CHANGELOG.md
@@ -1,3 +1,10 @@
+# @forestadmin/ai-proxy [1.10.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/ai-proxy@1.9.0...@forestadmin/ai-proxy@1.10.0) (2026-05-20)
+
+
+### Features
+
+* **ai-proxy:** export FOREST_INTEGRATION_NAMES as runtime const [PRD-375] ([#1588](https://github.com/ForestAdmin/agent-nodejs/issues/1588)) ([89f4f64](https://github.com/ForestAdmin/agent-nodejs/commit/89f4f643ba8b773bce362b6212c9249268dcdf59))
+
 # @forestadmin/ai-proxy [1.9.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/ai-proxy@1.8.0...@forestadmin/ai-proxy@1.9.0) (2026-05-11)
 
 

--- a/packages/ai-proxy/CHANGELOG.md
+++ b/packages/ai-proxy/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @forestadmin/ai-proxy [1.10.1](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/ai-proxy@1.10.0...@forestadmin/ai-proxy@1.10.1) (2026-05-20)
+
+
+### Bug Fixes
+
+* **ai-proxy:** re-export FOREST_INTEGRATION_NAMES from package index [PRD-375] ([#1589](https://github.com/ForestAdmin/agent-nodejs/issues/1589)) ([909d050](https://github.com/ForestAdmin/agent-nodejs/commit/909d050e77b7df2a84dbda6dc93ebf559d6f2a6c))
+
 # @forestadmin/ai-proxy [1.10.0](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/ai-proxy@1.9.0...@forestadmin/ai-proxy@1.10.0) (2026-05-20)
 
 

--- a/packages/ai-proxy/package.json
+++ b/packages/ai-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/ai-proxy",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {

--- a/packages/ai-proxy/package.json
+++ b/packages/ai-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/ai-proxy",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {

--- a/packages/ai-proxy/src/forest-integration-client.ts
+++ b/packages/ai-proxy/src/forest-integration-client.ts
@@ -11,7 +11,8 @@ import getZendeskTools, { type ZendeskConfig } from './integrations/zendesk/tool
 import { validateZendeskConfig } from './integrations/zendesk/utils';
 
 export type CustomConfig = ZendeskConfig | KolarConfig | SnowflakeConfig;
-export type ForestIntegrationName = 'Zendesk' | 'Kolar' | 'Snowflake';
+export const FOREST_INTEGRATION_NAMES = ['Zendesk', 'Kolar', 'Snowflake'] as const;
+export type ForestIntegrationName = (typeof FOREST_INTEGRATION_NAMES)[number];
 
 export interface ForestIntegrationConfig {
   integrationName: ForestIntegrationName;

--- a/packages/ai-proxy/src/index.ts
+++ b/packages/ai-proxy/src/index.ts
@@ -7,6 +7,7 @@ export { createAiProvider } from './create-ai-provider';
 export { default as ProviderDispatcher } from './provider-dispatcher';
 
 export {
+  FOREST_INTEGRATION_NAMES,
   ForestIntegrationConfig,
   CustomConfig,
   ForestIntegrationName,

--- a/packages/datasource-mongo/package.json
+++ b/packages/datasource-mongo/package.json
@@ -15,7 +15,7 @@
     "@forestadmin/datasource-mongoose": "1.13.4",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "json-stringify-pretty-compact": "^3.0.0",
-    "mongoose": "8.21.0",
+    "mongoose": "8.22.1",
     "tunnel-ssh": "^5.2.0"
   },
   "files": [

--- a/packages/datasource-mongoose/package.json
+++ b/packages/datasource-mongoose/package.json
@@ -20,7 +20,7 @@
     "luxon": "^3.2.1"
   },
   "devDependencies": {
-    "mongoose": "8.21.0"
+    "mongoose": "8.22.1"
   },
   "peerDependencies": {
     "mongoose": "6.x || 7.x || 8.x"

--- a/packages/forest-cloud/CHANGELOG.md
+++ b/packages/forest-cloud/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/forest-cloud [1.12.123](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.122...@forestadmin/forest-cloud@1.12.123) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent:** upgraded to 1.78.12
+
 ## @forestadmin/forest-cloud [1.12.122](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.121...@forestadmin/forest-cloud@1.12.122) (2026-05-11)
 
 

--- a/packages/forest-cloud/CHANGELOG.md
+++ b/packages/forest-cloud/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/forest-cloud [1.12.124](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.123...@forestadmin/forest-cloud@1.12.124) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent:** upgraded to 1.78.13
+
 ## @forestadmin/forest-cloud [1.12.123](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forest-cloud@1.12.122...@forestadmin/forest-cloud@1.12.123) (2026-05-20)
 
 

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@forestadmin/forest-cloud",
-  "version": "1.12.123",
+  "version": "1.12.124",
   "description": "Utility to bootstrap and publish forest admin cloud projects customization",
   "dependencies": {
-    "@forestadmin/agent": "1.78.12",
+    "@forestadmin/agent": "1.78.13",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-mongo": "1.6.9",
     "@forestadmin/datasource-mongoose": "1.13.4",

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@forestadmin/forest-cloud",
-  "version": "1.12.122",
+  "version": "1.12.123",
   "description": "Utility to bootstrap and publish forest admin cloud projects customization",
   "dependencies": {
-    "@forestadmin/agent": "1.78.11",
+    "@forestadmin/agent": "1.78.12",
     "@forestadmin/datasource-customizer": "1.69.3",
     "@forestadmin/datasource-mongo": "1.6.9",
     "@forestadmin/datasource-mongoose": "1.13.4",

--- a/packages/forestadmin-client/CHANGELOG.md
+++ b/packages/forestadmin-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/forestadmin-client [1.39.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forestadmin-client@1.39.7...@forestadmin/forestadmin-client@1.39.8) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/ai-proxy:** upgraded to 1.10.0
+
 ## @forestadmin/forestadmin-client [1.39.7](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forestadmin-client@1.39.6...@forestadmin/forestadmin-client@1.39.7) (2026-05-11)
 
 

--- a/packages/forestadmin-client/CHANGELOG.md
+++ b/packages/forestadmin-client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## @forestadmin/forestadmin-client [1.39.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forestadmin-client@1.39.8...@forestadmin/forestadmin-client@1.39.9) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/ai-proxy:** upgraded to 1.10.1
+
 ## @forestadmin/forestadmin-client [1.39.8](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/forestadmin-client@1.39.7...@forestadmin/forestadmin-client@1.39.8) (2026-05-20)
 
 

--- a/packages/forestadmin-client/package.json
+++ b/packages/forestadmin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/forestadmin-client",
-  "version": "1.39.8",
+  "version": "1.39.9",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@forestadmin/ai-proxy": "1.10.0",
+    "@forestadmin/ai-proxy": "1.10.1",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "@types/json-api-serializer": "^2.6.3",
     "@types/jsonwebtoken": "^9.0.1",

--- a/packages/forestadmin-client/package.json
+++ b/packages/forestadmin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/forestadmin-client",
-  "version": "1.39.7",
+  "version": "1.39.8",
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "publishConfig": {
@@ -31,7 +31,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@forestadmin/ai-proxy": "1.9.0",
+    "@forestadmin/ai-proxy": "1.10.0",
     "@forestadmin/datasource-toolkit": "1.53.1",
     "@types/json-api-serializer": "^2.6.3",
     "@types/jsonwebtoken": "^9.0.1",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/mcp-server [1.11.10](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.11.9...@forestadmin/mcp-server@1.11.10) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent-client:** upgraded to 1.5.9
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.8
+
 ## @forestadmin/mcp-server [1.11.9](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.11.8...@forestadmin/mcp-server@1.11.9) (2026-05-11)
 
 

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,3 +1,14 @@
+## @forestadmin/mcp-server [1.11.11](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.11.10...@forestadmin/mcp-server@1.11.11) (2026-05-20)
+
+
+
+
+
+### Dependencies
+
+* **@forestadmin/agent-client:** upgraded to 1.5.10
+* **@forestadmin/forestadmin-client:** upgraded to 1.39.9
+
 ## @forestadmin/mcp-server [1.11.10](https://github.com/ForestAdmin/agent-nodejs/compare/@forestadmin/mcp-server@1.11.9...@forestadmin/mcp-server@1.11.10) (2026-05-20)
 
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/mcp-server",
-  "version": "1.11.10",
+  "version": "1.11.11",
   "description": "Model Context Protocol server for Forest Admin with OAuth authentication",
   "main": "dist/index.js",
   "bin": {
@@ -16,8 +16,8 @@
     "directory": "packages/mcp-server"
   },
   "dependencies": {
-    "@forestadmin/agent-client": "1.5.9",
-    "@forestadmin/forestadmin-client": "1.39.8",
+    "@forestadmin/agent-client": "1.5.10",
+    "@forestadmin/forestadmin-client": "1.39.9",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forestadmin/mcp-server",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "description": "Model Context Protocol server for Forest Admin with OAuth authentication",
   "main": "dist/index.js",
   "bin": {
@@ -16,8 +16,8 @@
     "directory": "packages/mcp-server"
   },
   "dependencies": {
-    "@forestadmin/agent-client": "1.5.8",
-    "@forestadmin/forestadmin-client": "1.39.7",
+    "@forestadmin/agent-client": "1.5.9",
+    "@forestadmin/forestadmin-client": "1.39.8",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,6 +1851,21 @@
     jsonapi-serializer "^3.6.9"
     superagent "^10.3.0"
 
+"@forestadmin/ai-proxy@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@forestadmin/ai-proxy/-/ai-proxy-1.9.0.tgz#b61398831febf6ad003689107abad4521abea0d4"
+  integrity sha512-i04/C+9vjdanyEITU2cJNiAfBD13voguYoKMmbxBbIjAaipHi/1z14Ti9pQmEVd5lE21gxjtsNhjhSSEGeORqg==
+  dependencies:
+    "@forestadmin/agent-toolkit" "1.2.0"
+    "@forestadmin/datasource-toolkit" "1.53.1"
+    "@langchain/anthropic" "1.3.17"
+    "@langchain/community" "^1.1.19"
+    "@langchain/core" "1.1.15"
+    "@langchain/langgraph" "^1.1.0"
+    "@langchain/mcp-adapters" "1.1.1"
+    "@langchain/openai" "1.2.5"
+    zod "^4.3.5"
+
 "@forestadmin/context@1.37.1":
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/@forestadmin/context/-/context-1.37.1.tgz#301486c456061d43cb653b3e8be60644edb3f71a"
@@ -1889,6 +1904,18 @@
   version "1.39.5"
   resolved "https://registry.yarnpkg.com/@forestadmin/forestadmin-client/-/forestadmin-client-1.39.5.tgz#4475ba282f337c52022ce7a65c1a003c8798ef64"
   integrity sha512-EkVQmFXBQgOymPTKVewyAzgiBh9ReR/UdbHtpBaObCkOqqUPvLBV+ecywjeodnxHj5BPfEKteTrcMb4oRtjvqA==
+  dependencies:
+    eventsource "2.0.2"
+    json-api-serializer "^2.6.6"
+    jsonwebtoken "^9.0.3"
+    object-hash "^3.0.0"
+    openid-client "^5.7.1"
+    superagent "^10.3.0"
+
+"@forestadmin/forestadmin-client@1.39.7":
+  version "1.39.7"
+  resolved "https://registry.yarnpkg.com/@forestadmin/forestadmin-client/-/forestadmin-client-1.39.7.tgz#c0cea92295a7642955cdeb3d4641a81f2ad0e837"
+  integrity sha512-n+fkPC1Ze909J1IPiS1hFYXURtu7aKgqmVtHt8l95EZeXtDZgHeYp/74jHchKdxRFsU398gYuTsn99y+auLdNQ==
   dependencies:
     eventsource "2.0.2"
     json-api-serializer "^2.6.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8342,10 +8342,10 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.3.0.tgz#bdae493942483d299e7285dcb4627767d42e2793"
   integrity sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@^3.0.1, fast-uri@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-xml-builder@^1.2.0:
   version "1.2.0"
@@ -9409,10 +9409,10 @@ highlight.js@^10.7.1:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hono@^4.11.4:
-  version "4.12.14"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
-  integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
+hono@^4.11.4, hono@^4.12.18:
+  version "4.12.21"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.21.tgz#f11846462095d365b9a8b4859b37c02cb0981df3"
+  integrity sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==
 
 hook-std@^4.0.0:
   version "4.0.0"
@@ -11319,13 +11319,12 @@ koa@^3.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
-"langsmith@>=0.4.0 <1.0.0", langsmith@^0.5.18:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.21.tgz#2f4cd30dafc22922e423cf0f151ead5f636e76b0"
-  integrity sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==
+"langsmith@>=0.4.0 <1.0.0", langsmith@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.6.3.tgz#a3d8ad58d66a47d3697e3c69b2be3f6df5233190"
+  integrity sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==
   dependencies:
     p-queue "6.6.2"
-    uuid "10.0.0"
 
 lerna@^8.2.3:
   version "8.2.3"
@@ -12682,10 +12681,10 @@ mongodb@~6.20.0:
     bson "^6.10.4"
     mongodb-connection-string-url "^3.0.2"
 
-mongoose@8.21.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.21.0.tgz#e4b940a6b22c2fc176916667766f34656e352906"
-  integrity sha512-dW2U01gN8EVQT5KAO5AkzjbqWc8A/CsEq15jOzq/M9ISpy8jw3iq7W9ZP135h9zykFOMt3AMxq4+anvt2YNJgw==
+mongoose@8.22.1:
+  version "8.22.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.22.1.tgz#6b873d88b883c9b283e2a3b94cdc541d108ea94a"
+  integrity sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==
   dependencies:
     bson "^6.10.4"
     kareem "2.6.3"
@@ -17323,11 +17322,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@10.0.0, uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
 uuid@11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
@@ -17337,6 +17331,11 @@ uuid@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^13.0.0, uuid@^13.0.1:
   version "13.0.2"


### PR DESCRIPTION
Merge `main` into the mapper feature branch to bring it up to date with the latest releases (changelogs, package bumps, dependency updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `FOREST_INTEGRATION_NAMES` as a runtime constant from `@forestadmin/ai-proxy`
> - Adds `FOREST_INTEGRATION_NAMES` as an exported `const` array `['Zendesk', 'Kolar', 'Snowflake']` in [`forest-integration-client.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1597/files#diff-5bc11695132aa6279baadd1b8d87a30c7b4e7f01754a70a1c8fc43b5ba68ee67), replacing the previous hardcoded string-literal union type.
> - Re-exports `FOREST_INTEGRATION_NAMES` from the package index so it is importable at runtime from `@forestadmin/ai-proxy`.
> - Bumps `langsmith` to `^0.6.0`, `mongoose` to `8.22.1`, and propagates internal `@forestadmin/*` package version bumps across the monorepo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75168fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->