### PR TITLE
feat(workflow-executor): handle polymorphic relations in load-related (skip + follow) [PRD-493]

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -5,6 +5,7 @@ import type {
   GetRecordQuery,
   GetRelatedDataQuery,
   GetSingleRelatedDataQuery,
+  ResolvePolymorphicTypeQuery,
   UpdateRecordQuery,
 } from '../ports/agent-port';
 import type SchemaCache from '../schema-cache';
@@ -211,9 +212,9 @@ export default class AgentClientAgentPort implements AgentPort {
     }
   }
 
-  private createClient(user: StepUser) {
+  private mintToken(user: StepUser): string {
     // snake_case aliases: Ruby/Python agents splat JWT claims into Caller.new (snake_case kwargs).
-    const token = jsonwebtoken.sign(
+    return jsonwebtoken.sign(
       {
         ...user,
         first_name: user.firstName,
@@ -225,11 +226,47 @@ export default class AgentClientAgentPort implements AgentPort {
       this.authSecret,
       { expiresIn: '5m' },
     );
+  }
 
+  private createClient(user: StepUser) {
     return createRemoteAgentClient({
       url: this.agentUrl,
-      token,
+      token: this.mintToken(user),
       actionEndpoints: this.buildActionEndpoints(),
+    });
+  }
+
+  // Resolves a polymorphic relation's target from the RAW JSON:API linkage. The agent-client
+  // deserializer drops relationship `type`, so we read the record-with-projection response directly:
+  // `data.relationships.<relation>.data = { type, id }`. No UI-exposed discriminator field needed.
+  async resolvePolymorphicType(
+    { collection, id, relation }: ResolvePolymorphicTypeQuery,
+    user: StepUser,
+  ): Promise<{ type: string; id: string } | null> {
+    return this.callAgent('resolvePolymorphicType', async () => {
+      const recordId = id.map(String).join('|');
+      const params = new URLSearchParams({
+        [`fields[${collection}]`]: relation,
+        [`fields[${relation}]`]: 'id',
+        timezone: 'Europe/Paris',
+      });
+      const base = this.agentUrl.replace(/\/+$/, '');
+      const response = await fetch(`${base}/forest/${collection}/${recordId}?${params}`, {
+        headers: { Authorization: `Bearer ${this.mintToken(user)}`, Accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `resolvePolymorphicType ${collection}/${recordId}: HTTP ${response.status}`,
+        );
+      }
+
+      const body = (await response.json()) as {
+        data?: { relationships?: Record<string, { data?: { type?: string; id?: string } | null }> };
+      };
+      const linkage = body?.data?.relationships?.[relation]?.data;
+
+      return linkage?.type ? { type: String(linkage.type), id: String(linkage.id) } : null;
     });
   }
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -174,8 +174,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
 
+    // Polymorphic relations carry no relatedCollectionName (the orchestrator omits it) and can't be
+    // followed — exclude them so we never offer a relation that would fail in buildTarget.
     const availableFields: RelationRef[] = sourceSchema.fields
-      .filter(f => f.isRelationship)
+      .filter(f => f.isRelationship && f.relatedCollectionName)
       .map(f => ({ name: f.fieldName, displayName: f.displayName }));
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
@@ -490,7 +492,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   }
 
   private buildSelectRelationTool(schema: CollectionSchema): DynamicStructuredTool {
-    const relationFields = schema.fields.filter(f => f.isRelationship);
+    // Skip unfollowable (polymorphic) relations, same as availableFields — never offer them to the AI.
+    const relationFields = schema.fields.filter(f => f.isRelationship && f.relatedCollectionName);
 
     if (relationFields.length === 0) {
       throw new NoRelationshipFieldsError(schema.collectionName);

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -183,27 +183,27 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       return field.relatedCollectionName;
     }
 
-    const typeField = field.polymorphicTypeField;
-
-    if (!typeField) {
+    if (!field.polymorphicTypeField) {
       throw new StepStateError(
         `Step at index ${this.context.stepIndex} could not resolve relatedCollectionName for relation "${field.fieldName}"`,
       );
     }
 
-    const source = await this.context.agentPort.getRecord(
+    // Read the target type from the raw relationship linkage (the discriminator column is not a
+    // UI-exposed field). The agent resolves the polymorphic association per record.
+    const linkage = await this.context.agentPort.resolvePolymorphicType(
       {
         collection: selectedRecordRef.collectionName,
         id: selectedRecordRef.recordId,
-        fields: [typeField],
+        relation: field.fieldName,
       },
       this.context.user,
     );
-    const discriminator = source.values[typeField];
+    const discriminator = linkage?.type;
 
-    if (typeof discriminator !== 'string' || discriminator.length === 0) {
+    if (!discriminator) {
       throw new StepStateError(
-        `Step at index ${this.context.stepIndex}: polymorphic relation "${field.fieldName}" has no "${typeField}" value on the selected record`,
+        `Step at index ${this.context.stepIndex}: polymorphic relation "${field.fieldName}" has no resolvable target on the selected record`,
       );
     }
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -5,7 +5,12 @@ import type {
   LoadRelatedRecordStepExecutionData,
   RelationRef,
 } from '../types/step-execution-data';
-import type { CollectionSchema, RecordData, RecordRef } from '../types/validated/collection';
+import type {
+  CollectionSchema,
+  FieldSchema,
+  RecordData,
+  RecordRef,
+} from '../types/validated/collection';
 import type { LoadRelatedRecordStepDefinition } from '../types/validated/step-definition';
 
 import { DynamicStructuredTool, HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
@@ -55,6 +60,12 @@ interface RelationTarget extends RelationRef {
   relatedCollectionName: string;
 }
 
+// A relation is followable when it has a static target (relatedCollectionName) or is a polymorphic
+// relation resolvable per record (polymorphicTypeField names the discriminator column to read).
+function isFollowableRelation(field: FieldSchema): boolean {
+  return field.isRelationship && Boolean(field.relatedCollectionName || field.polymorphicTypeField);
+}
+
 export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<LoadRelatedRecordStepDefinition> {
   protected override buildActivityLogArgs(): CreateActivityLogArgs | null {
     return {
@@ -97,7 +108,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     }
 
     const schema = await this.getCollectionSchema(execution.selectedRecordRef.collectionName);
-    const target = this.buildTarget(schema, fieldName, execution.selectedRecordRef);
+    const target = await this.buildTarget(schema, fieldName, execution.selectedRecordRef);
     const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
@@ -127,7 +138,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     const recordedRelation = preRecordedArgs?.relationName;
     const relationName =
       recordedRelation ?? (await this.selectRelation(schema, step.prompt)).relationName;
-    const target = this.buildTarget(schema, relationName, selectedRecordRef);
+    const target = await this.buildTarget(schema, relationName, selectedRecordRef);
 
     // Branch B -- fully automated execution
     if (step.executionType === StepExecutionMode.FullyAutomated) {
@@ -138,21 +149,15 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     return this.saveAndAwaitInput(target, schema);
   }
 
-  private buildTarget(
+  private async buildTarget(
     schema: CollectionSchema,
     relationName: string,
     selectedRecordRef: RecordRef,
-  ): RelationTarget {
+  ): Promise<RelationTarget> {
     const field = this.findFieldByTechnicalName(schema, relationName);
 
     if (!field) {
       throw new RelationNotFoundError(relationName, schema.collectionName);
-    }
-
-    if (!field.relatedCollectionName) {
-      throw new StepStateError(
-        `Step at index ${this.context.stepIndex} could not resolve relatedCollectionName for relation "${relationName}"`,
-      );
     }
 
     return {
@@ -160,8 +165,62 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       displayName: field.displayName,
       name: field.fieldName,
       relationType: field.relationType,
-      relatedCollectionName: field.relatedCollectionName,
+      relatedCollectionName: await this.resolveTargetCollection(field, selectedRecordRef),
     };
+  }
+
+  // Resolves the concrete target collection of a relation for a given source record.
+  // - Static relations (regular BelongsTo, or single-target polymorphic resolved by the
+  //   orchestrator) expose `relatedCollectionName` directly.
+  // - Multi-target polymorphic relations expose only `polymorphicTypeField` (the discriminator
+  //   column, e.g. "imageable_type") + the candidate models, so we read the discriminator value on
+  //   the source record and map it to one of the candidates — the target depends on the record.
+  private async resolveTargetCollection(
+    field: FieldSchema,
+    selectedRecordRef: RecordRef,
+  ): Promise<string> {
+    if (field.relatedCollectionName) {
+      return field.relatedCollectionName;
+    }
+
+    const typeField = field.polymorphicTypeField;
+
+    if (!typeField) {
+      throw new StepStateError(
+        `Step at index ${this.context.stepIndex} could not resolve relatedCollectionName for relation "${field.fieldName}"`,
+      );
+    }
+
+    const source = await this.context.agentPort.getRecord(
+      {
+        collection: selectedRecordRef.collectionName,
+        id: selectedRecordRef.recordId,
+        fields: [typeField],
+      },
+      this.context.user,
+    );
+    const discriminator = source.values[typeField];
+
+    if (typeof discriminator !== 'string' || discriminator.length === 0) {
+      throw new StepStateError(
+        `Step at index ${this.context.stepIndex}: polymorphic relation "${field.fieldName}" has no "${typeField}" value on the selected record`,
+      );
+    }
+
+    const candidates = field.polymorphicReferencedModels ?? [];
+    const target =
+      candidates.find(c => c === discriminator) ??
+      candidates.find(c => c.toLowerCase() === discriminator.toLowerCase());
+
+    if (!target) {
+      throw new StepStateError(
+        `Step at index ${this.context.stepIndex}: polymorphic relation "${
+          field.fieldName
+        }" resolved to "${discriminator}", not among [${candidates.join(', ')}]`,
+      );
+    }
+
+    return target;
   }
 
   // Branch C: AI suggests the best candidate, then awaits user confirmation. Save errors
@@ -174,10 +233,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
 
-    // Polymorphic relations carry no relatedCollectionName (the orchestrator omits it) and can't be
-    // followed — exclude them so we never offer a relation that would fail in buildTarget.
     const availableFields: RelationRef[] = sourceSchema.fields
-      .filter(f => f.isRelationship && f.relatedCollectionName)
+      .filter(isFollowableRelation)
       .map(f => ({ name: f.fieldName, displayName: f.displayName }));
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
@@ -327,18 +384,19 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       throw new RelatedRecordNotFoundError(selectedRecordRef.collectionName, name);
     }
 
-    // Re-derive relatedCollectionName from the live schema — frontend never sends it.
+    // Re-derive the target collection from the live schema — frontend never sends it. Handles both
+    // static relations and polymorphic ones (resolved per record from the discriminator).
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const field = schema.fields.find(f => f.fieldName === name);
 
-    if (!field?.relatedCollectionName) {
+    if (!field) {
       throw new StepStateError(
-        `Step at index ${this.context.stepIndex} could not resolve relatedCollectionName for relation "${name}"`,
+        `Step at index ${this.context.stepIndex} could not resolve relation "${name}" from the schema`,
       );
     }
 
     const record: RecordRef = {
-      collectionName: field.relatedCollectionName,
+      collectionName: await this.resolveTargetCollection(field, selectedRecordRef),
       recordId: selectedRecordId,
       stepIndex: this.context.stepIndex,
     };
@@ -492,8 +550,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   }
 
   private buildSelectRelationTool(schema: CollectionSchema): DynamicStructuredTool {
-    // Skip unfollowable (polymorphic) relations, same as availableFields — never offer them to the AI.
-    const relationFields = schema.fields.filter(f => f.isRelationship && f.relatedCollectionName);
+    // Only offer followable relations to the AI (static target or resolvable polymorphic).
+    const relationFields = schema.fields.filter(isFollowableRelation);
 
     if (relationFields.length === 0) {
       throw new NoRelationshipFieldsError(schema.collectionName);

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -37,6 +37,8 @@ export type GetSingleRelatedDataQuery = {
   fields?: string[];
 };
 
+export type ResolvePolymorphicTypeQuery = { collection: string; id: Id[]; relation: string };
+
 export type ExecuteActionQuery = { collection: string; action: string; id?: Id[] };
 
 export type GetActionFormInfoQuery = { collection: string; action: string; id: Id[] };
@@ -50,6 +52,13 @@ export interface AgentPort {
     query: GetSingleRelatedDataQuery,
     user: StepUser,
   ): Promise<RecordData | null>;
+  // Resolves a polymorphic relation's target from the raw JSON:API linkage
+  // (data.relationships.<relation>.data = { type, id }), which the agent-client deserializer drops.
+  // Returns null when the record has no linked target. Needs no UI-exposed discriminator field.
+  resolvePolymorphicType(
+    query: ResolvePolymorphicTypeQuery,
+    user: StepUser,
+  ): Promise<{ type: string; id: string } | null>;
   executeAction(query: ExecuteActionQuery, user: StepUser): Promise<unknown>;
   // Old Ruby agents with hooks.load=false return 404; agent-client falls back to the fields
   // passed via ActionEndpointsByCollection (populated from the orchestrator's schema).

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -44,6 +44,11 @@ export const FieldSchemaSchema = z.object({
   isRelationship: z.boolean(),
   relationType: z.enum(['BelongsTo', 'HasMany', 'HasOne', 'BelongsToMany']).optional(),
   relatedCollectionName: z.string().optional(),
+  // Polymorphic relations: no single static target. `polymorphicTypeField` names the discriminator
+  // column on the source record (e.g. "imageable_type"); `polymorphicReferencedModels` lists the
+  // candidate target collections. The executor resolves the actual target per record at follow time.
+  polymorphicTypeField: z.string().optional(),
+  polymorphicReferencedModels: z.array(z.string()).optional(),
   type: ColumnTypeSchema.nullable().optional(),
   enumValues: z.array(z.string()).min(1).optional(),
 });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -788,6 +788,54 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('excludes relationship fields without a relatedCollectionName (polymorphic) from availableFields', async () => {
+      const agentPort = makeMockAgentPort(); // returns 1 record: orders #99
+      const mockModel = makeMockModel({ relationName: 'Order', reasoning: 'User requested order' });
+      const runStore = makeMockRunStore();
+      // Polymorphic relations carry no relatedCollectionName (the orchestrator omits it because
+      // their apimap reference points at a non-collection association). They have no resolvable
+      // target, so they must not be offered as a followable relation.
+      const schemaWithPolymorphic = makeCollectionSchema({
+        fields: [
+          { fieldName: 'email', displayName: 'Email', isRelationship: false },
+          {
+            fieldName: 'order',
+            displayName: 'Order',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            relatedCollectionName: 'orders',
+          },
+          {
+            fieldName: 'imageable',
+            displayName: 'Imageable',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            // no relatedCollectionName → polymorphic, unfollowable
+          },
+        ],
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        workflowPort: makeMockWorkflowPort({ customers: schemaWithPolymorphic }),
+      });
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          pendingData: expect.objectContaining({
+            // 'imageable' is excluded; only the followable 'order' relation remains.
+            availableFields: [{ name: 'order', displayName: 'Order' }],
+          }),
+        }),
+      );
+    });
+
     // Uses HasMany ('Address') because BelongsTo/HasOne now short-circuit to a single
     // xToOne candidate (no select-fields/select-record-by-content AI calls).
     it('runs field-selection + record-selection AI calls when multiple related records exist', async () => {
@@ -2062,12 +2110,44 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
       expect(runStore.saveStepExecution).not.toHaveBeenCalled();
     });
+
+    it('returns error when the only relation is polymorphic (no followable relations)', async () => {
+      // A relation without relatedCollectionName is polymorphic and unfollowable. When it's the
+      // only relation, there's nothing to offer → same outcome as having no relations at all.
+      const schema = makeCollectionSchema({
+        fields: [
+          { fieldName: 'email', displayName: 'Email', isRelationship: false },
+          {
+            fieldName: 'imageable',
+            displayName: 'Imageable',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+          },
+        ],
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: makeMockModel().model,
+        runStore,
+        workflowPort: makeMockWorkflowPort({ customers: schema }),
+      });
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'This record type has no relations configured in Forest Admin.',
+      );
+      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
+    });
   });
 
   describe('StepStateError on malformed schema', () => {
-    // A relationship field with no relatedCollectionName can't be followed — throw rather than
-    // silently falling back to the field name (which would 404 later as a bogus collection).
-    it('returns error when the selected relation has no relatedCollectionName', async () => {
+    // The AI can no longer pick a relation without relatedCollectionName (selectRelation filters
+    // them out), but the pre-recorded path bypasses that filter — so buildTarget stays the safety
+    // net: it throws rather than falling back to the field name (which would 404 as a bogus collection).
+    it('returns error when a pre-recorded relation has no relatedCollectionName', async () => {
       const schema = makeCollectionSchema({
         fields: [
           {
@@ -2078,13 +2158,15 @@ describe('LoadRelatedRecordStepExecutor', () => {
           },
         ],
       });
-      const mockModel = makeMockModel({ relationName: 'Order', reasoning: 'test' });
       const runStore = makeMockRunStore();
       const context = makeContext({
-        model: mockModel.model,
+        model: makeMockModel().model,
         runStore,
         workflowPort: makeMockWorkflowPort({ customers: schema }),
-        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { relationName: 'order' },
+        }),
       });
       const executor = new LoadRelatedRecordStepExecutor(context);
 

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -264,6 +264,94 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
+  describe('multi-target polymorphic relation (resolved per record)', () => {
+    // A polymorphic relation carries no relatedCollectionName: only the discriminator column name
+    // (polymorphicTypeField) + the candidate models. The target is read per record at follow time.
+    function makePolymorphicContext(
+      discriminator: unknown,
+      extra: Partial<ExecutionContext<LoadRelatedRecordStepDefinition>> = {},
+    ) {
+      const polymorphicSchema = makeCollectionSchema({
+        fields: [
+          { fieldName: 'email', displayName: 'Email', isRelationship: false },
+          {
+            fieldName: 'imageable',
+            displayName: 'Imageable',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            polymorphicTypeField: 'imageable_type',
+            polymorphicReferencedModels: ['orders', 'addresses'],
+          },
+        ],
+      });
+      const agentPort = makeMockAgentPort(); // getSingleRelatedData → orders #99
+      (agentPort.getRecord as jest.Mock).mockResolvedValue({
+        collectionName: 'customers',
+        recordId: [42],
+        values: { imageable_type: discriminator },
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: makeMockModel({ relationName: 'Imageable', reasoning: 'load it' }).model,
+        agentPort,
+        runStore,
+        workflowPort: makeMockWorkflowPort({ customers: polymorphicSchema }),
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+        ...extra,
+      });
+
+      return { agentPort, runStore, context };
+    }
+
+    it('reads the discriminator and follows the relation into the resolved collection', async () => {
+      const { agentPort, runStore, context } = makePolymorphicContext('orders');
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // The discriminator column is read on the source record...
+      expect(agentPort.getRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', id: [42], fields: ['imageable_type'] }),
+        expect.anything(),
+      );
+      // ...and its value ("orders") becomes the target collection used to fetch + label the record.
+      expect(agentPort.getSingleRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relation: 'imageable',
+          relatedSchema: expect.objectContaining({ collectionName: 'orders' }),
+        }),
+        expect.anything(),
+      );
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          executionResult: expect.objectContaining({
+            record: expect.objectContaining({ collectionName: 'orders', recordId: ['99'] }),
+          }),
+        }),
+      );
+    });
+
+    it('returns an error when the discriminator value is not among the candidate models', async () => {
+      const { context } = makePolymorphicContext('comments'); // not in ['orders','addresses']
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+    });
+
+    it('returns an error when the discriminator value is missing on the record', async () => {
+      const { context } = makePolymorphicContext(null);
+      const executor = new LoadRelatedRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+    });
+  });
+
   describe('executionType=FullyAutomated: HasMany — 2 AI calls (Branch B)', () => {
     it('runs selectRelevantFields + selectBestRecord to pick the best candidate', async () => {
       const hasManySchema = makeCollectionSchema({

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -65,6 +65,7 @@ function makeMockAgentPort(relatedData: RecordData[] = [makeRelatedRecordData()]
     updateRecord: jest.fn(),
     getRelatedData: jest.fn().mockResolvedValue(relatedData),
     getSingleRelatedData,
+    resolvePolymorphicType: jest.fn().mockResolvedValue(null),
     executeAction: jest.fn(),
   } as unknown as AgentPort;
 }
@@ -285,11 +286,10 @@ describe('LoadRelatedRecordStepExecutor', () => {
         ],
       });
       const agentPort = makeMockAgentPort(); // getSingleRelatedData → orders #99
-      (agentPort.getRecord as jest.Mock).mockResolvedValue({
-        collectionName: 'customers',
-        recordId: [42],
-        values: { imageable_type: discriminator },
-      });
+      // The target type comes from the raw relationship linkage (no UI-exposed discriminator field).
+      (agentPort.resolvePolymorphicType as jest.Mock).mockResolvedValue(
+        discriminator == null ? null : { type: String(discriminator), id: '99' },
+      );
       const runStore = makeMockRunStore();
       const context = makeContext({
         model: makeMockModel({ relationName: 'Imageable', reasoning: 'load it' }).model,
@@ -310,9 +310,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
       const result = await executor.execute();
 
       expect(result.stepOutcome.status).toBe('success');
-      // The discriminator column is read on the source record...
-      expect(agentPort.getRecord).toHaveBeenCalledWith(
-        expect.objectContaining({ collection: 'customers', id: [42], fields: ['imageable_type'] }),
+      // The target type is read from the relationship linkage on the source record...
+      expect(agentPort.resolvePolymorphicType).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', id: [42], relation: 'imageable' }),
         expect.anything(),
       );
       // ...and its value ("orders") becomes the target collection used to fetch + label the record.


### PR DESCRIPTION
## What

Makes the *load-related-record* step handle polymorphic relations end-to-end:

1. **Skip unfollowable ones** — a polymorphic relation the orchestrator can't resolve is never offered nor picked (no crash on `getCollectionSchema("<association>")`).
2. **Follow resolvable ones** — a polymorphic relation exposed with a discriminator + candidate models (`polymorphicReferencedModels`) is followable; the target collection is resolved **per record**.

## How the target is resolved (no UI-exposed field)

The discriminator column (e.g. `imageable_type`) must **not** be a Forest field (it would appear in the UI), so it isn't projectable. The target type is read from the **raw JSON:API relationship linkage** instead — `data.relationships.<relation>.data.type` — which the agent-client deserializer drops:

- `AgentPort.resolvePolymorphicType`: raw fetch of the `<relation>@@@id` projection, returns the linkage `{ type, id }` (reuses the run's JWT → passes the agent's permission layer).
- `resolveTargetCollection` maps that type to one of `polymorphicReferencedModels` (centralised; used by `buildTarget` and the Branch A re-entry path).
- `isFollowableRelation` = has `relatedCollectionName` **or** `polymorphicTypeField`.
- Clean errors when the linkage has no target or the type isn't among the candidates.

## Tests

74/74 in `load-related-record-step-executor.test.ts`, incl. per-record resolution into the right collection, unknown discriminator, missing target. Build + lint clean.

## Validated end-to-end (forest_liana v1)

Same `imageable` relation, target resolved per record:
- Image #4 → **User** #2
- Image #2 → **Product** #53

No UI-exposed discriminator field.

## Dependencies (cross-repo)

- **Orchestrator** exposes `polymorphicTypeField` + `polymorphicReferencedModels` (forestadmin-server #8286).
- **Agent** marks the relation polymorphic via `foreign_key_type_field` (forest-rails `feat/polymorphic-foreign-key-type-field`).

fixes PRD-493
