### PR TITLE
fix(ai-proxy): route Forest connectors via tool-provider split in AiClient

### DIFF
--- a/packages/ai-proxy/src/ai-client.ts
+++ b/packages/ai-proxy/src/ai-client.ts
@@ -1,12 +1,14 @@
-import type { McpConfiguration } from './mcp-client';
 import type { AiConfiguration } from './provider';
+import type RemoteTool from './remote-tool';
+import type { ToolProvider } from './tool-provider';
+import type { ToolConfig } from './tool-provider-factory';
 import type { Logger } from '@forestadmin/datasource-toolkit';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { createBaseChatModel } from './create-base-chat-model';
 import { AINotConfiguredError } from './errors';
 import getAiConfiguration from './get-ai-configuration';
-import McpClient from './mcp-client';
+import { createToolProviders } from './tool-provider-factory';
 import validateAiConfigurations from './validate-ai-configurations';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -14,7 +16,7 @@ export class AiClient {
   private readonly aiConfigurations: AiConfiguration[];
   private readonly logger?: Logger;
   private readonly modelCache = new Map<string, BaseChatModel>();
-  private mcpClient?: McpClient;
+  private toolProviders: ToolProvider[] = [];
 
   constructor(params?: { aiConfigurations?: AiConfiguration[]; logger?: Logger }) {
     this.aiConfigurations = params?.aiConfigurations ?? [];
@@ -36,32 +38,34 @@ export class AiClient {
     return model;
   }
 
-  async loadRemoteTools(
-    mcpConfig: McpConfiguration,
-  ): Promise<Awaited<ReturnType<McpClient['loadTools']>>> {
-    await this.disposeMcpClient('Error closing previous MCP connection');
+  async loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
+    await this.disposeToolProviders('Error closing previous remote tool connection');
 
-    const newClient = new McpClient(mcpConfig, this.logger);
-    const tools = await newClient.loadTools();
-    this.mcpClient = newClient;
+    const providers = createToolProviders(configs, this.logger);
+    const toolsByProvider = await Promise.all(providers.map(p => p.loadTools()));
+    this.toolProviders = providers;
 
-    return tools;
+    return toolsByProvider.flat();
   }
 
   async closeConnections(): Promise<void> {
-    await this.disposeMcpClient('Error during MCP connection cleanup');
+    await this.disposeToolProviders('Error during remote tool connection cleanup');
   }
 
-  private async disposeMcpClient(errorMessage: string): Promise<void> {
-    if (!this.mcpClient) return;
+  private async disposeToolProviders(errorMessage: string): Promise<void> {
+    if (this.toolProviders.length === 0) return;
 
-    try {
-      await this.mcpClient.dispose();
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      this.logger?.('Error', errorMessage, err);
-    } finally {
-      this.mcpClient = undefined;
-    }
+    const providers = this.toolProviders;
+    this.toolProviders = [];
+
+    const results = await Promise.allSettled(providers.map(p => p.dispose()));
+
+    results.forEach(result => {
+      if (result.status === 'rejected') {
+        const { reason } = result;
+        const err = reason instanceof Error ? reason : new Error(String(reason));
+        this.logger?.('Error', errorMessage, err);
+      }
+    });
   }
 }

--- a/packages/ai-proxy/test/ai-client-routing.test.ts
+++ b/packages/ai-proxy/test/ai-client-routing.test.ts
@@ -1,0 +1,92 @@
+import type { ForestIntegrationConfig } from '../src/forest-integration-client';
+
+import { AiClient } from '../src';
+import ForestIntegrationClient from '../src/forest-integration-client';
+import McpClient from '../src/mcp-client';
+
+// Real `createToolProviders` is used — only the underlying client constructors are mocked,
+// so we can assert that AiClient.loadRemoteTools routes each config kind to the right
+// provider. This is the PRD-400 regression guard: against the pre-fix code (which built
+// McpClient directly with the unfiltered config), the assertion below would fail because
+// the Forest connector entry would appear in McpClient's args.
+
+jest.mock('../src/mcp-client', () => {
+  return jest.fn().mockImplementation(() => ({
+    loadTools: jest.fn().mockResolvedValue([]),
+    checkConnection: jest.fn(),
+    dispose: jest.fn(),
+  }));
+});
+
+jest.mock('../src/forest-integration-client', () => {
+  const actual = jest.requireActual('../src/forest-integration-client');
+
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn().mockImplementation(() => ({
+      loadTools: jest.fn().mockResolvedValue([]),
+      checkConnection: jest.fn(),
+      dispose: jest.fn(),
+    })),
+  };
+});
+
+const MockedMcpClient = McpClient as jest.MockedClass<typeof McpClient>;
+const MockedForestIntegrationClient = ForestIntegrationClient as jest.MockedClass<
+  typeof ForestIntegrationClient
+>;
+
+describe('AiClient.loadRemoteTools — routing (PRD-400 regression)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes a Forest connector config to ForestIntegrationClient and NEVER to McpClient', async () => {
+    const zendesk: ForestIntegrationConfig = {
+      id: 'db-id-zendesk',
+      isForestConnector: true,
+      integrationName: 'Zendesk',
+      config: { subdomain: 'acme', email: 'ops@acme.com', apiToken: 'tok' },
+    };
+
+    const client = new AiClient({});
+    await client.loadRemoteTools({ Zendesk: zendesk });
+
+    expect(MockedForestIntegrationClient).toHaveBeenCalledTimes(1);
+    expect(MockedForestIntegrationClient).toHaveBeenCalledWith([zendesk], undefined);
+    expect(MockedMcpClient).not.toHaveBeenCalled();
+  });
+
+  it('splits a mixed config: MCP entries go to McpClient, Forest connectors to ForestIntegrationClient', async () => {
+    const mcp = { url: 'https://mcp.example.com/mcp' };
+    const zendesk: ForestIntegrationConfig = {
+      id: 'db-id-zendesk',
+      isForestConnector: true,
+      integrationName: 'Zendesk',
+      config: { subdomain: 'acme', email: 'ops@acme.com', apiToken: 'tok' },
+    };
+
+    const client = new AiClient({});
+    await client.loadRemoteTools({ 'my-mcp': mcp, Zendesk: zendesk });
+
+    // McpClient must receive ONLY the MCP entry — never the Forest connector.
+    // This is the exact failure mode PRD-400 surfaced.
+    expect(MockedMcpClient).toHaveBeenCalledTimes(1);
+    expect(MockedMcpClient).toHaveBeenCalledWith({ configs: { 'my-mcp': mcp } }, undefined);
+
+    expect(MockedForestIntegrationClient).toHaveBeenCalledTimes(1);
+    expect(MockedForestIntegrationClient).toHaveBeenCalledWith([zendesk], undefined);
+  });
+
+  it('routes a pure MCP config only to McpClient, not to ForestIntegrationClient', async () => {
+    const mcp = { url: 'https://mcp.example.com/mcp' };
+
+    const client = new AiClient({});
+    await client.loadRemoteTools({ 'my-mcp': mcp });
+
+    expect(MockedMcpClient).toHaveBeenCalledTimes(1);
+    expect(MockedMcpClient).toHaveBeenCalledWith({ configs: { 'my-mcp': mcp } }, undefined);
+    expect(MockedForestIntegrationClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai-proxy/test/ai-client.test.ts
+++ b/packages/ai-proxy/test/ai-client.test.ts
@@ -177,28 +177,6 @@ describe('loadRemoteTools', () => {
     expect(result).toEqual([...mcpTools, ...integrationTools]);
   });
 
-  it('does not crash on Forest connector configs that lack MCP transport fields', async () => {
-    // Regression for PRD-400: before the fix, Forest connector configs (e.g. Zendesk)
-    // were forwarded to MultiServerMCPClient and failed Zod validation because they have
-    // neither `command`+`args` nor `url`.
-    const zendeskTools = [{ name: 'get-tickets' }];
-    mockedCreateToolProviders.mockReturnValue([
-      mockProvider({ loadTools: jest.fn().mockResolvedValue(zendeskTools) }),
-    ]);
-
-    const client = new AiClient({});
-    const configs = {
-      Zendesk: {
-        isForestConnector: true,
-        integrationName: 'Zendesk',
-        config: { subdomain: 'x', email: 'y', apiToken: 'z' },
-      },
-    } as never;
-
-    await expect(client.loadRemoteTools(configs)).resolves.toEqual(zendeskTools);
-    expect(mockedCreateToolProviders).toHaveBeenCalledWith(configs, undefined);
-  });
-
   it('disposes the previously-loaded providers before loading new ones', async () => {
     const firstDispose = jest.fn().mockResolvedValue(undefined);
     const secondDispose = jest.fn().mockResolvedValue(undefined);

--- a/packages/ai-proxy/test/ai-client.test.ts
+++ b/packages/ai-proxy/test/ai-client.test.ts
@@ -1,17 +1,26 @@
+import type { ToolProvider } from '../src/tool-provider';
 import type { Logger } from '@forestadmin/datasource-toolkit';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AIModelNotSupportedError, AINotConfiguredError, AiClient } from '../src';
-import McpClient from '../src/mcp-client';
+import { createToolProviders } from '../src/tool-provider-factory';
 
-jest.mock('../src/mcp-client', () => {
-  return jest.fn().mockImplementation(() => ({
+jest.mock('../src/tool-provider-factory', () => ({
+  createToolProviders: jest.fn().mockReturnValue([]),
+}));
+
+const mockedCreateToolProviders = createToolProviders as jest.MockedFunction<
+  typeof createToolProviders
+>;
+
+function mockProvider(overrides: Partial<ToolProvider> = {}): ToolProvider {
+  return {
     loadTools: jest.fn().mockResolvedValue([]),
-    dispose: jest.fn(),
-  }));
-});
-
-const MockedMcpClient = McpClient as jest.MockedClass<typeof McpClient>;
+    checkConnection: jest.fn().mockResolvedValue(true as const),
+    dispose: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
 
 const createBaseChatModelMock = jest.fn().mockReturnValue({} as BaseChatModel);
 jest.mock('../src/create-base-chat-model', () => ({
@@ -149,162 +158,109 @@ describe('loadRemoteTools', () => {
     jest.clearAllMocks();
   });
 
-  it('creates an McpClient and returns loaded tools', async () => {
-    const fakeTools = [{ name: 'tool1' }];
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue(fakeTools),
-          dispose: jest.fn(),
-        } as unknown as McpClient),
-    );
+  it('delegates to createToolProviders and returns the flattened tools', async () => {
+    const mcpTools = [{ name: 'mcp-tool' }];
+    const integrationTools = [{ name: 'zendesk-tool' }];
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ loadTools: jest.fn().mockResolvedValue(mcpTools) }),
+      mockProvider({ loadTools: jest.fn().mockResolvedValue(integrationTools) }),
+    ]);
 
     const client = new AiClient({});
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
+    const configs = {
+      'mcp-1': { url: 'http://example.com' },
+    } as never;
 
-    const result = await client.loadRemoteTools(mcpConfig);
+    const result = await client.loadRemoteTools(configs);
 
-    expect(MockedMcpClient).toHaveBeenCalledWith(mcpConfig, undefined);
-    expect(result).toBe(fakeTools);
+    expect(mockedCreateToolProviders).toHaveBeenCalledWith(configs, undefined);
+    expect(result).toEqual([...mcpTools, ...integrationTools]);
   });
 
-  it('closes previous client before creating a new one', async () => {
-    const disposeMock1 = jest.fn();
-    const disposeMock2 = jest.fn();
-
-    jest
-      .mocked(McpClient)
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue([]),
-            dispose: disposeMock1,
-          } as unknown as McpClient),
-      )
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue([]),
-            dispose: disposeMock2,
-          } as unknown as McpClient),
-      );
+  it('does not crash on Forest connector configs that lack MCP transport fields', async () => {
+    // Regression for PRD-400: before the fix, Forest connector configs (e.g. Zendesk)
+    // were forwarded to MultiServerMCPClient and failed Zod validation because they have
+    // neither `command`+`args` nor `url`.
+    const zendeskTools = [{ name: 'get-tickets' }];
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ loadTools: jest.fn().mockResolvedValue(zendeskTools) }),
+    ]);
 
     const client = new AiClient({});
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
+    const configs = {
+      Zendesk: {
+        isForestConnector: true,
+        integrationName: 'Zendesk',
+        config: { subdomain: 'x', email: 'y', apiToken: 'z' },
+      },
+    } as never;
 
