### PR TITLE
fix(workflow-executor): sign agent JWT with snake_case identity claims (PRD-432)

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -179,9 +179,19 @@ export default class AgentClientAgentPort implements AgentPort {
   }
 
   private createClient(user: StepUser) {
-    const token = jsonwebtoken.sign({ ...user, scope: 'step-execution' }, this.authSecret, {
-      expiresIn: '5m',
-    });
+    // snake_case aliases: Ruby/Python agents splat JWT claims into Caller.new (snake_case kwargs).
+    const token = jsonwebtoken.sign(
+      {
+        ...user,
+        first_name: user.firstName,
+        last_name: user.lastName,
+        rendering_id: user.renderingId,
+        permission_level: user.permissionLevel,
+        scope: 'step-execution',
+      },
+      this.authSecret,
+      { expiresIn: '5m' },
+    );
 
     return createRemoteAgentClient({
       url: this.agentUrl,

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1,6 +1,7 @@
 import type { StepUser } from '../../src/types/execution-context';
 
 import { createRemoteAgentClient } from '@forestadmin/agent-client';
+import jsonwebtoken from 'jsonwebtoken';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
 import { AgentProbeError, RecordNotFoundError } from '../../src/errors';
@@ -199,6 +200,29 @@ describe('AgentClientAgentPort', () => {
         }),
       );
       expect(result.collectionName).toBe('unknown');
+    });
+  });
+
+  describe('agent JWT', () => {
+    it('signs both camelCase and snake_case identity claims for cross-runtime agents', async () => {
+      mockCollection.list.mockResolvedValue([{ id: 42 }]);
+
+      await port.getRecord({ collection: 'users', id: [42] }, user);
+
+      const { token } = mockedCreateRemoteAgentClient.mock.calls[0][0];
+      const payload = jsonwebtoken.verify(token, 'test-secret') as Record<string, unknown>;
+
+      expect(payload).toMatchObject({
+        firstName: 'Test',
+        lastName: 'User',
+        renderingId: 1,
+        permissionLevel: 'admin',
+        first_name: 'Test',
+        last_name: 'User',
+        rendering_id: 1,
+        permission_level: 'admin',
+        scope: 'step-execution',
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

The executor mints the JWT it sends to the agent from `StepUser` (camelCase). Ruby/Python agents splat JWT claims straight into `Caller.new`, which requires **snake_case** kwargs (`first_name`, `last_name`, `rendering_id`, `permission_level`). The camelCase-only token made that call fail with a **500 `ArgumentError`**.

The TypeScript agent reads camelCase, so there is no single canonical casing.

## Fix

Emit **both** casings in the signed JWT:
- The Ruby `Caller` absorbs the extra camelCase keys via `**_extra_args`.
- The TS agent ignores the snake_case ones.

Only the 4 multi-word identity fields get aliases — `id`, `email`, `team`, `role`, `tags` are already identical across casings.

## Testing

- New test decodes the signed JWT and asserts both camelCase **and** snake_case claims (+ `scope`) are present.
- `yarn workspace @forestadmin/workflow-executor test` → 35/35 pass.
- Lint clean (0 errors).

fixes PRD-432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sign agent JWTs with snake_case identity claims in `AgentClientAgentPort.createClient`
> Adds `first_name`, `last_name`, `rendering_id`, and `permission_level` snake_case fields to the JWT payload alongside the existing camelCase equivalents. Adds a test suite in [agent-client-agent-port.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1620/files#diff-22a2115dddda11057fe52890dae8030174d6b71d092e9d794b34237c9c30e420) that verifies both camelCase and snake_case claims and the expected scope are present in the signed token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74349e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->