### PR TITLE
refactor(agent-client): move polymorphic linkage read into the lib [PRD-493]

### DIFF
--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -179,9 +179,8 @@ export default class Collection extends CollectionChart {
     });
   }
 
-  // Reads a to-one relation's raw JSON:API linkage ({ type, id }) via a `<relation>@@@id` projection.
-  // Used for polymorphic relations where the target `type` is the discriminator: the deserializer
-  // drops relationship types, so the raw body is read. Returns null when there is no linked record.
+  // Raw JSON:API linkage { type, id } of a to-one relation (via a `<relation>@@@id` projection) —
+  // needed for polymorphic relations, where the deserializer drops the `type`. Null if no target.
   async getRelationLinkage(
     id: RecordId,
     relation: string,

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -171,18 +171,16 @@ export default class Collection extends CollectionChart {
     });
   }
 
-  // `raw` returns the undeserialized JSON:API body (the deserializer drops relationship `type`,
-  // which callers reading a polymorphic relation's linkage need).
   async getOne<Data = unknown>(
     id: RecordId,
     options?: SelectOptions,
-    { raw = false }: { raw?: boolean } = {},
+    { skipDeserialization = false }: { skipDeserialization?: boolean } = {},
   ): Promise<Data> {
     return this.httpRequester.query<Data>({
       method: 'get',
       path: `/forest/${this.name}/${serializeRecordId(id)}`,
       query: QuerySerializer.serialize(options, this.name),
-      raw,
+      skipDeserialization,
     });
   }
 

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -171,32 +171,19 @@ export default class Collection extends CollectionChart {
     });
   }
 
-  async getOne<Data = unknown>(id: RecordId, options?: SelectOptions): Promise<Data> {
+  // `raw` returns the undeserialized JSON:API body (the deserializer drops relationship `type`,
+  // which callers reading a polymorphic relation's linkage need).
+  async getOne<Data = unknown>(
+    id: RecordId,
+    options?: SelectOptions,
+    { raw = false }: { raw?: boolean } = {},
+  ): Promise<Data> {
     return this.httpRequester.query<Data>({
       method: 'get',
       path: `/forest/${this.name}/${serializeRecordId(id)}`,
       query: QuerySerializer.serialize(options, this.name),
+      raw,
     });
-  }
-
-  // Raw JSON:API linkage { type, id } of a to-one relation (via a `<relation>@@@id` projection) —
-  // needed for polymorphic relations, where the deserializer drops the `type`. Null if no target.
-  async getRelationLinkage(
-    id: RecordId,
-    relation: string,
-  ): Promise<{ type: string; id: string } | null> {
-    const body = await this.httpRequester.query<{
-      data?: { relationships?: Record<string, { data?: { type?: string; id?: string } | null }> };
-    }>({
-      method: 'get',
-      path: `/forest/${this.name}/${serializeRecordId(id)}`,
-      query: QuerySerializer.serialize({ fields: [`${relation}@@@id`] }, this.name),
-      raw: true,
-    });
-
-    const linkage = body?.data?.relationships?.[relation]?.data;
-
-    return linkage?.type ? { type: String(linkage.type), id: String(linkage.id) } : null;
   }
 
   private getActionInfo(

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -179,6 +179,27 @@ export default class Collection extends CollectionChart {
     });
   }
 
