### PR TITLE
fix(workflow-executor): enforce a minimum Node.js version

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -10,6 +10,9 @@ client data ever leaves your infrastructure.
 
 ### Install
 
+Requires Node.js 20 or higher. The executor refuses to start on older runtimes
+with an explicit message.
+
 ```bash
 npm install -g @forestadmin/workflow-executor
 ```

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -10,8 +10,6 @@ client data ever leaves your infrastructure.
 
 ### Install
 
-Requires Node.js 20 or higher.
-
 ```bash
 npm install -g @forestadmin/workflow-executor
 ```

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -10,8 +10,7 @@ client data ever leaves your infrastructure.
 
 ### Install
 
-Requires Node.js 20 or higher. The executor refuses to start on older runtimes
-with an explicit message.
+Requires Node.js 20 or higher.
 
 ```bash
 npm install -g @forestadmin/workflow-executor

--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -6,6 +6,9 @@
     "forest-workflow-executor": "dist/cli.js"
   },
   "license": "GPL-3.0",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -7,7 +7,7 @@
   },
   "license": "GPL-3.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.12.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,7 +1,11 @@
-// Driven by the heaviest runtime dependency floor: @langchain/openai requires Node >= 20
-// (koa requires >= 18). Keep this module free of heavy imports so the CLI entry can run the
-// guard before those modules are evaluated on an unsupported runtime.
-export const MINIMUM_NODE_MAJOR = 20;
+// The minimum Node major is the single source of truth in package.json `engines.node` (which npm
+// also reads at install time); derive it here so the runtime guard can never drift from it.
+// Requiring a JSON file keeps this module free of heavy imports, so the CLI entry can run the guard
+// before koa / @langchain/openai are evaluated — on an unsupported runtime those would crash first.
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+const { engines } = require('../package.json') as { engines?: { node?: string } };
+
+export const MINIMUM_NODE_MAJOR = Number.parseInt(/\d+/.exec(engines?.node ?? '')?.[0] ?? '', 10);
 
 function parseMajor(version: string): number {
   return Number.parseInt(version.replace(/^v/, ''), 10);

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,7 +1,9 @@
-// Pulls the leading major out of any version-ish string: a version (`v20.1.0`) or an engines
-// range (`>=20.0.0`) both yield 20.
-function parseMajor(version: string): number {
-  return Number.parseInt(/\d+/.exec(version)?.[0] ?? '', 10);
+// Pulls [major, minor, patch] out of any version-ish string: a version (`v22.11.0`) or an engines
+// range (`>=22.12.0`) both parse to their numeric parts.
+function parseVersion(version: string): [number, number, number] {
+  const [major = 0, minor = 0, patch = 0] = (version.match(/\d+/g) ?? []).map(Number);
+
+  return [major, minor, patch];
 }
 
 // Single source of truth for the floor: read it from package.json `engines.node` so the runtime
@@ -9,28 +11,34 @@ function parseMajor(version: string): number {
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
 const { engines } = require('../package.json') as { engines?: { node?: string } };
 
-export const MINIMUM_NODE_MAJOR = parseMajor(engines?.node ?? '');
+export const MINIMUM_NODE_VERSION = (engines?.node ?? '').replace(/^\D*/, '');
 
 export function isSupportedNodeVersion(
   currentVersion: string,
-  minimumMajor: number = MINIMUM_NODE_MAJOR,
+  minimumVersion: string = MINIMUM_NODE_VERSION,
 ): boolean {
-  return parseMajor(currentVersion) >= minimumMajor;
+  const [curMajor, curMinor, curPatch] = parseVersion(currentVersion);
+  const [minMajor, minMinor, minPatch] = parseVersion(minimumVersion);
+
+  if (curMajor !== minMajor) return curMajor > minMajor;
+  if (curMinor !== minMinor) return curMinor > minMinor;
+
+  return curPatch >= minPatch;
 }
 
 export function unsupportedNodeVersionMessage(
   currentVersion: string,
-  minimumMajor: number = MINIMUM_NODE_MAJOR,
+  minimumVersion: string = MINIMUM_NODE_VERSION,
 ): string {
   return (
-    `The Forest workflow executor requires Node.js ${minimumMajor} or higher, ` +
+    `The Forest workflow executor requires Node.js ${minimumVersion} or higher, ` +
     `but the current version is ${currentVersion}. Please upgrade Node.js to continue.`
   );
 }
 
 interface CheckNodeVersionDeps {
   currentVersion?: string;
-  minimumMajor?: number;
+  minimumVersion?: string;
   printError?: (message: string) => void;
   exit?: (code: number) => void;
 }
@@ -38,15 +46,15 @@ interface CheckNodeVersionDeps {
 export default function checkNodeVersion(deps: CheckNodeVersionDeps = {}): void {
   const {
     currentVersion = process.version,
-    minimumMajor = MINIMUM_NODE_MAJOR,
+    minimumVersion = MINIMUM_NODE_VERSION,
     printError = (message: string) => {
       process.stderr.write(`${message}\n`);
     },
     exit = (code: number) => process.exit(code),
   } = deps;
 
-  if (isSupportedNodeVersion(currentVersion, minimumMajor)) return;
+  if (isSupportedNodeVersion(currentVersion, minimumVersion)) return;
 
-  printError(unsupportedNodeVersionMessage(currentVersion, minimumMajor));
+  printError(unsupportedNodeVersionMessage(currentVersion, minimumVersion));
   exit(1);
 }

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,0 +1,48 @@
+// Driven by the heaviest runtime dependency floor: @langchain/openai requires Node >= 20
+// (koa requires >= 18). Keep this module free of heavy imports so the CLI entry can run the
+// guard before those modules are evaluated on an unsupported runtime.
+export const MINIMUM_NODE_MAJOR = 20;
+
+function parseMajor(version: string): number {
+  return Number.parseInt(version.replace(/^v/, ''), 10);
+}
+
+export function isSupportedNodeVersion(
+  currentVersion: string,
+  minimumMajor: number = MINIMUM_NODE_MAJOR,
+): boolean {
+  return parseMajor(currentVersion) >= minimumMajor;
+}
+
+export function unsupportedNodeVersionMessage(
+  currentVersion: string,
+  minimumMajor: number = MINIMUM_NODE_MAJOR,
+): string {
+  return (
+    `The Forest workflow executor requires Node.js ${minimumMajor} or higher, ` +
+    `but the current version is ${currentVersion}. Please upgrade Node.js to continue.`
+  );
+}
+
+interface CheckNodeVersionDeps {
+  currentVersion?: string;
+  minimumMajor?: number;
+  printError?: (message: string) => void;
+  exit?: (code: number) => void;
+}
+
+export default function checkNodeVersion(deps: CheckNodeVersionDeps = {}): void {
+  const {
+    currentVersion = process.version,
+    minimumMajor = MINIMUM_NODE_MAJOR,
+    printError = (message: string) => {
+      process.stderr.write(`${message}\n`);
+    },
+    exit = (code: number) => process.exit(code),
+  } = deps;
+
+  if (isSupportedNodeVersion(currentVersion, minimumMajor)) return;
+
+  printError(unsupportedNodeVersionMessage(currentVersion, minimumMajor));
+  exit(1);
+}

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,5 +1,3 @@
-// Pulls [major, minor, patch] out of any version-ish string: a version (`v22.11.0`) or an engines
-// range (`>=22.12.0`) both parse to their numeric parts.
 function parseVersion(version: string): [number, number, number] {
   const [major = 0, minor = 0, patch = 0] = (version.match(/\d+/g) ?? []).map(Number);
 

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,13 +1,15 @@
+// Pulls the leading major out of any version-ish string: a version (`v20.1.0`) or an engines
+// range (`>=20.0.0`) both yield 20.
+function parseMajor(version: string): number {
+  return Number.parseInt(/\d+/.exec(version)?.[0] ?? '', 10);
+}
+
 // Single source of truth for the floor: read it from package.json `engines.node` so the runtime
 // guard can't drift from the version npm enforces at install time.
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
 const { engines } = require('../package.json') as { engines?: { node?: string } };
 
-export const MINIMUM_NODE_MAJOR = Number.parseInt(/\d+/.exec(engines?.node ?? '')?.[0] ?? '', 10);
-
-function parseMajor(version: string): number {
-  return Number.parseInt(version.replace(/^v/, ''), 10);
-}
+export const MINIMUM_NODE_MAJOR = parseMajor(engines?.node ?? '');
 
 export function isSupportedNodeVersion(
   currentVersion: string,

--- a/packages/workflow-executor/src/check-node-version.ts
+++ b/packages/workflow-executor/src/check-node-version.ts
@@ -1,7 +1,5 @@
-// The minimum Node major is the single source of truth in package.json `engines.node` (which npm
-// also reads at install time); derive it here so the runtime guard can never drift from it.
-// Requiring a JSON file keeps this module free of heavy imports, so the CLI entry can run the guard
-// before koa / @langchain/openai are evaluated — on an unsupported runtime those would crash first.
+// Single source of truth for the floor: read it from package.json `engines.node` so the runtime
+// guard can't drift from the version npm enforces at install time.
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
 const { engines } = require('../package.json') as { engines?: { node?: string } };
 

--- a/packages/workflow-executor/src/cli.ts
+++ b/packages/workflow-executor/src/cli.ts
@@ -1,11 +1,27 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-import { buildDatabaseExecutor, buildInMemoryExecutor } from './build-workflow-executor';
-import { runCli } from './cli-core';
-import { extractErrorMessage } from './errors';
+import type * as BuildWorkflowExecutor from './build-workflow-executor';
+import type * as CliCore from './cli-core';
+import type * as Errors from './errors';
+
+import checkNodeVersion from './check-node-version';
+
+// Fail fast with a clear message on an unsupported Node.js runtime before requiring the rest
+// of the CLI: its transitive dependencies (koa, @langchain/openai) would otherwise crash with
+// a cryptic low-level error on an old runtime, hiding the real cause. The heavy requires below
+// are deferred until after the guard so they are never evaluated on a runtime too old to load
+// them.
+checkNodeVersion();
 
 if (require.main === module) {
+  /* eslint-disable global-require, @typescript-eslint/no-var-requires */
+  const { buildDatabaseExecutor, buildInMemoryExecutor } =
+    require('./build-workflow-executor') as typeof BuildWorkflowExecutor;
+  const { runCli } = require('./cli-core') as typeof CliCore;
+  const { extractErrorMessage } = require('./errors') as typeof Errors;
+  /* eslint-enable global-require, @typescript-eslint/no-var-requires */
+
   runCli(process.argv.slice(2), process.env, {
     buildDatabase: buildDatabaseExecutor,
     buildInMemory: buildInMemoryExecutor,

--- a/packages/workflow-executor/src/cli.ts
+++ b/packages/workflow-executor/src/cli.ts
@@ -1,29 +1,27 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-import type * as BuildWorkflowExecutor from './build-workflow-executor';
-import type * as CliCore from './cli-core';
-import type * as Errors from './errors';
-
 import checkNodeVersion from './check-node-version';
 
-// Run the guard before the rest of the CLI loads: a static import would evaluate koa /
-// @langchain/openai first and crash cryptically on an old runtime, before the guard could report.
+// Run the guard before the rest of the CLI loads. The heavy modules are imported dynamically so
+// they are evaluated only after the guard: a static import would load koa / @langchain/openai
+// first and crash cryptically on an old runtime, before the guard could report.
 checkNodeVersion();
 
 if (require.main === module) {
-  /* eslint-disable global-require, @typescript-eslint/no-var-requires */
-  const { buildDatabaseExecutor, buildInMemoryExecutor } =
-    require('./build-workflow-executor') as typeof BuildWorkflowExecutor;
-  const { runCli } = require('./cli-core') as typeof CliCore;
-  const { extractErrorMessage } = require('./errors') as typeof Errors;
-  /* eslint-enable global-require, @typescript-eslint/no-var-requires */
+  void (async () => {
+    const { buildDatabaseExecutor, buildInMemoryExecutor } = await import(
+      './build-workflow-executor'
+    );
+    const { runCli } = await import('./cli-core');
+    const { extractErrorMessage } = await import('./errors');
 
-  runCli(process.argv.slice(2), process.env, {
-    buildDatabase: buildDatabaseExecutor,
-    buildInMemory: buildInMemoryExecutor,
-  }).catch((err: unknown) => {
-    console.error(`Error: ${extractErrorMessage(err)}`);
-    process.exit(1);
-  });
+    runCli(process.argv.slice(2), process.env, {
+      buildDatabase: buildDatabaseExecutor,
+      buildInMemory: buildInMemoryExecutor,
+    }).catch((err: unknown) => {
+      console.error(`Error: ${extractErrorMessage(err)}`);
+      process.exit(1);
+    });
+  })();
 }

--- a/packages/workflow-executor/src/cli.ts
+++ b/packages/workflow-executor/src/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
+// CLI entrypoint with side effects, not unit-testable; the guard and run wiring it composes are
+// unit-tested in check-node-version and cli-core.
+/* istanbul ignore file */
 
 import checkNodeVersion from './check-node-version';
 

--- a/packages/workflow-executor/src/cli.ts
+++ b/packages/workflow-executor/src/cli.ts
@@ -7,11 +7,8 @@ import type * as Errors from './errors';
 
 import checkNodeVersion from './check-node-version';
 
-// Fail fast with a clear message on an unsupported Node.js runtime before requiring the rest
-// of the CLI: its transitive dependencies (koa, @langchain/openai) would otherwise crash with
-// a cryptic low-level error on an old runtime, hiding the real cause. The heavy requires below
-// are deferred until after the guard so they are never evaluated on a runtime too old to load
-// them.
+// Run the guard before the rest of the CLI loads: a static import would evaluate koa /
+// @langchain/openai first and crash cryptically on an old runtime, before the guard could report.
 checkNodeVersion();
 
 if (require.main === module) {

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -1,26 +1,7 @@
-/**
- * TDD (red) for PRD-496 — workflow-executor must enforce and communicate a minimum Node.js version.
- *
- * These tests define the contract for a new, *intentionally dependency-free* preflight module
- * `src/check-node-version.ts`. It must have no heavy imports (no koa, no @langchain/openai, no
- * build-workflow-executor) so the CLI entry can run the guard BEFORE those modules are evaluated —
- * otherwise an old runtime crashes on those imports first, which is the bug being fixed.
- *
- * Expected public surface (to be implemented in a later step):
- *   - export const MINIMUM_NODE_MAJOR: number
- *   - export function isSupportedNodeVersion(currentVersion: string, minimumMajor?: number): boolean
- *   - export function unsupportedNodeVersionMessage(currentVersion: string, minimumMajor?: number): string
- *   - export default function checkNodeVersion(deps?: {
- *       currentVersion?: string;          // defaults to the running version
- *       minimumMajor?: number;            // defaults to MINIMUM_NODE_MAJOR
- *       printError?: (message: string) => void;  // defaults to writing to stderr
- *       exit?: (code: number) => void;           // defaults to process.exit
- *     }): void
- *
- * The floor value itself (20 vs 22 vs 24) is an open product decision, so these tests never assert
- * an absolute floor: pure-function tests pass the minimum explicitly, and the engines check asserts
- * agreement with MINIMUM_NODE_MAJOR rather than a literal.
- */
+// The guard's module must stay dependency-free so the CLI entry can run it before the heavy
+// imports (koa, @langchain/openai) are evaluated; on an old runtime those imports crash first.
+// The floor is asserted only relative to MINIMUM_NODE_MAJOR, never as a literal, since the chosen
+// version is a product decision.
 import checkNodeVersion, {
   MINIMUM_NODE_MAJOR,
   isSupportedNodeVersion,
@@ -133,20 +114,4 @@ describe('package.json engines', () => {
 
     expect(enginesMajor).toBe(MINIMUM_NODE_MAJOR);
   });
-});
-
-describe('robustness to malformed version input (policy undecided)', () => {
-  // process.version is always well-formed, so these only matter if the pure function is reused.
-  // The desired behaviour — throw a clear error vs. fail closed (treat as unsupported) — is an
-  // implementation decision; left as titles until that is settled.
-  it.todo('rejects an empty version string');
-
-  it.todo('rejects a non-version string such as "garbage"');
-});
-
-describe('preflight ordering (verified end-to-end, not in unit scope)', () => {
-  // The guard only fixes the bug if it runs before the heavy CLI imports (koa, @langchain/openai)
-  // are evaluated. The exact wiring (separate bootstrap module vs. inline in the bin) is an
-  // implementation decision and is best validated on a real old Node runtime by hand.
-  it.todo('runs the version guard before requiring build-workflow-executor / koa / @langchain');
 });

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -98,7 +98,7 @@ describe('MINIMUM_NODE_VERSION', () => {
     expect(pkg.engines?.node).toMatch(/\d/);
   });
 
-  it('is derived from package.json engines as the current floor of 22.12', () => {
-    expect(MINIMUM_NODE_VERSION).toBe('22.12.0');
+  it('derives a clean version string from engines.node', () => {
+    expect(MINIMUM_NODE_VERSION).toMatch(/^\d+(\.\d+)*$/);
   });
 });

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -1,7 +1,8 @@
-// The guard's module must stay dependency-free so the CLI entry can run it before the heavy
-// imports (koa, @langchain/openai) are evaluated; on an old runtime those imports crash first.
-// The floor is asserted only relative to MINIMUM_NODE_MAJOR, never as a literal, since the chosen
-// version is a product decision.
+// The guard's module stays dependency-free so the CLI entry can run it before the heavy imports
+// (koa, @langchain/openai) are evaluated; on an old runtime those imports crash first.
+// Pure-function tests pass an explicit minimum (a fixed fixture, e.g. 20) to exercise the
+// comparison; only the default-floor and engines tests are tied to MINIMUM_NODE_MAJOR so they
+// stay correct whatever floor is chosen.
 import checkNodeVersion, {
   MINIMUM_NODE_MAJOR,
   isSupportedNodeVersion,
@@ -13,8 +14,10 @@ describe('isSupportedNodeVersion', () => {
     expect(isSupportedNodeVersion('22.3.0', 20)).toBe(true);
   });
 
-  it('returns true at exactly the minimum major (boundary)', () => {
+  it('returns true at the minimum major regardless of minor/patch (boundary)', () => {
     expect(isSupportedNodeVersion('20.0.0', 20)).toBe(true);
+    expect(isSupportedNodeVersion('20.0.1', 20)).toBe(true);
+    expect(isSupportedNodeVersion('20.1.0', 20)).toBe(true);
   });
 
   it('returns false one major below the minimum (boundary)', () => {

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -109,7 +109,7 @@ describe('MINIMUM_NODE_MAJOR', () => {
     expect(pkg.engines?.node).toMatch(/\d/);
   });
 
-  it('is derived from package.json engines as the current floor of 20', () => {
-    expect(MINIMUM_NODE_MAJOR).toBe(20);
+  it('is derived from package.json engines as the current floor of 22', () => {
+    expect(MINIMUM_NODE_MAJOR).toBe(22);
   });
 });

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -1,53 +1,46 @@
-// The minimum Node major is read from package.json `engines.node`, so the guard's module is the
+// The minimum Node version is read from package.json `engines.node`, so the guard's module is the
 // single source of truth shared with the install-time engines declaration. Version inputs below
-// are expressed relative to MINIMUM_NODE_MAJOR so the suite stays correct whatever floor is set.
+// are expressed relative to the parsed floor so the suite stays correct whatever floor is set.
 import checkNodeVersion, {
-  MINIMUM_NODE_MAJOR,
+  MINIMUM_NODE_VERSION,
   isSupportedNodeVersion,
   unsupportedNodeVersionMessage,
 } from '../src/check-node-version';
 
+const [FLOOR_MAJOR, FLOOR_MINOR] = MINIMUM_NODE_VERSION.split('.').map(Number);
+
 describe('isSupportedNodeVersion', () => {
   it('returns true when the major version is above the minimum', () => {
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR + 2}.3.0`, MINIMUM_NODE_MAJOR)).toBe(true);
+    expect(isSupportedNodeVersion(`${FLOOR_MAJOR + 1}.0.0`)).toBe(true);
   });
 
