### PR TITLE
feat(workflow-executor): use the step title as the AI prompt fallback

### DIFF
--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -21,7 +21,7 @@ import {
 function mapTask(task: ServerWorkflowTask): StepDefinition {
   // executionType is passed through as-is; each schema's .default().catch() handles
   // missing or unsupported values without requiring an explicit mapping here.
-  const base = { prompt: task.prompt, executionType: task.executionType };
+  const base = { prompt: task.prompt, executionType: task.executionType, title: task.title };
 
   switch (task.taskType) {
     case ServerTaskTypeEnum.McpServer:
@@ -65,6 +65,7 @@ function mapCondition(condition: ServerWorkflowCondition): ConditionStepDefiniti
     type: StepType.Condition,
     prompt: condition.prompt,
     executionType: condition.executionType,
+    title: condition.title,
     options,
   });
 }

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -224,16 +224,22 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   }
 
   protected buildContextMessage(): SystemMessage {
-    const { user } = this.context;
+    const { user, stepDefinition } = this.context;
     const now = new Date();
 
-    return new SystemMessage(
-      [
-        `Step executed by: ${user.firstName} ${user.lastName} (${user.email}, id: ${user.id})`,
-        `Role: ${user.role} | Team: ${user.team}`,
-        `Current date and time: ${now.toISOString()} (UTC)`,
-      ].join('\n'),
-    );
+    const lines = [
+      `Step executed by: ${user.firstName} ${user.lastName} (${user.email}, id: ${user.id})`,
+      `Role: ${user.role} | Team: ${user.team}`,
+      `Current date and time: ${now.toISOString()} (UTC)`,
+    ];
+
+    // Fall back to the step title only when there is no prompt — the prompt, when present, is the
+    // authoritative intent (surfaced by each executor), so the title would just be noise.
+    if (!stepDefinition.prompt?.trim() && stepDefinition.title) {
+      lines.push(`Step title: "${stepDefinition.title}"`);
+    }
+
+    return new SystemMessage(lines.join('\n'));
   }
 
   protected async buildPreviousStepsMessages(): Promise<SystemMessage[]> {

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -25,6 +25,7 @@ export enum StepExecutionMode {
 const sharedFields = {
   prompt: z.string().optional(),
   aiConfigName: z.string().optional(),
+  title: z.string().optional(),
 };
 
 // Use z.enum(EnumObject), not z.nativeEnum — the latter is deprecated in zod 4.

--- a/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
@@ -118,6 +118,7 @@ describe('toAvailableStepExecution', () => {
       stepDefinition: {
         type: StepType.ReadRecord,
         prompt: 'prompt',
+        title: 'Task',
         executionType: ServerStepExecutionTypeEnum.FullyAutomated,
       },
       previousSteps: [],
@@ -189,6 +190,7 @@ describe('toAvailableStepExecution', () => {
     expect(result?.stepDefinition).toEqual({
       type: StepType.Guidance,
       prompt: 'follow the guide',
+      title: 'guidance',
       executionType: ServerStepExecutionTypeEnum.Manual,
     });
   });

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -60,6 +60,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(task)).toEqual({
         type: StepType.ReadRecord,
         prompt: 'read it',
+        title: 'Test task',
         executionType: ServerStepExecutionTypeEnum.FullyAutomated,
       });
     });
@@ -70,6 +71,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(task)).toEqual({
         type: StepType.UpdateRecord,
         prompt: 'update it',
+        title: 'Test task',
         executionType: ServerStepExecutionTypeEnum.AutomatedWithConfirmation,
       });
     });
@@ -80,6 +82,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(task)).toEqual({
         type: StepType.TriggerAction,
         prompt: 'trigger it',
+        title: 'Test task',
         executionType: ServerStepExecutionTypeEnum.AutomatedWithConfirmation,
       });
     });
@@ -93,6 +96,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(task)).toEqual({
         type: StepType.LoadRelatedRecord,
         prompt: 'load it',
+        title: 'Test task',
         executionType: ServerStepExecutionTypeEnum.AutomatedWithConfirmation,
       });
     });
@@ -108,6 +112,7 @@ describe('toStepDefinition', () => {
         type: StepType.Mcp,
         prompt: 'run mcp',
         mcpServerId: 'mcp-abc',
+        title: 'Test task',
         executionType: ServerStepExecutionTypeEnum.AutomatedWithConfirmation,
       });
     });