-    await client.loadRemoteTools(mcpConfig);
-    await client.loadRemoteTools(mcpConfig);
-
-    expect(disposeMock1).toHaveBeenCalledTimes(1);
-    expect(MockedMcpClient).toHaveBeenCalledTimes(2);
+    await expect(client.loadRemoteTools(configs)).resolves.toEqual(zendeskTools);
+    expect(mockedCreateToolProviders).toHaveBeenCalledWith(configs, undefined);
   });
 
-  it('passes the logger to McpClient', async () => {
-    const customLogger: Logger = jest.fn();
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue([]),
-          dispose: jest.fn(),
-        } as unknown as McpClient),
-    );
+  it('disposes the previously-loaded providers before loading new ones', async () => {
+    const firstDispose = jest.fn().mockResolvedValue(undefined);
+    const secondDispose = jest.fn().mockResolvedValue(undefined);
 
-    const client = new AiClient({ logger: customLogger });
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
+    mockedCreateToolProviders
+      .mockReturnValueOnce([mockProvider({ dispose: firstDispose })])
+      .mockReturnValueOnce([mockProvider({ dispose: secondDispose })]);
 
-    await client.loadRemoteTools(mcpConfig);
+    const client = new AiClient({});
+    await client.loadRemoteTools({});
+    await client.loadRemoteTools({});
 
-    expect(MockedMcpClient).toHaveBeenCalledWith(mcpConfig, customLogger);
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(secondDispose).not.toHaveBeenCalled();
+    expect(mockedCreateToolProviders).toHaveBeenCalledTimes(2);
   });
 
