### PR TITLE
docs(workflow-executor): drop @draft type-spec comments

### DIFF
--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import type { StepUser } from '../types/execution-context';
 import type { CollectionSchema, RecordData } from '../types/validated/collection';
 

--- a/packages/workflow-executor/src/ports/run-store.ts
+++ b/packages/workflow-executor/src/ports/run-store.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import type { Logger } from './logger-port';
 import type { StepExecutionData } from '../types/step-execution-data';
 

--- a/packages/workflow-executor/src/ports/workflow-port.ts
+++ b/packages/workflow-executor/src/ports/workflow-port.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import type { AvailableStepExecution, StepUser } from '../types/execution-context';
 import type { CollectionSchema } from '../types/validated/collection';
 import type { StepOutcome } from '../types/validated/step-outcome';

--- a/packages/workflow-executor/src/types/execution-context.ts
+++ b/packages/workflow-executor/src/types/execution-context.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import type { ActivityLogPort } from '../ports/activity-log-port';
 import type { AgentPort } from '../ports/agent-port';
 import type { Logger } from '../ports/logger-port';

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import type { RecordId, RecordRef } from './validated/collection';
 import type {
   LoadRelatedRecordConfirmation,

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import { z } from 'zod';
 
 // -- Schema types (structure of a collection — source: WorkflowPort) --

--- a/packages/workflow-executor/src/types/validated/execution.ts
+++ b/packages/workflow-executor/src/types/validated/execution.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import { z } from 'zod';
 
 import { RecordRefSchema } from './collection';

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import { z } from 'zod';
 
 export enum StepType {

--- a/packages/workflow-executor/src/types/validated/step-outcome.ts
+++ b/packages/workflow-executor/src/types/validated/step-outcome.ts
@@ -1,5 +1,3 @@
-/** @draft Types derived from the workflow-executor spec -- subject to change. */
-
 import { z } from 'zod';
 
 import { StepType } from './step-definition';


### PR DESCRIPTION
Removes the `/** @draft Types derived from the workflow-executor spec -- subject to change. */` header comment from the 9 type/port files in `workflow-executor`.

The types have stabilized and crossed several trust boundaries (zod validation, adapters, executors) — the "draft / subject to change" disclaimer is stale and adds noise to every file head.

No behavior change: 18 deletions (comment line + trailing blank), build/lint/test green (933 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `@draft` type-spec comments from workflow-executor ports and types
> Drops the leading `@draft` comment header lines from 9 files across the `packages/workflow-executor` ports and types directories. This is a documentation-only cleanup with no runtime impact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2245746.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->