### PR TITLE
fix(workflow-executor): merge leading SystemMessages for Anthropic compat

### DIFF
--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -150,6 +150,12 @@ export class InvalidAIResponseError extends WorkflowExecutorError {
   }
 }
 
+export class InvalidAiRequestError extends WorkflowExecutorError {
+  constructor(message: string) {
+    super(message, 'Step configuration error — please contact your administrator.');
+  }
+}
+
 export class RelationNotFoundError extends WorkflowExecutorError {
   constructor(name: string, collectionName: string) {
     super(

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -291,12 +291,44 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     return [new SystemMessage(summary)];
   }
 
+  private static mergeLeadingSystemMessages(messages: BaseMessage[]): BaseMessage[] {
+    let i = 0;
+    while (i < messages.length && messages[i]._getType() === 'system') i += 1;
+    if (i <= 1) return messages;
+
+    const merged = new SystemMessage(
+      messages
+        .slice(0, i)
+        .map(m => String(m.content))
+        .join('\n\n'),
+    );
+
+    return [merged, ...messages.slice(i)];
+  }
+
+  private static assertNoMidArraySystemMessages(messages: BaseMessage[]): void {
+    let seenNonSystem = false;
+
+    for (const msg of messages) {
+      if (msg._getType() !== 'system') {
+        seenNonSystem = true;
+      } else if (seenNonSystem) {
+        throw new Error(
+          'Invariant violation: SystemMessage after a non-system message — Anthropic rejects this payload. Move all system context to the front of the messages array.',
+        );
+      }
+    }
+  }
+
   protected async invokeWithTools<T = Record<string, unknown>>(
     messages: BaseMessage[],
     tools: StructuredToolInterface[],
   ): Promise<{ toolName: string; args: T }> {
+    BaseStepExecutor.assertNoMidArraySystemMessages(messages);
     const modelWithTools = this.context.model.bindTools(tools, { tool_choice: 'any' });
-    const response = await modelWithTools.invoke(messages);
+    const response = await modelWithTools.invoke(
+      BaseStepExecutor.mergeLeadingSystemMessages(messages),
+    );
     const toolCall = response.tool_calls?.[0];
 
     if (toolCall !== undefined) {

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -293,7 +293,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
 
   private static mergeLeadingSystemMessages(messages: BaseMessage[]): BaseMessage[] {
     let i = 0;
-    while (i < messages.length && messages[i]._getType() === 'system') i += 1;
+    while (i < messages.length && messages[i] instanceof SystemMessage) i += 1;
     if (i <= 1) return messages;
 
     const merged = new SystemMessage(
@@ -310,7 +310,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     let seenNonSystem = false;
 
     for (const msg of messages) {
-      if (msg._getType() !== 'system') {
+      if (!(msg instanceof SystemMessage)) {
         seenNonSystem = true;
       } else if (seenNonSystem) {
         throw new Error(

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -17,6 +17,7 @@ import type {
 import { SystemMessage } from '@forestadmin/ai-proxy';
 
 import {
+  InvalidAiRequestError,
   MalformedToolCallError,
   MissingToolCallError,
   StepStateError,
@@ -299,7 +300,8 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     const merged = new SystemMessage(
       messages
         .slice(0, i)
-        .map(m => String(m.content))
+        .map(m => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)))
+        .filter(Boolean)
         .join('\n\n'),
     );
 
@@ -309,12 +311,12 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   private static assertNoMidArraySystemMessages(messages: BaseMessage[]): void {
     let seenNonSystem = false;
 
-    for (const msg of messages) {
-      if (!(msg instanceof SystemMessage)) {
+    for (let i = 0; i < messages.length; i += 1) {
+      if (!(messages[i] instanceof SystemMessage)) {
         seenNonSystem = true;
       } else if (seenNonSystem) {
-        throw new Error(
-          'Invariant violation: SystemMessage after a non-system message — Anthropic rejects this payload. Move all system context to the front of the messages array.',
+        throw new InvalidAiRequestError(
+          `SystemMessage at position ${i} appears after a non-system message — move all system context to the front of the messages array.`,
         );
       }
     }

--- a/packages/workflow-executor/src/index.ts
+++ b/packages/workflow-executor/src/index.ts
@@ -86,6 +86,7 @@ export {
   NoRelationshipFieldsError,
   RelatedRecordNotFoundError,
   InvalidAIResponseError,
+  InvalidAiRequestError,
   RelationNotFoundError,
   FieldNotFoundError,
   ActionNotFoundError,

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -8,7 +8,7 @@ import type { StepDefinition } from '../../src/types/validated/step-definition';
 import type { BaseStepStatus, StepOutcome } from '../../src/types/validated/step-outcome';
 import type { BaseMessage, DynamicStructuredTool } from '@forestadmin/ai-proxy';
 
-import { SystemMessage } from '@forestadmin/ai-proxy';
+import { HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
 
 import {
   MalformedToolCallError,
@@ -789,10 +789,6 @@ describe('BaseStepExecutor', () => {
     });
 
     describe('SystemMessage handling for Anthropic compat', () => {
-      const { HumanMessage } = jest.requireActual<typeof import('@forestadmin/ai-proxy')>(
-        '@forestadmin/ai-proxy',
-      );
-
       it('merges multiple leading SystemMessages into a single one', async () => {
         const { model, invoke } = makeMockModel({
           tool_calls: [{ name: 'tool', args: {}, id: 'c1' }],

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -787,6 +787,73 @@ describe('BaseStepExecutor', () => {
         'AI returned a malformed tool call for "unknown": Something broke',
       );
     });
+
+    describe('SystemMessage handling for Anthropic compat', () => {
+      const { HumanMessage } = jest.requireActual<typeof import('@forestadmin/ai-proxy')>(
+        '@forestadmin/ai-proxy',
+      );
+
+      it('merges multiple leading SystemMessages into a single one', async () => {
+        const { model, invoke } = makeMockModel({
+          tool_calls: [{ name: 'tool', args: {}, id: 'c1' }],
+        });
+        const executor = new TestableExecutor(makeContext({ model }));
+        const messages = [
+          new SystemMessage('context'),
+          new SystemMessage('previous steps'),
+          new SystemMessage('step prompt'),
+          new HumanMessage('request'),
+        ];
+
+        await executor.invokeWithTool(messages, dummyTool);
+
+        const passedMessages = invoke.mock.calls[0][0] as BaseMessage[];
+        expect(passedMessages).toHaveLength(2);
+        expect(passedMessages[0]).toBeInstanceOf(SystemMessage);
+        expect(passedMessages[0].content).toBe('context\n\nprevious steps\n\nstep prompt');
+        expect(passedMessages[1]).toBeInstanceOf(HumanMessage);
+      });
+
+      it('leaves messages unchanged when only one leading SystemMessage', async () => {
+        const { model, invoke } = makeMockModel({
+          tool_calls: [{ name: 'tool', args: {}, id: 'c1' }],
+        });
+        const executor = new TestableExecutor(makeContext({ model }));
+        const messages = [new SystemMessage('only system'), new HumanMessage('request')];
+
+        await executor.invokeWithTool(messages, dummyTool);
+
+        expect(invoke).toHaveBeenCalledWith(messages);
+      });
+
+      it('leaves messages unchanged when there is no SystemMessage', async () => {
+        const { model, invoke } = makeMockModel({
+          tool_calls: [{ name: 'tool', args: {}, id: 'c1' }],
+        });
+        const executor = new TestableExecutor(makeContext({ model }));
+        const messages = [new HumanMessage('only human')];
+
+        await executor.invokeWithTool(messages, dummyTool);
+
+        expect(invoke).toHaveBeenCalledWith(messages);
+      });
+
+      it('throws when a SystemMessage appears after a non-system message', async () => {
+        const { model } = makeMockModel({
+          tool_calls: [{ name: 'tool', args: {}, id: 'c1' }],
+        });
+        const executor = new TestableExecutor(makeContext({ model }));
+        const messages = [
+          new SystemMessage('leading'),
+          new HumanMessage('request'),
+          new SystemMessage('mid-array (invalid for Anthropic)'),
+        ];
+
+        await expect(executor.invokeWithTool(messages, dummyTool)).rejects.toThrow(
+          /Invariant violation.*SystemMessage after a non-system message/,
+        );
+      });
+    });
   });
 
   describe('patchAndReloadPendingData', () => {

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -11,6 +11,7 @@ import type { BaseMessage, DynamicStructuredTool } from '@forestadmin/ai-proxy';
 import { HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
 
 import {
+  InvalidAiRequestError,
   MalformedToolCallError,
   MissingToolCallError,
   NoRecordsError,
@@ -846,7 +847,10 @@ describe('BaseStepExecutor', () => {
         ];
 
         await expect(executor.invokeWithTool(messages, dummyTool)).rejects.toThrow(
-          /Invariant violation.*SystemMessage after a non-system message/,
+          InvalidAiRequestError,
+        );
+        await expect(executor.invokeWithTool(messages, dummyTool)).rejects.toThrow(
+          /SystemMessage at position 2 appears after a non-system message/,
         );
       });
     });

--- a/packages/workflow-executor/test/executors/condition-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/condition-step-executor.test.ts
@@ -156,11 +156,11 @@ describe('ConditionStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      expect(messages).toHaveLength(3);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('workflow gateway decision');
-      expect(messages[1].content).toContain('80% confident');
-      expect(messages[2].content).toBe('**Question**: Custom prompt for this step');
+      expect(messages[0].content).toContain('workflow gateway decision');
+      expect(messages[0].content).toContain('80% confident');
+      expect(messages[1].content).toBe('**Question**: Custom prompt for this step');
     });
 
     it('uses default question when step.prompt is undefined', async () => {
@@ -226,12 +226,12 @@ describe('ConditionStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      expect(messages).toHaveLength(4);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Previous question');
-      expect(messages[1].content).toContain('"answer":"Yes"');
-      expect(messages[2].content).toContain('workflow gateway decision');
-      expect(messages[3].content).toContain('**Question**');
+      expect(messages[0].content).toContain('Previous question');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[0].content).toContain('workflow gateway decision');
+      expect(messages[1].content).toContain('**Question**');
     });
   });
 

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -1587,12 +1587,11 @@ describe('LoadRelatedRecordStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      // context + previous steps message + system prompt + collection info + human message = 5
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Should we proceed?');
-      expect(messages[1].content).toContain('"answer":"Yes"');
-      expect(messages[2].content).toContain('loading a related record');
+      expect(messages[0].content).toContain('Should we proceed?');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[0].content).toContain('loading a related record');
     });
   });
 

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -938,10 +938,9 @@ describe('McpStepExecutor', () => {
       await executor.execute();
 
       const messages = modelInvoke.mock.calls[0][0];
-      // context + previous steps message + system prompt + human message = 4
-      expect(messages).toHaveLength(4);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Should we send a notification?');
+      expect(messages[0].content).toContain('Should we send a notification?');
     });
   });
 

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -424,12 +424,11 @@ describe('ReadRecordStepExecutor', () => {
       const readTool = bindTools.mock.calls[1][0][0];
       expect(readTool.name).toBe('read-selected-record-fields');
 
-      // Record selection includes previous steps context + system prompt + user prompt
       const selectMessages = invoke.mock.calls[0][0];
-      expect(selectMessages).toHaveLength(3);
+      expect(selectMessages).toHaveLength(2);
       expect(selectMessages[0].content).toContain('Step executed by');
-      expect(selectMessages[1].content).toContain('selecting the most relevant record');
-      expect(selectMessages[2].content).toContain('Read the customer email');
+      expect(selectMessages[0].content).toContain('selecting the most relevant record');
+      expect(selectMessages[1].content).toContain('Read the customer email');
 
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -826,12 +825,11 @@ describe('ReadRecordStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      // context + previous steps summary + system prompt + collection info + human message = 5
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Should we proceed?');
-      expect(messages[1].content).toContain('"answer":"Yes"');
-      expect(messages[2].content).toContain('reading fields from a record');
+      expect(messages[0].content).toContain('Should we proceed?');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[0].content).toContain('reading fields from a record');
     });
   });
 

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -1038,12 +1038,11 @@ describe('TriggerRecordActionStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      // context + previous steps message + system prompt + collection info + human message = 5
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Should we proceed?');
-      expect(messages[1].content).toContain('"answer":"Yes"');
-      expect(messages[2].content).toContain('triggering an action');
+      expect(messages[0].content).toContain('Should we proceed?');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[0].content).toContain('triggering an action');
     });
   });
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1089,12 +1089,11 @@ describe('UpdateRecordStepExecutor', () => {
       await executor.execute();
 
       const messages = mockModel.invoke.mock.calls[0][0];
-      // context + previous steps summary + system prompt + collection info + human message = 5
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('Step executed by');
-      expect(messages[1].content).toContain('Should we proceed?');
-      expect(messages[1].content).toContain('"answer":"Yes"');
-      expect(messages[2].content).toContain('updating a field on a record');
+      expect(messages[0].content).toContain('Should we proceed?');
+      expect(messages[0].content).toContain('"answer":"Yes"');
+      expect(messages[0].content).toContain('updating a field on a record');
     });
   });
 


### PR DESCRIPTION
## Summary

When using `AI_PROVIDER=anthropic`, every AI-powered step crashed with:
\`\`\`
Error: System messages are only permitted as the first passed message.
\`\`\`

Anthropic's LangChain adapter extracts \`messages[0]\` as the \`system\` param and throws on any subsequent \`SystemMessage\`. OpenAI accepts them anywhere — that's why this only surfaced with Anthropic.

Every executor builds prompts as:
- \`buildContextMessage()\` — \`SystemMessage\`
- \`buildPreviousStepsMessages()\` — \`SystemMessage[]\`
- step-specific \`SystemMessage\` (\`GATEWAY_SYSTEM_PROMPT\`, \`READ_RECORD_SYSTEM_PROMPT\`, etc.)
- \`HumanMessage(prompt)\`

so the array starts with 2..N consecutive \`SystemMessage\`s. With Anthropic that crashes every step.

## Fix

Two static helpers added to \`BaseStepExecutor\`, called in \`invokeWithTools\` before passing messages to the model:

- **\`mergeLeadingSystemMessages\`** — joins consecutive leading \`SystemMessage\`s with blank lines into a single one. Preserves the context separation, no truncation. No change in individual executors.
- **\`assertNoMidArraySystemMessages\`** — throws an invariant violation if a \`SystemMessage\` appears after a non-system message. The merge only covers leading ones; a mid-array \`SystemMessage\` would still crash with Anthropic. Surfacing it as a developer error here is safer than letting it leak to the provider.

## Test plan

- [x] New tests in \`base-step-executor.test.ts\` covering: merge of multiple leading SystemMessages, pass-through for single SystemMessage, pass-through for no SystemMessage, invariant violation for mid-array SystemMessage.
- [x] \`base-step-executor.test.ts\` — 39/39 pass (35 existing + 4 new).
- [x] Verified live with \`AI_PROVIDER=anthropic\` + \`AI_MODEL=claude-sonnet-4-6\` on the \`_example\` agent: Get Data step now fetches successfully where it previously crashed.

fixes PRD-413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge leading SystemMessages in `BaseStepExecutor` for Anthropic compatibility
> - Adds `mergeLeadingSystemMessages` to consolidate consecutive leading `SystemMessage` instances into one before model invocation, satisfying Anthropic's message format requirements.
> - Adds `assertNoMidArraySystemMessages` to throw synchronously if a `SystemMessage` appears after any non-system message in the array.
> - Both helpers are called in `invokeWithTools` before binding and invoking the model.
> - Behavioral Change: executor tests across multiple step types now expect fewer messages (merged system context in the first message), reflecting the new consolidation behavior.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1604 opened
>
> - Modified system message handling in `BaseStepExecutor` to merge leading `SystemMessage` instances by serializing non-string content with `JSON.stringify`, filtering out falsy values, and throwing `InvalidAiRequestError` with position-specific details when a `SystemMessage` appears after non-system messages [44fd961]
> - Added `InvalidAiRequestError` class to `workflow-executor` package as a new `WorkflowExecutorError` subclass and exported it from the package root [44fd961]
> - Updated test suite to import and expect `InvalidAiRequestError` when validating system message positioning and updated error message regex expectations [44fd961]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66ca13a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->