-  it('still creates a new client when closing the previous one fails', async () => {
-    const mockLogger = jest.fn();
+  it('passes the logger to createToolProviders', async () => {
+    const logger: Logger = jest.fn();
+    mockedCreateToolProviders.mockReturnValue([]);
+
+    const client = new AiClient({ logger });
+    await client.loadRemoteTools({});
+
+    expect(mockedCreateToolProviders).toHaveBeenCalledWith({}, logger);
+  });
+
+  it('logs and continues when disposing a previous provider fails', async () => {
+    const logger: Logger = jest.fn();
     const closeError = new Error('Close failed');
-    const fakeTools = [{ name: 'tool1' }];
 
-    jest
-      .mocked(McpClient)
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue([]),
-            dispose: jest.fn().mockRejectedValue(closeError),
-          } as unknown as McpClient),
-      )
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue(fakeTools),
-            dispose: jest.fn(),
-          } as unknown as McpClient),
-      );
+    mockedCreateToolProviders
+      .mockReturnValueOnce([mockProvider({ dispose: jest.fn().mockRejectedValue(closeError) })])
+      .mockReturnValueOnce([
+        mockProvider({ loadTools: jest.fn().mockResolvedValue([{ name: 'next' }]) }),
+      ]);
 
-    const client = new AiClient({ logger: mockLogger });
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
+    const client = new AiClient({ logger });
+    await client.loadRemoteTools({});
+    const result = await client.loadRemoteTools({});
 
