### PR TITLE
chore(security): patch 3 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,9 @@
     "@hono/node-server": "^1.19.13",
     "langsmith": "^0.6.0",
     "lodash": "^4.18.0",
-    "**/@langchain/langgraph-sdk/uuid": "^13.0.1",
-    "**/socks/ip-address": "^10.1.1",
     "**/express-rate-limit/ip-address": "^10.1.1",
     "**/@aws-sdk/xml-builder/fast-xml-parser": "^5.7.0",
-    "**/@modelcontextprotocol/sdk/hono": "^4.12.18",
-    "**/ajv/fast-uri": "^3.1.2"
+    "**/@fastify/ajv-compiler/fast-uri": "^3.1.2",
+    "**/fast-json-stringify/fast-uri": "^3.1.2"
   }
 }

--- a/packages/forest-cloud/package.json
+++ b/packages/forest-cloud/package.json
@@ -24,7 +24,7 @@
     "joi": "^17.12.2",
     "ora": "^3.2.0",
     "subscriptions-transport-ws": "^0.9.19",
-    "ws": "^8.16.0"
+    "ws": "^8.20.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8337,12 +8337,7 @@ fast-safe-stringify@2.1.1, fast-safe-stringify@^2.0.7, fast-safe-stringify@^2.0.
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-uri@^2.0.0, fast-uri@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.3.0.tgz#bdae493942483d299e7285dcb4627767d42e2793"
-  integrity sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==
-
-fast-uri@^3.0.1, fast-uri@^3.1.2:
+fast-uri@^2.0.0, fast-uri@^2.1.0, fast-uri@^3.0.1, fast-uri@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
@@ -17733,10 +17728,10 @@ write-pkg@4.0.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.16.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@^8.20.1:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-naming@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

3 fixed, 1 ignored, 4 deferred, 2 resolutions added, 4 resolutions removed. | label: :lock: security applied

## Fixed

| Done | Alert | Package | Ecosystem | From → To | Severity | Change |
|---|---|---|---|---|---|---|
| - [x] | [#364](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/364) | `ws` | npm | 8.17.1 → 8.21.0 | medium | Bumped direct dep `ws` in `packages/forest-cloud/package.json` from `^8.16.0` → `^8.20.1` |
| - [x] | [#358](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/358) | `fast-uri` | npm | 2.3.0 → 3.1.2 | high | Added scoped resolutions `**/@fastify/ajv-compiler/fast-uri` and `**/fast-json-stringify/fast-uri` → `^3.1.2` |
| - [x] | [#357](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/357) | `fast-uri` | npm | 2.3.0 → 3.1.2 | high | Same resolutions as [#358](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/358) (covers both ranges; 3.1.2 ≥ both 3.1.1 and 3.1.2 patches) |

## Ignored

| Dismissed | Alert | Package | Reason |
|---|---|---|---|
| - [x] | [#349](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/349) | `ip-address` | **Vulnerable code path unreachable.** Hoisted `ip-address@10.2.0` already exceeds the patched `10.1.1`. The only remaining instance, `ip-address@5.9.4`, is pulled in solely by `forest-ip-utils`, which calls only `Address6` + `Address6.bigInteger()` (verified by reading `forest-ip-utils/dist/index.js`). None of the vulnerable HTML-emitting methods (`group()`, `link()`, `spanAll()`, `AddressError.parseMessage`) are reached from our code (verified by `grep -rE "Address6\\.(group\\|link\\|spanAll)\\|parseMessage" packages/*/src packages/*/test`). The advisory itself notes "zero consumers of group(), link(), or spanAll() across published npm packages." |

## Deferred (opened &lt; 7 days ago — next run)

- [#365](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/365) `@tootallnate/once` (6d)
- [#366](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/366) `uuid` (6d)
- [#367](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/367) `qs` (4d)
- [#368](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/368) `tmp` (1d)

## Resolutions added

| Alert | Package + pin | Parent chain tried | Why bump wasn't viable | File | Form |
|---|---|---|---|---|---|
| [#357](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/357), [#358](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/358) | `fast-uri: ^3.1.2` | `@fastify/ajv-compiler@^2.x → fast-uri@^2.0.0`; bumping `@fastify/ajv-compiler` to 3.x requires Fastify 4.x→5.x (breaking) | Patched `@fastify/ajv-compiler` releases still pin `fast-uri@^2.x`; only a major bump publishes a 3.x fast-uri | root `package.json` | scoped (`**/@fastify/ajv-compiler/fast-uri`) |
| [#357](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/357), [#358](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/358) | `fast-uri: ^3.1.2` | `fast-json-stringify@^5.x → fast-uri@^2.1.0` (transitively via `fastify4`'s `@fastify/fast-json-stringify-compiler`) | Same — `fast-json-stringify@5.x` still depends on `fast-uri@^2.1.0`; 3.x of fast-uri lands only in `fast-json-stringify@6.x` (peer of Fastify 5) | root `package.json` | scoped (`**/fast-json-stringify/fast-uri`) |

## Resolutions removed

| File | Pinned package + version | Reason |
|---|---|---|
| root `package.json` | `**/socks/ip-address: ^10.1.1` | **Redundant** — `socks` declares `ip-address: ^10.0.1`, which now naturally resolves to `10.2.0` (≥ 10.1.1). Verified by removing the entry and re-running `yarn install`; the resolved version was unchanged. |
| root `package.json` | `**/ajv/fast-uri: ^3.1.2` | **Redundant** — `ajv` declares `fast-uri: ^3.0.1`, which naturally resolves to `3.1.2`. Verified by removing the entry and re-running `yarn install`. |
| root `package.json` | `**/@langchain/langgraph-sdk/uuid: ^13.0.1` | **Redundant** — `@langchain/langgraph-sdk` declares `uuid: ^13.0.0`, which naturally resolves to `13.0.2`. Verified. |
| root `package.json` | `**/@modelcontextprotocol/sdk/hono: ^4.12.18` | **Redundant** — `@modelcontextprotocol/sdk` declares `hono: ^4.11.4`, which naturally resolves to `4.12.21`. Verified. |

## Risks

- **`ws` 8.17.1 → 8.21.0** (3 minor versions in the 8.x line): no API breakage between minors; the changelog covers bug fixes, perf tweaks, and the buffer-disclosure fix that is the point of this bump. `forest-cloud` uses `ws` only via `apollo-link-ws` + `subscriptions-transport-ws` for a single GraphQL subscription client — no behavior change beyond the patched vuln.
- **`fast-uri` 2.3.0 → 3.1.2** (major bump, applied via Yarn resolution on transitive deps of Fastify's ajv-compiler and fast-json-stringify): API change is minimal (`fast-uri` exposes `parse`/`serialize`/`equal` and a couple of helpers; the 3.x line keeps the same surface but fixes percent-encoded authority and dot-segment parsing). Risk: if Fastify's compilers exercise edge cases that 3.x parses differently, we'd see it in route-validation tests. Our `fastify`/`fastify2`/`fastify4` matrix is exercised by `packages/agent` integration tests.
- **Removed resolutions**: no version changes — each removal was verified to leave the resolved version identical.

## Manual testing

Covered by CI.

## Validation

✅ CI green

