### PR TITLE
fix: compute livequery segment on SA routes

### DIFF
--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -117,9 +117,11 @@ export default class QueryStringParser {
   }
 
   static parseLiveQuerySegment(context: Context) {
-    const { query } = context.request as any;
-    const segmentQuery = query.segmentQuery?.toString();
-    const connectionName = query.connectionName?.toString();
+    const { query, body } = context.request as any;
+    const subsetQuery = body?.data?.attributes?.all_records_subset_query;
+    const segmentQuery = subsetQuery?.segmentQuery?.toString() ?? query.segmentQuery?.toString();
+    const connectionName =
+      subsetQuery?.connectionName?.toString() ?? query.connectionName?.toString();
 
     if (!segmentQuery) {
       return null;

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -418,6 +418,46 @@ describe('QueryStringParser', () => {
         );
       });
     });
+
+    describe('when the live query segment is provided in the bulk action subset query', () => {
+      test('should parse it from all_records_subset_query', () => {
+        const context = {
+          request: {
+            query: {},
+            body: {
+              data: {
+                attributes: {
+                  all_records_subset_query: {
+                    segmentQuery: 'SELECT * FROM toto',
+                    connectionName: 'main',
+                  },
+                },
+              },
+            },
+          },
+        } as unknown as Context;
+
+        expect(QueryStringParser.parseLiveQuerySegment(context)).toEqual({
+          query: 'SELECT * FROM toto',
+          connectionName: 'main',
+        });
+      });
+
+      test('should throw when connectionName is missing in the subset query', () => {
+        const context = {
+          request: {
+            query: {},
+            body: {
+              data: { attributes: { all_records_subset_query: { segmentQuery: 'SELECT 1' } } },
+            },
+          },
+        } as unknown as Context;
+
+        expect(() => QueryStringParser.parseLiveQuerySegment(context)).toThrow(
+          new UnprocessableError('Missing native query connection attribute'),
+        );
+      });
+    });
   });
 
   describe('parseCaller', () => {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseLiveQuerySegment` to read segment query from request body on SA routes
> On smart action (SA) routes, the segment query is sent in `request.body.data.attributes.all_records_subset_query` rather than as query parameters. `parseLiveQuerySegment` in [query-string.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1651/files#diff-fd8b84f20d0c331a34d7399c832497c1cc74c7ac552f0d727a7c8a9c3e37525f) now reads `segmentQuery` and `connectionName` from that body attribute when present, falling back to existing query param behavior. It still returns `null` when no segment query is found and still throws `UnprocessableError` when `connectionName` is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b86bc1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->