-    await client.loadRemoteTools(mcpConfig);
-    const result = await client.loadRemoteTools(mcpConfig);
-
-    expect(result).toBe(fakeTools);
-    expect(MockedMcpClient).toHaveBeenCalledTimes(2);
-    expect(mockLogger).toHaveBeenCalledWith(
+    expect(result).toEqual([{ name: 'next' }]);
+    expect(logger).toHaveBeenCalledWith(
       'Error',
-      'Error closing previous MCP connection',
+      'Error closing previous remote tool connection',
       closeError,
     );
   });
 
-  it('wraps non-Error thrown values when closing previous client fails', async () => {
-    const mockLogger = jest.fn();
-
-    jest
-      .mocked(McpClient)
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue([]),
-            dispose: jest.fn().mockRejectedValue('string error'),
-          } as unknown as McpClient),
-      )
-      .mockImplementationOnce(
-        () =>
-          ({
-            loadTools: jest.fn().mockResolvedValue([]),
-            dispose: jest.fn(),
-          } as unknown as McpClient),
-      );
-
-    const client = new AiClient({ logger: mockLogger });
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
-
-    await client.loadRemoteTools(mcpConfig);
-    await client.loadRemoteTools(mcpConfig);
-
-    expect(mockLogger).toHaveBeenCalledWith(
-      'Error',
-      'Error closing previous MCP connection',
-      expect.objectContaining({ message: 'string error' }),
-    );
-  });
-
-  it('does not store mcpClient reference when loadTools fails', async () => {
-    const loadToolsError = new Error('loadTools failed');
-
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockRejectedValue(loadToolsError),
-          dispose: jest.fn(),
-        } as unknown as McpClient),
-    );
+  it('does not retain providers when loadTools fails', async () => {
+    const dispose = jest.fn().mockResolvedValue(undefined);
+    const loadError = new Error('loadTools failed');
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ loadTools: jest.fn().mockRejectedValue(loadError), dispose }),
+    ]);
 
     const client = new AiClient({});
