### PR TITLE
feat(mcp-server): annotate read-only tools with readOnlyHint

### DIFF
--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -90,6 +90,7 @@ export default function declareDescribeCollectionTool(
     mcpServer,
     'describeCollection',
     {
+      annotations: { readOnlyHint: true },
       title: 'Describe a collection',
       description: `Discover a collection's schema: fields, types, operators, relations, and available actions. Always call this first before querying or modifying data.
 

--- a/packages/mcp-server/src/tools/get-action-form.ts
+++ b/packages/mcp-server/src/tools/get-action-form.ts
@@ -25,6 +25,7 @@ export default function declareGetActionFormTool(
     mcpServer,
     'getActionForm',
     {
+      annotations: { readOnlyHint: true },
       title: 'Retrieve action form',
       description: `Retrieve and validate the form for a specific action. This tool MUST be called before executeAction to ensure all required fields are filled.
 

--- a/packages/mcp-server/src/tools/list-related.ts
+++ b/packages/mcp-server/src/tools/list-related.ts
@@ -82,6 +82,7 @@ export default function declareListRelatedTool(
     mcpServer,
     'listRelated',
     {
+      annotations: { readOnlyHint: true },
       title: 'List records from a relation',
       description: 'Retrieve a list of records from a one-to-many or many-to-many relation.',
       inputSchema: listArgumentShape,

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -87,6 +87,7 @@ export default function declareListTool(
     mcpServer,
     'list',
     {
+      annotations: { readOnlyHint: true },
       title: 'List records from a collection',
       description: 'Retrieve a list of records from the specified collection.',
       inputSchema: listArgumentShape,

--- a/packages/mcp-server/src/utils/tool-with-logging.ts
+++ b/packages/mcp-server/src/utils/tool-with-logging.ts
@@ -5,6 +5,7 @@ import type {
   CallToolResult,
   ServerNotification,
   ServerRequest,
+  ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { z } from 'zod';
@@ -19,6 +20,7 @@ interface ToolConfig<TSchema extends ZodRawShape> {
   title: string;
   description: string;
   inputSchema: TSchema;
+  annotations?: ToolAnnotations;
 }
 
 type RegisterToolConfig = Parameters<McpServer['registerTool']>[1];

--- a/packages/mcp-server/test/helpers/registered-tool-config.ts
+++ b/packages/mcp-server/test/helpers/registered-tool-config.ts
@@ -1,5 +1,3 @@
-// Shape of the config object captured from `mcpServer.registerTool` in the tool tests —
-// mirrors the fields the tests assert on (title / description / inputSchema / annotations).
 export type RegisteredToolConfig = {
   title: string;
   description: string;

--- a/packages/mcp-server/test/helpers/registered-tool-config.ts
+++ b/packages/mcp-server/test/helpers/registered-tool-config.ts
@@ -1,0 +1,8 @@
+// Shape of the config object captured from `mcpServer.registerTool` in the tool tests —
+// mirrors the fields the tests assert on (title / description / inputSchema / annotations).
+export type RegisteredToolConfig = {
+  title: string;
+  description: string;
+  inputSchema: unknown;
+  annotations?: { readOnlyHint?: boolean };
+};

--- a/packages/mcp-server/test/tools/associate.test.ts
+++ b/packages/mcp-server/test/tools/associate.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -21,7 +22,7 @@ describe('declareAssociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +58,12 @@ describe('declareAssociateTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Link a record to another through a one-to-many or many-to-many relation. For many-to-many relations, this creates a new entry in the join table.',
       );
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -21,12 +22,7 @@ describe('declareCreateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: {
-    title: string;
-    description: string;
-    inputSchema: unknown;
-    annotations?: { readOnlyHint?: boolean };
-  };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -21,7 +21,12 @@ describe('declareCreateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: unknown;
+    annotations?: { readOnlyHint?: boolean };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +62,12 @@ describe('declareCreateTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Create a new record in the specified collection.',
       );
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -21,7 +22,7 @@ describe('declareDeleteTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +58,12 @@ describe('declareDeleteTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Delete one or more records from the specified collection.',
       );
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -32,7 +32,12 @@ describe('declareDescribeCollectionTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: unknown;
+    annotations?: { readOnlyHint?: boolean };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -74,6 +79,12 @@ describe('declareDescribeCollectionTool', () => {
       );
       expect(registeredToolConfig.description).toContain('Actions properties:');
       expect(registeredToolConfig.description).toContain('download:');
+    });
+
+    it('should be annotated as read-only', () => {
+      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -32,12 +33,7 @@ describe('declareDescribeCollectionTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: {
-    title: string;
-    description: string;
-    inputSchema: unknown;
-    annotations?: { readOnlyHint?: boolean };
-  };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/dissociate.test.ts
+++ b/packages/mcp-server/test/tools/dissociate.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -21,7 +22,7 @@ describe('declareDissociateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +58,12 @@ describe('declareDissociateTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Unlink records from a one-to-many or many-to-many relation. For many-to-many relations, this removes entries from the join table without deleting the target records.',
       );
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -27,7 +28,7 @@ const mockWithActivityLog = withActivityLog as jest.MockedFunction<typeof withAc
 describe('declareExecuteActionTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,6 +63,12 @@ describe('declareExecuteActionTool', () => {
         'Execute a specific action on one or more records',
       );
       expect(registeredToolConfig.description).toContain('MUST call getActionForm first');
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -24,12 +25,7 @@ const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction
 describe('declareGetActionFormTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: {
-    title: string;
-    description: string;
-    inputSchema: unknown;
-    annotations?: { readOnlyHint?: boolean };
-  };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -24,7 +24,12 @@ const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction
 describe('declareGetActionFormTool', () => {
   let mcpServer: McpServer;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: unknown;
+    annotations?: { readOnlyHint?: boolean };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,6 +61,12 @@ describe('declareGetActionFormTool', () => {
         'Retrieve and validate the form for a specific action',
       );
       expect(registeredToolConfig.description).toContain('canExecute');
+    });
+
+    it('should be annotated as read-only', () => {
+      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -28,12 +29,7 @@ describe('declareListRelatedTool', () => {
   let mockLogger: Logger;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: {
-    title: string;
-    description: string;
-    inputSchema: unknown;
-    annotations?: { readOnlyHint?: boolean };
-  };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -28,7 +28,12 @@ describe('declareListRelatedTool', () => {
   let mockLogger: Logger;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: unknown;
+    annotations?: { readOnlyHint?: boolean };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -96,6 +101,12 @@ describe('declareListRelatedTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Retrieve a list of records from a one-to-many or many-to-many relation.',
       );
+    });
+
+    it('should be annotated as read-only', () => {
+      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -29,7 +29,12 @@ describe('declareListTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: {
+    title: string;
+    description: string;
+    inputSchema: unknown;
+    annotations?: { readOnlyHint?: boolean };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -94,6 +99,12 @@ describe('declareListTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Retrieve a list of records from the specified collection.',
       );
+    });
+
+    it('should be annotated as read-only', () => {
+      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -29,12 +30,7 @@ describe('declareListTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: {
-    title: string;
-    description: string;
-    inputSchema: unknown;
-    annotations?: { readOnlyHint?: boolean };
-  };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -1,5 +1,6 @@
 import type { ForestServerClient } from '../../src/http-client';
 import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
@@ -21,7 +22,7 @@ describe('declareUpdateTool', () => {
   let mcpServer: McpServer;
   let mockForestServerClient: jest.Mocked<ForestServerClient>;
   let registeredToolHandler: (options: unknown, extra: unknown) => Promise<unknown>;
-  let registeredToolConfig: { title: string; description: string; inputSchema: unknown };
+  let registeredToolConfig: RegisteredToolConfig;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +58,12 @@ describe('declareUpdateTool', () => {
       expect(registeredToolConfig.description).toBe(
         'Update an existing record in the specified collection.',
       );
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {


### PR DESCRIPTION
## Summary

I'm adding `readOnlyHint: true` annotation to the tools that only read data, so MCP clients can distinguish safe read operations from the ones that modify data. With the hint in place, a client can auto-approve the read tools without prompting and treat the mutating tools with appropriate care.

The four read-only tools are now annotated:

- `describeCollection`
- `list`
- `listRelated`
- `getActionForm`

The mutating tools (`create`, `update`, `delete`, `associate`, `dissociate`, `executeAction`) are intentionally left unannotated.

The `ToolConfig` helper in `tool-with-logging.ts` now accepts an optional `annotations` field, typed as the SDK's `ToolAnnotations`, which flows through `registerTool` to the wire. Coverage was added asserting the read tools carry the hint and that a mutating tool does not.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Annotate read-only MCP server tools with `readOnlyHint`
> Adds `annotations: { readOnlyHint: true }` to the `list`, `listRelated`, `describeCollection`, and `getActionForm` tools in the MCP server. The `ToolConfig` interface in [tool-with-logging.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1661/files#diff-1989bb6374348e66de98a0d536b15201ebde9a1430c7f5ded16df0addd68fba6) is extended with an optional `annotations` field typed as `ToolAnnotations` from the MCP SDK. Tests are added across all tools to assert the presence or absence of `readOnlyHint` as appropriate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b8e64b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->