-  it('returns true at the minimum major regardless of minor/patch (boundary)', () => {
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(true);
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.1`, MINIMUM_NODE_MAJOR)).toBe(true);
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.1.0`, MINIMUM_NODE_MAJOR)).toBe(true);
+  it('returns true at the exact minimum major.minor (boundary)', () => {
+    expect(isSupportedNodeVersion(`${FLOOR_MAJOR}.${FLOOR_MINOR}.0`)).toBe(true);
   });
 
-  it('returns false one major below the minimum (boundary)', () => {
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 1}.9.9`, MINIMUM_NODE_MAJOR)).toBe(false);
+  it('returns true above the minimum minor within the same major', () => {
+    expect(isSupportedNodeVersion(`${FLOOR_MAJOR}.${FLOOR_MINOR + 1}.0`)).toBe(true);
   });
 
-  it('returns false for a much older major', () => {
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 4}.20.2`, MINIMUM_NODE_MAJOR)).toBe(
-      false,
-    );
+  it('returns false below the minimum minor within the same major', () => {
+    expect(isSupportedNodeVersion(`${FLOOR_MAJOR}.${FLOOR_MINOR - 1}.9`)).toBe(false);
   });
 
-  it('compares by major only, so an old major with a high minor is still unsupported', () => {
-    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 2}.99.99`, MINIMUM_NODE_MAJOR)).toBe(
-      false,
-    );
+  it('returns false one major below the minimum', () => {
+    expect(isSupportedNodeVersion(`${FLOOR_MAJOR - 1}.99.9`)).toBe(false);
   });
 
   it("ignores a leading 'v', matching both process.version and process.versions.node forms", () => {
-    expect(isSupportedNodeVersion(`v${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(true);
-    expect(isSupportedNodeVersion(`v${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(
-      isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR),
-    );
+    expect(isSupportedNodeVersion(`v${FLOOR_MAJOR}.${FLOOR_MINOR}.0`)).toBe(true);
   });
 });
 
 describe('unsupportedNodeVersionMessage', () => {
   it('names both the required minimum and the detected version, with actionable wording', () => {
-    const detected = `v${MINIMUM_NODE_MAJOR - 2}.20.0`;
-    const message = unsupportedNodeVersionMessage(detected, MINIMUM_NODE_MAJOR);
+    const detected = `v${FLOOR_MAJOR}.${FLOOR_MINOR - 1}.0`;
+    const message = unsupportedNodeVersionMessage(detected);
 
-    expect(message).toContain(String(MINIMUM_NODE_MAJOR));
+    expect(message).toContain(MINIMUM_NODE_VERSION);
     expect(message).toContain(detected);
     expect(message).toMatch(/required|higher/i);
   });
@@ -58,14 +51,14 @@ describe('checkNodeVersion', () => {
     const printError = jest.fn();
     const exit = jest.fn();
 
-    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR}.0.0`, printError, exit });
+    checkNodeVersion({ currentVersion: `v${FLOOR_MAJOR}.${FLOOR_MINOR}.0`, printError, exit });
 
     expect(printError).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });
 
