### PR TITLE
fix(workflow-executor): accept orchestrator wire form for composite columnType [PRD-464]

### DIFF
--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -28,13 +28,20 @@ export const PRIMITIVE_TYPES = [
 ] as const;
 export type PrimitiveType = (typeof PRIMITIVE_TYPES)[number];
 
-// Mirrors ColumnType = PrimitiveTypes | [ColumnType] | { [key: string]: ColumnType }
+// Mirrors ColumnType = PrimitiveTypes | [ColumnType] | { [key: string]: ColumnType }.
+// The orchestrator additionally serializes composite types as { fields: [{ field, type }] }
+// (array-of-entries wire form) — accepted here and normalized to the native record shape.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ColumnTypeSchema: z.ZodType<any> = z.lazy(() =>
   z.union([
     z.enum(PRIMITIVE_TYPES),
     z.tuple([ColumnTypeSchema]),
     z.record(z.string(), ColumnTypeSchema),
+    z
+      .object({
+        fields: z.array(z.object({ field: z.string(), type: ColumnTypeSchema })),
+      })
+      .transform(obj => Object.fromEntries(obj.fields.map(f => [f.field, f.type]))),
   ]),
 );
 

--- a/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
+++ b/packages/workflow-executor/test/adapters/forest-server-workflow-port.test.ts
@@ -818,6 +818,102 @@ describe('ForestServerWorkflowPort', () => {
       });
     });
 
+    it('accepts a composite type sent as the native record form { data: String }', async () => {
+      mockQuery.mockResolvedValue({
+        collectionName: 'users',
+        collectionDisplayName: 'Users',
+        primaryKeyFields: ['id'],
+        fields: [
+          {
+            fieldName: 'embedded',
+            displayName: 'Embedded',
+            isRelationship: false,
+            type: { data: 'String' },
+          },
+        ],
+        actions: [],
+      });
+
+      const result = await port.getCollectionSchema('users', '42');
+
+      expect(result.fields[0].type).toEqual({ data: 'String' });
+    });
+
+    it('accepts the orchestrator wire form { fields: [{ field, type }] } and normalizes it to a record', async () => {
+      mockQuery.mockResolvedValue({
+        collectionName: 'users',
+        collectionDisplayName: 'Users',
+        primaryKeyFields: ['id'],
+        fields: [
+          {
+            fieldName: 'embedded',
+            displayName: 'Embedded',
+            isRelationship: false,
+            type: { fields: [{ field: 'data', type: 'String' }] },
+          },
+        ],
+        actions: [],
+      });
+
+      const result = await port.getCollectionSchema('users', '42');
+
+      expect(result.fields[0].type).toEqual({ data: 'String' });
+    });
+
+    it('normalizes a multi-entry wire-form composite type to its full record form', async () => {
+      mockQuery.mockResolvedValue({
+        collectionName: 'users',
+        collectionDisplayName: 'Users',
+        primaryKeyFields: ['id'],
+        fields: [
+          {
+            fieldName: 'profile',
+            displayName: 'Profile',
+            isRelationship: false,
+            type: {
+              fields: [
+                { field: 'firstName', type: 'String' },
+                { field: 'age', type: 'Number' },
+              ],
+            },
+          },
+        ],
+        actions: [],
+      });
+
+      const result = await port.getCollectionSchema('users', '42');
+
+      expect(result.fields[0].type).toEqual({ firstName: 'String', age: 'Number' });
+    });
+
+    it('accepts a nested wire-form composite type (composite inside composite)', async () => {
+      mockQuery.mockResolvedValue({
+        collectionName: 'users',
+        collectionDisplayName: 'Users',
+        primaryKeyFields: ['id'],
+        fields: [
+          {
+            fieldName: 'meta',
+            displayName: 'Meta',
+            isRelationship: false,
+            type: {
+              fields: [
+                {
+                  field: 'inner',
+                  type: { fields: [{ field: 'leaf', type: 'Boolean' }] },
+                },
+              ],
+            },
+          },
+        ],
+        actions: [],
+      });
+
+      const result = await port.getCollectionSchema('users', '42');
+
+      expect(result.fields[0].type).toEqual({ inner: { leaf: 'Boolean' } });
+    });
+
     it('rejects enumValues: [] (empty enum is invalid)', async () => {
       mockQuery.mockResolvedValue({
         collectionName: 'users',


### PR DESCRIPTION
## Summary

- `ColumnTypeSchema` rejected the orchestrator's wire-form representation of composite column types (`{ fields: [{ field, type }] }`), breaking any workflow targeting a collection that contains a composite/embedded field — e.g. an `embedded` field declared with `columnType: { data: "String" }`.
- Add a fourth union branch that accepts the wire form and `.transform`s it back to the canonical `Record<string, ColumnType>` shape so downstream consumers see no difference.
- Add Jest coverage for native record form, single-entry wire form, multi-entry wire form, and nested-composite wire form.

## Bug

Step dispatch failed with:

```
Run <runId> mapper produced invalid AvailableStepExecution — fields.N.type: Invalid input
ZodError [...] path: ["fields", N, "type"]
```

Stack: `ReadRecordStepExecutor.getCollectionSchema` → `ForestServerWorkflowPort.callPort` → `CollectionSchemaSchema.parse`.

## Test plan

- [x] `yarn workspace @forestadmin/workflow-executor test` — 914 tests pass, 4 new tests in `forest-server-workflow-port.test.ts`
- [ ] Smoke-test a workflow on a collection with an `embedded` computed field

fixes PRD-464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept orchestrator wire form for composite `columnType` in workflow executor
> - Extends `ColumnTypeSchema` in [collection.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1632/files#diff-b531cab4040638c8075825f7fe7c720b2b72d92f56ff849bff39f9e0824ab2bd) to accept composite types in the orchestrator's wire form `{ fields: [{ field, type }] }`, in addition to the native record form.
> - Adds a transform that normalizes the wire form into a record/object shape, including nested composite types.
> - Adds four test cases in [forest-server-workflow-port.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1632/files#diff-371411a051dd8bbc3071c3bebf34364469d596222ef19d9ba78d4086b96ad1f1) covering native record form, single- and multi-entry wire form, and nested wire form composites.
>
> #### 🖇️ Linked Issues
> Relates to [PRD-464](ticket:linear/PRD-464).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de33f2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->