### PR TITLE
fix(workflow-executor): pass collectionId to MCP activity log

### DIFF
--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -37,6 +37,7 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
       renderingId: this.context.user.renderingId,
       action: 'action',
       type: 'write',
+      collectionId: this.context.collectionId,
       label: this.context.stepDefinition.mcpServerId,
     };
   }

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -1033,4 +1033,36 @@ describe('McpStepExecutor', () => {
       });
     });
   });
+
+  describe('activity log', () => {
+    it('creates activity log with collectionId, renderingId, action, type and mcpServerId as label', async () => {
+      const tool = new MockRemoteTool({ name: 'send_notification', sourceId: 'mcp-server-1' });
+      const { model } = makeMockModel('send_notification', { message: 'Hello' });
+      const activityLogPort = {
+        createPending: jest.fn().mockResolvedValue({ id: 'log-1', index: '0' }),
+        markSucceeded: jest.fn().mockResolvedValue(undefined),
+        markFailed: jest.fn().mockResolvedValue(undefined),
+      };
+      const context = makeContext({
+        model,
+        collectionId: 'col-1',
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          mcpServerId: 'my-mcp-server',
+        }),
+        activityLogPort,
+      });
+      const executor = new McpStepExecutor(context, [tool]);
+
+      await executor.execute();
+
+      expect(activityLogPort.createPending).toHaveBeenCalledWith({
+        renderingId: 1,
+        action: 'action',
+        type: 'write',
+        collectionId: 'col-1',
+        label: 'my-mcp-server',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- The MCP step executor was the only one missing `collectionId` in `buildActivityLogArgs`
- Without it, activity logs created by MCP steps were not linked to their collection in the Forest Admin UI

## Root cause

`McpStepExecutor.buildActivityLogArgs` returned `renderingId`, `action`, `type`, and `label` but omitted `collectionId`, which is present in all other step executors (`update-record`, `trigger-record-action`, `load-related-record`).

fixes PRD-414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `collectionId` to MCP activity log in `McpStepExecutor.buildActivityLogArgs`
> Adds `collectionId` from `this.context` to the `CreateActivityLogArgs` returned by `buildActivityLogArgs` in [mcp-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1608/files#diff-b9fa635d111c8d393b6d32ef10b419db5c7b0dc0c166e499599676f3d8c876e5). A new test in [mcp-step-executor.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1608/files#diff-30ceea78036bb35ab748a5db006aa0c7165f05029716f9ac4b1a411ec9444ddc) verifies that `activityLogPort.createPending` receives `collectionId` when executing a fully automated MCP step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dacdac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->