-    const mcpConfig = { configs: { server1: { command: 'test', args: [] } } };
+    await expect(client.loadRemoteTools({})).rejects.toThrow(loadError);
 
-    await expect(client.loadRemoteTools(mcpConfig)).rejects.toThrow(loadToolsError);
-
-    // dispose should be a no-op since mcpClient was never stored
+    // closeConnections must be a no-op since providers were never stored.
     await expect(client.closeConnections()).resolves.toBeUndefined();
+    expect(dispose).not.toHaveBeenCalled();
   });
 });
 
@@ -313,95 +269,79 @@ describe('closeConnections', () => {
     jest.clearAllMocks();
   });
 
-  it('closes the McpClient', async () => {
-    const disposeMock = jest.fn();
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue([]),
-          dispose: disposeMock,
-        } as unknown as McpClient),
-    );
+  it('disposes every stored provider', async () => {
+    const firstDispose = jest.fn().mockResolvedValue(undefined);
+    const secondDispose = jest.fn().mockResolvedValue(undefined);
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ dispose: firstDispose }),
+      mockProvider({ dispose: secondDispose }),
+    ]);
 
     const client = new AiClient({});
-    await client.loadRemoteTools({ configs: { server1: { command: 'test', args: [] } } });
+    await client.loadRemoteTools({});
 
     await client.closeConnections();
 
-    expect(disposeMock).toHaveBeenCalledTimes(1);
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(secondDispose).toHaveBeenCalledTimes(1);
   });
 
