### PR TITLE
docs(workflow-executor): fix README inaccuracies

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -24,7 +24,7 @@ npm install -g @forestadmin/workflow-executor
 | `DATABASE_URL` | ✓* | — | Postgres connection string (*not needed with `--in-memory`) |
 | `HTTP_PORT` | — | `3400` | Port for the executor HTTP server |
 | `FOREST_SERVER_URL` | — | `https://api.forestadmin.com` | Orchestrator URL |
-| `POLLING_INTERVAL_MS` | — | `5000` | Poll cadence for pending steps |
+| `POLLING_INTERVAL_MS` | — | `30000` | Poll cadence for pending steps |
 | `STOP_TIMEOUT_MS` | — | `30000` | Graceful shutdown deadline |
 
 Optional AI configuration (all-or-nothing — falls back to server AI if any is missing):
@@ -44,9 +44,10 @@ forest-workflow-executor
 You should see (pretty format when stdout is a TTY):
 
 ```
-13:33:42 info  Workflow executor starting mode="database" forestServerUrl="https://api.forestadmin.com" agentUrl="http://localhost:3351" httpPort=3400 pollingIntervalMs=5000 aiConfig="server fallback"
+13:33:42 info  Workflow executor starting mode="database" forestServerUrl="https://api.forestadmin.com" agentUrl="http://localhost:3351" httpPort=3400 pollingIntervalMs=30000 aiConfig="server fallback"
+13:33:42 info  Agent probe passed
 13:33:42 info  Workflow executor ready url="http://localhost:3400"
-13:33:47 info  Poll cycle completed fetched=0 dispatching=0
+13:34:12 info  Poll cycle completed fetched=0 dispatching=0 malformed=0
 ```
 
 When stdout is piped, redirected or inside a container, logs are emitted as
@@ -54,7 +55,7 @@ structured JSON instead — ready to be ingested by Datadog, CloudWatch, Loki, e
 
 ```json
 {"message":"Workflow executor ready","timestamp":"2026-04-20T13:33:42.000Z","url":"http://localhost:3400"}
-{"message":"Poll cycle completed","timestamp":"2026-04-20T13:33:47.000Z","fetched":0,"dispatching":0}
+{"message":"Poll cycle completed","timestamp":"2026-04-20T13:34:12.000Z","fetched":0,"dispatching":0,"malformed":0}
 ```
 
 ### Log format overrides
@@ -76,16 +77,19 @@ curl http://localhost:3400/health
 
 ### Graceful shutdown
 
-Send `SIGTERM` or `SIGINT`. The executor drains in-flight steps, closes the HTTP
-server, and exits with code `0`. Steps that don't drain within `STOP_TIMEOUT_MS`
-are force-killed and the process exits with code `1`.
+Send `SIGTERM` or `SIGINT`. The executor stops polling, drains in-flight steps,
+closes the HTTP server, and exits with code `0`. Steps still running after
+`STOP_TIMEOUT_MS` are not awaited — the executor logs a `Drain timeout` error and
+completes the shutdown anyway (they are abandoned, not force-killed). Interrupted
+steps are safe to replay: a write-ahead idempotency log prevents duplicate side
+effects on the next run.
 
 ### Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | Graceful shutdown |
-| `1` | Startup error (missing env, invalid config) or forced shutdown |
+| `0` | Graceful shutdown (including when a drain timed out) |
+| `1` | Startup error (missing env, invalid config) or resource cleanup failure during shutdown |
 
 ### In-memory mode (dev only)
 


### PR DESCRIPTION
## What

Fixes three inaccuracies in `packages/workflow-executor/README.md`, found while writing the developer-guide setup page:

1. **`POLLING_INTERVAL_MS` default** — documented as `5000`, actually `30000` (`defaults.ts`: `DEFAULT_POLLING_INTERVAL_MS = 30_000`). Fixed in both the env table and the log example.
2. **Startup log example** — was missing the `Agent probe passed` line (logged in `runner.start()`) and `malformed=0` on the `Poll cycle completed` line (third context key in `runner.ts`). The poll timestamp was also wrong: the first poll fires *after* the interval (`setTimeout(..., pollingIntervalMs)`), not ~5s in.
3. **Graceful shutdown / exit codes** — the README claimed steps are "force-killed and the process exits with code `1`" after `STOP_TIMEOUT_MS`. In reality (`runner.ts` `Promise.race` + `build-workflow-executor.ts`), a drain timeout logs a `Drain timeout` error, abandons the in-flight steps, and still exits `0`. Exit `1` only happens on startup error or a resource-cleanup failure during shutdown.

## Why

The developer-guide page initially inherited these errors from the README. Fixing the source so the next person doesn't recopy them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inaccuracies in workflow-executor README
> Updates [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1644/files#diff-84aa4115ae7aaddeae8ef0aa0f2f1fae55b5692e9eb4340a0ec43f2c3c3c0b3b) to correct several inaccuracies introduced by prior changes.
>
> - Changes documented `POLLING_INTERVAL_MS` default from 5000 to 30000 and updates example timestamps accordingly
> - Adds an "Agent probe passed" log line to the startup example and a "malformed" counter to poll cycle log examples
> - Revises the graceful shutdown description: polling stops first, steps still running after `STOP_TIMEOUT_MS` are not awaited or force-killed, a "Drain timeout" is logged, and interrupted steps are safe to replay via a write-ahead idempotency log
> - Corrects exit codes: code 0 now covers graceful shutdown even when drain timed out; code 1 now covers startup errors or resource cleanup failures
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25d3dc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->