### PR TITLE
fix(workflow-executor): reject duplicate triggers of in-flight runs (PRD-468)

### DIFF
--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -328,6 +328,13 @@ export class UserMismatchError extends Error {
   }
 }
 
+export class RunAlreadyInFlightError extends Error {
+  constructor(runId: string) {
+    super(`Run "${runId}" is already being processed`);
+    this.name = 'RunAlreadyInFlightError';
+  }
+}
+
 export class PendingDataNotFoundError extends Error {
   constructor(runId: string, stepIndex: number) {
     super(`Step ${stepIndex} in run "${runId}" not found or has no pending data`);

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -13,6 +13,7 @@ import koaJwt from 'koa-jwt';
 import serializeStepForWire from './step-serializer';
 import ConsoleLogger from '../adapters/console-logger';
 import {
+  RunAlreadyInFlightError,
   RunNotFoundError,
   UserMismatchError,
   WorkflowExecutorError,
@@ -187,6 +188,13 @@ export default class ExecutorHttpServer {
       if (err instanceof RunNotFoundError) {
         ctx.status = 404;
         ctx.body = { error: 'Run not found or unavailable' };
+
+        return;
+      }
+
+      if (err instanceof RunAlreadyInFlightError) {
+        ctx.status = 400;
+        ctx.body = { error: err.message };
 
         return;
       }

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -14,6 +14,7 @@ import ConsoleLogger from './adapters/console-logger';
 import { DEFAULT_MAX_CHAIN_DEPTH, DEFAULT_STOP_TIMEOUT_MS } from './defaults';
 import {
   MalformedRunError,
+  RunAlreadyInFlightError,
   RunNotFoundError,
   UserMismatchError,
   causeMessage,
@@ -164,6 +165,12 @@ export default class Runner {
     runId: string,
     options?: { pendingData?: unknown; bearerUserId?: number },
   ): Promise<void> {
+    // Best-effort local short-circuit: skip the orchestrator round-trip when THIS instance is
+    // already running the run. It is NOT a concurrency guard — inFlightRuns is per-instance and a
+    // deployment can run several executors, so genuine duplicate-execution prevention is the
+    // orchestrator's job (it atomically claims a pending run; concurrent triggers get nothing).
+    this.assertRunNotInFlight(runId);
+
     let dispatch: AvailableRunDispatch | null;
 
     try {
@@ -184,16 +191,15 @@ export default class Runner {
       throw new UserMismatchError(runId);
     }
 
-    if (this.inFlightRuns.has(step.runId)) {
-      this.logger.info('Trigger ignored — run already in flight', {
-        runId: step.runId,
-        stepIndex: step.stepIndex,
-      });
-
-      return;
-    }
-
     await this.executeStep(step, auth.forestServerToken, options?.pendingData);
+  }
+
+  private assertRunNotInFlight(runId: string): void {
+    if (this.inFlightRuns.has(runId)) {
+      this.logger.info('Trigger ignored — run already in flight', { runId });
+
+      throw new RunAlreadyInFlightError(runId);
+    }
   }
 
   private schedulePoll(): void {

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -4,7 +4,12 @@ import type Runner from '../../src/runner';
 import jsonwebtoken from 'jsonwebtoken';
 import request from 'supertest';
 
-import { MalformedRunError, RunNotFoundError, UserMismatchError } from '../../src/errors';
+import {
+  MalformedRunError,
+  RunAlreadyInFlightError,
+  RunNotFoundError,
+  UserMismatchError,
+} from '../../src/errors';
 import ExecutorHttpServer from '../../src/http/executor-http-server';
 
 const AUTH_SECRET = 'test-auth-secret';
@@ -464,6 +469,22 @@ describe('ExecutorHttpServer', () => {
 
       expect(response.status).toBe(403);
       expect(response.body).toEqual({ error: 'Forbidden' });
+    });
+
+    it('returns 400 when triggerPoll rejects with RunAlreadyInFlightError', async () => {
+      const runner = createMockRunner({
+        triggerPoll: jest.fn().mockRejectedValue(new RunAlreadyInFlightError('run-1')),
+      });
+
+      const server = createServer({ runner });
+      const token = signToken({ id: 1 });
+
+      const response = await request(server.callback)
+        .post('/runs/run-1/trigger')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ error: 'Run "run-1" is already being processed' });
     });
 
     it('returns 500 when triggerPoll rejects with an unexpected error', async () => {

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -11,6 +11,7 @@ import type { BaseChatModel } from '@forestadmin/ai-proxy';
 import {
   ConfigurationError,
   MalformedRunError,
+  RunAlreadyInFlightError,
   RunNotFoundError,
   UserMismatchError,
 } from '../src/errors';
@@ -624,8 +625,7 @@ describe('deduplication', () => {
     const poll1 = runner.triggerPoll('run-1');
     await Promise.resolve(); // let getAvailableRun resolve and step key get added
 
-    // Second poll: step is in-flight → should be skipped
-    await runner.triggerPoll('run-1');
+    await expect(runner.triggerPoll('run-1')).rejects.toThrow(RunAlreadyInFlightError);
 
     expect(executeSpy).toHaveBeenCalledTimes(1);
 
@@ -680,6 +680,104 @@ describe('deduplication', () => {
 });
 
 // ---------------------------------------------------------------------------
+// PRD-468 — concurrent / duplicate triggers of the same run
+// ---------------------------------------------------------------------------
+
+describe('PRD-468 concurrent duplicate triggers', () => {
+  it('executes only ONCE for concurrent triggers — the orchestrator denies the second dispatch', async () => {
+    const workflowPort = createMockWorkflowPort();
+    const step = makePendingStep({ runId: 'run-1', stepId: 'step-concurrent' });
+    workflowPort.getAvailableRun
+      .mockResolvedValueOnce({ step, auth: { forestServerToken: 'test-forest-token' } })
+      .mockResolvedValueOnce(null);
+
+    runner = new Runner(createRunnerConfig({ workflowPort }));
+
+    const results = await Promise.allSettled([
+      runner.triggerPoll('run-1'),
+      runner.triggerPoll('run-1'),
+    ]);
+
+    expect(results.filter(r => r.status === 'fulfilled')).toHaveLength(1);
+    const rejected = results.filter(r => r.status === 'rejected');
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(RunNotFoundError);
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a duplicate trigger of an in-flight run WITHOUT an orchestrator round-trip', async () => {
+    const workflowPort = createMockWorkflowPort();
+    const step = makePendingStep({ runId: 'run-1', stepId: 'step-inflight-dup' });
+    workflowPort.getAvailableRun.mockResolvedValue({
+      step,
+      auth: { forestServerToken: 'test-forest-token' },
+    });
+
+    const unblockRef = { fn: (): void => {} };
+    executeSpy.mockReturnValueOnce(
+      new Promise(resolve => {
+        unblockRef.fn = () =>
+          resolve({
+            stepOutcome: {
+              type: 'record',
+              stepId: 'step-inflight-dup',
+              stepIndex: 0,
+              status: 'success',
+            },
+          });
+      }),
+    );
+
+    runner = new Runner(createRunnerConfig({ workflowPort }));
+
+    const poll1 = runner.triggerPoll('run-1');
+    await flushPromises();
+
+    await expect(runner.triggerPoll('run-1')).rejects.toThrow(RunAlreadyInFlightError);
+
+    expect(workflowPort.getAvailableRun).toHaveBeenCalledTimes(1);
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+
+    unblockRef.fn();
+    await poll1;
+  });
+
+  it('signals a conflict (does not silently resolve) for a duplicate trigger of an in-flight run', async () => {
+    const workflowPort = createMockWorkflowPort();
+    const step = makePendingStep({ runId: 'run-1', stepId: 'step-inflight-conflict' });
+    workflowPort.getAvailableRun.mockResolvedValue({
+      step,
+      auth: { forestServerToken: 'test-forest-token' },
+    });
+
+    const unblockRef = { fn: (): void => {} };
+    executeSpy.mockReturnValueOnce(
+      new Promise(resolve => {
+        unblockRef.fn = () =>
+          resolve({
+            stepOutcome: {
+              type: 'record',
+              stepId: 'step-inflight-conflict',
+              stepIndex: 0,
+              status: 'success',
+            },
+          });
+      }),
+    );
+
+    runner = new Runner(createRunnerConfig({ workflowPort }));
+
+    const poll1 = runner.triggerPoll('run-1');
+    await flushPromises();
+
+    await expect(runner.triggerPoll('run-1')).rejects.toThrow(RunAlreadyInFlightError);
+
+    unblockRef.fn();
+    await poll1;
+  });
+});
+
+// ---------------------------------------------------------------------------
 // triggerPoll
 // ---------------------------------------------------------------------------
 
@@ -729,7 +827,7 @@ describe('triggerPoll', () => {
     const poll1 = runner.triggerPoll('run-1');
     await Promise.resolve();
 
-    await runner.triggerPoll('run-1');
+    await expect(runner.triggerPoll('run-1')).rejects.toThrow(RunAlreadyInFlightError);
 
     expect(executeSpy).toHaveBeenCalledTimes(1);
 
@@ -951,9 +1049,9 @@ describe('chain', () => {
     const first = runner.triggerPoll('run-1');
     await Promise.resolve();
     // Concurrent trigger arrives — even though the chain will advance stepId, dedup is by runId.
-    await runner.triggerPoll('run-1');
+    await expect(runner.triggerPoll('run-1')).rejects.toThrow(RunAlreadyInFlightError);
 
-    // Only the initial step ran so far; the concurrent trigger was dropped.
+    // Only the initial step ran so far; the concurrent trigger was rejected.
     expect(executeSpy).toHaveBeenCalledTimes(1);
 
     unblockRef.fn();


### PR DESCRIPTION
## What

A duplicate trigger for a run already executing **on this instance** was silently accepted (`200`) after a wasted orchestrator round-trip — the `inFlightRuns` check sat *after* `getAvailableRun` and only `return`ed.

`triggerPoll` now checks `inFlightRuns` **up front** (`assertRunNotInFlight`), before the orchestrator round-trip, and throws the boundary `RunAlreadyInFlightError` → `handleTrigger` maps it to `400` so the front knows the trigger was rejected, not silently accepted.

## Important: this is an optimization, not a concurrency guard

`inFlightRuns` is **per-instance** and a deployment can run **several executors**, so an executor-side check can never be the duplicate-execution guard. Genuine concurrency dedup is the **orchestrator's** job: it atomically claims a `pending` run (`UPDATE … WHERE runState='pending' … FOR UPDATE SKIP LOCKED`), so concurrent triggers — on this executor or another — get nothing back.

The up-front check is purely a best-effort local short-circuit to skip a useless orchestrator round-trip when *this* instance already knows it's running the run.

## Changes
- `assertRunNotInFlight(runId)` early in `triggerPoll` (+ explanatory comment on the intent)
- new boundary `RunAlreadyInFlightError`, mapped to `400` in `handleTrigger`
- tests: the concurrent-trigger test asserts a single execution **because the orchestrator denies the second dispatch** (the dedup is orchestrator-driven by design)

fixes PRD-468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject duplicate triggers of in-flight workflow runs with a 400 error
> - `Runner.triggerPoll` previously silently skipped duplicate triggers; it now throws `RunAlreadyInFlightError` via a new `assertRunNotInFlight` helper when the run ID is already being processed.
> - The `POST /runs/:runId/trigger` endpoint in [`executor-http-server.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1634/files#diff-f24eaa83e4d72cc710e9cb4cea88a2047543ee3c17a0b68627f6af587546b614) catches `RunAlreadyInFlightError` and returns a 400 response with the error message.
> - Behavioral Change: callers that previously received a silent no-op on duplicate trigger requests will now receive a 400 error response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e0f685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->