### PR TITLE
feat(workflow-executor): align datasource activity-log labels with the browser engine [PRD-449]

### DIFF
--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -10,7 +10,7 @@ import type {
 } from '../ports/agent-port';
 import type SchemaResolver from '../schema-resolver';
 import type { StepUser } from '../types/execution-context';
-import type { RecordData } from '../types/validated/collection';
+import type { CollectionSchema, RecordData } from '../types/validated/collection';
 
 type WriteOptions = { beforeCall: () => Promise<void> };
 
@@ -42,7 +42,7 @@ export default class AgentWithLog {
   }
 
   async getRecord(query: GetRecordQuery): Promise<RecordData> {
-    const collectionId = await this.resolveCollectionId(query.collection);
+    const { collectionId } = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
       { action: 'index', type: 'read', collectionId, recordId: query.id },
@@ -51,28 +51,40 @@ export default class AgentWithLog {
   }
 
   async getRelatedData(query: GetRelatedDataQuery): Promise<RecordData[]> {
-    const collectionId = await this.resolveCollectionId(query.collection);
+    const schema = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
-      { action: 'listRelatedData', type: 'read', collectionId, recordId: query.id },
+      {
+        action: 'listRelatedData',
+        type: 'read',
+        collectionId: schema.collectionId,
+        recordId: query.id,
+        label: this.relationLabel(schema, query.relation),
+      },
       { operation: () => this.agentPort.getRelatedData(query, this.user) },
     );
   }
 
   async getSingleRelatedData(query: GetSingleRelatedDataQuery): Promise<RecordData | null> {
-    const collectionId = await this.resolveCollectionId(query.collection);
+    const schema = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
-      { action: 'listRelatedData', type: 'read', collectionId, recordId: query.id },
+      {
+        action: 'listRelatedData',
+        type: 'read',
+        collectionId: schema.collectionId,
+        recordId: query.id,
+        label: this.relationLabel(schema, query.relation),
+      },
       { operation: () => this.agentPort.getSingleRelatedData(query, this.user) },
     );
   }
 
   async updateRecord(query: UpdateRecordQuery, opts: WriteOptions): Promise<RecordData> {
-    const collectionId = await this.resolveCollectionId(query.collection);
+    const { collectionId } = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
-      { action: 'update', type: 'write', collectionId, recordId: query.id },
+      { action: 'update', type: 'write', collectionId, recordId: query.id, label: 'updated' },
       {
         operation: () => this.agentPort.updateRecord(query, this.user),
         beforeCall: opts.beforeCall,
@@ -81,10 +93,16 @@ export default class AgentWithLog {
   }
 
   async executeAction(query: ExecuteActionQuery, opts: WriteOptions): Promise<unknown> {
-    const collectionId = await this.resolveCollectionId(query.collection);
+    const { collectionId } = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
-      { action: 'action', type: 'write', collectionId, recordId: query.id },
+      {
+        action: 'action',
+        type: 'write',
+        collectionId,
+        recordId: query.id,
+        label: `triggered the action "${query.action}"`,
+      },
       {
         operation: () => this.agentPort.executeAction(query, this.user),
         beforeCall: opts.beforeCall,
@@ -98,9 +116,16 @@ export default class AgentWithLog {
     return this.agentPort.getActionFormInfo(query, this.user);
   }
 
-  private async resolveCollectionId(collectionName: string): Promise<string> {
-    const schema = await this.schemaResolver.resolve(collectionName);
+  // ISO with the browser engine: `list relation "<displayName>"`. The query carries the technical
+  // relation name; resolve its displayName from the source schema, falling back to the technical
+  // name when the field is absent (resilient to orchestrator schema drift).
+  private relationLabel(schema: CollectionSchema, relation: string): string {
+    const displayName = schema.fields.find(f => f.fieldName === relation)?.displayName ?? relation;
 
-    return schema.collectionId;
+    return `list relation "${displayName}"`;
+  }
+
+  private resolveSchema(collectionName: string): Promise<CollectionSchema> {
+    return this.schemaResolver.resolve(collectionName);
   }
 }

--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -120,7 +120,9 @@ export default class AgentWithLog {
   // relation name; resolve its displayName from the source schema, falling back to the technical
   // name when the field is absent (resilient to orchestrator schema drift).
   private relationLabel(schema: CollectionSchema, relation: string): string {
-    const displayName = schema.fields.find(f => f.fieldName === relation)?.displayName ?? relation;
+    const displayName =
+      schema.fields.filter(f => f.isRelationship).find(f => f.fieldName === relation)
+        ?.displayName ?? relation;
 
     return `list relation "${displayName}"`;
   }

--- a/packages/workflow-executor/test/executors/agent-with-log.test.ts
+++ b/packages/workflow-executor/test/executors/agent-with-log.test.ts
@@ -21,16 +21,26 @@ function makeUser(): StepUser {
   } as StepUser;
 }
 
-function makeSchema(collectionId = 'col-customers'): CollectionSchema {
+function makeSchema(
+  collectionId = 'col-customers',
+  fields: CollectionSchema['fields'] = [],
+): CollectionSchema {
   return {
     collectionName: 'customers',
     collectionId,
     collectionDisplayName: 'Customers',
     primaryKeyFields: ['id'],
     referenceField: null,
-    fields: [],
+    fields,
     actions: [],
   };
+}
+
+function makeRelationField(
+  fieldName: string,
+  displayName: string,
+): CollectionSchema['fields'][number] {
+  return { fieldName, displayName, isRelationship: true, relationType: 'BelongsTo' };
 }
 
 function makeActivityLogPort() {
@@ -93,7 +103,53 @@ describe('AgentWithLog', () => {
       expect(result).toEqual({ collectionName: 'customers', recordId: [42], values: {} });
     });
 
-    it('logs getRelatedData as listRelatedData/read', async () => {
+    it('logs getRelatedData as listRelatedData/read labelled with the relation displayName', async () => {
+      const schema = makeSchema('col-customers', [makeRelationField('orders', 'Orders')]);
+      const { deps, activityLogPort, schemaResolver } = makeDeps();
+      (schemaResolver.resolve as jest.Mock).mockResolvedValue(schema);
+      const agent = new AgentWithLog(deps);
+
+      await agent.getRelatedData({
+        collection: 'customers',
+        id: [42],
+        relation: 'orders',
+        relatedSchema: makeSchema('col-orders'),
+        limit: 50,
+      });
+
+      expect(activityLogPort.createPending).toHaveBeenCalledWith({
+        renderingId: 1,
+        action: 'listRelatedData',
+        type: 'read',
+        collectionId: 'col-customers',
+        recordId: [42],
+        label: 'list relation "Orders"',
+      });
+    });
+
+    it('logs getSingleRelatedData as listRelatedData/read labelled with the relation displayName (xToOne)', async () => {
+      const schema = makeSchema('col-customers', [makeRelationField('order', 'Order')]);
+      const { deps, activityLogPort, schemaResolver } = makeDeps();
+      (schemaResolver.resolve as jest.Mock).mockResolvedValue(schema);
+      const agent = new AgentWithLog(deps);
+
+      await agent.getSingleRelatedData({
+        collection: 'customers',
+        id: [42],
+        relation: 'order',
+        relatedSchema: makeSchema('col-orders'),
+      });
+
+      expect(activityLogPort.createPending).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'listRelatedData',
+          type: 'read',
+          label: 'list relation "Order"',
+        }),
+      );
+    });
+
+    it('falls back to the technical relation name when the field is absent from the schema', async () => {
       const { deps, activityLogPort } = makeDeps();
       const agent = new AgentWithLog(deps);
 
@@ -106,29 +162,51 @@ describe('AgentWithLog', () => {
       });
 
       expect(activityLogPort.createPending).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'listRelatedData', type: 'read', recordId: [42] }),
-      );
-    });
-
-    it('logs getSingleRelatedData as listRelatedData/read (xToOne)', async () => {
-      const { deps, activityLogPort } = makeDeps();
-      const agent = new AgentWithLog(deps);
-
-      await agent.getSingleRelatedData({
-        collection: 'customers',
-        id: [42],
-        relation: 'order',
-        relatedSchema: makeSchema('col-orders'),
-      });
-
-      expect(activityLogPort.createPending).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'listRelatedData', type: 'read', recordId: [42] }),
+        expect.objectContaining({ label: 'list relation "orders"' }),
       );
     });
   });
 
   describe('write methods', () => {
-    it('logs updateRecord as update/write and forwards beforeCall before the side effect', async () => {
+    it('logs updateRecord as update/write with the static "updated" label', async () => {
+      const { deps, activityLogPort } = makeDeps();
+      const agent = new AgentWithLog(deps);
+
+      await agent.updateRecord(
+        { collection: 'customers', id: [42], values: { name: 'X' } },
+        { beforeCall: async () => undefined },
+      );
+
+      expect(activityLogPort.createPending).toHaveBeenCalledWith({
+        renderingId: 1,
+        action: 'update',
+        type: 'write',
+        collectionId: 'col-customers',
+        recordId: [42],
+        label: 'updated',
+      });
+    });
+
+    it('logs executeAction labelled with the action technical name', async () => {
+      const { deps, activityLogPort } = makeDeps();
+      const agent = new AgentWithLog(deps);
+
+      await agent.executeAction(
+        { collection: 'customers', action: 'send_email', id: [42] },
+        { beforeCall: async () => undefined },
+      );
+
+      expect(activityLogPort.createPending).toHaveBeenCalledWith({
+        renderingId: 1,
+        action: 'action',
+        type: 'write',
+        collectionId: 'col-customers',
+        recordId: [42],
+        label: 'triggered the action "send_email"',
+      });
+    });
+
+    it('runs beforeCall between createPending and the agent call (audit precedes the side effect)', async () => {
       const order: string[] = [];
       const { deps, agentPort, activityLogPort } = makeDeps();
       (agentPort.updateRecord as jest.Mock).mockImplementation(async () => {

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -796,6 +796,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
         type: 'read',
         collectionId: 'col-customers',
         recordId: [42],
+        label: 'list relation "Order"',
       });
     });
 
@@ -819,6 +820,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
           type: 'read',
           collectionId: 'col-customers',
           recordId: [42],
+          label: 'list relation "Order"',
         }),
       );
     });

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -259,6 +259,7 @@ describe('TriggerRecordActionStepExecutor', () => {
         type: 'write',
         collectionId: 'col-customers',
         recordId: [42],
+        label: 'triggered the action "send-welcome-email"',
       });
     });
 