@@ -128,6 +133,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(task)).toEqual({
         type: StepType.Guidance,
         prompt: 'guide them',
+        title: 'Test task',
         executionType: StepExecutionMode.Manual,
       });
     });
@@ -196,6 +202,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(condition)).toEqual({
         type: StepType.Condition,
         prompt: 'Choose one',
+        title: 'Test condition',
         options: ['Yes', 'No'],
         executionType: StepExecutionMode.FullyAutomated,
       });
@@ -210,6 +217,7 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(condition)).toEqual({
         type: StepType.Condition,
         prompt: 'Choose one',
+        title: 'Test condition',
         options: ['Approve', 'Reject'],
         executionType: StepExecutionMode.FullyAutomated,
       });

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -61,6 +61,10 @@ class TestableExecutor extends BaseStepExecutor {
     return super.buildPreviousStepsMessages();
   }
 
+  override buildContextMessage(): SystemMessage {
+    return super.buildContextMessage();
+  }
+
   override invokeWithTool<T = Record<string, unknown>>(
     messages: BaseMessage[],
     tool: DynamicStructuredTool,
@@ -175,6 +179,53 @@ function makeContext(
 }
 
 describe('BaseStepExecutor', () => {
+  describe('buildContextMessage', () => {
+    it('falls back to the step title when there is no prompt', () => {
+      const context = makeContext({
+        stepDefinition: {
+          type: StepType.Condition,
+          executionType: StepExecutionMode.Manual,
+          options: ['A', 'B'],
+          title: 'Load the store',
+        },
+      });
+
+      const message = new TestableExecutor(context).buildContextMessage();
+
+      expect(message.content as string).toContain('Step title: "Load the store"');
+    });
+
+    it('omits the title when a prompt is present (the prompt is authoritative)', () => {
+      const context = makeContext({
+        stepDefinition: {
+          type: StepType.Condition,
+          executionType: StepExecutionMode.Manual,
+          options: ['A', 'B'],
+          prompt: 'Pick one',
+          title: 'Load the store',
+        },
+      });
+
+      const message = new TestableExecutor(context).buildContextMessage();
+
+      expect(message.content as string).not.toContain('Step title');
+    });
+
+    it('omits the title line when the step has neither prompt nor title', () => {
+      const context = makeContext({
+        stepDefinition: {
+          type: StepType.Condition,
+          executionType: StepExecutionMode.Manual,
+          options: ['A', 'B'],
+        },
+      });
+
+      const message = new TestableExecutor(context).buildContextMessage();
+
+      expect(message.content as string).not.toContain('Step title');
+    });
+  });
+
   describe('buildPreviousStepsMessages', () => {
     it('returns empty array for empty history', async () => {
       const executor = new TestableExecutor(makeContext());


### PR DESCRIPTION
## What

The orchestrator sends a `title` on every step (`ServerWorkflowStepBase.title`) but the mapper dropped it. Carry it into the domain `StepDefinition` and, in `buildContextMessage`, **fall back to it only when the step has no prompt**.

The prompt, when present, is the authoritative intent (surfaced by each executor), so showing the title too would just be noise. The title rescues steps whose prompt arrives empty (e.g. a load-related step whose prompt is `""` while the title says `"Load the store"`).

## Rule
- prompt present → only the prompt (no title line)
- no prompt → `Step title: "<title>"` is added to the context

## Changes
- add optional `title` to the shared `StepDefinition` fields
- map `task.title` / `condition.title` in `step-definition-mapper`
- `buildContextMessage` appends the title only when the prompt is absent
- tests: mapper threading + the three `buildContextMessage` cases (fallback / prompt-wins / neither)

Small, self-contained slice extracted from the load-related work (#1630). Build + lint clean, 952 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use step title as AI prompt fallback in workflow executor
> - Adds an optional `title` field to all `StepDefinition` variants in [step-definition.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1635/files#diff-66dcc667cb1ebecf3964eecfb28391b1cb81e16c853ad79d4f9017172521aea3) and propagates it through the task and condition mappers in [step-definition-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1635/files#diff-b7de2aee7747c46286af27c1dac9169be8f2469b8a2bebe327065e1cc51efe02).
> - Updates `BaseStepExecutor.buildContextMessage` in [base-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1635/files#diff-f2629617b13363027748d444be5374dd404d26c2f031b0b1a967cceb01d6c6d9) to append a `Step title:` line to the system context message when the step has no prompt; the title is omitted when a prompt is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c1b8e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->