### PR TITLE
fix(workflow-executor): fix warnings during installation

### DIFF
--- a/packages/workflow-executor/package.json
+++ b/packages/workflow-executor/package.json
@@ -33,7 +33,7 @@
     "@forestadmin/ai-proxy": "1.11.1",
     "@forestadmin/forestadmin-client": "1.40.1",
     "@koa/bodyparser": "^6.1.0",
-    "@koa/router": "^13.1.0",
+    "@koa/router": "^15.6.0",
     "jsonwebtoken": "^9.0.3",
     "koa": "^3.0.1",
     "koa-jwt": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,16 @@
     koa-compose "^4.1.0"
     path-to-regexp "^6.3.0"
 
+"@koa/router@^15.6.0":
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-15.6.0.tgz#7e13f8828b24102676033b3343e825ef2b5d571b"
+  integrity sha512-iEOXlvGIBqSNkGXrg0XtMARAOm5zA24oedXxiTGEkrD4JgwVjfRDddCQvW1s4WEcwDYvyecRbf8BikXsuEEj8w==
+  dependencies:
+    debug "^4.4.3"
+    http-errors "^2.0.1"
+    koa-compose "^4.1.0"
+    path-to-regexp "^8.4.2"
+
 "@langchain/anthropic@1.3.17":
   version "1.3.17"
   resolved "https://registry.yarnpkg.com/@langchain/anthropic/-/anthropic-1.3.17.tgz#441a4bc1e38c41760e8957e87ef8f549c9c62f09"
@@ -14510,6 +14520,11 @@ path-to-regexp@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.3.0.tgz#aa818a6981f99321003a08987d3cec9c3474cd1f"
   integrity sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==
+
+path-to-regexp@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
 
 path-to-regexp@~0.1.12:
   version "0.1.13"


### PR DESCRIPTION
## Problem

Installing `@forestadmin/workflow-executor` emits a deprecation warning for `@koa/router@13.1.0` (transitive of the v13 line, now superseded).

## Root cause

The package pinned `@koa/router` to `^13.1.0`, which resolves to a deprecated release.

## Fix

Bump `@koa/router` to `^15.6.0` and refresh the lockfile.

## Scope / safety

- Only the dependency range in `packages/workflow-executor/package.json` and `yarn.lock` change.
- No source code modified.
- Build OK, full test suite OK (45 suites / 988 tests).
- The `@koa/router@13` deprecation warning no longer appears in a clean consumer install.

## Remaining deprecation warnings (not fixable here)

After this bump, a clean consumer install still emits these deprecation warnings. None of them can be removed by a dependency bump, and they are documented here so they are not mistaken for actionable items.

### `dottie@2.0.7` and `uuid@8.3.2` — via `sequelize`

```
sequelize@6.37.8 ├── dottie@2.0.7   (deprecated)
                 └── uuid@8.3.2     (deprecated)
```

- `sequelize@6.37.8` is the latest stable release of the v6 line (`dist-tags: latest = 6.37.8`); it still pins `dottie` and `uuid@^8`.
- The only published v7 is `7.0.0-alpha.9` — an **alpha**, unfit for a published library (unstable API, may regress at any release).
- A consumer-side `overrides` is not a viable fix: `dottie` has **no** non-deprecated version (the package is abandoned, no drop-in replacement), and forcing `uuid@8 → 11` breaks the ESM/CJS export shape Sequelize 6 expects (untested combination, runtime risk).
- `overrides`/`resolutions` declared inside this package are **ignored** by consumers anyway — only the consumer project's root `package.json` `overrides` is honored ([npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json/#overrides)).
- Removing these requires Sequelize 7 stable (a major migration, not a bump) and is blocked by the rest of the workspace (`datasource-sequelize`, `datasource-sql`, `agent`) being pinned to `< 7`.

### `lodash.get@4.4.2` and `lodash.isequal@4.5.0` — via `umzug`

```
umzug@3.8.3 └── @rushstack/ts-command-line@4.19.1
              └── z-schema@5.0.5
                ├── lodash.get@4.4.2     (deprecated)
                └── lodash.isequal@4.5.0 (deprecated)
```

- `umzug@3.8.3` is the latest stable release; the deprecated packages sit 4 levels deep, none exposed directly.
- The actual culprit is `z-schema`, which still depends on the split, deprecated `lodash.*` packages. The fix must come from `z-schema` / `@rushstack/ts-command-line` / `umzug` upstream — not something a consumer or this package can bump away.

### LangChain / community (out of scope by request)

`@langchain/community@1.1.29` (deprecated upstream as a whole), `node-domexception@1.0.0`, and `uuid@10.0.0` come via `@forestadmin/ai-proxy`. Explicitly excluded from this change.

## How to test

```bash
yarn workspace @forestadmin/workflow-executor build
cd packages/workflow-executor && npm pack
# install the tarball in a temp project and check:
npm ls @koa/router   # -> @koa/router@15.6.0, no v13 deprecation warning
```

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