+  // Reads a to-one relation's raw JSON:API linkage ({ type, id }) via a `<relation>@@@id` projection.
+  // Used for polymorphic relations where the target `type` is the discriminator: the deserializer
+  // drops relationship types, so the raw body is read. Returns null when there is no linked record.
+  async getRelationLinkage(
+    id: RecordId,
+    relation: string,
+  ): Promise<{ type: string; id: string } | null> {
+    const body = await this.httpRequester.query<{
+      data?: { relationships?: Record<string, { data?: { type?: string; id?: string } | null }> };
+    }>({
+      method: 'get',
+      path: `/forest/${this.name}/${serializeRecordId(id)}`,
+      query: QuerySerializer.serialize({ fields: [`${relation}@@@id`] }, this.name),
+      raw: true,
+    });
+
+    const linkage = body?.data?.relationships?.[relation]?.data;
+
+    return linkage?.type ? { type: String(linkage.type), id: String(linkage.id) } : null;
+  }
+
   private getActionInfo(
     actionEndpoints: ActionEndpointsByCollection,
     collectionName: string,

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -26,7 +26,7 @@ export default class HttpRequester {
     query,
     maxTimeAllowed,
     contentType,
-    raw,
+    skipDeserialization,
   }: {
     method: 'get' | 'post' | 'put' | 'delete';
     path: string;
@@ -34,8 +34,7 @@ export default class HttpRequester {
     query?: Record<string, unknown>;
     maxTimeAllowed?: number;
     contentType?: 'application/json' | 'text/csv';
-    // Return the raw JSON:API body (skip deserialization, which drops relationship `type`).
-    raw?: boolean;
+    skipDeserialization?: boolean;
   }): Promise<Data> {
     try {
       const url = this.buildUrl(path);
@@ -51,7 +50,7 @@ export default class HttpRequester {
 
       const response = await req;
 
-      if (raw) {
+      if (skipDeserialization) {
         return response.body as Data;
       }
 

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -26,6 +26,7 @@ export default class HttpRequester {
     query,
     maxTimeAllowed,
     contentType,
+    raw,
   }: {
     method: 'get' | 'post' | 'put' | 'delete';
     path: string;
@@ -33,6 +34,9 @@ export default class HttpRequester {
     query?: Record<string, unknown>;
     maxTimeAllowed?: number;
     contentType?: 'application/json' | 'text/csv';
+    // Return the raw JSON:API body instead of deserializing. The deserializer drops relationship
+    // `type`, so callers needing the polymorphic discriminator read the raw linkage themselves.
+    raw?: boolean;
   }): Promise<Data> {
     try {
       const url = this.buildUrl(path);
@@ -47,6 +51,10 @@ export default class HttpRequester {
       if (body) req.send(body);
 
       const response = await req;
+
+      if (raw) {
+        return response.body as Data;
+      }
 
       try {
         return (await this.deserializer.deserialize(response.body)) as Data;

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -34,8 +34,7 @@ export default class HttpRequester {
     query?: Record<string, unknown>;
     maxTimeAllowed?: number;
     contentType?: 'application/json' | 'text/csv';
-    // Return the raw JSON:API body instead of deserializing. The deserializer drops relationship
-    // `type`, so callers needing the polymorphic discriminator read the raw linkage themselves.
+    // Return the raw JSON:API body (skip deserialization, which drops relationship `type`).
     raw?: boolean;
   }): Promise<Data> {
     try {

--- a/packages/agent-client/test/domains/collection.test.ts
+++ b/packages/agent-client/test/domains/collection.test.ts
@@ -174,38 +174,28 @@ describe('Collection', () => {
     });
   });
 
-  describe('getRelationLinkage', () => {
-    it('reads the raw linkage via a <relation>@@@id projection and returns { type, id }', async () => {
-      httpRequester.query.mockResolvedValue({
+  describe('getOne', () => {
+    it('deserializes by default (raw not set)', async () => {
+      httpRequester.query.mockResolvedValue({ id: 7, name: 'Alice' });
+
+      const result = await collection.getOne(7);
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'get', path: '/forest/users/7', raw: false }),
+      );
+      expect(result).toEqual({ id: 7, name: 'Alice' });
+    });
+
+    it('returns the raw JSON:API body when raw is set (e.g. to read a relationship type)', async () => {
+      const body = {
         data: { relationships: { commentable: { data: { type: 'orders', id: '99' } } } },
-      });
+      };
+      httpRequester.query.mockResolvedValue(body);
 
-      const result = await collection.getRelationLinkage(7, 'commentable');
+      const result = await collection.getOne(7, { fields: ['commentable@@@id'] }, { raw: true });
 
-      expect(httpRequester.query).toHaveBeenCalledWith(
-        expect.objectContaining({ method: 'get', path: '/forest/users/7', raw: true }),
-      );
-      expect(result).toEqual({ type: 'orders', id: '99' });
-    });
-
-    it('pipe-encodes composite ids', async () => {
-      httpRequester.query.mockResolvedValue({
-        data: { relationships: { commentable: { data: { type: 'orders', id: '1|2' } } } },
-      });
-
-      await collection.getRelationLinkage([1, 'abc'], 'commentable');
-
-      expect(httpRequester.query).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/forest/users/1|abc', raw: true }),
-      );
-    });
-
-    it('returns null when there is no linked record', async () => {
-      httpRequester.query.mockResolvedValue({
-        data: { relationships: { commentable: { data: null } } },
-      });
-
-      expect(await collection.getRelationLinkage(7, 'commentable')).toBeNull();
+      expect(httpRequester.query).toHaveBeenCalledWith(expect.objectContaining({ raw: true }));
+      expect(result).toEqual(body);
     });
   });
 

--- a/packages/agent-client/test/domains/collection.test.ts
+++ b/packages/agent-client/test/domains/collection.test.ts
@@ -175,26 +175,36 @@ describe('Collection', () => {
   });
 
   describe('getOne', () => {
-    it('deserializes by default (raw not set)', async () => {
+    it('deserializes by default (skipDeserialization not set)', async () => {
       httpRequester.query.mockResolvedValue({ id: 7, name: 'Alice' });
 
       const result = await collection.getOne(7);
 
       expect(httpRequester.query).toHaveBeenCalledWith(
-        expect.objectContaining({ method: 'get', path: '/forest/users/7', raw: false }),
+        expect.objectContaining({
+          method: 'get',
+          path: '/forest/users/7',
+          skipDeserialization: false,
+        }),
       );
       expect(result).toEqual({ id: 7, name: 'Alice' });
     });
 
-    it('returns the raw JSON:API body when raw is set (e.g. to read a relationship type)', async () => {
+    it('returns the raw JSON:API body when skipDeserialization is set', async () => {
       const body = {
         data: { relationships: { commentable: { data: { type: 'orders', id: '99' } } } },
       };
       httpRequester.query.mockResolvedValue(body);
 
-      const result = await collection.getOne(7, { fields: ['commentable@@@id'] }, { raw: true });
+      const result = await collection.getOne(
+        7,
+        { fields: ['commentable@@@id'] },
+        { skipDeserialization: true },
+      );
 
-      expect(httpRequester.query).toHaveBeenCalledWith(expect.objectContaining({ raw: true }));
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({ skipDeserialization: true }),
+      );
       expect(result).toEqual(body);
     });
   });

--- a/packages/agent-client/test/domains/collection.test.ts
+++ b/packages/agent-client/test/domains/collection.test.ts
@@ -174,6 +174,41 @@ describe('Collection', () => {
     });
   });
 
+  describe('getRelationLinkage', () => {
+    it('reads the raw linkage via a <relation>@@@id projection and returns { type, id }', async () => {
+      httpRequester.query.mockResolvedValue({
+        data: { relationships: { commentable: { data: { type: 'orders', id: '99' } } } },
+      });
+
+      const result = await collection.getRelationLinkage(7, 'commentable');
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'get', path: '/forest/users/7', raw: true }),
+      );
+      expect(result).toEqual({ type: 'orders', id: '99' });
+    });
+
+    it('pipe-encodes composite ids', async () => {
+      httpRequester.query.mockResolvedValue({
+        data: { relationships: { commentable: { data: { type: 'orders', id: '1|2' } } } },
+      });
+
+      await collection.getRelationLinkage([1, 'abc'], 'commentable');
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/forest/users/1|abc', raw: true }),
+      );
+    });
+
+    it('returns null when there is no linked record', async () => {
+      httpRequester.query.mockResolvedValue({
+        data: { relationships: { commentable: { data: null } } },
+      });
+
+      expect(await collection.getRelationLinkage(7, 'commentable')).toBeNull();
+    });
+  });
+
   describe('delete', () => {
     it('should call httpRequester.query with DELETE method and correct body', async () => {
       httpRequester.query.mockResolvedValue({});

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -247,14 +247,26 @@ export default class AgentClientAgentPort implements AgentPort {
     });
   }
 
-  // Delegates to the lib's raw linkage read — agent-client owns URL/auth/projection.
+  // Resolves a polymorphic relation's target from the raw JSON:API linkage. The deserializer drops
+  // relationship `type`, so we read the raw body (getOne `raw`) via a `<relation>@@@id` projection
+  // and extract the linkage here — agent-client stays generic (URL/auth/serialization).
   async resolvePolymorphicType(
     { collection, id, relation }: ResolvePolymorphicTypeQuery,
     user: StepUser,
   ): Promise<{ type: string; id: string } | null> {
-    return this.callAgent('resolvePolymorphicType', async () =>
-      this.createClient(user).collection(collection).getRelationLinkage(id, relation),
-    );
+    return this.callAgent('resolvePolymorphicType', async () => {
+      const body = await this.createClient(user)
+        .collection(collection)
+        .getOne<{
+          data?: {
+            relationships?: Record<string, { data?: { type?: string; id?: string } | null }>;
+          };
+        }>(id, { fields: [`${relation}@@@id`] }, { raw: true });
+
+      const linkage = body?.data?.relationships?.[relation]?.data;
+
+      return linkage?.type ? { type: String(linkage.type), id: String(linkage.id) } : null;
+    });
   }
 
   // Hits GET /forest/ (public, no auth required across all agent versions). A 4xx here means

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -247,37 +247,15 @@ export default class AgentClientAgentPort implements AgentPort {
     });
   }
 
-  // The agent-client deserializer drops relationship `type`, so read the raw record-with-projection
-  // response: `data.relationships.<relation>.data = { type, id }`. No UI-exposed discriminator needed.
+  // Reads the polymorphic relation's target via agent-client's raw linkage read (the deserializer
+  // drops relationship `type`). agent-client owns URL/auth/projection — no hand-rolled fetch here.
   async resolvePolymorphicType(
     { collection, id, relation }: ResolvePolymorphicTypeQuery,
     user: StepUser,
   ): Promise<{ type: string; id: string } | null> {
-    return this.callAgent('resolvePolymorphicType', async () => {
-      const recordId = id.map(String).join('|');
-      const params = new URLSearchParams({
-        [`fields[${collection}]`]: relation,
-        [`fields[${relation}]`]: 'id',
-        timezone: 'Europe/Paris', // matches HttpRequester's default
-      });
-      const base = this.agentUrl.replace(/\/+$/, '');
-      const response = await fetch(`${base}/forest/${collection}/${recordId}?${params}`, {
-        headers: { Authorization: `Bearer ${this.mintToken(user)}`, Accept: 'application/json' },
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `resolvePolymorphicType ${collection}/${recordId}: HTTP ${response.status}`,
-        );
-      }
-
-      const body = (await response.json()) as {
-        data?: { relationships?: Record<string, { data?: { type?: string; id?: string } | null }> };
-      };
-      const linkage = body?.data?.relationships?.[relation]?.data;
-
-      return linkage?.type ? { type: String(linkage.type), id: String(linkage.id) } : null;
-    });
+    return this.callAgent('resolvePolymorphicType', async () =>
+      this.createClient(user).collection(collection).getRelationLinkage(id, relation),
+    );
   }
 
   // Hits GET /forest/ (public, no auth required across all agent versions). A 4xx here means

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -261,7 +261,7 @@ export default class AgentClientAgentPort implements AgentPort {
           data?: {
             relationships?: Record<string, { data?: { type?: string; id?: string } | null }>;
           };
-        }>(id, { fields: [`${relation}@@@id`] }, { raw: true });
+        }>(id, { fields: [`${relation}@@@id`] }, { skipDeserialization: true });
 
       const linkage = body?.data?.relationships?.[relation]?.data;
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -247,8 +247,7 @@ export default class AgentClientAgentPort implements AgentPort {
     });
   }
 
-  // Reads the polymorphic relation's target via agent-client's raw linkage read (the deserializer
-  // drops relationship `type`). agent-client owns URL/auth/projection — no hand-rolled fetch here.
+  // Delegates to the lib's raw linkage read — agent-client owns URL/auth/projection.
   async resolvePolymorphicType(
     { collection, id, relation }: ResolvePolymorphicTypeQuery,
     user: StepUser,

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -841,7 +841,7 @@ describe('AgentClientAgentPort', () => {
       expect(mockCollection.getOne).toHaveBeenCalledWith(
         [7],
         { fields: ['commentable@@@id'] },
-        { raw: true },
+        { skipDeserialization: true },
       );
     });
 
@@ -856,7 +856,7 @@ describe('AgentClientAgentPort', () => {
       expect(mockCollection.getOne).toHaveBeenCalledWith(
         ['tenant-1', 5],
         { fields: ['commentable@@@id'] },
-        { raw: true },
+        { skipDeserialization: true },
       );
     });
 

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -26,6 +26,7 @@ function createMockClient() {
     list: jest.fn(),
     getOne: jest.fn(),
     update: jest.fn(),
+    getRelationLinkage: jest.fn(),
     relation: jest.fn().mockReturnValue(mockRelation),
     action: jest.fn().mockResolvedValue(mockAction),
   };
@@ -824,24 +825,8 @@ describe('AgentClientAgentPort', () => {
   });
 
   describe('resolvePolymorphicType', () => {
-    let fetchSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(jest.fn());
-    });
-
-    afterEach(() => {
-      fetchSpy.mockRestore();
-    });
-
-    function linkageResponse(data: unknown) {
-      return new Response(JSON.stringify({ data: { relationships: { commentable: { data } } } }), {
-        status: 200,
-      });
-    }
-
-    it('reads the linkage type/id and projects the relation on the by-id route', async () => {
-      fetchSpy.mockResolvedValue(linkageResponse({ type: 'orders', id: '99' }));
+    it('delegates to agent-client getRelationLinkage on the source collection', async () => {
+      mockCollection.getRelationLinkage.mockResolvedValue({ type: 'orders', id: '99' });
 
       const result = await port.resolvePolymorphicType(
         { collection: 'comments', id: [7], relation: 'commentable' },
@@ -849,27 +834,25 @@ describe('AgentClientAgentPort', () => {
       );
 
       expect(result).toEqual({ type: 'orders', id: '99' });
-
-      const [url, options] = fetchSpy.mock.calls[0];
-      expect(url).toContain('http://localhost:3310/forest/comments/7?');
-      expect(url).toContain(`${encodeURIComponent('fields[comments]')}=commentable`);
-      expect(url).toContain(`${encodeURIComponent('fields[commentable]')}=id`);
-      expect(options.headers.Authorization).toMatch(/^Bearer /);
+      expect(mockCollection.getRelationLinkage).toHaveBeenCalledWith([7], 'commentable');
     });
 
-    it('joins composite ids with "|" in the by-id route', async () => {
-      fetchSpy.mockResolvedValue(linkageResponse({ type: 'orders', id: '1|2' }));
+    it('passes composite ids through to the linkage read', async () => {
+      mockCollection.getRelationLinkage.mockResolvedValue({ type: 'orders', id: '1|2' });
 
       await port.resolvePolymorphicType(
         { collection: 'comments', id: ['tenant-1', 5], relation: 'commentable' },
         user,
       );
 
-      expect(fetchSpy.mock.calls[0][0]).toContain('/forest/comments/tenant-1|5?');
+      expect(mockCollection.getRelationLinkage).toHaveBeenCalledWith(
+        ['tenant-1', 5],
+        'commentable',
+      );
     });
 
     it('returns null when the relation has no linkage', async () => {
-      fetchSpy.mockResolvedValue(linkageResponse(null));
+      mockCollection.getRelationLinkage.mockResolvedValue(null);
 
       const result = await port.resolvePolymorphicType(
         { collection: 'comments', id: [7], relation: 'commentable' },
@@ -879,8 +862,8 @@ describe('AgentClientAgentPort', () => {
       expect(result).toBeNull();
     });
 
-    it('throws AgentPortError when the agent responds non-2xx', async () => {
-      fetchSpy.mockResolvedValue(new Response(null, { status: 500 }));
+    it('wraps agent errors in AgentPortError', async () => {
+      mockCollection.getRelationLinkage.mockRejectedValue(new Error('boom'));
 
       await expect(
         port.resolvePolymorphicType(

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -26,7 +26,6 @@ function createMockClient() {
     list: jest.fn(),
     getOne: jest.fn(),
     update: jest.fn(),
-    getRelationLinkage: jest.fn(),
     relation: jest.fn().mockReturnValue(mockRelation),
     action: jest.fn().mockResolvedValue(mockAction),
   };
@@ -825,8 +824,12 @@ describe('AgentClientAgentPort', () => {
   });
 
   describe('resolvePolymorphicType', () => {
-    it('delegates to agent-client getRelationLinkage on the source collection', async () => {
-      mockCollection.getRelationLinkage.mockResolvedValue({ type: 'orders', id: '99' });
+    function linkageBody(data: unknown) {
+      return { data: { relationships: { commentable: { data } } } };
+    }
+
+    it('reads the raw linkage via getOne and extracts { type, id }', async () => {
+      mockCollection.getOne.mockResolvedValue(linkageBody({ type: 'orders', id: '99' }));
 
       const result = await port.resolvePolymorphicType(
         { collection: 'comments', id: [7], relation: 'commentable' },
@@ -834,25 +837,31 @@ describe('AgentClientAgentPort', () => {
       );
 
       expect(result).toEqual({ type: 'orders', id: '99' });
-      expect(mockCollection.getRelationLinkage).toHaveBeenCalledWith([7], 'commentable');
+      // raw projection read on the source record, parsing done here in the adapter.
+      expect(mockCollection.getOne).toHaveBeenCalledWith(
+        [7],
+        { fields: ['commentable@@@id'] },
+        { raw: true },
+      );
     });
 
-    it('passes composite ids through to the linkage read', async () => {
-      mockCollection.getRelationLinkage.mockResolvedValue({ type: 'orders', id: '1|2' });
+    it('passes composite ids through to the raw read', async () => {
+      mockCollection.getOne.mockResolvedValue(linkageBody({ type: 'orders', id: '1|2' }));
 
       await port.resolvePolymorphicType(
         { collection: 'comments', id: ['tenant-1', 5], relation: 'commentable' },
         user,
       );
 
-      expect(mockCollection.getRelationLinkage).toHaveBeenCalledWith(
+      expect(mockCollection.getOne).toHaveBeenCalledWith(
         ['tenant-1', 5],
-        'commentable',
+        { fields: ['commentable@@@id'] },
+        { raw: true },
       );
     });
 
     it('returns null when the relation has no linkage', async () => {
-      mockCollection.getRelationLinkage.mockResolvedValue(null);
+      mockCollection.getOne.mockResolvedValue(linkageBody(null));
 
       const result = await port.resolvePolymorphicType(
         { collection: 'comments', id: [7], relation: 'commentable' },
@@ -863,7 +872,7 @@ describe('AgentClientAgentPort', () => {
     });
 
     it('wraps agent errors in AgentPortError', async () => {
-      mockCollection.getRelationLinkage.mockRejectedValue(new Error('boom'));
+      mockCollection.getOne.mockRejectedValue(new Error('boom'));
 
       await expect(
         port.resolvePolymorphicType(


### PR DESCRIPTION
## What

Follow-up to #1647 (merged). Review feedback: the polymorphic linkage read belongs in **agent-client** (the lib that centralises agent calls), not hand-rolled in the workflow-executor adapter.

## Before

`AgentClientAgentPort.resolvePolymorphicType` did a manual `fetch` — rebuilding the URL, minting the token, serialising the projection query by hand — bypassing agent-client.

## After

- **`HttpRequester.query`** gains a `raw` option returning the undeserialized JSON:API body (the deserializer drops relationship `type`, the polymorphic discriminator).
- **`Collection.getRelationLinkage(id, relation)`** reads a to-one relation's raw linkage `{ type, id }` via a `<relation>@@@id` projection, reusing `QuerySerializer`, the by-id route and the client's auth. Returns `null` when there is no linked record.
- **`AgentClientAgentPort.resolvePolymorphicType`** now delegates to it — no hand-rolled fetch/URL/token.

## Tests

- agent-client `collection.test.ts`: new `getRelationLinkage` cases (raw projection, composite ids, null). 70 pass.
- executor `agent-client-agent-port.test.ts`: `resolvePolymorphicType` asserts delegation (no fetch spy). 131 pass.
- Builds + lint clean. No behaviour change.

Refs PRD-493

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move polymorphic linkage resolution into agent-client library
> - Adds a `raw` option to `HttpRequester.query` and `Collection.getOne` in [agent-client](https://github.com/ForestAdmin/agent-nodejs/pull/1654/files#diff-99fa5c55a7aedf57003829a23b6cd75d55a35d40af1918aa96581f33318f2658) that returns the undeserialized JSON:API body, preserving relationship `type` fields.
> - Rewrites `AgentClientAgentPort.resolvePolymorphicType` in [agent-client-agent-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1654/files#diff-1e123e0cbe27612cfd4c2f0c74aa6529888468059a8106cdc6bab8375b9b141a) to use `getOne({ raw: true })` instead of constructing a manual `fetch` call to the agent URL.
> - Extracts polymorphic linkage from `body.data.relationships[relation].data` and returns `{ type, id }` or `null`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1654 opened
>
> - Renamed the `raw` option to `skipDeserialization` across `agent-client` package [9bbb98d]
> - Updated `AgentClientAgentPort.resolvePolymorphicType` to use the renamed option [9bbb98d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2a0cdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->