### PR TITLE
fix(workflow-executor): skip activity-log update when server returns no id (PRD-428)

### DIFF
--- a/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
+++ b/packages/workflow-executor/src/adapters/forestadmin-client-activity-log-port.ts
@@ -39,6 +39,16 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
         { logger: this.logger },
       );
 
+      // 200 with id:null → server declined to persist; skip the later status PATCH (PRD-428).
+      if (!response.id) {
+        this.logger.warn('activity log not persisted by server — skipping status update', {
+          action: args.action,
+          collectionId: args.collectionId,
+        });
+
+        return { id: null };
+      }
+
       return { id: response.id, index: response.attributes.index };
     } catch (cause) {
       this.logger.error('activity log create failed', {
@@ -52,6 +62,11 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
   }
 
   async markSucceeded(handle: ActivityLogHandle): Promise<void> {
+    // Not persisted (see createPending) → nothing to patch; skip to avoid a permanent-404 storm.
+    if (!('index' in handle)) return undefined;
+
+    const { id, index } = handle;
+
     return this.drainer.track(async () => {
       try {
         await withRetry(
@@ -59,14 +74,14 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           () =>
             this.service.updateActivityLogStatus({
               forestServerToken: this.forestServerToken,
-              activityLog: { id: handle.id, attributes: { index: handle.index } },
+              activityLog: { id, attributes: { index } },
               status: 'completed',
             }),
           { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
         this.logger.error('activity log mark-as-completed failed', {
-          handleId: handle.id,
+          handleId: id,
           error: extractErrorMessage(err),
         });
       }
@@ -74,6 +89,11 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
   }
 
   async markFailed(handle: ActivityLogHandle): Promise<void> {
+    // Not persisted (see markSucceeded) → skip.
+    if (!('index' in handle)) return undefined;
+
+    const { id, index } = handle;
+
     return this.drainer.track(async () => {
       try {
         await withRetry(
@@ -81,14 +101,14 @@ export default class ForestadminClientActivityLogPort implements ActivityLogPort
           () =>
             this.service.updateActivityLogStatus({
               forestServerToken: this.forestServerToken,
-              activityLog: { id: handle.id, attributes: { index: handle.index } },
+              activityLog: { id, attributes: { index } },
               status: 'failed',
             }),
           { logger: this.logger, extraRetryStatuses: [404] },
         );
       } catch (err) {
         this.logger.error('activity log mark-as-failed failed', {
-          handleId: handle.id,
+          handleId: id,
           error: extractErrorMessage(err),
         });
       }

--- a/packages/workflow-executor/src/ports/activity-log-port.ts
+++ b/packages/workflow-executor/src/ports/activity-log-port.ts
@@ -11,10 +11,8 @@ export interface CreateActivityLogArgs {
   label?: string;
 }
 
-export interface ActivityLogHandle {
-  id: string;
-  index: string;
-}
+// `{ id: null }` = server declined to persist (see createPending); guards narrow on `id`.
+export type ActivityLogHandle = { id: string; index: string } | { id: null };
 
 // Per-run scoped port: token baked into the adapter's constructor. markSucceeded/markFailed
 // retry transient failures internally and are invoked with `void` from AgentWithLog.

--- a/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forestadmin-client-activity-log-port.test.ts
@@ -200,6 +200,29 @@ describe('ForestadminClientActivityLogPort', () => {
       );
     });
 
+    it('returns a no-id handle and warns once when the server declines to persist (id:null)', async () => {
+      const service = makeService();
+      service.createActivityLog.mockResolvedValue({
+        id: null,
+        attributes: { index: '0' },
+      } as never);
+      const logger = makeLogger();
+      const port = makePort(service, { logger });
+
+      const handle = await port.createPending({
+        renderingId: 5,
+        action: 'update',
+        type: 'write',
+        collectionId: 'col-1',
+      });
+
+      expect(handle).toEqual({ id: null });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'activity log not persisted by server — skipping status update',
+        { action: 'update', collectionId: 'col-1' },
+      );
+    });
+
     it('feeds args.collectionId into the lib collectionName slot (JSON:API relationship id)', async () => {
       const service = makeService();
       service.createActivityLog.mockResolvedValue({
@@ -264,6 +287,17 @@ describe('ForestadminClientActivityLogPort', () => {
       await expect(promise).resolves.toBeUndefined();
       expect(service.updateActivityLogStatus).toHaveBeenCalledTimes(2);
     });
+
+    it('skips the status update for a not-persisted (id:null) handle', async () => {
+      const service = makeService();
+      const drainer = new ActivityLogDrainer();
+      const trackSpy = jest.spyOn(drainer, 'track');
+      const port = makePort(service, { drainer });
+
+      await expect(port.markSucceeded({ id: null })).resolves.toBeUndefined();
+      expect(service.updateActivityLogStatus).not.toHaveBeenCalled();
+      expect(trackSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('markFailed', () => {
@@ -315,6 +349,17 @@ describe('ForestadminClientActivityLogPort', () => {
       await jest.advanceTimersByTimeAsync(100);
       await expect(promise).resolves.toBeUndefined();
       expect(service.updateActivityLogStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips the status update for a not-persisted (id:null) handle', async () => {
+      const service = makeService();
+      const drainer = new ActivityLogDrainer();
+      const trackSpy = jest.spyOn(drainer, 'track');
+      const port = makePort(service, { drainer });
+
+      await expect(port.markFailed({ id: null })).resolves.toBeUndefined();
+      expect(service.updateActivityLogStatus).not.toHaveBeenCalled();
+      expect(trackSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Problem

When an MCP step completes, the executor logs showed a burst of retry warnings ending in an error:

```
warn  "activity log mark-as-completed" failed, retrying attempt=1 status=404 error="Activity log not found"
warn  "activity log mark-as-completed" failed, retrying attempt=2 status=404 error="Activity log not found"
warn  "activity log mark-as-completed" failed, retrying attempt=3 status=404 error="Activity log not found"
error activity log mark-as-completed failed handleId=null error="Activity log not found"
```

## Root cause (confirmed in `forestadmin-server`)

The Forest server's `ActivityLogCreator.create()` returns `null` when the request carries no collection (authorization check), and the create route then responds **HTTP 200 with `data: { id: null }`** by design. `createPending` returned that handle verbatim, so the subsequent mark-as-completed/failed `PATCH /{index}/null/status` hit a **permanent 404** — retried 3× (404 is in `extraRetryStatuses`) before a swallowed error, polluting logs and burning background latency on every affected step.

## Fix (client robustness)

- `createPending` warns once when the server returns no id.
- `markSucceeded` / `markFailed` early-return when the handle has no id → kills the 404 storm at the source.
- 404 stays retriable for **valid** ids (transient read-path propagation) — unchanged.

This is defense-in-depth; the functional fix that makes the log actually persist (passing `collectionId`) already landed in #1608.

## Tests
- `createPending` returns a non-persisted handle and warns on 200 + `id: null`.
- `markSucceeded` / `markFailed` do not call `updateActivityLogStatus` when the handle has no id.
- Existing valid-id behavior (incl. 404 retry) unchanged. Full suite: 836/836 green, lint clean, build OK.

fixes PRD-428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip activity-log updates in `ForestadminClientActivityLogPort` when server returns no id
> - `createPending` now checks the server response id and returns `{ id: null }` with a warning log instead of proceeding when the server declines to persist the activity log.
> - `markSucceeded` and `markFailed` both short-circuit immediately when given a `{ id: null }` handle, skipping the drainer registration and status PATCH calls.
> - `ActivityLogHandle` in [activity-log-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1615/files#diff-c22bb4587a52235a0745b2e37acaae46ca961f3124a5e19f3a5aa7654d431edb) is updated to a union type to reflect the nullable id case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de9f473.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->