### PR TITLE
fix(workflow-executor): exclude embedded fields from read/update steps

### DIFF
--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { NoReadableFieldsError, NoResolvedFieldsError } from '../errors';
 import RecordStepExecutor from './record-step-executor';
+import { isEmbeddedField } from '../types/validated/collection';
 
 const READ_RECORD_SYSTEM_PROMPT = `You are an AI agent reading fields from a record to answer a user request.
 Select the field(s) that best answer the request. You can read one field or multiple fields at once.
@@ -85,7 +86,7 @@ export default class ReadRecordStepExecutor extends RecordStepExecutor<ReadRecor
   }
 
   private buildReadFieldTool(schema: CollectionSchema): DynamicStructuredTool {
-    const nonRelationFields = schema.fields.filter(f => !f.isRelationship);
+    const nonRelationFields = schema.fields.filter(f => !f.isRelationship && !isEmbeddedField(f));
 
     if (nonRelationFields.length === 0) {
       throw new NoReadableFieldsError(schema.collectionName);

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -14,6 +14,7 @@ import {
   StepStateError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
+import { isEmbeddedField } from '../types/validated/collection';
 import { StepExecutionMode } from '../types/validated/step-definition';
 
 const UPDATE_RECORD_SYSTEM_PROMPT = `You are an AI agent updating a field on a record based on a user request.
@@ -312,7 +313,9 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     // Exclude type-less fields: they can't be coerced/written, so offering them to the AI would
     // let a single drifted field fail the whole step. The override path still rejects an explicit
     // type-less target via FieldTypeMissingError.
-    const nonRelationFields = schema.fields.filter(f => !f.isRelationship && f.type != null);
+    const nonRelationFields = schema.fields.filter(
+      f => !f.isRelationship && f.type != null && !isEmbeddedField(f),
+    );
 
     if (nonRelationFields.length === 0) {
       throw new NoWritableFieldsError(schema.collectionName);

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -54,6 +54,20 @@ export const FieldSchemaSchema = z.object({
 });
 export type FieldSchema = z.infer<typeof FieldSchemaSchema>;
 
+function isEmbeddedColumnType(type: FieldSchema['type']): boolean {
+  if (type === null || type === undefined) return false;
+  if (Array.isArray(type)) return isEmbeddedColumnType(type[0]);
+
+  return typeof type === 'object';
+}
+
+// An object (Mongo sub-document) or array-of-objects columnType. These render through the
+// embedded-document widget, which the orchestrator engine cannot display — so, matching the
+// browser engine (which excludes them too), they are not offered as readable/editable fields.
+export function isEmbeddedField(field: FieldSchema): boolean {
+  return isEmbeddedColumnType(field.type);
+}
+
 // ActionSchema.fields / hooks content is a discriminated union owned by the upstream
 // `@forestadmin/forestadmin-client` lib and consumed downstream by `@forestadmin/agent-client`.
 // We validate the envelope shape only — detail re-validation would duplicate the lib's job.

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -61,9 +61,9 @@ function isEmbeddedColumnType(type: FieldSchema['type']): boolean {
   return typeof type === 'object';
 }
 
-// An object (Mongo sub-document) or array-of-objects columnType. These render through the
-// embedded-document widget, which the orchestrator engine cannot display — so, matching the
-// browser engine (which excludes them too), they are not offered as readable/editable fields.
+// An object (Mongo sub-document) or array-of-objects columnType. Displaying embedded documents
+// in workflow steps is not supported yet, so these fields are excluded from read/update field
+// selection rather than read and returned to the frontend.
 export function isEmbeddedField(field: FieldSchema): boolean {
   return isEmbeddedColumnType(field.type);
 }

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -1369,4 +1369,96 @@ describe('ReadRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
     });
   });
