### PR TITLE
fix(workflow-executor): always log WorkflowExecutorError message, even without cause

### DIFF
--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -80,13 +80,11 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
       }
 
       if (error instanceof WorkflowExecutorError) {
-        if (error.cause !== undefined) {
-          this.context.logger.error(error.message, {
-            ...this.logCtx,
-            cause: extractErrorMessage(error.cause),
-            stack: error.cause instanceof Error ? error.cause.stack : undefined,
-          });
-        }
+        this.context.logger.error(error.message, {
+          ...this.logCtx,
+          cause: extractErrorMessage(error.cause),
+          stack: error.cause instanceof Error ? error.cause.stack : undefined,
+        });
 
         return this.buildOutcomeResult({ status: 'error', error: error.userMessage });
       }

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -340,11 +340,15 @@ describe('BaseStepExecutor', () => {
       );
     });
 
-    it('does not log when WorkflowExecutorError has no cause', async () => {
+    it('logs error.message even when WorkflowExecutorError has no cause', async () => {
       const logger = makeMockLogger();
-      const executor = new TestableExecutor(makeContext({ logger }), new MissingToolCallError());
+      const err = new MissingToolCallError();
+      const executor = new TestableExecutor(makeContext({ logger }), err);
       await executor.execute();
-      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        err.message,
+        expect.not.objectContaining({ cause: expect.anything() }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- `WorkflowExecutorError` thrown without a `cause` (e.g. Zod validation failure on `pendingData`) was silently swallowed — no log on the executor side
- Now always logs `error.message`; `cause` and `stack` are appended when present

## Test plan
- [ ] `base-step-executor.test.ts` updated: verifies `logger.error` is called with the error message even when no cause is set
- [ ] 791 tests passing

fixes PRD-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BaseStepExecutor` to always log `WorkflowExecutorError` message even without a cause
> Previously, `WorkflowExecutorError` instances without a `cause` were silently swallowed — no error log was emitted. The fix removes the conditional guard in [`base-step-executor.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1601/files#diff-f2629617b13363027748d444be5374dd404d26c2f031b0b1a967cceb01d6c6d9) so `logger.error` is always called with `error.message`. When a cause is present, logging behavior is unchanged (message, cause, stack).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 347f1f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->