### PR TITLE
fix(workflow-executor): self-descriptive log messages for activity log operations

### DIFF
--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -24,7 +24,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
   async createPending(args: CreateActivityLogArgs): Promise<ActivityLogHandle> {
     try {
       const response = await withRetry(
-        'Activity log createPending',
+        'activity log create',
         () =>
           this.service.createActivityLog({
             forestServerToken: this.forestServerToken,
@@ -42,7 +42,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
 
       return { id: response.id, index: response.attributes.index };
     } catch (cause) {
-      this.logger.error('Failed to create activity log', {
+      this.logger.error('activity log create failed', {
         action: args.action,
         collectionId: args.collectionId,
         status: (cause as { status?: number }).status,
@@ -56,7 +56,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
     return this.drainer.track(async () => {
       try {
         await withRetry(
-          'Activity log markSucceeded',
+          'activity log mark-as-completed',
           () =>
             this.service.updateActivityLogStatus({
               forestServerToken: this.forestServerToken,
@@ -66,7 +66,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
-        this.logger.error('Failed to mark activity log as succeeded', {
+        this.logger.error('activity log mark-as-completed failed', {
           handleId: handle.id,
           error: extractErrorMessage(err),
         });
@@ -78,7 +78,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
     return this.drainer.track(async () => {
       try {
         await withRetry(
-          'Activity log markFailed',
+          'activity log mark-as-failed',
           () =>
             this.service.updateActivityLogStatus({
               forestServerToken: this.forestServerToken,
@@ -88,7 +88,7 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
-        this.logger.error('Failed to mark activity log as failed', {
+        this.logger.error('activity log mark-as-failed failed', {
           handleId: handle.id,
           stepErrorMessage: errorMessage,
           error: extractErrorMessage(err),

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -78,7 +78,7 @@ describe('ForestadminClientActivityLogPort', () => {
       expect(handle).toEqual({ id: 'log-2', index: '1' });
       expect(service.createActivityLog).toHaveBeenCalledTimes(2);
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('createPending'),
+        expect.stringContaining('activity log create'),
         expect.objectContaining({ attempt: 1 }),
       );
     });
@@ -194,7 +194,7 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        'Failed to mark activity log as succeeded',
+        'activity log mark-as-completed failed',
         expect.objectContaining({ handleId: 'log-1' }),
       );
     });
@@ -246,7 +246,7 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(2_600);
       await expect(promise).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalledWith(
-        'Failed to mark activity log as failed',
+        'activity log mark-as-failed failed',
         expect.objectContaining({
           handleId: 'log-1',
           stepErrorMessage: 'step-error-msg',


### PR DESCRIPTION
## Summary
- Replaced opaque `Activity log markSucceeded` / `Activity log markFailed` / `Activity log createPending` labels with self-descriptive messages readable without field inspection
- Pattern: `activity log <operation> failed` for errors, `"activity log <operation>" failed, retrying` for retries

Before:
```
warn: "Activity log markSucceeded" failed, retrying
error: Failed to mark activity log as succeeded
```
After:
```
warn: "activity log mark-as-completed" failed, retrying
error: activity log mark-as-completed failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize log message format for activity log operations in workflow-executor
> Updates the `withRetry` operation labels and error log messages in `ForestadminClientActivityLogPort` to use a consistent lowercase hyphenated format (e.g. `activity log create`, `activity log mark-as-completed failed`) instead of the previous mixed-case camelCase style. Test expectations in the corresponding test file are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b46209a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->