+
+  describe('embedded-document fields excluded', () => {
+    it('excludes an embedded-document field from the field list advertised to the AI', async () => {
+      // Given: a scalar field and an object/embedded-document field on the same collection.
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            { fieldName: 'email', displayName: 'Email', isRelationship: false },
+            {
+              fieldName: 'identity',
+              displayName: 'Identity',
+              isRelationship: false,
+              type: { ssn: 'String', nationality: 'String' },
+            },
+          ],
+        }),
+      });
+      const mockModel = makeMockModel({ fieldNames: ['email'] });
+      const context = makeContext({ model: mockModel.model, workflowPort });
+      const executor = new ReadRecordStepExecutor(context);
+
+      // When
+      const result = await executor.execute();
+
+      // Then: the scalar reads successfully and the embedded field was never offered to the AI.
+      expect(result.stepOutcome.status).toBe('success');
+      const tool = mockModel.bindTools.mock.calls[0][0][0];
+      const advertisedFields = tool.schema.shape.fieldNames.description;
+      expect(advertisedFields).toContain('"Email"');
+      expect(advertisedFields).not.toContain('Identity');
+    });
+
+    it('returns the no-readable-fields error when the only non-relationship field is an embedded document', async () => {
+      // Given: a collection whose sole non-relationship field is an object/embedded-document.
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            {
+              fieldName: 'identity',
+              displayName: 'Identity',
+              isRelationship: false,
+              type: { ssn: 'String', nationality: 'String' },
+            },
+          ],
+        }),
+      });
+      const mockModel = makeMockModel({ fieldNames: ['identity'] });
+      const runStore = makeMockRunStore();
+      const context = makeContext({ model: mockModel.model, runStore, workflowPort });
+      const executor = new ReadRecordStepExecutor(context);
+
+      // When
+      const result = await executor.execute();
+
+      // Then
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'This record type has no readable fields configured in Forest Admin.',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+
+    it('returns the no-readable-fields error when the only non-relationship field is an embedded array', async () => {
+      // Given: a collection whose sole non-relationship field is an array-of-embedded-documents.
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            {
+              fieldName: 'bills',
+              displayName: 'Bills',
+              isRelationship: false,
+              type: [{ title: 'String', amount: 'Number' }],
+            },
+          ],
+        }),
+      });
+      const mockModel = makeMockModel({ fieldNames: ['bills'] });
+      const runStore = makeMockRunStore();
+      const context = makeContext({ model: mockModel.model, runStore, workflowPort });
+      const executor = new ReadRecordStepExecutor(context);
+
+      // When
+      const result = await executor.execute();
+
+      // Then
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'This record type has no readable fields configured in Forest Admin.',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -875,6 +875,110 @@ describe('UpdateRecordStepExecutor', () => {
     });
   });
 