@@ -344,6 +345,7 @@ describe('TriggerRecordActionStepExecutor', () => {
         type: 'write',
         collectionId: 'col-orders',
         recordId: [99],
+        label: 'triggered the action "cancel-order"',
       });
     });
   });

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -258,6 +258,7 @@ describe('UpdateRecordStepExecutor', () => {
         type: 'write',
         collectionId: 'col-customers',
         recordId: [42],
+        label: 'updated',
       });
     });
 
@@ -356,6 +357,7 @@ describe('UpdateRecordStepExecutor', () => {
         type: 'write',
         collectionId: 'col-orders',
         recordId: [99],
+        label: 'updated',
       });
     });
 


### PR DESCRIPTION
## What

Aligns the datasource activity-log labels emitted by the workflow-executor with the legacy browser engine (ISO), fixing a production audit-trail crash on label-less entries.

fixes PRD-449

## Context

Since the activity-log refactor (PRD-442), logs are emitted per datasource call in `AgentWithLog.audit()`, not per step. This dissolves the original dynamic-label problem (the name is now known at the call site, after AI resolution) — no executor or base-class refactor needed. The fix is just injecting the ISO `label` into each audit target.

## Changes (`agent-with-log.ts`)

| Operation | Label | Source |
|---|---|---|
| `update` | `updated` | static |
| `action` | `triggered the action "<technical name>"` | `query.action` |
| `listRelatedData` | `list relation "<displayName>"` | resolved from source schema, falls back to technical name |
| `index` (read) | none | ISO; `getRecord` is shared across step types, a blanket label would mislabel update/trigger/load reads |

