### PR TITLE
fix(workflow-executor): scope collection schema cache by rendering [PRD-440]

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -243,7 +243,7 @@ export default class AgentClientAgentPort implements AgentPort {
     return createRemoteAgentClient({
       url: this.agentUrl,
       token: this.mintToken(user),
-      actionEndpoints: this.buildActionEndpoints(),
+      actionEndpoints: this.buildActionEndpoints(user.renderingId),
     });
   }
 
@@ -291,10 +291,10 @@ export default class AgentClientAgentPort implements AgentPort {
     }
   }
 
-  private buildActionEndpoints(): ActionEndpointsByCollection {
+  private buildActionEndpoints(renderingId: number): ActionEndpointsByCollection {
     const endpoints: ActionEndpointsByCollection = {};
 
-    for (const [collectionName, schema] of this.schemaCache) {
+    for (const [collectionName, schema] of this.schemaCache.entriesForRendering(renderingId)) {
       endpoints[collectionName] = {};
 
       for (const action of schema.actions) {

--- a/packages/workflow-executor/src/executors/step-executor-factory.ts
+++ b/packages/workflow-executor/src/executors/step-executor-factory.ts
@@ -135,7 +135,12 @@ export default class StepExecutorFactory {
     activityLogPort: ActivityLogPort,
     incomingPendingData?: unknown,
   ): ExecutionContext {
-    const schemaResolver = new SchemaResolver(cfg.schemaCache, cfg.workflowPort, step.runId);
+    const schemaResolver = new SchemaResolver(
+      cfg.schemaCache,
+      cfg.workflowPort,
+      step.runId,
+      step.user.renderingId,
+    );
     const activityLog = new ActivityLog(activityLogPort, step.user);
 
     return {

--- a/packages/workflow-executor/src/schema-cache.ts
+++ b/packages/workflow-executor/src/schema-cache.ts
@@ -2,8 +2,17 @@ import type { CollectionSchema } from './types/validated/collection';
 
 import { DEFAULT_SCHEMA_CACHE_TTL_S } from './defaults';
 
+type Entry = { collectionName: string; schema: CollectionSchema; fetchedAt: number };
+
+// A collection's schema (display names, exposed fields, actions) depends on the rendering it is
+// resolved for, so entries are keyed by (renderingId, collectionName). A shared, collection-only
+// key would let a run reuse another rendering's schema within the TTL window (PRD-440).
 export default class SchemaCache {
-  private readonly store = new Map<string, { schema: CollectionSchema; fetchedAt: number }>();
+  // Separates the two key parts so the prefix scan in entriesForRendering can't confuse
+  // rendering 1 with rendering 11, and a collection name can't spill into the rendering segment.
+  private static readonly SEPARATOR = String.fromCharCode(0);
+
+  private readonly store = new Map<string, Entry>();
   private readonly ttlS: number;
   private readonly now: () => number;
 
@@ -12,13 +21,14 @@ export default class SchemaCache {
     this.now = now;
   }
 
-  get(collectionName: string): CollectionSchema | undefined {
-    const entry = this.store.get(collectionName);
+  get(renderingId: number, collectionName: string): CollectionSchema | undefined {
+    const key = SchemaCache.key(renderingId, collectionName);
+    const entry = this.store.get(key);
 
     if (!entry) return undefined;
 
-    if (this.now() - entry.fetchedAt > this.ttlS * 1000) {
-      this.store.delete(collectionName);
+    if (this.isExpired(entry)) {
+      this.store.delete(key);
 
       return undefined;
     }
@@ -26,20 +36,31 @@ export default class SchemaCache {
     return entry.schema;
   }
 
-  set(collectionName: string, schema: CollectionSchema): void {
-    this.store.set(collectionName, { schema, fetchedAt: this.now() });
+  set(renderingId: number, collectionName: string, schema: CollectionSchema): void {
+    this.store.set(SchemaCache.key(renderingId, collectionName), {
+      collectionName,
+      schema,
+      fetchedAt: this.now(),
+    });
   }
 
-  // Yields non-expired entries; deletes stale ones along the way.
-  *[Symbol.iterator](): IterableIterator<[string, CollectionSchema]> {
-    const now = this.now();
+  // Yields the given rendering's non-expired entries; deletes stale ones along the way.
+  *entriesForRendering(renderingId: number): IterableIterator<[string, CollectionSchema]> {
+    const prefix = SchemaCache.key(renderingId, '');
 
     for (const [key, entry] of this.store) {
-      if (now - entry.fetchedAt <= this.ttlS * 1000) {
-        yield [key, entry.schema];
-      } else {
-        this.store.delete(key);
+      if (key.startsWith(prefix)) {
+        if (this.isExpired(entry)) this.store.delete(key);
+        else yield [entry.collectionName, entry.schema];
       }
     }
+  }
+
+  private isExpired(entry: Entry): boolean {
+    return this.now() - entry.fetchedAt > this.ttlS * 1000;
+  }
+
+  private static key(renderingId: number, collectionName: string): string {
+    return `${renderingId}${SchemaCache.SEPARATOR}${collectionName}`;
   }
 }

--- a/packages/workflow-executor/src/schema-resolver.ts
+++ b/packages/workflow-executor/src/schema-resolver.ts
@@ -2,28 +2,32 @@ import type { WorkflowPort } from './ports/workflow-port';
 import type SchemaCache from './schema-cache';
 import type { CollectionSchema } from './types/validated/collection';
 
-// Per-run schema resolution: binds the shared SchemaCache, the orchestrator port and the
-// current runId once, so callers never thread a loader. Writes into the SAME SchemaCache
-// instance AgentClientAgentPort reads from (get/iterate): the resolver always populates an
-// entry before the agent-port reads it, so the agent-port's SchemaNotCachedError guard does
-// not fire under normal TTLs (a TTL shorter than a single step's round-trip could still evict).
+// Per-run schema resolution: binds the shared SchemaCache, the orchestrator port, the current
+// runId and its renderingId once, so callers never thread a loader. Cache reads/writes are scoped
+// to the rendering so a run never reuses another rendering's schema (PRD-440). Writes into the
+// SAME SchemaCache instance AgentClientAgentPort reads from (scoped by the same renderingId): the
+// resolver always populates an entry before the agent-port reads it, so the agent-port's
+// SchemaNotCachedError guard does not fire under normal TTLs (a TTL shorter than a single step's
+// round-trip could still evict).
 export default class SchemaResolver {
   private readonly cache: SchemaCache;
   private readonly workflowPort: WorkflowPort;
   private readonly runId: string;
+  private readonly renderingId: number;
 
-  constructor(cache: SchemaCache, workflowPort: WorkflowPort, runId: string) {
+  constructor(cache: SchemaCache, workflowPort: WorkflowPort, runId: string, renderingId: number) {
     this.cache = cache;
     this.workflowPort = workflowPort;
     this.runId = runId;
+    this.renderingId = renderingId;
   }
 
   async resolve(collectionName: string): Promise<CollectionSchema> {
-    const cached = this.cache.get(collectionName);
+    const cached = this.cache.get(this.renderingId, collectionName);
     if (cached) return cached;
 
     const schema = await this.workflowPort.getCollectionSchema(collectionName, this.runId);
-    this.cache.set(collectionName, schema);
+    this.cache.set(this.renderingId, collectionName, schema);
 
     return schema;
   }

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -52,7 +52,7 @@ describe('AgentClientAgentPort', () => {
     mockedCreateRemoteAgentClient.mockReturnValue(mocks.client as any);
 
     const schemaCache = new SchemaCache();
-    schemaCache.set('users', {
+    schemaCache.set(1, 'users', {
       collectionName: 'users',
       collectionId: 'col-users',
       collectionDisplayName: 'Users',
@@ -66,7 +66,7 @@ describe('AgentClientAgentPort', () => {
         { name: 'archive', displayName: 'Archive', endpoint: '/forest/actions/archive' },
       ],
     });
-    schemaCache.set('orders', {
+    schemaCache.set(1, 'orders', {
       collectionName: 'orders',
       collectionId: 'col-orders',
       collectionDisplayName: 'Orders',
@@ -77,7 +77,7 @@ describe('AgentClientAgentPort', () => {
       ],
       actions: [],
     });
-    schemaCache.set('posts', {
+    schemaCache.set(1, 'posts', {
       collectionName: 'posts',
       collectionId: 'col-posts',
       collectionDisplayName: 'Posts',
@@ -764,7 +764,7 @@ describe('AgentClientAgentPort', () => {
   describe('buildActionEndpoints', () => {
     it('passes fields and hooks from schema to agent-client (supports Ruby agent fallback)', async () => {
       const schemaCache = new SchemaCache();
-      schemaCache.set('users', {
+      schemaCache.set(1, 'users', {
         collectionName: 'users',
         collectionId: 'col-users',
         collectionDisplayName: 'Users',

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -154,7 +154,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: makeMockLogger(),
     ...overrides,

--- a/packages/workflow-executor/test/executors/condition-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/condition-step-executor.test.ts
@@ -83,7 +83,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/executors/guidance-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/guidance-step-executor.test.ts
@@ -60,7 +60,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -203,7 +203,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -121,7 +121,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -130,7 +130,7 @@ function makeContext(
   const workflowPort = overrides.workflowPort ?? makeMockWorkflowPort();
   const schemaCache = new SchemaCache();
   const schemaResolver =
-    overrides.schemaResolver ?? new SchemaResolver(schemaCache, workflowPort, runId);
+    overrides.schemaResolver ?? new SchemaResolver(schemaCache, workflowPort, runId, 1);
 
   const base: Omit<ExecutionContext<ReadRecordStepDefinition>, 'agent' | 'activityLog'> = {
     runId,

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -144,7 +144,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -146,7 +146,7 @@ function makeContext(
       permissionLevel: 'admin',
       tags: {},
     },
-    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId),
+    schemaResolver: new SchemaResolver(schemaCache, workflowPort, runId, 1),
     previousSteps: [],
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     ...overrides,

--- a/packages/workflow-executor/test/schema-cache.test.ts
+++ b/packages/workflow-executor/test/schema-cache.test.ts
@@ -2,6 +2,9 @@ import type { CollectionSchema } from '../src/types/validated/collection';
 
 import SchemaCache from '../src/schema-cache';
 
+const RENDERING_A = 100;
+const RENDERING_B = 200;
+
 function makeSchema(collectionName: string): CollectionSchema {
   return {
     collectionName,
@@ -18,16 +21,16 @@ describe('SchemaCache', () => {
     it('returns undefined for unknown keys', () => {
       const cache = new SchemaCache();
 
-      expect(cache.get('unknown')).toBeUndefined();
+      expect(cache.get(RENDERING_A, 'unknown')).toBeUndefined();
     });
 
     it('returns the schema after set', () => {
       const cache = new SchemaCache();
       const schema = makeSchema('customers');
 
-      cache.set('customers', schema);
+      cache.set(RENDERING_A, 'customers', schema);
 
-      expect(cache.get('customers')).toBe(schema);
+      expect(cache.get(RENDERING_A, 'customers')).toBe(schema);
     });
 
     it('overwrites existing entry on set', () => {
@@ -35,10 +38,43 @@ describe('SchemaCache', () => {
       const old = makeSchema('customers');
       const updated = { ...makeSchema('customers'), primaryKeyFields: ['uid'] };
 
-      cache.set('customers', old);
-      cache.set('customers', updated);
+      cache.set(RENDERING_A, 'customers', old);
+      cache.set(RENDERING_A, 'customers', updated);
 
-      expect(cache.get('customers')).toBe(updated);
+      expect(cache.get(RENDERING_A, 'customers')).toBe(updated);
+    });
+  });
+
+  describe('rendering isolation', () => {
+    it('does not return another rendering schema for the same collection (PRD-440)', () => {
+      const cache = new SchemaCache();
+      const schemaA = makeSchema('customers');
+
+      cache.set(RENDERING_A, 'customers', schemaA);
+
+      expect(cache.get(RENDERING_B, 'customers')).toBeUndefined();
+    });
+
+    it('keeps per-rendering schemas independent', () => {
+      const cache = new SchemaCache();
+      const schemaA = makeSchema('customers');
+      const schemaB = { ...makeSchema('customers'), collectionDisplayName: 'Clients' };
+
+      cache.set(RENDERING_A, 'customers', schemaA);
+      cache.set(RENDERING_B, 'customers', schemaB);
+
+      expect(cache.get(RENDERING_A, 'customers')).toBe(schemaA);
+      expect(cache.get(RENDERING_B, 'customers')).toBe(schemaB);
+    });
+
+    it('does not confuse rendering 1 with rendering 11', () => {
+      const cache = new SchemaCache();
+      const schema1 = makeSchema('customers');
+
+      cache.set(1, 'customers', schema1);
+
+      expect(cache.get(11, 'customers')).toBeUndefined();
+      expect([...cache.entriesForRendering(11)]).toHaveLength(0);
     });
   });
 
@@ -49,85 +85,86 @@ describe('SchemaCache', () => {
       const cache = new SchemaCache(1, () => time);
       const schema = makeSchema('customers');
 
-      cache.set('customers', schema);
+      cache.set(RENDERING_A, 'customers', schema);
       time = 999;
 
-      expect(cache.get('customers')).toBe(schema);
+      expect(cache.get(RENDERING_A, 'customers')).toBe(schema);
     });
 
     it('returns undefined after TTL expires', () => {
       let time = 0;
       const cache = new SchemaCache(1, () => time);
 
-      cache.set('customers', makeSchema('customers'));
+      cache.set(RENDERING_A, 'customers', makeSchema('customers'));
       time = 1001;
 
-      expect(cache.get('customers')).toBeUndefined();
+      expect(cache.get(RENDERING_A, 'customers')).toBeUndefined();
     });
 
     it('deletes the expired entry from the store on get', () => {
       let time = 0;
       const cache = new SchemaCache(1, () => time);
 
-      cache.set('customers', makeSchema('customers'));
+      cache.set(RENDERING_A, 'customers', makeSchema('customers'));
       time = 1001;
 
-      cache.get('customers'); // triggers delete
+      cache.get(RENDERING_A, 'customers'); // triggers delete
       time = 0; // rewind — entry should still be gone
 
-      expect(cache.get('customers')).toBeUndefined();
+      expect(cache.get(RENDERING_A, 'customers')).toBeUndefined();
     });
 
     it('refreshes TTL when entry is re-set', () => {
       let time = 0;
       const cache = new SchemaCache(1, () => time);
 
-      cache.set('customers', makeSchema('customers'));
+      cache.set(RENDERING_A, 'customers', makeSchema('customers'));
       time = 800;
-      cache.set('customers', makeSchema('customers')); // re-set refreshes
+      cache.set(RENDERING_A, 'customers', makeSchema('customers')); // re-set refreshes
       time = 1500; // 700ms since re-set, within TTL
 
-      expect(cache.get('customers')).toBeDefined();
+      expect(cache.get(RENDERING_A, 'customers')).toBeDefined();
     });
   });
 
-  describe('iterator', () => {
-    it('yields all non-expired entries', () => {
+  describe('entriesForRendering', () => {
+    it('yields only the given rendering non-expired entries', () => {
       const cache = new SchemaCache();
 
-      cache.set('customers', makeSchema('customers'));
-      cache.set('orders', makeSchema('orders'));
+      cache.set(RENDERING_A, 'customers', makeSchema('customers'));
+      cache.set(RENDERING_A, 'orders', makeSchema('orders'));
+      cache.set(RENDERING_B, 'customers', makeSchema('customers'));
 
-      const entries = [...cache];
+      const entries = [...cache.entriesForRendering(RENDERING_A)];
 
-      expect(entries).toHaveLength(2);
-      expect(entries[0][0]).toBe('customers');
-      expect(entries[1][0]).toBe('orders');
+      expect(entries.map(([name]) => name).sort()).toEqual(['customers', 'orders']);
     });
 
     it('skips and deletes expired entries', () => {
       let time = 0;
       const cache = new SchemaCache(1, () => time);
 
-      cache.set('fresh', makeSchema('fresh'));
+      cache.set(RENDERING_A, 'fresh', makeSchema('fresh'));
       time = 500;
-      cache.set('also-fresh', makeSchema('also-fresh'));
+      cache.set(RENDERING_A, 'also-fresh', makeSchema('also-fresh'));
       time = 1100; // 'fresh' expired, 'also-fresh' still valid
 
-      const entries = [...cache];
+      const entries = [...cache.entriesForRendering(RENDERING_A)];
 
       expect(entries).toHaveLength(1);
       expect(entries[0][0]).toBe('also-fresh');
 
       // expired entry was cleaned up
       time = 0;
-      expect(cache.get('fresh')).toBeUndefined();
+      expect(cache.get(RENDERING_A, 'fresh')).toBeUndefined();
     });
 
-    it('returns empty for a fresh cache', () => {
+    it('returns empty for a rendering with no entries', () => {
       const cache = new SchemaCache();
 
-      expect([...cache]).toHaveLength(0);
+      cache.set(RENDERING_A, 'customers', makeSchema('customers'));
+
+      expect([...cache.entriesForRendering(RENDERING_B)]).toHaveLength(0);
     });
   });
 });

--- a/packages/workflow-executor/test/schema-resolver.test.ts
+++ b/packages/workflow-executor/test/schema-resolver.test.ts
@@ -4,11 +4,14 @@ import type { CollectionSchema } from '../src/types/validated/collection';
 import SchemaCache from '../src/schema-cache';
 import SchemaResolver from '../src/schema-resolver';
 
-function makeSchema(collectionName: string): CollectionSchema {
+const RENDERING_A = 100;
+const RENDERING_B = 200;
+
+function makeSchema(collectionName: string, displayName = collectionName): CollectionSchema {
   return {
     collectionName,
     collectionId: `col-${collectionName}`,
-    collectionDisplayName: collectionName,
+    collectionDisplayName: displayName,
     primaryKeyFields: ['id'],
     fields: [],
     actions: [],
@@ -25,9 +28,9 @@ describe('SchemaResolver', () => {
   it('returns the cached schema without calling the orchestrator on a hit', async () => {
     const cache = new SchemaCache();
     const schema = makeSchema('customers');
-    cache.set('customers', schema);
+    cache.set(RENDERING_A, 'customers', schema);
     const workflowPort = makeWorkflowPort(makeSchema('other'));
-    const resolver = new SchemaResolver(cache, workflowPort, 'run-1');
+    const resolver = new SchemaResolver(cache, workflowPort, 'run-1', RENDERING_A);
 
     const result = await resolver.resolve('customers');
 
@@ -39,7 +42,7 @@ describe('SchemaResolver', () => {
     const cache = new SchemaCache();
     const schema = makeSchema('orders');
     const workflowPort = makeWorkflowPort(schema);
-    const resolver = new SchemaResolver(cache, workflowPort, 'run-42');
+    const resolver = new SchemaResolver(cache, workflowPort, 'run-42', RENDERING_A);
 
     const result = await resolver.resolve('orders');
 
@@ -52,14 +55,31 @@ describe('SchemaResolver', () => {
     expect(workflowPort.getCollectionSchema).toHaveBeenCalledTimes(1);
   });
 
-  it('writes the fetched schema into the shared cache (read back by other consumers)', async () => {
+  it('writes the fetched schema into the shared cache scoped to its rendering', async () => {
     const cache = new SchemaCache();
     const schema = makeSchema('products');
-    const resolver = new SchemaResolver(cache, makeWorkflowPort(schema), 'run-1');
+    const resolver = new SchemaResolver(cache, makeWorkflowPort(schema), 'run-1', RENDERING_A);
 
     await resolver.resolve('products');
 
     // The same shared SchemaCache instance is what AgentClientAgentPort reads via .get().
-    expect(cache.get('products')).toBe(schema);
+    expect(cache.get(RENDERING_A, 'products')).toBe(schema);
+  });
+
+  it('does not reuse another rendering schema for the same collection (PRD-440)', async () => {
+    const cache = new SchemaCache();
+    const schemaA = makeSchema('customers', 'Customers');
+    cache.set(RENDERING_A, 'customers', schemaA);
+
+    const schemaB = makeSchema('customers', 'Clients');
+    const workflowPort = makeWorkflowPort(schemaB);
+    const resolverB = new SchemaResolver(cache, workflowPort, 'run-B', RENDERING_B);
+
+    const result = await resolverB.resolve('customers');
+
+    // Rendering B must fetch its own schema instead of reusing rendering A's cached one.
+    expect(workflowPort.getCollectionSchema).toHaveBeenCalledWith('customers', 'run-B');
+    expect(result).toBe(schemaB);
+    expect(result.collectionDisplayName).toBe('Clients');
   });
 });


### PR DESCRIPTION
## Problem

When workflows run on the same collection across different renderings, a run could operate with the collection schema (field **display names** and **which fields are exposed**, plus actions) belonging to a *different* rendering. Because workflow steps reference fields by their display name, this led to fields being mismatched or resolved incorrectly during a run.

### Root cause

`SchemaCache` is a process-wide singleton keyed **only by `collectionName`**. The schema is fetched per run via `getCollectionSchema(collectionName, runId)` (the orchestrator resolves the rendering from the `runId`), so the fetched schema *is* rendering-specific — but the cache key dropped the rendering. Within the cache TTL (default 10 min):

```
Run A (rendering 100) → resolve("customers") → fetch schema(100) → cache["customers"] = schemaA
Run B (rendering 200) → resolve("customers") → cache HIT → returns schemaA  ❌
```

## Fix

Key cache entries by **`(renderingId, collectionName)`**:

- **`SchemaCache`** — composite key; `get/set(renderingId, …)`; the global iterator is replaced by `entriesForRendering(renderingId)` (NUL separator so rendering `1` is never confused with `11`).
- **`SchemaResolver`** — binds the run's `renderingId` and uses it for cache `get`/`set`.
- **`StepExecutorFactory`** — passes `step.user.renderingId` to the resolver.
- **`AgentClientAgentPort`** — builds action endpoints from the current user's rendering via `entriesForRendering(user.renderingId)` (iterating the whole cache would otherwise mix action schemas across renderings).

`renderingId` (not `runId`) is the cache dimension on purpose: two runs of the **same** rendering keep sharing the cache (efficiency), only different renderings are isolated. TTL/eviction logic is unchanged, just applied per `(rendering, collection)`. No new dependency, no orchestrator contract change.

## Testing

- `SchemaCache`: rendering isolation, no `1`/`11` confusion, TTL per key, `entriesForRendering` scoping.
- `SchemaResolver`: regression test — rendering B fetches its own schema instead of reusing rendering A's cached one.
- `AgentClientAgentPort` + 8 executor tests updated to the new signatures.
- **1002 tests pass**, lint clean, build green.

fixes PRD-440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope workflow-executor collection schema cache by rendering ID
> - `SchemaCache` now stores entries keyed by `renderingId + collectionName` composite key; `get`, `set`, and the new `entriesForRendering` method all require a `renderingId`, isolating cached schemas per rendering.
> - `SchemaResolver` accepts and stores a `renderingId`, passing it through to all cache reads and writes so resolvers never reuse schemas from other renderings.
> - `AgentClientAgentPort.buildActionEndpoints` now accepts a `renderingId` and iterates only over cache entries for that rendering, so action endpoints are scoped to the current user's rendering.
> - Behavioral Change: cache entries that were previously shared across all renderings are now isolated; any code constructing `SchemaCache`, `SchemaResolver`, or calling `buildActionEndpoints` must supply a `renderingId`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f388e5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->