+  describe('embedded-document fields excluded', () => {
+    it('does not offer an embedded-document field to the AI, so a scalar field still updates', async () => {
+      // Given: a scalar field and an object/embedded-document field on the same collection.
+      const agentPort = makeMockAgentPort({ status: 'active' });
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            { fieldName: 'status', displayName: 'Status', isRelationship: false, type: 'String' },
+            {
+              fieldName: 'identity',
+              displayName: 'Identity',
+              isRelationship: false,
+              type: { ssn: 'String', nationality: 'String' },
+            },
+          ],
+        }),
+      });
+      const mockModel = makeMockModel({
+        input: { fieldName: 'Status', value: 'active', reasoning: 'r' },
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        workflowPort,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      // When
+      const result = await executor.execute();
+
+      // Then: the scalar updates, and the embedded field is not an accepted choice on the tool.
+      // (value: null is valid for any field — `.nullable()` — so a throw isolates the field-name rejection.)
+      expect(result.stepOutcome.status).toBe('success');
+      const tool = mockModel.bindTools.mock.calls[0][0][0];
+      expect(() =>
+        tool.schema.parse({ input: { fieldName: 'Status', value: null, reasoning: 'r' } }),
+      ).not.toThrow();
+      expect(() =>
+        tool.schema.parse({ input: { fieldName: 'Identity', value: null, reasoning: 'r' } }),
+      ).toThrow();
+    });
+
+    it('returns the no-editable-fields error when the only non-relationship field is an embedded document', async () => {
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            {
+              fieldName: 'identity',
+              displayName: 'Identity',
+              isRelationship: false,
+              type: { ssn: 'String', nationality: 'String' },
+            },
+          ],
+        }),
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        runStore,
+        workflowPort,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'This record type has no editable fields configured in Forest Admin.',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+
+    it('returns the no-editable-fields error when the only non-relationship field is an embedded array', async () => {
+      const workflowPort = makeMockWorkflowPort({
+        customers: makeCollectionSchema({
+          fields: [
+            {
+              fieldName: 'bills',
+              displayName: 'Bills',
+              isRelationship: false,
+              type: [{ title: 'String', amount: 'Number' }],
+            },
+          ],
+        }),
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        runStore,
+        workflowPort,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'This record type has no editable fields configured in Forest Admin.',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
+  });
+
   describe('resolveFieldName failure', () => {
     it('returns error when field is not found during executionType=FullyAutomated (Branch B)', async () => {
       // AI returns a display name that doesn't match any field in the schema

--- a/packages/workflow-executor/test/types/collection.test.ts
+++ b/packages/workflow-executor/test/types/collection.test.ts
@@ -1,0 +1,33 @@
+import type { FieldSchema } from '../../src/types/validated/collection';
+
+import { isEmbeddedField } from '../../src/types/validated/collection';
+
+function fieldWithType(type: FieldSchema['type']): FieldSchema {
+  return { fieldName: 'attr', displayName: 'Attr', isRelationship: false, type };
+}
+
+describe('isEmbeddedField', () => {
+  it('returns true for an object (embedded document) columnType', () => {
+    expect(isEmbeddedField(fieldWithType({ ssn: 'String', nationality: 'String' }))).toBe(true);
+  });
+
+  it('returns true for an array-of-objects (embedded array) columnType', () => {
+    expect(isEmbeddedField(fieldWithType([{ title: 'String', amount: 'Number' }]))).toBe(true);
+  });
+
+  it('returns false for a primitive columnType', () => {
+    expect(isEmbeddedField(fieldWithType('String'))).toBe(false);
+  });
+
+  it('returns false for an array-of-primitives columnType', () => {
+    expect(isEmbeddedField(fieldWithType(['String']))).toBe(false);
+  });
+
+  it('returns false when the columnType is null', () => {
+    expect(isEmbeddedField(fieldWithType(null))).toBe(false);
+  });
+
+  it('returns false when the columnType is undefined', () => {
+    expect(isEmbeddedField(fieldWithType(undefined))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The orchestrator engine's get-data (ReadRecord) and update-record steps offered embedded object / array-of-object columns to the AI. The executor read them and returned plain JSON, which the orchestrator frontend can't render (it expects an Ember Data model) — crashing the workflow panel in dev/staging, blank-rendering in production.

The browser engine never exposes embedded fields for selection, so this filters them out in the executor to match that behaviour, rather than rendering them (parity-correct, no frontend change).

## Changes

- `isEmbeddedField` predicate in `types/validated/collection.ts` (object or array-of-object columnType).
- read-record and update-record field selection now exclude embedded fields.

## Tests

- Predicate unit tests + read/update executor tests (embedded field not offered to the AI; an only-embedded schema yields the no-readable/editable-fields error). Impacted suites 130/130 green; eslint/tsc/prettier clean.

## Notes

- Targets `feat/prd-214-server-step-mapper` (the executor work branch); the `workflow-executor` package is not yet on `main`.
- PRD-488 (relation / `asModels` projection 400) is a separate, related executor bug tracked on its own ticket — not addressed here.

fixes PRD-481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude embedded-document fields from workflow read and update steps
> - Adds `isEmbeddedField` and `isEmbeddedColumnType` helpers in [`collection.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1639/files#diff-b531cab4040638c8075825f7fe7c720b2b72d92f56ff849bff39f9e0824ab2bd) to detect object and array-of-object field types.
> - Filters out embedded-document fields in `ReadRecordStepExecutor.buildReadFieldTool` and `UpdateRecordStepExecutor.buildUpdateFieldTool`, alongside the existing exclusion of relationship fields.
> - When all remaining non-relationship fields are embedded, the executors now throw `NoReadableFieldsError` or `NoWritableFieldsError` respectively.
> - Behavioral Change: the AI tool no longer receives embedded fields as candidates for read or update operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 118f19a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->