### PR TITLE
fix(workflow-executor): bump @koa/router to ^15.6.0

### DIFF
--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -33,7 +33,7 @@
     "@forestadmin/ai-proxy": "1.11.1",
     "@forestadmin/forestadmin-client": "1.40.1",
     "@koa/bodyparser": "^6.1.0",
-    "@koa/router": "^13.1.0",
+    "@koa/router": "^15.6.0",
     "jsonwebtoken": "^9.0.3",
     "koa": "^3.0.1",
     "koa-jwt": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,16 @@
     koa-compose "^4.1.0"
     path-to-regexp "^6.3.0"
 
+"@koa/router@^15.6.0":
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-15.6.0.tgz#7e13f8828b24102676033b3343e825ef2b5d571b"
+  integrity sha512-iEOXlvGIBqSNkGXrg0XtMARAOm5zA24oedXxiTGEkrD4JgwVjfRDddCQvW1s4WEcwDYvyecRbf8BikXsuEEj8w==
+  dependencies:
+    debug "^4.4.3"
+    http-errors "^2.0.1"
+    koa-compose "^4.1.0"
+    path-to-regexp "^8.4.2"
+
 "@langchain/anthropic@1.3.17":
   version "1.3.17"
   resolved "https://registry.yarnpkg.com/@langchain/anthropic/-/anthropic-1.3.17.tgz#441a4bc1e38c41760e8957e87ef8f549c9c62f09"
@@ -14510,6 +14520,11 @@ path-to-regexp@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.3.0.tgz#aa818a6981f99321003a08987d3cec9c3474cd1f"
   integrity sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==
+
+path-to-regexp@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
 
 path-to-regexp@~0.1.12:
   version "0.1.13"


### PR DESCRIPTION
## Problem

Installing `@forestadmin/workflow-executor` emits a deprecation warning for `@koa/router@13.1.0` (transitive of the v13 line, now superseded).

## Root cause

The package pinned `@koa/router` to `^13.1.0`, which resolves to a deprecated release.

## Fix

Bump `@koa/router` to `^15.6.0` and refresh the lockfile.

## Scope / safety

- Only the dependency range in `packages/workflow-executor/package.json` and `yarn.lock` change.
- No source code modified.
- Build OK, full test suite OK (45 suites / 988 tests).
- The `@koa/router@13` deprecation warning no longer appears in a clean consumer install.
- Out of scope: `sequelize` (dottie, uuid) and `umzug` (z-schema → lodash.get/lodash.isequal) warnings — both are already on their latest stable releases and cannot be removed by a simple bump.

## How to test

```bash
yarn workspace @forestadmin/workflow-executor build
cd packages/workflow-executor && npm pack
# install the tarball in a temp project and check:
npm ls @koa/router   # -> @koa/router@15.6.0, no v13 deprecation warning
```

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