-  it('prints the unsupported-version message and exits with code 1 when too old', () => {
-    const detected = `v${MINIMUM_NODE_MAJOR - 2}.20.0`;
+  it('prints the unsupported-version message and exits with code 1 below the minimum minor', () => {
+    const detected = `v${FLOOR_MAJOR}.${FLOOR_MINOR - 1}.0`;
     const printError = jest.fn();
     const exit = jest.fn();
 
@@ -76,14 +69,10 @@ describe('checkNodeVersion', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
-  it('treats one major below the floor as unsupported', () => {
+  it('exits with code 1 when a full major below the minimum', () => {
     const exit = jest.fn();
 
-    checkNodeVersion({
-      currentVersion: `${MINIMUM_NODE_MAJOR - 1}.9.9`,
-      printError: jest.fn(),
-      exit,
-    });
+    checkNodeVersion({ currentVersion: `${FLOOR_MAJOR - 1}.99.9`, printError: jest.fn(), exit });
 
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -92,15 +81,15 @@ describe('checkNodeVersion', () => {
     const printError = jest.fn();
     const exit = jest.fn();
 
-    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR + 2}.0.0`, printError, exit });
-    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR + 2}.0.0`, printError, exit });
+    checkNodeVersion({ currentVersion: `v${FLOOR_MAJOR + 1}.0.0`, printError, exit });
+    checkNodeVersion({ currentVersion: `v${FLOOR_MAJOR + 1}.0.0`, printError, exit });
 
     expect(printError).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });
 });
 
-describe('MINIMUM_NODE_MAJOR', () => {
+describe('MINIMUM_NODE_VERSION', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
   const pkg = require('../package.json') as { engines?: { node?: string } };
 
@@ -109,7 +98,7 @@ describe('MINIMUM_NODE_MAJOR', () => {
     expect(pkg.engines?.node).toMatch(/\d/);
   });
 
-  it('is derived from package.json engines as the current floor of 22', () => {
-    expect(MINIMUM_NODE_MAJOR).toBe(22);
+  it('is derived from package.json engines as the current floor of 22.12', () => {
+    expect(MINIMUM_NODE_VERSION).toBe('22.12.0');
   });
 });

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -33,6 +33,10 @@ describe('isSupportedNodeVersion', () => {
   it("ignores a leading 'v', matching both process.version and process.versions.node forms", () => {
     expect(isSupportedNodeVersion(`v${FLOOR_MAJOR}.${FLOOR_MINOR}.0`)).toBe(true);
   });
+
+  it('treats an unparseable version as unsupported (fail closed)', () => {
+    expect(isSupportedNodeVersion('not-a-version')).toBe(false);
+  });
 });
 
 describe('unsupportedNodeVersionMessage', () => {
@@ -86,6 +90,19 @@ describe('checkNodeVersion', () => {
 
     expect(printError).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('writes to stderr and calls process.exit(1) by default on an unsupported runtime', () => {
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    checkNodeVersion({ currentVersion: `v${FLOOR_MAJOR - 1}.0.0` });
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(MINIMUM_NODE_VERSION));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });
 

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -1,0 +1,152 @@
+/**
+ * TDD (red) for PRD-496 — workflow-executor must enforce and communicate a minimum Node.js version.
+ *
+ * These tests define the contract for a new, *intentionally dependency-free* preflight module
+ * `src/check-node-version.ts`. It must have no heavy imports (no koa, no @langchain/openai, no
+ * build-workflow-executor) so the CLI entry can run the guard BEFORE those modules are evaluated —
+ * otherwise an old runtime crashes on those imports first, which is the bug being fixed.
+ *
+ * Expected public surface (to be implemented in a later step):
+ *   - export const MINIMUM_NODE_MAJOR: number
+ *   - export function isSupportedNodeVersion(currentVersion: string, minimumMajor?: number): boolean
+ *   - export function unsupportedNodeVersionMessage(currentVersion: string, minimumMajor?: number): string
+ *   - export default function checkNodeVersion(deps?: {
+ *       currentVersion?: string;          // defaults to the running version
+ *       minimumMajor?: number;            // defaults to MINIMUM_NODE_MAJOR
+ *       printError?: (message: string) => void;  // defaults to writing to stderr
+ *       exit?: (code: number) => void;           // defaults to process.exit
+ *     }): void
+ *
+ * The floor value itself (20 vs 22 vs 24) is an open product decision, so these tests never assert
+ * an absolute floor: pure-function tests pass the minimum explicitly, and the engines check asserts
+ * agreement with MINIMUM_NODE_MAJOR rather than a literal.
+ */
+import checkNodeVersion, {
+  MINIMUM_NODE_MAJOR,
+  isSupportedNodeVersion,
+  unsupportedNodeVersionMessage,
+} from '../src/check-node-version';
+
+describe('isSupportedNodeVersion', () => {
+  it('returns true when the major version is above the minimum', () => {
+    expect(isSupportedNodeVersion('22.3.0', 20)).toBe(true);
+  });
+
+  it('returns true at exactly the minimum major (boundary)', () => {
+    expect(isSupportedNodeVersion('20.0.0', 20)).toBe(true);
+  });
+
+  it('returns false one major below the minimum (boundary)', () => {
+    expect(isSupportedNodeVersion('19.9.9', 20)).toBe(false);
+  });
+
+  it('returns false for a much older major', () => {
+    expect(isSupportedNodeVersion('16.20.2', 20)).toBe(false);
+  });
+
+  it('compares by major only, so an old major with a high minor is still unsupported', () => {
+    expect(isSupportedNodeVersion('18.99.99', 20)).toBe(false);
+  });
+
+  it("ignores a leading 'v', matching both process.version and process.versions.node forms", () => {
+    expect(isSupportedNodeVersion('v20.0.0', 20)).toBe(true);
+    expect(isSupportedNodeVersion('v20.0.0', 20)).toBe(isSupportedNodeVersion('20.0.0', 20));
+  });
+});
+
+describe('unsupportedNodeVersionMessage', () => {
+  it('names both the required minimum and the detected version, with actionable wording', () => {
+    const message = unsupportedNodeVersionMessage('v18.20.0', 20);
+
+    expect(message).toContain('20');
+    expect(message).toContain('18.20.0');
+    expect(message).toMatch(/required|higher/i);
+  });
+});
+
+describe('checkNodeVersion', () => {
+  it('neither prints nor exits when the running version is supported (happy path)', () => {
+    const printError = jest.fn();
+    const exit = jest.fn();
+
+    checkNodeVersion({ currentVersion: 'v20.0.0', minimumMajor: 20, printError, exit });
+
+    expect(printError).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('prints the unsupported-version message and exits with code 1 when too old', () => {
+    const printError = jest.fn();
+    const exit = jest.fn();
+
+    checkNodeVersion({ currentVersion: 'v18.20.0', minimumMajor: 20, printError, exit });
+
+    expect(printError).toHaveBeenCalledTimes(1);
+    expect(printError).toHaveBeenCalledWith(unsupportedNodeVersionMessage('v18.20.0', 20));
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('treats one major below MINIMUM_NODE_MAJOR as unsupported by default', () => {
+    const exit = jest.fn();
+
+    checkNodeVersion({
+      currentVersion: `${MINIMUM_NODE_MAJOR - 1}.0.0`,
+      printError: jest.fn(),
+      exit,
+    });
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('treats MINIMUM_NODE_MAJOR as supported by default', () => {
+    const exit = jest.fn();
+
+    checkNodeVersion({ currentVersion: `${MINIMUM_NODE_MAJOR}.0.0`, printError: jest.fn(), exit });
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent across repeated calls on a supported version', () => {
+    const printError = jest.fn();
+    const exit = jest.fn();
+
+    checkNodeVersion({ currentVersion: 'v22.0.0', minimumMajor: 20, printError, exit });
+    checkNodeVersion({ currentVersion: 'v22.0.0', minimumMajor: 20, printError, exit });
+
+    expect(printError).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('package.json engines', () => {
+  // cli-core.ts already reads package.json this way; mirror it to avoid JSON-import config.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+  const pkg = require('../package.json') as { engines?: { node?: string } };
+
+  it('declares a minimum Node.js version in engines.node', () => {
+    expect(typeof pkg.engines?.node).toBe('string');
+    expect(pkg.engines?.node).toMatch(/\d/);
+  });
+
+  it('declares an engines.node minimum that agrees with the runtime guard floor', () => {
+    const enginesMajor = Number(/(\d+)/.exec(pkg.engines?.node ?? '')?.[1]);
+
+    expect(enginesMajor).toBe(MINIMUM_NODE_MAJOR);
+  });
+});
+
+describe('robustness to malformed version input (policy undecided)', () => {
+  // process.version is always well-formed, so these only matter if the pure function is reused.
+  // The desired behaviour — throw a clear error vs. fail closed (treat as unsupported) — is an
+  // implementation decision; left as titles until that is settled.
+  it.todo('rejects an empty version string');
+
+  it.todo('rejects a non-version string such as "garbage"');
+});
+
+describe('preflight ordering (verified end-to-end, not in unit scope)', () => {
+  // The guard only fixes the bug if it runs before the heavy CLI imports (koa, @langchain/openai)
+  // are evaluated. The exact wiring (separate bootstrap module vs. inline in the bin) is an
+  // implementation decision and is best validated on a real old Node runtime by hand.
+  it.todo('runs the version guard before requiring build-workflow-executor / koa / @langchain');
+});

--- a/packages/workflow-executor/test/check-node-version.test.ts
+++ b/packages/workflow-executor/test/check-node-version.test.ts
@@ -1,8 +1,6 @@
-// The guard's module stays dependency-free so the CLI entry can run it before the heavy imports
-// (koa, @langchain/openai) are evaluated; on an old runtime those imports crash first.
-// Pure-function tests pass an explicit minimum (a fixed fixture, e.g. 20) to exercise the
-// comparison; only the default-floor and engines tests are tied to MINIMUM_NODE_MAJOR so they
-// stay correct whatever floor is chosen.
+// The minimum Node major is read from package.json `engines.node`, so the guard's module is the
+// single source of truth shared with the install-time engines declaration. Version inputs below
+// are expressed relative to MINIMUM_NODE_MAJOR so the suite stays correct whatever floor is set.
 import checkNodeVersion, {
   MINIMUM_NODE_MAJOR,
   isSupportedNodeVersion,
@@ -11,39 +9,46 @@ import checkNodeVersion, {
 
 describe('isSupportedNodeVersion', () => {
   it('returns true when the major version is above the minimum', () => {
-    expect(isSupportedNodeVersion('22.3.0', 20)).toBe(true);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR + 2}.3.0`, MINIMUM_NODE_MAJOR)).toBe(true);
   });
 
   it('returns true at the minimum major regardless of minor/patch (boundary)', () => {
-    expect(isSupportedNodeVersion('20.0.0', 20)).toBe(true);
-    expect(isSupportedNodeVersion('20.0.1', 20)).toBe(true);
-    expect(isSupportedNodeVersion('20.1.0', 20)).toBe(true);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(true);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.1`, MINIMUM_NODE_MAJOR)).toBe(true);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.1.0`, MINIMUM_NODE_MAJOR)).toBe(true);
   });
 
   it('returns false one major below the minimum (boundary)', () => {
-    expect(isSupportedNodeVersion('19.9.9', 20)).toBe(false);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 1}.9.9`, MINIMUM_NODE_MAJOR)).toBe(false);
   });
 
   it('returns false for a much older major', () => {
-    expect(isSupportedNodeVersion('16.20.2', 20)).toBe(false);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 4}.20.2`, MINIMUM_NODE_MAJOR)).toBe(
+      false,
+    );
   });
 
   it('compares by major only, so an old major with a high minor is still unsupported', () => {
-    expect(isSupportedNodeVersion('18.99.99', 20)).toBe(false);
+    expect(isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR - 2}.99.99`, MINIMUM_NODE_MAJOR)).toBe(
+      false,
+    );
   });
 
   it("ignores a leading 'v', matching both process.version and process.versions.node forms", () => {
-    expect(isSupportedNodeVersion('v20.0.0', 20)).toBe(true);
-    expect(isSupportedNodeVersion('v20.0.0', 20)).toBe(isSupportedNodeVersion('20.0.0', 20));
+    expect(isSupportedNodeVersion(`v${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(true);
+    expect(isSupportedNodeVersion(`v${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR)).toBe(
+      isSupportedNodeVersion(`${MINIMUM_NODE_MAJOR}.0.0`, MINIMUM_NODE_MAJOR),
+    );
   });
 });
 
 describe('unsupportedNodeVersionMessage', () => {
   it('names both the required minimum and the detected version, with actionable wording', () => {
-    const message = unsupportedNodeVersionMessage('v18.20.0', 20);
+    const detected = `v${MINIMUM_NODE_MAJOR - 2}.20.0`;
+    const message = unsupportedNodeVersionMessage(detected, MINIMUM_NODE_MAJOR);
 
-    expect(message).toContain('20');
-    expect(message).toContain('18.20.0');
+    expect(message).toContain(String(MINIMUM_NODE_MAJOR));
+    expect(message).toContain(detected);
     expect(message).toMatch(/required|higher/i);
   });
 });
@@ -53,28 +58,29 @@ describe('checkNodeVersion', () => {
     const printError = jest.fn();
     const exit = jest.fn();
 
-    checkNodeVersion({ currentVersion: 'v20.0.0', minimumMajor: 20, printError, exit });
+    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR}.0.0`, printError, exit });
 
     expect(printError).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });
 
   it('prints the unsupported-version message and exits with code 1 when too old', () => {
+    const detected = `v${MINIMUM_NODE_MAJOR - 2}.20.0`;
     const printError = jest.fn();
     const exit = jest.fn();
 
-    checkNodeVersion({ currentVersion: 'v18.20.0', minimumMajor: 20, printError, exit });
+    checkNodeVersion({ currentVersion: detected, printError, exit });
 
     expect(printError).toHaveBeenCalledTimes(1);
-    expect(printError).toHaveBeenCalledWith(unsupportedNodeVersionMessage('v18.20.0', 20));
+    expect(printError).toHaveBeenCalledWith(unsupportedNodeVersionMessage(detected));
     expect(exit).toHaveBeenCalledWith(1);
   });
 
-  it('treats one major below MINIMUM_NODE_MAJOR as unsupported by default', () => {
+  it('treats one major below the floor as unsupported', () => {
     const exit = jest.fn();
 
     checkNodeVersion({
-      currentVersion: `${MINIMUM_NODE_MAJOR - 1}.0.0`,
+      currentVersion: `${MINIMUM_NODE_MAJOR - 1}.9.9`,
       printError: jest.fn(),
       exit,
     });
@@ -82,28 +88,19 @@ describe('checkNodeVersion', () => {
     expect(exit).toHaveBeenCalledWith(1);
   });
 
-  it('treats MINIMUM_NODE_MAJOR as supported by default', () => {
-    const exit = jest.fn();
-
-    checkNodeVersion({ currentVersion: `${MINIMUM_NODE_MAJOR}.0.0`, printError: jest.fn(), exit });
-
-    expect(exit).not.toHaveBeenCalled();
-  });
-
   it('is idempotent across repeated calls on a supported version', () => {
     const printError = jest.fn();
     const exit = jest.fn();
 
-    checkNodeVersion({ currentVersion: 'v22.0.0', minimumMajor: 20, printError, exit });
-    checkNodeVersion({ currentVersion: 'v22.0.0', minimumMajor: 20, printError, exit });
+    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR + 2}.0.0`, printError, exit });
+    checkNodeVersion({ currentVersion: `v${MINIMUM_NODE_MAJOR + 2}.0.0`, printError, exit });
 
     expect(printError).not.toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();
   });
 });
 
-describe('package.json engines', () => {
-  // cli-core.ts already reads package.json this way; mirror it to avoid JSON-import config.
+describe('MINIMUM_NODE_MAJOR', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
   const pkg = require('../package.json') as { engines?: { node?: string } };
 
@@ -112,9 +109,7 @@ describe('package.json engines', () => {
     expect(pkg.engines?.node).toMatch(/\d/);
   });
 
-  it('declares an engines.node minimum that agrees with the runtime guard floor', () => {
-    const enginesMajor = Number(/(\d+)/.exec(pkg.engines?.node ?? '')?.[1]);
-
-    expect(enginesMajor).toBe(MINIMUM_NODE_MAJOR);
+  it('is derived from package.json engines as the current floor of 20', () => {
+    expect(MINIMUM_NODE_MAJOR).toBe(20);
   });
 });


### PR DESCRIPTION
## Summary

The workflow-executor did not declare or enforce a minimum Node.js version. On a too-old runtime it crashed with a cryptic low-level error from its dependencies, giving the user no hint that the Node version was the cause.

This adds:
- **A zero-dependency preflight guard** (`src/check-node-version.ts`) that fails fast with a clear message and a non-zero exit code.
- **`engines: { "node": ">=20.0.0" }`** in `package.json` — install-time signal.
- **`cli.ts` runs the guard before loading the heavy CLI modules**, so `koa`/`@langchain/openai` are never evaluated on a runtime too old to load them. Without this ordering the transitive imports crash first and the user never sees the version message. (Typed via erased `import type * as` so type safety is preserved.)
- **A README note** documenting the requirement.

## Why Node 20

20 is the real hard dependency floor (`@langchain/openai` requires `>=20`, koa `>=18`) and an active LTS — the lowest version that actually works, so the executor fails fast below it without rejecting versions that would otherwise run. Trivially overridable via `MINIMUM_NODE_MAJOR` + the engines string; the tests are floor-agnostic.

## Tests

- New unit tests for the guard: pure version comparison (boundaries, `v`-prefix, major-only), the message wording, the print + `exit(1)` behaviour, idempotency, and `engines`/floor consistency.
- `cli.test.ts` regression passes.
- Three `it.todo` placeholders flag deliberately-deferred items: malformed-version policy (a decision; `process.version` is always well-formed) and the before-heavy-imports ordering (best verified end-to-end on a real old runtime).

## Notes for the reviewer

- **Draft** pending the manual functional check on an actual old Node runtime (confirm the message + non-zero exit), per the test plan.
- **Unrelated / pre-existing:** a fresh worktree currently shows `tsc` errors in `@forestadmin/ai-proxy` / `datasource-toolkit` (`BaseChatModel`, `Collection.getOne`) — these are present on `main` and clear once the workspace deps are rebuilt; this PR does not touch those packages.

fixes PRD-496

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce a minimum Node.js version (>=22.12.0) in the workflow-executor CLI
> - Adds a `checkNodeVersion` guard in [`check-node-version.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1641/files#diff-c6e137910b85106b9841944448fb743b376c979bba2a4cb955c3362f9f8d3a65) that compares `process.version` against the minimum declared in `package.json`; exits with code 1 and a descriptive stderr message on unsupported runtimes.
> - Invokes the guard at the top of [`cli.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1641/files#diff-b2ec3456ad1cb5329b3aeeff794496545e7ac8e3e653d2910ac4a4103235c044) before any other module loads; subsequent imports are made dynamic so the check runs first.
> - Declares `"engines": { "node": ">=22.12.0" }` in [`package.json`](https://github.com/ForestAdmin/agent-nodejs/pull/1641/files#diff-39959c5d53211b31724a713f0f4021345ce98a0dd752aadcde43c1729bdff151) so package managers can also warn or reject installs on unsupported runtimes.
> - Behavioral Change: running the CLI on Node.js < 22.12.0 now terminates immediately with exit code 1 instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8577b19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->