- `resolveCollectionId` -> `resolveSchema` (returns the full `CollectionSchema`) so the relation displayName can be looked up.
- `action` label only fires in FullyAutomated mode (preserved naturally: `executeAction` is only called in that branch; otherwise the front executes and logs).

## Tests

- `agent-with-log.test.ts`: exact-label assertions for update / action / relation displayName + technical-name fallback.
- Updated existing `createPending` assertions in update / trigger / load-related executor tests.

## Validation

- `yarn workspace @forestadmin/workflow-executor test` -> 925/925
- `yarn workspace @forestadmin/workflow-executor lint` -> 0 errors
- `yarn workspace @forestadmin/workflow-executor build` -> ok

## Out of scope

- MCP executor (already labelled)
- The N-logs-per-step behavior of load-related (pre-existing since PRD-442)
- Rich `\"...in workflow Y\"` labels (requires orchestrator contract change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add labels to datasource activity-log entries in `AgentWithLog`
> - `getRelatedData` and `getSingleRelatedData` now include a `label` of `'list relation "<displayName>"'` (falling back to the technical relation name) in their activity log payloads.
> - `updateRecord` adds a static `'updated'` label; `executeAction` adds `'triggered the action "<action>"'` using the technical action name.
> - A new `resolveSchema` helper replaces the removed `resolveCollectionId` helper, returning the full `CollectionSchema` so call sites can access both the `collectionId` and field metadata needed for label computation.
>
> #### 🖇️ Linked Issues
> Relates to [PRD-449](ticket:linear/PRD-449).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1631 opened
>
> - Modified `AgentWithLog.relationLabel` method in `workflow-executor` package to filter schema fields by relationship status before resolving display names [4dad2f2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7d7642.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->