-  it('is a no-op when no McpClient exists', async () => {
+  it('is a no-op when no providers have been loaded', async () => {
     const client = new AiClient({});
 
     await expect(client.closeConnections()).resolves.toBeUndefined();
   });
 
-  it('logs error and clears reference when dispose throws', async () => {
-    const mockLogger = jest.fn();
+  it('logs and clears the reference when dispose throws', async () => {
+    const logger: Logger = jest.fn();
     const closeError = new Error('close failed');
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue([]),
-          dispose: jest.fn().mockRejectedValue(closeError),
-        } as unknown as McpClient),
-    );
+    const dispose = jest.fn().mockRejectedValue(closeError);
+    mockedCreateToolProviders.mockReturnValue([mockProvider({ dispose })]);
 
-    const client = new AiClient({ logger: mockLogger });
-    await client.loadRemoteTools({ configs: { server1: { command: 'test', args: [] } } });
+    const client = new AiClient({ logger });
+    await client.loadRemoteTools({});
 
-    // Should not throw — error is caught and logged
     await client.closeConnections();
 
-    expect(mockLogger).toHaveBeenCalledWith(
+    expect(logger).toHaveBeenCalledWith(
       'Error',
-      'Error during MCP connection cleanup',
+      'Error during remote tool connection cleanup',
       closeError,
     );
 
-    // Second call should be a no-op (reference cleared in finally block)
+    // Second call is a no-op because the reference was cleared.
     await expect(client.closeConnections()).resolves.toBeUndefined();
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('wraps non-Error thrown values during cleanup', async () => {
-    const mockLogger = jest.fn();
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue([]),
-          dispose: jest.fn().mockRejectedValue('string error'),
-        } as unknown as McpClient),
-    );
+  it('wraps non-Error rejections during cleanup', async () => {
+    const logger: Logger = jest.fn();
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ dispose: jest.fn().mockRejectedValue('string error') }),
+    ]);
 
-    const client = new AiClient({ logger: mockLogger });
-    await client.loadRemoteTools({ configs: { server1: { command: 'test', args: [] } } });
+    const client = new AiClient({ logger });
+    await client.loadRemoteTools({});
 
     await client.closeConnections();
 
-    expect(mockLogger).toHaveBeenCalledWith(
+    expect(logger).toHaveBeenCalledWith(
       'Error',
-      'Error during MCP connection cleanup',
+      'Error during remote tool connection cleanup',
       expect.objectContaining({ message: 'string error' }),
     );
   });
 
   it('is safe to call twice', async () => {
-    const disposeMock = jest.fn();
-    jest.mocked(McpClient).mockImplementation(
-      () =>
-        ({
-          loadTools: jest.fn().mockResolvedValue([]),
-          dispose: disposeMock,
-        } as unknown as McpClient),
-    );
+    const dispose = jest.fn().mockResolvedValue(undefined);
+    mockedCreateToolProviders.mockReturnValue([mockProvider({ dispose })]);
 
     const client = new AiClient({});
-    await client.loadRemoteTools({ configs: { server1: { command: 'test', args: [] } } });
+    await client.loadRemoteTools({});
 
     await client.closeConnections();
     await client.closeConnections();
 
-    expect(disposeMock).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/workflow-executor/src/adapters/ai-client-adapter.ts
+++ b/packages/workflow-executor/src/adapters/ai-client-adapter.ts
@@ -1,5 +1,5 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { AiConfiguration, McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { AiConfiguration, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AiClient } from '@forestadmin/ai-proxy';
@@ -23,8 +23,8 @@ export default class AiClientAdapter implements AiModelPort {
     }
   }
 
-  loadRemoteTools(config: McpConfiguration): Promise<RemoteTool[]> {
-    return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(config));
+  loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
+    return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(configs));
   }
 
   closeConnections(): Promise<void> {

--- a/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
+++ b/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
@@ -1,5 +1,5 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AiModelPortError } from '../errors';
@@ -19,7 +19,7 @@ export default class AlwaysErrorAiModelPort implements AiModelPort {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  loadRemoteTools(_config: McpConfiguration): Promise<RemoteTool[]> {
+  loadRemoteTools(_configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
     return Promise.resolve([]);
   }
 

--- a/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
+++ b/packages/workflow-executor/src/adapters/forest-server-workflow-port.ts
@@ -4,12 +4,12 @@ import type {
   AvailableRunDispatch,
   AvailableRunsBatch,
   MalformedRunInfo,
-  McpServers,
   WorkflowPort,
 } from '../ports/workflow-port';
 import type { StepUser } from '../types/execution-context';
 import type { CollectionSchema } from '../types/validated/collection';
 import type { StepOutcome } from '../types/validated/step-outcome';
+import type { ToolConfig } from '@forestadmin/ai-proxy';
 import type { HttpOptions } from '@forestadmin/forestadmin-client';
 
 import { ServerUtils } from '@forestadmin/forestadmin-client';
@@ -203,10 +203,11 @@ export default class ForestServerWorkflowPort implements WorkflowPort {
     );
   }
 
-  async getMcpServerConfigs(): Promise<McpServers> {
+  async getMcpServerConfigs(): Promise<Record<string, ToolConfig>> {
     return this.callPort(
       'getMcpServerConfigs',
-      () => ServerUtils.query<McpServers>(this.options, 'get', ROUTES.mcpServerConfigs),
+      () =>
+        ServerUtils.query<Record<string, ToolConfig>>(this.options, 'get', ROUTES.mcpServerConfigs),
       { retry: true },
     );
   }

--- a/packages/workflow-executor/src/adapters/server-ai-adapter.ts
+++ b/packages/workflow-executor/src/adapters/server-ai-adapter.ts
@@ -1,5 +1,5 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 import { AiClient } from '@forestadmin/ai-proxy';
@@ -50,8 +50,8 @@ export default class ServerAiAdapter implements AiModelPort {
     }
   }
 
-  loadRemoteTools(config: McpConfiguration): Promise<RemoteTool[]> {
-    return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(config));
+  loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
+    return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(configs));
   }
 
   closeConnections(): Promise<void> {

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -68,7 +68,7 @@ export type {
   Limit,
   UpdateRecordQuery,
 } from './ports/agent-port';
-export type { McpServers, WorkflowPort } from './ports/workflow-port';
+export type { WorkflowPort } from './ports/workflow-port';
 export type { RunStore } from './ports/run-store';
 export type { Logger } from './ports/logger-port';
 export { default as ConsoleLogger } from './adapters/console-logger';

--- a/packages/workflow-executor/src/ports/ai-model-port.ts
+++ b/packages/workflow-executor/src/ports/ai-model-port.ts
@@ -1,8 +1,8 @@
-import type { McpConfiguration, RemoteTool } from '@forestadmin/ai-proxy';
+import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 export interface AiModelPort {
   getModel(aiConfigName?: string): BaseChatModel;
-  loadRemoteTools(config: McpConfiguration): Promise<RemoteTool[]>;
+  loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]>;
   closeConnections(): Promise<void>;
 }

