### PR TITLE
refactor(workflow-executor): centralize HTTP error mapping into typed errors [PRD-477]

### DIFF
--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -42,7 +42,6 @@ export abstract class WorkflowExecutorError extends Error {
 // over HTTP; step-execution failures (RecordNotFoundError, …) stay plain WorkflowExecutorError —
 // they never reach toHttpError (the step executor turns them into a step error outcome).
 export abstract class NotFoundError extends WorkflowExecutorError {}
-export abstract class ConflictError extends WorkflowExecutorError {}
 export abstract class AccessDeniedError extends WorkflowExecutorError {}
 export abstract class UnavailableError extends WorkflowExecutorError {}
 
@@ -342,7 +341,9 @@ export class UserMismatchError extends AccessDeniedError {
   }
 }
 
-export class RunAlreadyInFlightError extends ConflictError {
+// Stays uncategorized: it maps to 400 (see toHttpError) rather than a category status. Kept as a
+// distinct class so toHttpError can flag it as expected churn (a double trigger isn't log-worthy).
+export class RunAlreadyInFlightError extends WorkflowExecutorError {
   constructor(runId: string) {
     super(`Run "${runId}" is already being processed`);
   }

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -323,8 +323,10 @@ export class RunNotFoundError extends Error {
 }
 
 export class UserMismatchError extends Error {
-  constructor(runId: string) {
-    super(`User not authorized for run "${runId}"`);
+  // bearerUserId/ownerUserId are kept in the message (not the HTTP body) so the centralized
+  // request log retains who attempted to act on a run they don't own — an authz forensic signal.
+  constructor(runId: string, bearerUserId: number, ownerUserId: number) {
+    super(`User ${bearerUserId} not authorized for run "${runId}" (owned by user ${ownerUserId})`);
     this.name = 'UserMismatchError';
   }
 }

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -312,29 +312,31 @@ export class ConfigurationError extends Error {
   }
 }
 
-export class RunNotFoundError extends Error {
-  cause?: unknown;
-
+// Run lifecycle/access errors raised by the Runner (not step-execution failures). They extend
+// WorkflowExecutorError so they belong to the single domain-error family: toHttpError maps each
+// to its own status via an explicit branch, but any forgotten mapping still degrades to a 400
+// with the userMessage instead of a silent 500.
+export class RunNotFoundError extends WorkflowExecutorError {
   constructor(runId: string, cause?: unknown) {
-    super(`Run "${runId}" not found or unavailable`);
-    this.name = 'RunNotFoundError';
+    super(`Run "${runId}" not found or unavailable`, 'Run not found or unavailable');
     if (cause !== undefined) this.cause = cause;
   }
 }
 
-export class UserMismatchError extends Error {
-  // bearerUserId/ownerUserId are kept in the message (not the HTTP body) so the centralized
-  // request log retains who attempted to act on a run they don't own — an authz forensic signal.
+export class UserMismatchError extends WorkflowExecutorError {
+  // The bearer/owner ids stay in the technical `message` (logged via the cause) but NOT in the
+  // userMessage — the HTTP body must never leak who owns a run.
   constructor(runId: string, bearerUserId: number, ownerUserId: number) {
-    super(`User ${bearerUserId} not authorized for run "${runId}" (owned by user ${ownerUserId})`);
-    this.name = 'UserMismatchError';
+    super(
+      `User ${bearerUserId} not authorized for run "${runId}" (owned by user ${ownerUserId})`,
+      'You are not authorized to access this run.',
+    );
   }
 }
 
-export class RunAlreadyInFlightError extends Error {
+export class RunAlreadyInFlightError extends WorkflowExecutorError {
   constructor(runId: string) {
     super(`Run "${runId}" is already being processed`);
-    this.name = 'RunAlreadyInFlightError';
   }
 }
 

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -36,6 +36,16 @@ export abstract class WorkflowExecutorError extends Error {
   }
 }
 
+// Domain error CATEGORIES (transport-agnostic). toHttpError maps each category to one HTTP status,
+// so a new request-level error gets the right status simply by extending the right category — no
+// per-error binding in the HTTP layer. These are for Runner/request-level outcomes that surface
+// over HTTP; step-execution failures (RecordNotFoundError, …) stay plain WorkflowExecutorError —
+// they never reach toHttpError (the step executor turns them into a step error outcome).
+export abstract class NotFoundError extends WorkflowExecutorError {}
+export abstract class ConflictError extends WorkflowExecutorError {}
+export abstract class AccessDeniedError extends WorkflowExecutorError {}
+export abstract class UnavailableError extends WorkflowExecutorError {}
+
 export class MissingToolCallError extends WorkflowExecutorError {
   constructor() {
     super(
@@ -117,7 +127,7 @@ export class UnsupportedActionFormError extends WorkflowExecutorError {
   }
 }
 
-export class RunStorePortError extends WorkflowExecutorError {
+export class RunStorePortError extends UnavailableError {
   constructor(operation: string, cause: unknown) {
     super(
       `Run store "${operation}" failed: ${cause instanceof Error ? cause.message : String(cause)}`,
@@ -271,7 +281,7 @@ export class SchemaNotCachedError extends WorkflowExecutorError {
   }
 }
 
-export class WorkflowPortError extends WorkflowExecutorError {
+export class WorkflowPortError extends UnavailableError {
   constructor(operation: string, cause: unknown) {
     super(
       `Workflow port "${operation}" failed: ${
@@ -312,18 +322,16 @@ export class ConfigurationError extends Error {
   }
 }
 
-// Run lifecycle/access errors raised by the Runner (not step-execution failures). They extend
-// WorkflowExecutorError so they belong to the single domain-error family: toHttpError maps each
-// to its own status via an explicit branch, but any forgotten mapping still degrades to a 400
-// with the userMessage instead of a silent 500.
-export class RunNotFoundError extends WorkflowExecutorError {
+// Run lifecycle/access errors raised by the Runner. Each extends a domain category, so toHttpError
+// maps them by category (404/409/403) — no per-error HTTP binding.
+export class RunNotFoundError extends NotFoundError {
   constructor(runId: string, cause?: unknown) {
     super(`Run "${runId}" not found or unavailable`, 'Run not found or unavailable');
     if (cause !== undefined) this.cause = cause;
   }
 }
 
-export class UserMismatchError extends WorkflowExecutorError {
+export class UserMismatchError extends AccessDeniedError {
   // The bearer/owner ids stay in the technical `message` (logged via the cause) but NOT in the
   // userMessage — the HTTP body must never leak who owns a run.
   constructor(runId: string, bearerUserId: number, ownerUserId: number) {
@@ -334,7 +342,7 @@ export class UserMismatchError extends WorkflowExecutorError {
   }
 }
 
-export class RunAlreadyInFlightError extends WorkflowExecutorError {
+export class RunAlreadyInFlightError extends ConflictError {
   constructor(runId: string) {
     super(`Run "${runId}" is already being processed`);
   }

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -10,15 +10,15 @@ import http from 'http';
 import Koa from 'koa';
 import koaJwt from 'koa-jwt';
 
+import {
+  InvalidTokenUserIdHttpError,
+  RunAccessCheckUnavailableHttpError,
+  RunAccessDeniedHttpError,
+  toHttpError,
+} from './http-errors';
 import serializeStepForWire from './step-serializer';
 import ConsoleLogger from '../adapters/console-logger';
-import {
-  RunAlreadyInFlightError,
-  RunNotFoundError,
-  UserMismatchError,
-  WorkflowExecutorError,
-  extractErrorMessage,
-} from '../errors';
+import { extractErrorMessage } from '../errors';
 
 export interface ExecutorHttpServerOptions {
   port: number;
@@ -39,28 +39,39 @@ export default class ExecutorHttpServer {
     this.logger = options.logger ?? new ConsoleLogger();
     this.app = new Koa();
 
-    // Error middleware — catches all errors (including JWT 401) and returns structured JSON
+    // Error-translation middleware — the single place converting thrown errors (typed HTTP
+    // errors, domain errors via toHttpError, JWT 401) into HTTP responses. Handlers just throw.
     this.app.use(async (ctx, next) => {
       try {
         await next();
       } catch (err: unknown) {
-        const { status } = err as { status?: number };
+        const httpError = toHttpError(err);
 
-        if (status === 401) {
-          ctx.status = 401;
-          ctx.body = { error: 'Unauthorized' };
+        if (!httpError) {
+          this.logger.error('Unhandled HTTP error', {
+            method: ctx.method,
+            path: ctx.path,
+            error: extractErrorMessage(err),
+            stack: err instanceof Error ? err.stack : undefined,
+          });
+          ctx.status = 500;
+          ctx.body = { error: 'Internal server error' };
 
           return;
         }
 
-        this.logger.error('Unhandled HTTP error', {
-          method: ctx.method,
-          path: ctx.path,
-          error: extractErrorMessage(err),
-          stack: err instanceof Error ? err.stack : undefined,
-        });
-        ctx.status = 500;
-        ctx.body = { error: 'Internal server error' };
+        if (httpError.log) {
+          this.logger.error('HTTP request failed', {
+            method: ctx.method,
+            path: ctx.path,
+            status: httpError.status,
+            error: extractErrorMessage(httpError.cause ?? httpError),
+            stack: httpError.cause instanceof Error ? httpError.cause.stack : undefined,
+          });
+        }
+
+        ctx.status = httpError.status;
+        ctx.body = { error: httpError.userMessage };
       }
     });
 
@@ -133,17 +144,12 @@ export default class ExecutorHttpServer {
 
   private async hasRunAccessMiddleware(ctx: Koa.Context, next: Koa.Next): Promise<void> {
     const user = ctx.state.user as StepUser;
+    let allowed: boolean;
 
     try {
-      const allowed = await this.options.workflowPort.hasRunAccess(ctx.params.runId, user);
-
-      if (!allowed) {
-        ctx.status = 403;
-        ctx.body = { error: 'Forbidden' };
-
-        return;
-      }
+      allowed = await this.options.workflowPort.hasRunAccess(ctx.params.runId, user);
     } catch (err) {
+      // Logged here rather than by the translation middleware: the runId context lives here.
       this.logger.error('Failed to check run access', {
         runId: ctx.params.runId,
         method: ctx.method,
@@ -151,11 +157,11 @@ export default class ExecutorHttpServer {
         error: extractErrorMessage(err),
         stack: err instanceof Error ? err.stack : undefined,
       });
-      ctx.status = 503;
-      ctx.body = { error: 'Service unavailable' };
 
-      return;
+      throw new RunAccessCheckUnavailableHttpError(err);
     }
+
+    if (!allowed) throw new RunAccessDeniedHttpError();
 
     await next();
   }
@@ -170,58 +176,11 @@ export default class ExecutorHttpServer {
     const rawId = (ctx.state.user as { id?: unknown })?.id;
     const bearerUserId = typeof rawId === 'number' ? rawId : Number(rawId);
 
-    if (!Number.isFinite(bearerUserId)) {
-      ctx.status = 400;
-      ctx.body = { error: 'Missing or invalid user id in token' };
-
-      return;
-    }
+    if (!Number.isFinite(bearerUserId)) throw new InvalidTokenUserIdHttpError();
 
     const pendingData = (ctx.request.body as { pendingData?: unknown })?.pendingData;
 
-    try {
-      await this.options.runner.triggerPoll(runId, {
-        pendingData,
-        bearerUserId,
-      });
-    } catch (err) {
-      if (err instanceof RunNotFoundError) {
-        ctx.status = 404;
-        ctx.body = { error: 'Run not found or unavailable' };
-
-        return;
-      }
-
-      if (err instanceof RunAlreadyInFlightError) {
-        ctx.status = 400;
-        ctx.body = { error: err.message };
-
-        return;
-      }
-
-      if (err instanceof UserMismatchError) {
-        this.logger.error('User mismatch on trigger', { runId, bearerUserId });
-        ctx.status = 403;
-        ctx.body = { error: 'Forbidden' };
-
-        return;
-      }
-
-      if (err instanceof WorkflowExecutorError) {
-        this.logger.error('Malformed run on trigger', {
-          runId,
-          bearerUserId,
-          error: extractErrorMessage(err),
-          stack: err.stack,
-        });
-        ctx.status = 400;
-        ctx.body = { error: err.userMessage };
-
-        return;
-      }
-
-      throw err;
-    }
+    await this.options.runner.triggerPoll(runId, { pendingData, bearerUserId });
 
     ctx.status = 200;
     ctx.body = { triggered: true };

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -66,7 +66,11 @@ export default class ExecutorHttpServer {
             path: ctx.path,
             status: httpError.status,
             error: extractErrorMessage(httpError.cause ?? httpError),
-            stack: httpError.cause instanceof Error ? httpError.cause.stack : undefined,
+            // Prefer the cause's stack (points at the real fault site); fall back to the HTTP
+            // error's own stack so a log:true error without a cause never logs an empty stack.
+            stack:
+              (httpError.cause instanceof Error ? httpError.cause.stack : undefined) ??
+              httpError.stack,
           });
         }
 

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -11,9 +11,9 @@ import Koa from 'koa';
 import koaJwt from 'koa-jwt';
 
 import {
-  InvalidTokenUserIdHttpError,
-  RunAccessCheckUnavailableHttpError,
-  RunAccessDeniedHttpError,
+  BadRequestHttpError,
+  ForbiddenHttpError,
+  ServiceUnavailableHttpError,
   toHttpError,
 } from './http-errors';
 import serializeStepForWire from './step-serializer';
@@ -162,10 +162,11 @@ export default class ExecutorHttpServer {
         stack: err instanceof Error ? err.stack : undefined,
       });
 
-      throw new RunAccessCheckUnavailableHttpError(err);
+      // log:false — already logged above with the richer runId context.
+      throw new ServiceUnavailableHttpError('Service unavailable', { cause: err });
     }
 
-    if (!allowed) throw new RunAccessDeniedHttpError();
+    if (!allowed) throw new ForbiddenHttpError();
 
     await next();
   }
@@ -180,7 +181,9 @@ export default class ExecutorHttpServer {
     const rawId = (ctx.state.user as { id?: unknown })?.id;
     const bearerUserId = typeof rawId === 'number' ? rawId : Number(rawId);
 
-    if (!Number.isFinite(bearerUserId)) throw new InvalidTokenUserIdHttpError();
+    if (!Number.isFinite(bearerUserId)) {
+      throw new BadRequestHttpError('Missing or invalid user id in token');
+    }
 
     const pendingData = (ctx.request.body as { pendingData?: unknown })?.pendingData;
 

--- a/packages/workflow-executor/src/http/http-errors.ts
+++ b/packages/workflow-executor/src/http/http-errors.ts
@@ -1,18 +1,16 @@
 /* eslint-disable max-classes-per-file */
 import {
-  RunAlreadyInFlightError,
-  RunNotFoundError,
-  RunStorePortError,
-  UserMismatchError,
+  AccessDeniedError,
+  ConflictError,
+  NotFoundError,
+  UnavailableError,
   WorkflowExecutorError,
-  WorkflowPortError,
 } from '../errors';
 
 // HTTP-typed errors: each carries its response semantics (status + user-facing body) so the
-// error-translation middleware can render any thrown error without per-handler branching.
-// Hierarchy: BaseHttpError > abstract status class (NotFoundHttpError, …) > concrete case
-// (RunNotFoundHttpError, …). Status classes are abstract on purpose — every response the server
-// can produce is a named, greppable leaf class.
+// error-translation middleware can render any thrown error without per-handler branching. One
+// concrete class per status; handlers throw them directly, and toHttpError maps domain error
+// categories onto them.
 export abstract class BaseHttpError extends Error {
   readonly status: number;
   readonly userMessage: string;
@@ -35,111 +33,66 @@ export abstract class BaseHttpError extends Error {
   }
 }
 
-export abstract class BadRequestHttpError extends BaseHttpError {
+export class BadRequestHttpError extends BaseHttpError {
   constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
     super(400, userMessage, options);
   }
 }
 
-export abstract class UnauthorizedHttpError extends BaseHttpError {
+export class UnauthorizedHttpError extends BaseHttpError {
   constructor() {
     super(401, 'Unauthorized');
   }
 }
 
-export abstract class ForbiddenHttpError extends BaseHttpError {
+export class ForbiddenHttpError extends BaseHttpError {
+  // 403 bodies stay opaque ('Forbidden') on purpose — never echo why access was denied.
   constructor(options?: { log?: boolean; cause?: unknown }) {
     super(403, 'Forbidden', options);
   }
 }
 
-export abstract class NotFoundHttpError extends BaseHttpError {
-  constructor(userMessage: string) {
-    super(404, userMessage);
+export class NotFoundHttpError extends BaseHttpError {
+  constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+    super(404, userMessage, options);
   }
 }
 
-export abstract class ServiceUnavailableHttpError extends BaseHttpError {
+export class ConflictHttpError extends BaseHttpError {
+  constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+    super(409, userMessage, options);
+  }
+}
+
+export class ServiceUnavailableHttpError extends BaseHttpError {
   constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
     super(503, userMessage, options);
   }
 }
 
-export class InvalidTokenUserIdHttpError extends BadRequestHttpError {
-  constructor() {
-    super('Missing or invalid user id in token');
-  }
-}
-
-export class RunAlreadyInFlightHttpError extends BadRequestHttpError {
-  constructor(error: RunAlreadyInFlightError) {
-    super(error.message, { cause: error });
-  }
-}
-
-// Catch-all for domain errors surfacing through a handler: the request targeted a run/step whose
-// state or configuration prevents execution, so the crafted userMessage is shown as a 400.
-export class WorkflowStepFailedHttpError extends BadRequestHttpError {
-  constructor(error: WorkflowExecutorError) {
-    super(error.userMessage, { log: true, cause: error });
-  }
-}
-
-// Concrete leaves: the abstract status classes above can't be instantiated, so every emitted
-// response is one of these named leaf types.
-export class MissingOrInvalidTokenHttpError extends UnauthorizedHttpError {}
-
-export class RunAccessDeniedHttpError extends ForbiddenHttpError {}
-
-export class UserMismatchHttpError extends ForbiddenHttpError {
-  constructor(error: UserMismatchError) {
-    super({ log: true, cause: error });
-  }
-}
-
-export class RunNotFoundHttpError extends NotFoundHttpError {
-  constructor() {
-    super('Run not found or unavailable');
-  }
-}
-
-// hasRunAccess could not be checked (orchestrator unreachable) — logged at the throw site, where
-// the runId context lives.
-export class RunAccessCheckUnavailableHttpError extends ServiceUnavailableHttpError {
-  constructor(cause: unknown) {
-    super('Service unavailable', { cause });
-  }
-}
-
-// Store/orchestrator failures are server faults, not client mistakes: 503 (retryable), keeping
-// the domain userMessage in the body.
-export class UpstreamUnavailableHttpError extends ServiceUnavailableHttpError {
-  constructor(error: RunStorePortError | WorkflowPortError) {
-    super(error.userMessage, { log: true, cause: error });
-  }
-}
-
-// The single domain→HTTP mapping. Returns null when the error has no HTTP translation —
-// the middleware then responds 500 without leaking internals.
+// The single domain→HTTP mapping. Maps by domain category, not concrete class, so a new
+// NotFoundError/ConflictError/… is translated correctly without touching this function. Returns
+// null when the error has no HTTP translation — the middleware then responds 500 without leaking
+// internals.
 export function toHttpError(err: unknown): BaseHttpError | null {
   if (err instanceof BaseHttpError) return err;
 
   // koa-jwt rejects with an error object carrying status 401.
-  if ((err as { status?: number })?.status === 401) return new MissingOrInvalidTokenHttpError();
+  if ((err as { status?: number })?.status === 401) return new UnauthorizedHttpError();
 
-  // All branches below match WorkflowExecutorError subtypes and MUST precede the catch-all:
-  // each maps to a specific status (404/400/403/503), otherwise it would fall into the 400.
-  if (err instanceof RunNotFoundError) return new RunNotFoundHttpError();
-  if (err instanceof RunAlreadyInFlightError) return new RunAlreadyInFlightHttpError(err);
-  if (err instanceof UserMismatchError) return new UserMismatchHttpError(err);
+  // Category branches MUST precede the WorkflowExecutorError catch-all: every category extends it.
+  if (err instanceof NotFoundError) return new NotFoundHttpError(err.userMessage, { cause: err });
+  if (err instanceof ConflictError) return new ConflictHttpError(err.userMessage, { cause: err });
+  if (err instanceof AccessDeniedError) return new ForbiddenHttpError({ log: true, cause: err });
 
-  if (err instanceof RunStorePortError || err instanceof WorkflowPortError) {
-    return new UpstreamUnavailableHttpError(err);
+  if (err instanceof UnavailableError) {
+    return new ServiceUnavailableHttpError(err.userMessage, { log: true, cause: err });
   }
 
-  // Catch-all for any other domain error: 400 with its userMessage (safe fallback — a new
-  // WorkflowExecutorError subtype is never a silent 500).
-  if (err instanceof WorkflowExecutorError) return new WorkflowStepFailedHttpError(err);
+  // Uncategorized domain error: 400 with its userMessage (safe default — never a silent 500).
+  if (err instanceof WorkflowExecutorError) {
+    return new BadRequestHttpError(err.userMessage, { log: true, cause: err });
+  }
 
   return null;
 }

--- a/packages/workflow-executor/src/http/http-errors.ts
+++ b/packages/workflow-executor/src/http/http-errors.ts
@@ -21,7 +21,7 @@ export abstract class BaseHttpError extends Error {
   readonly log: boolean;
   cause?: unknown;
 
-  protected constructor(
+  constructor(
     status: number,
     userMessage: string,
     options: { log?: boolean; cause?: unknown } = {},
@@ -36,31 +36,31 @@ export abstract class BaseHttpError extends Error {
 }
 
 export abstract class BadRequestHttpError extends BaseHttpError {
-  protected constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+  constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
     super(400, userMessage, options);
   }
 }
 
 export abstract class UnauthorizedHttpError extends BaseHttpError {
-  protected constructor() {
+  constructor() {
     super(401, 'Unauthorized');
   }
 }
 
 export abstract class ForbiddenHttpError extends BaseHttpError {
-  protected constructor(options?: { log?: boolean; cause?: unknown }) {
+  constructor(options?: { log?: boolean; cause?: unknown }) {
     super(403, 'Forbidden', options);
   }
 }
 
 export abstract class NotFoundHttpError extends BaseHttpError {
-  protected constructor(userMessage: string) {
+  constructor(userMessage: string) {
     super(404, userMessage);
   }
 }
 
 export abstract class ServiceUnavailableHttpError extends BaseHttpError {
-  protected constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+  constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
     super(503, userMessage, options);
   }
 }
@@ -85,18 +85,11 @@ export class WorkflowStepFailedHttpError extends BadRequestHttpError {
   }
 }
 
-export class MissingOrInvalidTokenHttpError extends UnauthorizedHttpError {
-  // Widens the inherited protected constructor: leaves are the only instantiable classes.
-  public constructor() {
-    super();
-  }
-}
+// Concrete leaves: the abstract status classes above can't be instantiated, so every emitted
+// response is one of these named leaf types.
+export class MissingOrInvalidTokenHttpError extends UnauthorizedHttpError {}
 
-export class RunAccessDeniedHttpError extends ForbiddenHttpError {
-  public constructor() {
-    super();
-  }
-}
+export class RunAccessDeniedHttpError extends ForbiddenHttpError {}
 
 export class UserMismatchHttpError extends ForbiddenHttpError {
   constructor(error: UserMismatchError) {

--- a/packages/workflow-executor/src/http/http-errors.ts
+++ b/packages/workflow-executor/src/http/http-errors.ts
@@ -1,0 +1,149 @@
+/* eslint-disable max-classes-per-file */
+import {
+  RunAlreadyInFlightError,
+  RunNotFoundError,
+  RunStorePortError,
+  UserMismatchError,
+  WorkflowExecutorError,
+  WorkflowPortError,
+} from '../errors';
+
+// HTTP-typed errors: each carries its response semantics (status + user-facing body) so the
+// error-translation middleware can render any thrown error without per-handler branching.
+// Hierarchy: BaseHttpError > abstract status class (NotFoundHttpError, …) > concrete case
+// (RunNotFoundHttpError, …). Status classes are abstract on purpose — every response the server
+// can produce is a named, greppable leaf class.
+export abstract class BaseHttpError extends Error {
+  readonly status: number;
+  readonly userMessage: string;
+  // When true, the translation middleware logs the error (with its cause's stack) at error level.
+  // Off by default so expected client churn (completed run, double trigger) is not noise-logged.
+  readonly log: boolean;
+  cause?: unknown;
+
+  protected constructor(
+    status: number,
+    userMessage: string,
+    options: { log?: boolean; cause?: unknown } = {},
+  ) {
+    super(userMessage);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.userMessage = userMessage;
+    this.log = options.log ?? false;
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+export abstract class BadRequestHttpError extends BaseHttpError {
+  protected constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+    super(400, userMessage, options);
+  }
+}
+
+export abstract class UnauthorizedHttpError extends BaseHttpError {
+  protected constructor() {
+    super(401, 'Unauthorized');
+  }
+}
+
+export abstract class ForbiddenHttpError extends BaseHttpError {
+  protected constructor(options?: { log?: boolean; cause?: unknown }) {
+    super(403, 'Forbidden', options);
+  }
+}
+
+export abstract class NotFoundHttpError extends BaseHttpError {
+  protected constructor(userMessage: string) {
+    super(404, userMessage);
+  }
+}
+
+export abstract class ServiceUnavailableHttpError extends BaseHttpError {
+  protected constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
+    super(503, userMessage, options);
+  }
+}
+
+export class InvalidTokenUserIdHttpError extends BadRequestHttpError {
+  constructor() {
+    super('Missing or invalid user id in token');
+  }
+}
+
+export class RunAlreadyInFlightHttpError extends BadRequestHttpError {
+  constructor(error: RunAlreadyInFlightError) {
+    super(error.message, { cause: error });
+  }
+}
+
+// Catch-all for domain errors surfacing through a handler: the request targeted a run/step whose
+// state or configuration prevents execution, so the crafted userMessage is shown as a 400.
+export class WorkflowStepFailedHttpError extends BadRequestHttpError {
+  constructor(error: WorkflowExecutorError) {
+    super(error.userMessage, { log: true, cause: error });
+  }
+}
+
+export class MissingOrInvalidTokenHttpError extends UnauthorizedHttpError {
+  // Widens the inherited protected constructor: leaves are the only instantiable classes.
+  public constructor() {
+    super();
+  }
+}
+
+export class RunAccessDeniedHttpError extends ForbiddenHttpError {
+  public constructor() {
+    super();
+  }
+}
+
+export class UserMismatchHttpError extends ForbiddenHttpError {
+  constructor(error: UserMismatchError) {
+    super({ log: true, cause: error });
+  }
+}
+
+export class RunNotFoundHttpError extends NotFoundHttpError {
+  constructor() {
+    super('Run not found or unavailable');
+  }
+}
+
+// hasRunAccess could not be checked (orchestrator unreachable) — logged at the throw site, where
+// the runId context lives.
+export class RunAccessCheckUnavailableHttpError extends ServiceUnavailableHttpError {
+  constructor(cause: unknown) {
+    super('Service unavailable', { cause });
+  }
+}
+
+// Store/orchestrator failures are server faults, not client mistakes: 503 (retryable), keeping
+// the domain userMessage in the body.
+export class UpstreamUnavailableHttpError extends ServiceUnavailableHttpError {
+  constructor(error: RunStorePortError | WorkflowPortError) {
+    super(error.userMessage, { log: true, cause: error });
+  }
+}
+
+// The single domain→HTTP mapping. Returns null when the error has no HTTP translation —
+// the middleware then responds 500 without leaking internals.
+export function toHttpError(err: unknown): BaseHttpError | null {
+  if (err instanceof BaseHttpError) return err;
+
+  // koa-jwt rejects with an error object carrying status 401.
+  if ((err as { status?: number })?.status === 401) return new MissingOrInvalidTokenHttpError();
+
+  if (err instanceof RunNotFoundError) return new RunNotFoundHttpError();
+  if (err instanceof RunAlreadyInFlightError) return new RunAlreadyInFlightHttpError(err);
+  if (err instanceof UserMismatchError) return new UserMismatchHttpError(err);
+
+  // Must precede the WorkflowExecutorError catch-all: both extend it.
+  if (err instanceof RunStorePortError || err instanceof WorkflowPortError) {
+    return new UpstreamUnavailableHttpError(err);
+  }
+
+  if (err instanceof WorkflowExecutorError) return new WorkflowStepFailedHttpError(err);
+
+  return null;
+}

--- a/packages/workflow-executor/src/http/http-errors.ts
+++ b/packages/workflow-executor/src/http/http-errors.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-classes-per-file */
 import {
   AccessDeniedError,
-  ConflictError,
   NotFoundError,
+  RunAlreadyInFlightError,
   UnavailableError,
   WorkflowExecutorError,
 } from '../errors';
@@ -58,12 +58,6 @@ export class NotFoundHttpError extends BaseHttpError {
   }
 }
 
-export class ConflictHttpError extends BaseHttpError {
-  constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
-    super(409, userMessage, options);
-  }
-}
-
 export class ServiceUnavailableHttpError extends BaseHttpError {
   constructor(userMessage: string, options?: { log?: boolean; cause?: unknown }) {
     super(503, userMessage, options);
@@ -82,8 +76,12 @@ export function toHttpError(err: unknown): BaseHttpError | null {
 
   // Category branches MUST precede the WorkflowExecutorError catch-all: every category extends it.
   if (err instanceof NotFoundError) return new NotFoundHttpError(err.userMessage, { cause: err });
-  if (err instanceof ConflictError) return new ConflictHttpError(err.userMessage, { cause: err });
   if (err instanceof AccessDeniedError) return new ForbiddenHttpError({ log: true, cause: err });
+
+  // Expected client churn (a double trigger): 400, not logged. Precedes the catch-all, which logs.
+  if (err instanceof RunAlreadyInFlightError) {
+    return new BadRequestHttpError(err.userMessage, { cause: err });
+  }
 
   if (err instanceof UnavailableError) {
     return new ServiceUnavailableHttpError(err.userMessage, { log: true, cause: err });

--- a/packages/workflow-executor/src/http/http-errors.ts
+++ b/packages/workflow-executor/src/http/http-errors.ts
@@ -127,15 +127,18 @@ export function toHttpError(err: unknown): BaseHttpError | null {
   // koa-jwt rejects with an error object carrying status 401.
   if ((err as { status?: number })?.status === 401) return new MissingOrInvalidTokenHttpError();
 
+  // All branches below match WorkflowExecutorError subtypes and MUST precede the catch-all:
+  // each maps to a specific status (404/400/403/503), otherwise it would fall into the 400.
   if (err instanceof RunNotFoundError) return new RunNotFoundHttpError();
   if (err instanceof RunAlreadyInFlightError) return new RunAlreadyInFlightHttpError(err);
   if (err instanceof UserMismatchError) return new UserMismatchHttpError(err);
 
-  // Must precede the WorkflowExecutorError catch-all: both extend it.
   if (err instanceof RunStorePortError || err instanceof WorkflowPortError) {
     return new UpstreamUnavailableHttpError(err);
   }
 
+  // Catch-all for any other domain error: 400 with its userMessage (safe fallback — a new
+  // WorkflowExecutorError subtype is never a silent 500).
   if (err instanceof WorkflowExecutorError) return new WorkflowStepFailedHttpError(err);
 
   return null;

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -188,7 +188,7 @@ export default class Runner {
     const { step, auth } = dispatch;
 
     if (options?.bearerUserId !== undefined && step.user.id !== options.bearerUserId) {
-      throw new UserMismatchError(runId);
+      throw new UserMismatchError(runId, options.bearerUserId, step.user.id);
     }
 
     await this.executeStep(step, auth.forestServerToken, options?.pendingData);

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -493,7 +493,7 @@ describe('ExecutorHttpServer', () => {
       expect(response.body).toEqual({ error: 'Forbidden' });
     });
 
-    it('returns 400 when triggerPoll rejects with RunAlreadyInFlightError', async () => {
+    it('returns 409 (conflict) when triggerPoll rejects with RunAlreadyInFlightError', async () => {
       const runner = createMockRunner({
         triggerPoll: jest.fn().mockRejectedValue(new RunAlreadyInFlightError('run-1')),
       });
@@ -505,7 +505,7 @@ describe('ExecutorHttpServer', () => {
         .post('/runs/run-1/trigger')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(409);
       expect(response.body).toEqual({ error: 'Run "run-1" is already being processed' });
     });
 

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -493,7 +493,7 @@ describe('ExecutorHttpServer', () => {
       expect(response.body).toEqual({ error: 'Forbidden' });
     });
 
-    it('returns 409 (conflict) when triggerPoll rejects with RunAlreadyInFlightError', async () => {
+    it('returns 400 when triggerPoll rejects with RunAlreadyInFlightError', async () => {
       const runner = createMockRunner({
         triggerPoll: jest.fn().mockRejectedValue(new RunAlreadyInFlightError('run-1')),
       });
@@ -505,7 +505,7 @@ describe('ExecutorHttpServer', () => {
         .post('/runs/run-1/trigger')
         .set('Authorization', `Bearer ${token}`);
 
-      expect(response.status).toBe(409);
+      expect(response.status).toBe(400);
       expect(response.body).toEqual({ error: 'Run "run-1" is already being processed' });
     });
 

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -479,7 +479,7 @@ describe('ExecutorHttpServer', () => {
 
     it('returns 403 when triggerPoll rejects with UserMismatchError', async () => {
       const runner = createMockRunner({
-        triggerPoll: jest.fn().mockRejectedValue(new UserMismatchError('run-1')),
+        triggerPoll: jest.fn().mockRejectedValue(new UserMismatchError('run-1', 999, 1)),
       });
 
       const server = createServer({ runner });
@@ -546,10 +546,13 @@ describe('ExecutorHttpServer', () => {
       });
     });
 
-    it('logs translated errors flagged for logging (user mismatch) through the middleware', async () => {
+    it('logs translated errors flagged for logging, with the offending user id and the cause stack', async () => {
       const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+      // The domain error is the `cause`; the centralized log must surface its message (carrying
+      // the offending/owner user ids) and ITS stack — not the synthetic HTTP wrapper's stack.
+      const domainError = new UserMismatchError('run-1', 999, 1);
       const runner = createMockRunner({
-        triggerPoll: jest.fn().mockRejectedValue(new UserMismatchError('run-1')),
+        triggerPoll: jest.fn().mockRejectedValue(domainError),
       });
 
       const server = createServer({ runner, logger });
@@ -565,7 +568,8 @@ describe('ExecutorHttpServer', () => {
           method: 'POST',
           path: '/runs/run-1/trigger',
           status: 403,
-          error: 'User not authorized for run "run-1"',
+          error: 'User 999 not authorized for run "run-1" (owned by user 1)',
+          stack: domainError.stack,
         }),
       );
     });

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -8,7 +8,9 @@ import {
   MalformedRunError,
   RunAlreadyInFlightError,
   RunNotFoundError,
+  RunStorePortError,
   UserMismatchError,
+  WorkflowPortError,
 } from '../../src/errors';
 import ExecutorHttpServer from '../../src/http/executor-http-server';
 
@@ -305,6 +307,26 @@ describe('ExecutorHttpServer', () => {
       expect(runner.getRunStepExecutions).toHaveBeenCalledWith('run-1');
     });
 
+    it('returns 503 with userMessage when getRunStepExecutions rejects with RunStorePortError', async () => {
+      const runner = createMockRunner({
+        getRunStepExecutions: jest
+          .fn()
+          .mockRejectedValue(new RunStorePortError('getStepExecutions', new Error('db down'))),
+      });
+
+      const server = createServer({ runner });
+      const token = signToken({ id: 1 });
+
+      const response = await request(server.callback)
+        .get('/runs/run-1')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({
+        error: 'The step state could not be accessed. Please retry.',
+      });
+    });
+
     it('should return 500 when getRunStepExecutions rejects', async () => {
       const runner = createMockRunner({
         getRunStepExecutions: jest.fn().mockRejectedValue(new Error('db error')),
@@ -501,6 +523,67 @@ describe('ExecutorHttpServer', () => {
 
       expect(response.status).toBe(500);
       expect(response.body).toEqual({ error: 'Internal server error' });
+    });
+
+    it('returns 503 with userMessage when triggerPoll rejects with WorkflowPortError', async () => {
+      const runner = createMockRunner({
+        triggerPoll: jest
+          .fn()
+          .mockRejectedValue(new WorkflowPortError('getAvailableRun', new Error('http 502'))),
+      });
+
+      const server = createServer({ runner });
+      const token = signToken({ id: 1 });
+
+      const response = await request(server.callback)
+        .post('/runs/run-1/trigger')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({
+        error:
+          "This step couldn't be completed. Please try again, and contact your administrator if the problem continues.",
+      });
+    });
+
+    it('logs translated errors flagged for logging (user mismatch) through the middleware', async () => {
+      const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+      const runner = createMockRunner({
+        triggerPoll: jest.fn().mockRejectedValue(new UserMismatchError('run-1')),
+      });
+
+      const server = createServer({ runner, logger });
+      const token = signToken({ id: 1 });
+
+      await request(server.callback)
+        .post('/runs/run-1/trigger')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'HTTP request failed',
+        expect.objectContaining({
+          method: 'POST',
+          path: '/runs/run-1/trigger',
+          status: 403,
+          error: 'User not authorized for run "run-1"',
+        }),
+      );
+    });
+
+    it('does not log expected client churn (RunNotFoundError) through the middleware', async () => {
+      const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+      const runner = createMockRunner({
+        triggerPoll: jest.fn().mockRejectedValue(new RunNotFoundError('run-1')),
+      });
+
+      const server = createServer({ runner, logger });
+      const token = signToken({ id: 1 });
+
+      await request(server.callback)
+        .post('/runs/run-1/trigger')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('returns 400 with userMessage when triggerPoll rejects with MalformedRunError', async () => {

--- a/packages/workflow-executor/test/http/http-errors.test.ts
+++ b/packages/workflow-executor/test/http/http-errors.test.ts
@@ -9,7 +9,6 @@ import {
 import {
   BadRequestHttpError,
   BaseHttpError,
-  ConflictHttpError,
   ForbiddenHttpError,
   NotFoundHttpError,
   ServiceUnavailableHttpError,
@@ -23,7 +22,6 @@ describe('http status classes', () => {
     [new UnauthorizedHttpError(), 401, 'Unauthorized'],
     [new ForbiddenHttpError(), 403, 'Forbidden'],
     [new NotFoundHttpError('gone'), 404, 'gone'],
-    [new ConflictHttpError('busy'), 409, 'busy'],
     [new ServiceUnavailableHttpError('down'), 503, 'down'],
   ] as const)('%s carries its status and userMessage', (err, status, message) => {
     expect(err).toBeInstanceOf(BaseHttpError);
@@ -74,12 +72,12 @@ describe('toHttpError', () => {
     expect(result?.cause).toBe(domainError);
   });
 
-  it('maps a ConflictError category to 409 with its userMessage (not logged)', () => {
+  it('maps RunAlreadyInFlightError to 400 with its message, not logged (expected churn)', () => {
     const domainError = new RunAlreadyInFlightError('run-1');
     const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(ConflictHttpError);
-    expect(result?.status).toBe(409);
+    expect(result).toBeInstanceOf(BadRequestHttpError);
+    expect(result?.status).toBe(400);
     expect(result?.userMessage).toBe('Run "run-1" is already being processed');
     expect(result?.log).toBe(false);
     expect(result?.cause).toBe(domainError);

--- a/packages/workflow-executor/test/http/http-errors.test.ts
+++ b/packages/workflow-executor/test/http/http-errors.test.ts
@@ -1,0 +1,138 @@
+import {
+  InvalidPendingDataError,
+  RunAlreadyInFlightError,
+  RunNotFoundError,
+  RunStorePortError,
+  UserMismatchError,
+  WorkflowPortError,
+} from '../../src/errors';
+import {
+  BadRequestHttpError,
+  BaseHttpError,
+  ForbiddenHttpError,
+  InvalidTokenUserIdHttpError,
+  NotFoundHttpError,
+  RunAccessCheckUnavailableHttpError,
+  RunAccessDeniedHttpError,
+  RunAlreadyInFlightHttpError,
+  RunNotFoundHttpError,
+  ServiceUnavailableHttpError,
+  UpstreamUnavailableHttpError,
+  UserMismatchHttpError,
+  WorkflowStepFailedHttpError,
+  toHttpError,
+} from '../../src/http/http-errors';
+
+describe('http-errors hierarchy', () => {
+  it('exposes the three inheritance levels (precise > status class > BaseHttpError)', () => {
+    const err = new RunNotFoundHttpError();
+
+    expect(err).toBeInstanceOf(NotFoundHttpError);
+    expect(err).toBeInstanceOf(BaseHttpError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it.each([
+    [new InvalidTokenUserIdHttpError(), 400, 'Missing or invalid user id in token', false],
+    [new RunAccessDeniedHttpError(), 403, 'Forbidden', false],
+    [new RunNotFoundHttpError(), 404, 'Run not found or unavailable', false],
+    [new RunAccessCheckUnavailableHttpError(new Error('down')), 503, 'Service unavailable', false],
+  ] as const)('%s carries status %i, userMessage and log flag', (err, status, message, log) => {
+    expect(err.status).toBe(status);
+    expect(err.userMessage).toBe(message);
+    expect(err.log).toBe(log);
+    expect(err.name).toBe(err.constructor.name);
+  });
+});
+
+describe('toHttpError', () => {
+  it('passes through an already-typed HttpError unchanged', () => {
+    const err = new RunNotFoundHttpError();
+
+    expect(toHttpError(err)).toBe(err);
+  });
+
+  it('maps koa-jwt 401 errors (status property) to a 401 Unauthorized', () => {
+    const result = toHttpError(Object.assign(new Error('jwt expired'), { status: 401 }));
+
+    expect(result?.status).toBe(401);
+    expect(result?.userMessage).toBe('Unauthorized');
+  });
+
+  it('maps RunNotFoundError to 404 with the public message', () => {
+    const result = toHttpError(new RunNotFoundError('run-1'));
+
+    expect(result).toBeInstanceOf(RunNotFoundHttpError);
+    expect(result?.status).toBe(404);
+    expect(result?.userMessage).toBe('Run not found or unavailable');
+    expect(result?.log).toBe(false);
+  });
+
+  it('maps RunAlreadyInFlightError to 400 carrying the domain message', () => {
+    const domainError = new RunAlreadyInFlightError('run-1');
+    const result = toHttpError(domainError);
+
+    expect(result).toBeInstanceOf(RunAlreadyInFlightHttpError);
+    expect(result?.status).toBe(400);
+    expect(result?.userMessage).toBe('Run "run-1" is already being processed');
+    expect(result?.log).toBe(false);
+    expect(result?.cause).toBe(domainError);
+  });
+
+  it('maps UserMismatchError to a logged 403 Forbidden', () => {
+    const domainError = new UserMismatchError('run-1');
+    const result = toHttpError(domainError);
+
+    expect(result).toBeInstanceOf(UserMismatchHttpError);
+    expect(result?.status).toBe(403);
+    expect(result?.userMessage).toBe('Forbidden');
+    expect(result?.log).toBe(true);
+    expect(result?.cause).toBe(domainError);
+  });
+
+  it.each([
+    ['RunStorePortError', new RunStorePortError('getStepExecutions', new Error('db down'))],
+    ['WorkflowPortError', new WorkflowPortError('getAvailableRun', new Error('http 502'))],
+  ])('maps %s to 503 (not the 400 catch-all) with its userMessage', (_, domainError) => {
+    const result = toHttpError(domainError);
+
+    expect(result).toBeInstanceOf(UpstreamUnavailableHttpError);
+    expect(result).toBeInstanceOf(ServiceUnavailableHttpError);
+    expect(result?.status).toBe(503);
+    expect(result?.userMessage).toBe(domainError.userMessage);
+    expect(result?.log).toBe(true);
+    expect(result?.cause).toBe(domainError);
+  });
+
+  it('maps any other WorkflowExecutorError to a logged 400 with its userMessage', () => {
+    const domainError = new InvalidPendingDataError([]);
+    const result = toHttpError(domainError);
+
+    expect(result).toBeInstanceOf(WorkflowStepFailedHttpError);
+    expect(result).toBeInstanceOf(BadRequestHttpError);
+    expect(result?.status).toBe(400);
+    expect(result?.userMessage).toBe('The request body is invalid.');
+    expect(result?.log).toBe(true);
+    expect(result?.cause).toBe(domainError);
+  });
+
+  it('returns null for errors with no HTTP translation', () => {
+    expect(toHttpError(new Error('boom'))).toBeNull();
+    expect(toHttpError('not even an error')).toBeNull();
+    expect(toHttpError(undefined)).toBeNull();
+  });
+});
+
+describe('status classes hierarchy coverage', () => {
+  it.each([
+    [new InvalidTokenUserIdHttpError(), BadRequestHttpError],
+    [new UserMismatchHttpError(new UserMismatchError('run-1')), ForbiddenHttpError],
+    [
+      new UpstreamUnavailableHttpError(new WorkflowPortError('op', new Error('x'))),
+      ServiceUnavailableHttpError,
+    ],
+  ] as const)('%s extends its status class', (err, statusClass) => {
+    expect(err).toBeInstanceOf(statusClass);
+    expect(err).toBeInstanceOf(BaseHttpError);
+  });
+});

--- a/packages/workflow-executor/test/http/http-errors.test.ts
+++ b/packages/workflow-executor/test/http/http-errors.test.ts
@@ -80,7 +80,7 @@ describe('toHttpError', () => {
   });
 
   it('maps UserMismatchError to a logged 403 Forbidden', () => {
-    const domainError = new UserMismatchError('run-1');
+    const domainError = new UserMismatchError('run-1', 7, 42);
     const result = toHttpError(domainError);
 
     expect(result).toBeInstanceOf(UserMismatchHttpError);
@@ -126,7 +126,7 @@ describe('toHttpError', () => {
 describe('status classes hierarchy coverage', () => {
   it.each([
     [new InvalidTokenUserIdHttpError(), BadRequestHttpError],
-    [new UserMismatchHttpError(new UserMismatchError('run-1')), ForbiddenHttpError],
+    [new UserMismatchHttpError(new UserMismatchError('run-1', 7, 42)), ForbiddenHttpError],
     [
       new UpstreamUnavailableHttpError(new WorkflowPortError('op', new Error('x'))),
       ServiceUnavailableHttpError,

--- a/packages/workflow-executor/test/http/http-errors.test.ts
+++ b/packages/workflow-executor/test/http/http-errors.test.ts
@@ -9,45 +9,48 @@ import {
 import {
   BadRequestHttpError,
   BaseHttpError,
+  ConflictHttpError,
   ForbiddenHttpError,
-  InvalidTokenUserIdHttpError,
   NotFoundHttpError,
-  RunAccessCheckUnavailableHttpError,
-  RunAccessDeniedHttpError,
-  RunAlreadyInFlightHttpError,
-  RunNotFoundHttpError,
   ServiceUnavailableHttpError,
-  UpstreamUnavailableHttpError,
-  UserMismatchHttpError,
-  WorkflowStepFailedHttpError,
+  UnauthorizedHttpError,
   toHttpError,
 } from '../../src/http/http-errors';
 
-describe('http-errors hierarchy', () => {
-  it('exposes the three inheritance levels (precise > status class > BaseHttpError)', () => {
-    const err = new RunNotFoundHttpError();
-
-    expect(err).toBeInstanceOf(NotFoundHttpError);
-    expect(err).toBeInstanceOf(BaseHttpError);
-    expect(err).toBeInstanceOf(Error);
-  });
-
+describe('http status classes', () => {
   it.each([
-    [new InvalidTokenUserIdHttpError(), 400, 'Missing or invalid user id in token', false],
-    [new RunAccessDeniedHttpError(), 403, 'Forbidden', false],
-    [new RunNotFoundHttpError(), 404, 'Run not found or unavailable', false],
-    [new RunAccessCheckUnavailableHttpError(new Error('down')), 503, 'Service unavailable', false],
-  ] as const)('%s carries status %i, userMessage and log flag', (err, status, message, log) => {
+    [new BadRequestHttpError('bad'), 400, 'bad'],
+    [new UnauthorizedHttpError(), 401, 'Unauthorized'],
+    [new ForbiddenHttpError(), 403, 'Forbidden'],
+    [new NotFoundHttpError('gone'), 404, 'gone'],
+    [new ConflictHttpError('busy'), 409, 'busy'],
+    [new ServiceUnavailableHttpError('down'), 503, 'down'],
+  ] as const)('%s carries its status and userMessage', (err, status, message) => {
+    expect(err).toBeInstanceOf(BaseHttpError);
     expect(err.status).toBe(status);
     expect(err.userMessage).toBe(message);
-    expect(err.log).toBe(log);
     expect(err.name).toBe(err.constructor.name);
+  });
+
+  it('defaults log to false and omits an unset cause', () => {
+    const err = new NotFoundHttpError('gone');
+
+    expect(err.log).toBe(false);
+    expect(err.cause).toBeUndefined();
+  });
+
+  it('carries log and cause when provided', () => {
+    const cause = new Error('boom');
+    const err = new ServiceUnavailableHttpError('down', { log: true, cause });
+
+    expect(err.log).toBe(true);
+    expect(err.cause).toBe(cause);
   });
 });
 
 describe('toHttpError', () => {
   it('passes through an already-typed HttpError unchanged', () => {
-    const err = new RunNotFoundHttpError();
+    const err = new NotFoundHttpError('gone');
 
     expect(toHttpError(err)).toBe(err);
   });
@@ -55,35 +58,38 @@ describe('toHttpError', () => {
   it('maps koa-jwt 401 errors (status property) to a 401 Unauthorized', () => {
     const result = toHttpError(Object.assign(new Error('jwt expired'), { status: 401 }));
 
+    expect(result).toBeInstanceOf(UnauthorizedHttpError);
     expect(result?.status).toBe(401);
     expect(result?.userMessage).toBe('Unauthorized');
   });
 
-  it('maps RunNotFoundError to 404 with the public message', () => {
-    const result = toHttpError(new RunNotFoundError('run-1'));
+  it('maps a NotFoundError category to 404 with its userMessage (not logged)', () => {
+    const domainError = new RunNotFoundError('run-1');
+    const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(RunNotFoundHttpError);
+    expect(result).toBeInstanceOf(NotFoundHttpError);
     expect(result?.status).toBe(404);
     expect(result?.userMessage).toBe('Run not found or unavailable');
     expect(result?.log).toBe(false);
+    expect(result?.cause).toBe(domainError);
   });
 
-  it('maps RunAlreadyInFlightError to 400 carrying the domain message', () => {
+  it('maps a ConflictError category to 409 with its userMessage (not logged)', () => {
     const domainError = new RunAlreadyInFlightError('run-1');
     const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(RunAlreadyInFlightHttpError);
-    expect(result?.status).toBe(400);
+    expect(result).toBeInstanceOf(ConflictHttpError);
+    expect(result?.status).toBe(409);
     expect(result?.userMessage).toBe('Run "run-1" is already being processed');
     expect(result?.log).toBe(false);
     expect(result?.cause).toBe(domainError);
   });
 
-  it('maps UserMismatchError to a logged 403 Forbidden', () => {
+  it('maps an AccessDeniedError category to a logged 403 Forbidden (opaque body, no id leak)', () => {
     const domainError = new UserMismatchError('run-1', 7, 42);
     const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(UserMismatchHttpError);
+    expect(result).toBeInstanceOf(ForbiddenHttpError);
     expect(result?.status).toBe(403);
     expect(result?.userMessage).toBe('Forbidden');
     expect(result?.log).toBe(true);
@@ -93,22 +99,23 @@ describe('toHttpError', () => {
   it.each([
     ['RunStorePortError', new RunStorePortError('getStepExecutions', new Error('db down'))],
     ['WorkflowPortError', new WorkflowPortError('getAvailableRun', new Error('http 502'))],
-  ])('maps %s to 503 (not the 400 catch-all) with its userMessage', (_, domainError) => {
-    const result = toHttpError(domainError);
+  ])(
+    'maps an UnavailableError category (%s) to a logged 503 with its userMessage',
+    (_, domainError) => {
+      const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(UpstreamUnavailableHttpError);
-    expect(result).toBeInstanceOf(ServiceUnavailableHttpError);
-    expect(result?.status).toBe(503);
-    expect(result?.userMessage).toBe(domainError.userMessage);
-    expect(result?.log).toBe(true);
-    expect(result?.cause).toBe(domainError);
-  });
+      expect(result).toBeInstanceOf(ServiceUnavailableHttpError);
+      expect(result?.status).toBe(503);
+      expect(result?.userMessage).toBe(domainError.userMessage);
+      expect(result?.log).toBe(true);
+      expect(result?.cause).toBe(domainError);
+    },
+  );
 
-  it('maps any other WorkflowExecutorError to a logged 400 with its userMessage', () => {
+  it('maps any uncategorized WorkflowExecutorError to a logged 400 with its userMessage', () => {
     const domainError = new InvalidPendingDataError([]);
     const result = toHttpError(domainError);
 
-    expect(result).toBeInstanceOf(WorkflowStepFailedHttpError);
     expect(result).toBeInstanceOf(BadRequestHttpError);
     expect(result?.status).toBe(400);
     expect(result?.userMessage).toBe('The request body is invalid.');
@@ -120,19 +127,5 @@ describe('toHttpError', () => {
     expect(toHttpError(new Error('boom'))).toBeNull();
     expect(toHttpError('not even an error')).toBeNull();
     expect(toHttpError(undefined)).toBeNull();
-  });
-});
-
-describe('status classes hierarchy coverage', () => {
-  it.each([
-    [new InvalidTokenUserIdHttpError(), BadRequestHttpError],
-    [new UserMismatchHttpError(new UserMismatchError('run-1', 7, 42)), ForbiddenHttpError],
-    [
-      new UpstreamUnavailableHttpError(new WorkflowPortError('op', new Error('x'))),
-      ServiceUnavailableHttpError,
-    ],
-  ] as const)('%s extends its status class', (err, statusClass) => {
-    expect(err).toBeInstanceOf(statusClass);
-    expect(err).toBeInstanceOf(BaseHttpError);
   });
 });


### PR DESCRIPTION
## What

Centralizes the executor's error → HTTP-response mapping (PRD-477). Previously, translation was scattered across three places in `executor-http-server.ts` (error middleware, `hasRunAccessMiddleware`, `handleTrigger` with one `instanceof` branch per error type), and was already inconsistent — an orchestrator failure surfaced as 400 on `POST /trigger` but 500 on `GET /runs`.

## Design

**Domain error categories (transport-agnostic).** A small set of abstract categories under `WorkflowExecutorError` in `errors.ts`:

| Category | Meaning | HTTP |
|---|---|---|
| `NotFoundError` | the requested entity doesn't exist | 404 |
| `AccessDeniedError` | actor not permitted | 403 |
| `UnavailableError` | internal dependency down, retryable | 503 |
| *(uncategorized `WorkflowExecutorError`)* | known domain failure | 400 |

Run lifecycle errors extend their category: `RunNotFoundError → NotFoundError`, `UserMismatchError → AccessDeniedError`, `RunStorePortError`/`WorkflowPortError → UnavailableError`. `RunAlreadyInFlightError` stays a 400 (an explicit branch flags it as expected churn so it isn't logged).

**Single translator.** `toHttpError(err)` maps **by category, not by concrete class** — so a new request-level error (e.g. `StepNotFoundError extends NotFoundError`) gets the right status with **zero change to the HTTP layer**. Returns `null` for untranslatable errors → middleware responds a generic 500 (no internals leaked).

**Error-translation middleware** owns all mapping; handlers just `throw`. The HTTP side is one concrete class per status (`BadRequestHttpError`, `UnauthorizedHttpError`, `ForbiddenHttpError`, `NotFoundHttpError`, `ServiceUnavailableHttpError`) — no per-error leaf classes.

**Logging.** A `log` flag on each HTTP error: genuine server/security faults (503, user mismatch) are logged with the underlying cause's stack; expected client churn (404/400) stays out of the logs. `UserMismatchError` carries the bearer/owner ids in its technical message (logged) but **never** in the body — 403 responses stay opaque (`Forbidden`).

## ⚠️ Behaviour change (intentional)

Infra failures (`WorkflowPortError` / `RunStorePortError`) → **503** everywhere (were 400 on trigger, 500 on GET). Semantically correct (server fault, retryable). Every other response is byte-for-byte identical.

## Tests

- `test/http/http-errors.test.ts`: category mapping (404/403/503, the 400 default for an uncategorized `WorkflowExecutorError` incl. `RunAlreadyInFlightError`, `null` → 500), status-class invariants, koa-jwt 401.
- `test/http/executor-http-server.test.ts`: end-to-end statuses incl. the new 503, middleware logs `log:true` errors (asserting the stack comes from the cause) and stays quiet for expected churn.
- Full suite: 1018 passing; the existing http-server test lines pass unchanged (non-regression).

Refs PRD-477


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize HTTP error mapping in workflow-executor using typed domain errors
> - Introduces typed base error classes (`NotFoundError`, `AccessDeniedError`, `UnavailableError`) in [errors.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1657/files#diff-0109f91a733affdd89e2fae234f7010a44b4b923e1d56be5c84f8014b219cef0) and re-parents existing domain errors under them.
> - Adds [http-errors.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1657/files#diff-52c694f90bcb7a90ab609520d7e5c04d6461f0ea999fb4d85801f745a5597eba) with concrete HTTP error classes (400/401/403/404/503) and a `toHttpError` utility that maps domain errors to HTTP responses.
> - Refactors [executor-http-server.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1657/files#diff-f24eaa83e4d72cc710e9cb4cea88a2047543ee3c17a0b68627f6af587546b614) to bubble domain errors to a single middleware that calls `toHttpError`, replacing per-handler try/catch cascades.
> - `RunStorePortError` and `WorkflowPortError` now map to 503; `UserMismatchError` to logged 403; `RunAlreadyInFlightError` to non-logged 400; unmapped errors still return 500.
> - Behavioral Change: access-check failures now return 503 with a stable body; forbidden access returns 403; invalid bearer user ID returns 400; only selected errors are logged with cause stacks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f17687.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->