### PR TITLE
fix(workflow-executor): accept numeric value in update-record confirmation

### DIFF
--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 const updateRecordPatchSchema = z
   .object({
     userConfirmed: z.boolean(),
-    value: z.string().optional(), // user may override the AI-proposed value
+    value: z.union([z.string(), z.number()]).optional(), // user may override the AI-proposed value
   })
   .strict();
 

--- a/packages/workflow-executor/test/http/pending-data-validators.test.ts
+++ b/packages/workflow-executor/test/http/pending-data-validators.test.ts
@@ -22,6 +22,63 @@ describe('patchBodySchemas', () => {
     });
   });
 
+  describe('update-record', () => {
+    const schema = patchBodySchemas['update-record'];
+    if (!schema) throw new Error('update-record schema not registered');
+
+    it('accepts { userConfirmed: true } without value (AI-proposed value kept)', () => {
+      expect(schema.parse({ userConfirmed: true })).toEqual({ userConfirmed: true });
+    });
+
+    it('accepts string value override', () => {
+      expect(schema.parse({ userConfirmed: true, value: 'new' })).toEqual({
+        userConfirmed: true,
+        value: 'new',
+      });
+    });
+
+    it('accepts number value override', () => {
+      expect(schema.parse({ userConfirmed: true, value: 42 })).toEqual({
+        userConfirmed: true,
+        value: 42,
+      });
+    });
+
+    it('accepts empty string value', () => {
+      expect(schema.parse({ userConfirmed: true, value: '' })).toEqual({
+        userConfirmed: true,
+        value: '',
+      });
+    });
+
+    it('accepts zero value', () => {
+      expect(schema.parse({ userConfirmed: true, value: 0 })).toEqual({
+        userConfirmed: true,
+        value: 0,
+      });
+    });
+
+    it('rejects boolean value', () => {
+      expect(() => schema.parse({ userConfirmed: true, value: true })).toThrow();
+    });
+
+    it('rejects null value', () => {
+      expect(() => schema.parse({ userConfirmed: true, value: null })).toThrow();
+    });
+
+    it('rejects object value', () => {
+      expect(() => schema.parse({ userConfirmed: true, value: { foo: 'bar' } })).toThrow();
+    });
+
+    it('rejects missing userConfirmed', () => {
+      expect(() => schema.parse({ value: 'x' })).toThrow();
+    });
+
+    it('rejects unknown fields (strict schema)', () => {
+      expect(() => schema.parse({ userConfirmed: true, value: 'x', extra: 'leak' })).toThrow();
+    });
+  });
+
   describe('trigger-action', () => {
     const schema = patchBodySchemas['trigger-action'];
     if (!schema) throw new Error('trigger-action schema not registered');


### PR DESCRIPTION
## Summary
- `updateRecordPatchSchema.value` accepts `string | number` (was string-only) so the front can override AI-proposed numeric values without coercion.
- Adds 11 schema tests covering string/number/empty/zero accept paths and boolean/null/object/missing/unknown reject paths.

## Test plan
- [x] `yarn workspace @forestadmin/workflow-executor test test/http/pending-data-validators.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `update-record` patch validator to accept numeric values for `value`
> The `updateRecordPatchSchema` in [pending-data-validators.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1600/files#diff-3ea7ed8e1b0fbeae14884ba0498905c951e4a071e80bac7cb8408ab76d912198) previously only accepted strings for the `value` field, rejecting numeric inputs. The field type is broadened to `z.union([z.string(), z.number()]).optional()`. New tests cover string, number, empty string, and zero overrides, as well as rejection of booleans, null, and objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da9427b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->