### PR TITLE
fix(workflow-executor): align @forestadmin/* deps with the workspace

### DIFF
--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -77,6 +77,10 @@ const ANTHROPIC_UNSUPPORTED_MODELS = [
   'claude-3-7-sonnet-20250219', // EOL 2026-02-19
   'claude-opus-4-20250514', // Requires streaming (non-streaming times out)
   'claude-opus-4-1-20250805', // Requires streaming (non-streaming times out)
+  // Always-on thinking: rejects the `thinking: {type: 'disabled'}` LangChain sends by default,
+  // and requires thinking blocks to be replayed verbatim on multi-turn tool calls — our
+  // OpenAI-format message conversion drops them, so follow-up turns would be rejected too.
+  'claude-fable-5',
 ];
 
 function isAnthropicModelSupported(model: string): boolean {

--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -77,10 +77,7 @@ const ANTHROPIC_UNSUPPORTED_MODELS = [
   'claude-3-7-sonnet-20250219', // EOL 2026-02-19
   'claude-opus-4-20250514', // Requires streaming (non-streaming times out)
   'claude-opus-4-1-20250805', // Requires streaming (non-streaming times out)
-  // Always-on thinking: rejects the `thinking: {type: 'disabled'}` LangChain sends by default,
-  // and requires thinking blocks to be replayed verbatim on multi-turn tool calls — our
-  // OpenAI-format message conversion drops them, so follow-up turns would be rejected too.
-  'claude-fable-5',
+  'claude-fable-5', // Always-on thinking (rejects 'disabled'; proxy drops required thinking blocks)
 ];
 
 function isAnthropicModelSupported(model: string): boolean {

--- a/packages/ai-proxy/test/supported-models.test.ts
+++ b/packages/ai-proxy/test/supported-models.test.ts
@@ -12,4 +12,12 @@ describe('isModelSupportingTools', () => {
   it('should return false for a blacklisted model', () => {
     expect(isModelSupportingTools('gpt-4')).toBe(false);
   });
+
+  it('should return false for claude-fable-5 (always-on thinking incompatible with proxy)', () => {
+    expect(isModelSupportingTools('claude-fable-5', 'anthropic')).toBe(false);
+  });
+
+  it('should return true for other anthropic models', () => {
+    expect(isModelSupportingTools('claude-opus-4-8', 'anthropic')).toBe(true);
+  });
 });

--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@forestadmin/agent-client": "1.5.10",
-    "@forestadmin/ai-proxy": "1.10.1",
-    "@forestadmin/forestadmin-client": "1.39.9",
+    "@forestadmin/agent-client": "1.6.0",
+    "@forestadmin/ai-proxy": "1.11.0",
+    "@forestadmin/forestadmin-client": "1.40.0",
     "@koa/bodyparser": "^6.1.0",
     "@koa/router": "^13.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,6 +1841,43 @@
     path-to-regexp "^6.3.0"
     reusify "^1.0.4"
 
+"@forestadmin/agent-client@1.5.10":
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/@forestadmin/agent-client/-/agent-client-1.5.10.tgz#104166288155689f405489c71d91fc5573a6b775"
+  integrity sha512-156Y4FSsifd0UiPOzszqFeVr86rNE2pXRPPFC6g1fRd3RIFOSJBG8GScP+luj48poLwVBRfC1FaeFwkd6GSwYA==
+  dependencies:
+    "@forestadmin/datasource-toolkit" "1.53.1"
+    "@forestadmin/forestadmin-client" "1.39.9"
+    jsonapi-serializer "^3.6.9"
+    superagent "^10.3.0"
+
+"@forestadmin/agent@1.78.13":
+  version "1.78.13"
+  resolved "https://registry.yarnpkg.com/@forestadmin/agent/-/agent-1.78.13.tgz#3a2db3c55f75e241d3cd1d156e77acfdbd1d7fe0"
+  integrity sha512-LJygWzAJHFWFNL6ZUgn8ZW2EGm30k9OO6I+lbiLxMwRYwEyjUkeSVnQMPqqpDvv92CGuwPzeDhSUGrCd4p4l8g==
+  dependencies:
+    "@fast-csv/format" "^4.3.5"
+    "@forestadmin/agent-toolkit" "1.2.0"
+    "@forestadmin/datasource-customizer" "1.69.3"
+    "@forestadmin/datasource-toolkit" "1.53.1"
+    "@forestadmin/forestadmin-client" "1.39.9"
+    "@forestadmin/mcp-server" "1.11.11"
+    "@koa/bodyparser" "^6.0.0"
+    "@koa/cors" "^5.0.0"
+    "@koa/router" "^13.1.0"
+    "@paralleldrive/cuid2" "2.2.2"
+    "@types/koa__router" "^12.0.4"
+    forest-ip-utils "^1.0.1"
+    json-api-serializer "^2.6.6"
+    json-stringify-pretty-compact "^3.0.0"
+    jsonwebtoken "^9.0.3"
+    koa "^3.0.1"
+    koa-jwt "^4.0.4"
+    luxon "^3.2.1"
+    object-hash "^3.0.0"
+    superagent "^10.3.0"
+    uuid "11.1.1"
+
 "@forestadmin/context@1.37.1":
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/@forestadmin/context/-/context-1.37.1.tgz#301486c456061d43cb653b3e8be60644edb3f71a"
@@ -1874,6 +1911,32 @@
     luxon "^3.2.1"
     object-hash "^3.0.0"
     uuid "^9.0.0"
+
+"@forestadmin/forestadmin-client@1.39.9":
+  version "1.39.9"
+  resolved "https://registry.yarnpkg.com/@forestadmin/forestadmin-client/-/forestadmin-client-1.39.9.tgz#626f89d85ae5a0caa8f99261176616ceef7d2eb0"
+  integrity sha512-ODSqDnR9c9S8lH97+ftLW6qvpId7OSOkrEL3J1rNT37U4GAmUzNHBU7c8XWQMpnWhAtMcibKd9ksn1NftAmXrQ==
+  dependencies:
+    eventsource "2.0.2"
+    json-api-serializer "^2.6.6"
+    jsonwebtoken "^9.0.3"
+    object-hash "^3.0.0"
+    openid-client "^5.7.1"
+    superagent "^10.3.0"
+
+"@forestadmin/mcp-server@1.11.11":
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/@forestadmin/mcp-server/-/mcp-server-1.11.11.tgz#7a194b92eacaf16cd3add7f1f07167870292bfcb"
+  integrity sha512-gbACZqwzEqCjQVNWR7hF9s42Wa5k1CBDHQHe/QEq6ZaLh97itEtQ9HrOYq/6WmaWBjGeYa2llCanYcT7uYOHNw==
+  dependencies:
+    "@forestadmin/agent-client" "1.5.10"
+    "@forestadmin/forestadmin-client" "1.39.9"
+    "@modelcontextprotocol/sdk" "^1.28.0"
+    cors "^2.8.5"
+    express "^5.2.1"
+    jsonapi-serializer "^3.6.9"
+    jsonwebtoken "^9.0.3"
+    zod "^4.3.5"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"


### PR DESCRIPTION
## Summary

`@forestadmin/workflow-executor:build` is currently failing in CI (and on `main`) with a wall of `TS2305`/`TS2339`/`TS2614` errors:

```
'@forestadmin/ai-proxy' has no exported member 'AiClient' / 'BaseChatModel' / 'BaseMessage' / 'DynamicStructuredTool' / …
'@forestadmin/forestadmin-client' has no exported member 'ServerUtils'
Property 'getOne' does not exist on type 'Collection'   (@forestadmin/agent-client)
```

Root cause: `workflow-executor` pins its `@forestadmin/*` deps to **stale exact versions** that lag the workspace and don't export the APIs its source uses. Every other package in the monorepo references the current workspace versions and builds fine — `workflow-executor` is the lone laggard. (It's a chicken-and-egg: semantic-release bumps these on release, but the broken build blocks the release that would fix them.)

## Change

Bump the three pinned deps to the current workspace versions:

| dep | from | to |
|---|---|---|
| `@forestadmin/agent-client` | 1.5.10 | 1.6.0 |
| `@forestadmin/ai-proxy` | 1.10.1 | 1.11.0 |
| `@forestadmin/forestadmin-client` | 1.39.9 | 1.40.0 |

(plus the corresponding `yarn.lock` update).

## Also: exclude `claude-fable-5` from tool-supporting models (ai-proxy)

Fixing the build let the full test matrix run for the first time in a while, which unmasked a pre-existing failure in the required `LLM Integration Tests (ai-proxy)` job: Anthropic's new `claude-fable-5` fails the tool-support sweep. It has **always-on thinking** — it rejects the `thinking: {type: "disabled"}` param that LangChain sends by default, and it requires thinking blocks to be replayed verbatim on multi-turn tool calls, which the proxy's OpenAI-format message conversion drops. Adding it to `ANTHROPIC_UNSUPPORTED_MODELS` gives users a clear `AIModelNotSupportedError` upfront instead of provider 400s (same pattern as the o1/o3/o4 exclusions on the OpenAI side). Proper Fable support would need thinking-block passthrough in the wire format — a separate feature.

This has to land here rather than in its own PR because the integration job can't go green on any branch until this PR's build fix is on it.

## Verification

`lerna run build --scope @forestadmin/workflow-executor --include-dependencies` now succeeds (`tsc` clean) where it previously failed. ai-proxy unit tests (404) and lint pass; the previously failing `datasource-mongo` and OpenAI-503 failures cleared on re-run (flaky/transient).

This is independent of #1641 (PRD-496) — it unblocks the `workflow-executor` build on `main` for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `@forestadmin/*` dependencies in `workflow-executor` with workspace versions
> Bumps three direct dependencies in [package.json](https://github.com/ForestAdmin/agent-nodejs/pull/1643/files#diff-39959c5d53211b31724a713f0f4021345ce98a0dd752aadcde43c1729bdff151) to match the rest of the workspace: `@forestadmin/agent-client` to 1.6.0, `@forestadmin/ai-proxy` to 1.11.0, and `@forestadmin/forestadmin-client` to 1.40.0. The lockfile is updated accordingly.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1643 opened
>
> - Added 'claude-fable-5' to the `ANTHROPIC_UNSUPPORTED_MODELS` constant in the `ai-proxy` package with documentation explaining the incompatibility is due to always-on thinking requirements and mandatory verbatim replay of thinking blocks across tool calls, and added test cases verifying that `isModelSupportingTools` correctly identifies 'claude-fable-5' with provider 'anthropic' as unsupported while confirming 'claude-opus-4-8' remains supported [655833a]
> - Reformatted comment documentation for the `ANTHROPIC_UNSUPPORTED_MODELS` constant [2e56cd2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13493e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