--- a/packages/workflow-executor/src/ports/workflow-port.ts
+++ b/packages/workflow-executor/src/ports/workflow-port.ts
@@ -3,9 +3,7 @@
 import type { AvailableStepExecution, StepUser } from '../types/execution-context';
 import type { CollectionSchema } from '../types/validated/collection';
 import type { StepOutcome } from '../types/validated/step-outcome';
-import type { McpServers } from '@forestadmin/ai-proxy';
-
-export type { McpServers };
+import type { ToolConfig } from '@forestadmin/ai-proxy';
 
 export interface MalformedRunInfo {
   runId: string;
@@ -39,6 +37,6 @@ export interface WorkflowPort {
     stepOutcome: StepOutcome,
   ): Promise<AvailableRunDispatch | null>;
   getCollectionSchema(collectionName: string, runId: string): Promise<CollectionSchema>;
-  getMcpServerConfigs(): Promise<McpServers>;
+  getMcpServerConfigs(): Promise<Record<string, ToolConfig>>;
   hasRunAccess(runId: string, user: StepUser): Promise<boolean>;
 }

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -255,7 +255,7 @@ export default class Runner {
     const configs = await this.config.workflowPort.getMcpServerConfigs();
     if (Object.keys(configs).length === 0) return [];
 
-    return this.config.aiModelPort.loadRemoteTools({ configs });
+    return this.config.aiModelPort.loadRemoteTools(configs);
   }
 
   private executeStep(

--- a/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
@@ -37,11 +37,11 @@ describe('AiClientAdapter', () => {
 
   it('delegates loadRemoteTools to AiClient', async () => {
     const adapter = new AiClientAdapter([]);
-    const config = { configs: {} };
+    const configs = {};
 
-    await adapter.loadRemoteTools(config);
+    await adapter.loadRemoteTools(configs);
 
-    expect(mockLoadRemoteTools).toHaveBeenCalledWith(config);
+    expect(mockLoadRemoteTools).toHaveBeenCalledWith(configs);
   });
 
   it('delegates closeConnections to AiClient', async () => {

--- a/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
@@ -68,7 +68,7 @@ describe('ServerAiAdapter', () => {
 
   describe('loadRemoteTools', () => {
     it('delegates to internal AiClient', async () => {
-      const result = await adapter.loadRemoteTools({ configs: {} });
+      const result = await adapter.loadRemoteTools({});
 
       expect(result).toEqual([]);
     });

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1155,7 +1155,7 @@ describe('MCP lazy loading (via once thunk)', () => {
     expect(aiClient.loadRemoteTools).not.toHaveBeenCalled();
   });
 
-  it('wraps the orchestrator Record-shape configs as { configs } and calls loadRemoteTools once', async () => {
+  it('passes the orchestrator Record-shape configs directly to loadRemoteTools', async () => {
     const workflowPort = createMockWorkflowPort();
     const aiClient = createMockAiClient();
     const step = makePendingStep({
@@ -1179,7 +1179,7 @@ describe('MCP lazy loading (via once thunk)', () => {
 
     expect(workflowPort.getMcpServerConfigs).toHaveBeenCalledTimes(1);
     expect(aiClient.loadRemoteTools).toHaveBeenCalledTimes(1);
-    expect(aiClient.loadRemoteTools).toHaveBeenCalledWith({ configs: realConfigs });
+    expect(aiClient.loadRemoteTools).toHaveBeenCalledWith(realConfigs);
   });
 
   it('skips loadRemoteTools when the orchestrator returns an empty Record', async () => {


### PR DESCRIPTION
## Summary

- `AiClient.loadRemoteTools` now delegates to `createToolProviders` (same path as `Router` and `ToolSourceChecker`), so Forest-hosted connectors (Zendesk, Kolar, Snowflake) are routed to `ForestIntegrationClient` instead of being forwarded to `MultiServerMCPClient`.
- Before this fix, any workflow run whose `getMcpServerConfigs()` response included a Forest connector crashed at step setup with `ZodError invalid_union mcpServers.<name>` — Forest connector entries have neither `command`+`args` (stdio) nor `url` (HTTP), so the `@langchain/mcp-adapters` schema rejected them.
- Propagates the cleaner `Record<string, ToolConfig>` shape through `AiModelPort`, the three adapters (`ServerAiAdapter`, `AiClientAdapter`, `AlwaysErrorAiModelPort`), `Runner.fetchRemoteTools` (drops the now-redundant `{ configs }` wrapping), and `WorkflowPort.getMcpServerConfigs` (was mistyped as `McpServers` while the orchestrator already returns a mixed record).

Fixes [PRD-400](https://linear.app/forestadmin/issue/PRD-400/workflow-executor-forest-connectors-zendeskkolarsnowflake-crash).

## Test plan

- [x] `yarn workspace @forestadmin/ai-proxy test` — 400 passing (new regression test in `ai-client.test.ts` covers Forest connector configs lacking MCP transport fields).
- [x] `yarn workspace @forestadmin/workflow-executor test` — 786 passing.
- [x] `yarn workspace @forestadmin/ai-proxy lint && yarn workspace @forestadmin/workflow-executor lint` — clean (preexisting warnings only).
- [x] `yarn workspace @forestadmin/ai-proxy build && yarn workspace @forestadmin/workflow-executor build` — clean.
- [ ] Smoke test against the dev orchestrator with a workflow that has a Zendesk step: the executor must load the Zendesk tools and the step must reach AI selection without the Zod crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Forest connectors via a generic tool-provider split in `AiClient`
> - Replaces the single `McpClient` field in `AiClient` with a `toolProviders` array, allowing multiple provider kinds (e.g. MCP and Forest) to be loaded together via `createToolProviders`.
> - `loadRemoteTools` now accepts `Record<string, ToolConfig>` instead of `McpConfiguration`, creates providers for each config entry, flattens their tools, and disposes any previously loaded providers before replacing them.
> - All port interfaces (`AiModelPort`, `WorkflowPort`) and adapters are updated to use `Record<string, ToolConfig>` end-to-end, removing the `McpServers` wrapper type.
> - `disposeToolProviders` uses `Promise.allSettled` to isolate per-provider failures and log each rejection individually without interrupting others.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc1305.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->