### PR TITLE
feat(workflow-executor): use stored OAuth credentials for MCP steps [PRD-367]

### DIFF
--- a/packages/ai-proxy/src/ai-client.ts
+++ b/packages/ai-proxy/src/ai-client.ts
@@ -1,3 +1,4 @@
+import type { McpServerLoadFailure } from './mcp-client';
 import type { AiConfiguration } from './provider';
 import type RemoteTool from './remote-tool';
 import type { ToolProvider } from './tool-provider';
@@ -39,13 +40,31 @@ export class AiClient {
   }
 
   async loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
+    return (await this.loadRemoteToolsWithFailures(configs)).tools;
+  }
+
+  // Same load as loadRemoteTools, but also returns the classified per-server failures providers
+  // surface (only MCP providers do today). The default loadRemoteTools drops them, so existing
+  // consumers are unaffected.
+  async loadRemoteToolsWithFailures(
+    configs: Record<string, ToolConfig>,
+  ): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }> {
     await this.disposeToolProviders('Error closing previous remote tool connection');
 
     const providers = createToolProviders(configs, this.logger);
-    const toolsByProvider = await Promise.all(providers.map(p => p.loadTools()));
+    const resultsByProvider = await Promise.all(
+      providers.map(async provider =>
+        provider.loadToolsWithFailures
+          ? provider.loadToolsWithFailures()
+          : { tools: await provider.loadTools(), failures: [] },
+      ),
+    );
     this.toolProviders = providers;
 
-    return toolsByProvider.flat();
+    return {
+      tools: resultsByProvider.flatMap(result => result.tools),
+      failures: resultsByProvider.flatMap(result => result.failures),
+    };
   }
 
   async closeConnections(): Promise<void> {

--- a/packages/ai-proxy/src/index.ts
+++ b/packages/ai-proxy/src/index.ts
@@ -20,6 +20,7 @@ export * from './remote-tools';
 export { default as RemoteTool } from './remote-tool';
 export * from './router';
 export * from './mcp-client';
+export * from './mcp-auth-error';
 export * from './oauth-token-injector';
 export * from './errors';
 export * from './tool-provider';

--- a/packages/ai-proxy/src/mcp-auth-error.ts
+++ b/packages/ai-proxy/src/mcp-auth-error.ts
@@ -42,10 +42,11 @@ function errorChain(error: unknown): unknown[] {
 export function isMcpAuthError(error: unknown): boolean {
   return errorChain(error).some(link => {
     const status = statusOf(link);
+    // An explicit status is authoritative — a 403 is not a refreshable auth error even if its
+    // message says "unauthorized". Fall back to the message only when no status is present.
+    if (status !== undefined) return AUTH_STATUSES.has(status);
 
-    return (
-      (status !== undefined && AUTH_STATUSES.has(status)) || AUTH_PATTERN.test(messageOf(link))
-    );
+    return AUTH_PATTERN.test(messageOf(link));
   });
 }
 

--- a/packages/ai-proxy/src/mcp-auth-error.ts
+++ b/packages/ai-proxy/src/mcp-auth-error.ts
@@ -1,8 +1,10 @@
-// Classifies errors surfaced while connecting to or calling an MCP server. The MCP SDK / HTTP
+// Classifies errors surfaced while connecting to or calling an MCP server. Only 401 (the token was
+// rejected) is a refreshable auth failure; 403 is a permission/scope problem a token refresh or
+// re-consent cannot resolve, so it is left to surface as an ordinary failure. The MCP SDK / HTTP
 // transport reports failures in several shapes (a numeric status field, or only a message string),
 // so the checks walk the cause chain and inspect both structured status and the message text.
-const AUTH_STATUSES = new Set([401, 403]);
-const AUTH_PATTERN = /\b40[13]\b|unauthorized|forbidden/i;
+const AUTH_STATUSES = new Set([401]);
+const AUTH_PATTERN = /\b401\b|unauthorized/i;
 const CONNECTION_PATTERN =
   /econnrefused|econnreset|etimedout|enotfound|eai_again|fetch failed|network|socket|timeout|connect/i;
 

--- a/packages/ai-proxy/src/mcp-auth-error.ts
+++ b/packages/ai-proxy/src/mcp-auth-error.ts
@@ -1,0 +1,58 @@
+// Classifies errors surfaced while connecting to or calling an MCP server. The MCP SDK / HTTP
+// transport reports failures in several shapes (a numeric status field, or only a message string),
+// so the checks walk the cause chain and inspect both structured status and the message text.
+const AUTH_STATUSES = new Set([401, 403]);
+const AUTH_PATTERN = /\b40[13]\b|unauthorized|forbidden/i;
+const CONNECTION_PATTERN =
+  /econnrefused|econnreset|etimedout|enotfound|eai_again|fetch failed|network|socket|timeout|connect/i;
+
+export type McpLoadFailureKind = 'auth' | 'connection' | 'unknown';
+
+function statusOf(value: unknown): number | undefined {
+  const candidate = value as { code?: unknown; status?: unknown; statusCode?: unknown };
+
+  for (const field of [candidate?.code, candidate?.status, candidate?.statusCode]) {
+    if (typeof field === 'number') return field;
+  }
+
+  return undefined;
+}
+
+function messageOf(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+
+  return '';
+}
+
+function errorChain(error: unknown): unknown[] {
+  const links: unknown[] = [];
+  let current: unknown = error;
+
+  while (current && links.length < 10 && !links.includes(current)) {
+    links.push(current);
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return links;
+}
+
+export function isMcpAuthError(error: unknown): boolean {
+  return errorChain(error).some(link => {
+    const status = statusOf(link);
+
+    return (
+      (status !== undefined && AUTH_STATUSES.has(status)) || AUTH_PATTERN.test(messageOf(link))
+    );
+  });
+}
+
+export function classifyMcpLoadError(error: unknown): McpLoadFailureKind {
+  if (isMcpAuthError(error)) return 'auth';
+
+  const isConnectionFailure = errorChain(error).some(link =>
+    CONNECTION_PATTERN.test(messageOf(link)),
+  );
+
+  return isConnectionFailure ? 'connection' : 'unknown';
+}

--- a/packages/ai-proxy/src/mcp-client.ts
+++ b/packages/ai-proxy/src/mcp-client.ts
@@ -4,17 +4,27 @@ import type { Logger } from '@forestadmin/datasource-toolkit';
 import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 
 import { McpConnectionError } from './errors';
+import { type McpLoadFailureKind, classifyMcpLoadError } from './mcp-auth-error';
 import McpServerRemoteTool from './mcp-server-remote-tool';
 
 export type McpServers = MultiServerMCPClient['config']['mcpServers'];
 
 export type McpServerConfig = MultiServerMCPClient['config']['mcpServers'][string] & {
   id?: string;
+  // Executor-side routing hint served by the orchestrator; stripped before reaching the SDK.
+  authType?: string;
 };
 
 export type McpConfiguration = {
   configs: Record<string, McpServerConfig>;
 } & Omit<MultiServerMCPClient['config'], 'mcpServers'>;
+
+export interface McpServerLoadFailure {
+  server: string;
+  mcpServerId?: string;
+  kind: McpLoadFailureKind;
+  error: Error;
+}
 
 export default class McpClient implements ToolProvider {
   private readonly mcpClients: Record<string, MultiServerMCPClient> = {};
@@ -26,8 +36,11 @@ export default class McpClient implements ToolProvider {
     // split the config into several clients to be more resilient
     // if a mcp server is down, the others will still work
     Object.entries(config.configs).forEach(([name, serverConfig]) => {
-      const { id: mcpServerId, ...rest } = serverConfig as McpServerConfig &
-        Record<string, unknown>;
+      const {
+        id: mcpServerId,
+        authType,
+        ...rest
+      } = serverConfig as McpServerConfig & Record<string, unknown>;
       this.mcpServerIdsByName[name] = mcpServerId;
       this.mcpClients[name] = new MultiServerMCPClient({
         mcpServers: { [name]: rest as McpServerConfig },
@@ -36,9 +49,15 @@ export default class McpClient implements ToolProvider {
     });
   }
 
-  async loadTools(): Promise<McpServerRemoteTool[]> {
+  // Exposes per-server failures classified by cause (auth vs connection) alongside the tools that
+  // did load, so a caller holding a per-user token can tell a revoked token (retry after refresh)
+  // from an unreachable server (genuine failure). loadTools() keeps its tools-only contract.
+  async loadToolsWithFailures(): Promise<{
+    tools: McpServerRemoteTool[];
+    failures: McpServerLoadFailure[];
+  }> {
     const tools: McpServerRemoteTool[] = [];
-    const errors: Array<{ server: string; error: Error }> = [];
+    const failures: McpServerLoadFailure[] = [];
 
     await Promise.all(
       Object.entries(this.mcpClients).map(async ([name, client]) => {
@@ -55,22 +74,31 @@ export default class McpClient implements ToolProvider {
           tools.push(...extendedTools);
         } catch (error) {
           this.logger?.('Error', `Error loading tools for ${name}`, error as Error);
-          errors.push({ server: name, error: error as Error });
+          failures.push({
+            server: name,
+            mcpServerId: this.mcpServerIdsByName[name],
+            kind: classifyMcpLoadError(error),
+            error: error as Error,
+          });
         }
       }),
     );
 
     // Surface partial failures to provide better feedback
-    if (errors.length > 0) {
-      const errorMessage = errors.map(e => `${e.server}: ${e.error.message}`).join('; ');
+    if (failures.length > 0) {
+      const errorMessage = failures.map(f => `${f.server}: ${f.error.message}`).join('; ');
       this.logger?.(
         'Error',
-        `Failed to load tools from ${errors.length}/${Object.keys(this.mcpClients).length} ` +
+        `Failed to load tools from ${failures.length}/${Object.keys(this.mcpClients).length} ` +
           `MCP server(s): ${errorMessage}`,
       );
     }
 
-    return tools;
+    return { tools, failures };
+  }
+
+  async loadTools(): Promise<McpServerRemoteTool[]> {
+    return (await this.loadToolsWithFailures()).tools;
   }
 
   async checkConnection(): Promise<true> {

--- a/packages/ai-proxy/src/tool-provider.ts
+++ b/packages/ai-proxy/src/tool-provider.ts
@@ -1,7 +1,10 @@
+import type { McpServerLoadFailure } from './mcp-client';
 import type RemoteTool from './remote-tool';
 
 export interface ToolProvider {
   loadTools(): Promise<RemoteTool[]>;
+  // Optional richer variant: providers that can classify per-server failures expose them here.
+  loadToolsWithFailures?(): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }>;
   checkConnection(): Promise<true>;
   dispose(): Promise<void>;
 }

--- a/packages/ai-proxy/test/ai-client.test.ts
+++ b/packages/ai-proxy/test/ai-client.test.ts
@@ -242,6 +242,46 @@ describe('loadRemoteTools', () => {
   });
 });
 
+describe('loadRemoteToolsWithFailures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('aggregates tools and classified failures from providers that expose them', async () => {
+    const mcpTool = { name: 'mcp-tool' };
+    const failure = {
+      server: 'slack',
+      mcpServerId: 'srv-a',
+      kind: 'auth' as const,
+      error: new Error('401'),
+    };
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({
+        loadToolsWithFailures: jest
+          .fn()
+          .mockResolvedValue({ tools: [mcpTool], failures: [failure] }),
+      }),
+    ]);
+
+    const result = await new AiClient({}).loadRemoteToolsWithFailures({} as never);
+
+    expect(result.tools).toEqual([mcpTool]);
+    expect(result.failures).toEqual([failure]);
+  });
+
+  it('falls back to loadTools with no failures for providers that do not classify', async () => {
+    const integrationTool = { name: 'zendesk-tool' };
+    mockedCreateToolProviders.mockReturnValue([
+      mockProvider({ loadTools: jest.fn().mockResolvedValue([integrationTool]) }),
+    ]);
+
+    const result = await new AiClient({}).loadRemoteToolsWithFailures({} as never);
+
+    expect(result.tools).toEqual([integrationTool]);
+    expect(result.failures).toEqual([]);
+  });
+});
+
 describe('closeConnections', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/ai-proxy/test/mcp-auth-error.test.ts
+++ b/packages/ai-proxy/test/mcp-auth-error.test.ts
@@ -30,6 +30,12 @@ describe('isMcpAuthError', () => {
     expect(isMcpAuthError(new Error('500 Internal Server Error'))).toBe(false);
     expect(isMcpAuthError(undefined)).toBe(false);
   });
+
+  it('lets an explicit status win over an "unauthorized" message (a 403 stays non-auth)', () => {
+    expect(isMcpAuthError(Object.assign(new Error('Unauthorized scope'), { status: 403 }))).toBe(
+      false,
+    );
+  });
 });
 
 describe('classifyMcpLoadError', () => {

--- a/packages/ai-proxy/test/mcp-auth-error.test.ts
+++ b/packages/ai-proxy/test/mcp-auth-error.test.ts
@@ -12,14 +12,9 @@ describe('isMcpAuthError', () => {
     expect(isMcpAuthError({ code: 401 })).toBe(true);
   });
 
-  it('detects a 403 numeric status field', () => {
-    expect(isMcpAuthError(Object.assign(new Error('denied'), { status: 403 }))).toBe(true);
-  });
-
-  it('detects 401 / unauthorized / forbidden in the message', () => {
+  it('detects 401 / unauthorized in the message', () => {
     expect(isMcpAuthError(new Error('Request failed with status code 401'))).toBe(true);
     expect(isMcpAuthError(new Error('Unauthorized'))).toBe(true);
-    expect(isMcpAuthError(new Error('403 Forbidden'))).toBe(true);
   });
 
   it('walks the cause chain', () => {
@@ -28,7 +23,9 @@ describe('isMcpAuthError', () => {
     ).toBe(true);
   });
 
-  it('returns false for non-auth errors and nullish input', () => {
+  it('returns false for 403 (forbidden), non-auth errors, and nullish input', () => {
+    expect(isMcpAuthError(Object.assign(new Error('denied'), { status: 403 }))).toBe(false);
+    expect(isMcpAuthError(new Error('403 Forbidden'))).toBe(false);
     expect(isMcpAuthError(new Error('ECONNREFUSED'))).toBe(false);
     expect(isMcpAuthError(new Error('500 Internal Server Error'))).toBe(false);
     expect(isMcpAuthError(undefined)).toBe(false);
@@ -36,8 +33,8 @@ describe('isMcpAuthError', () => {
 });
 
 describe('classifyMcpLoadError', () => {
-  it("classifies auth failures as 'auth'", () => {
-    expect(classifyMcpLoadError(new Error('HTTP 403 Forbidden'))).toBe('auth');
+  it("classifies a 401 as 'auth'", () => {
+    expect(classifyMcpLoadError(new Error('HTTP 401 Unauthorized'))).toBe('auth');
     expect(classifyMcpLoadError({ status: 401 })).toBe('auth');
   });
 
@@ -49,7 +46,8 @@ describe('classifyMcpLoadError', () => {
     expect(classifyMcpLoadError(new Error('socket hang up'))).toBe('connection');
   });
 
-  it("classifies everything else as 'unknown'", () => {
+  it("classifies a 403 (forbidden) and anything else as 'unknown'", () => {
+    expect(classifyMcpLoadError(new Error('HTTP 403 Forbidden'))).toBe('unknown');
     expect(classifyMcpLoadError(new Error('tool schema invalid'))).toBe('unknown');
   });
 });

--- a/packages/ai-proxy/test/mcp-auth-error.test.ts
+++ b/packages/ai-proxy/test/mcp-auth-error.test.ts
@@ -1,0 +1,55 @@
+import { classifyMcpLoadError, isMcpAuthError } from '../src/mcp-auth-error';
+
+function withCause(message: string, cause: unknown): Error {
+  const error = new Error(message);
+  (error as { cause?: unknown }).cause = cause;
+
+  return error;
+}
+
+describe('isMcpAuthError', () => {
+  it('detects a 401 numeric status field', () => {
+    expect(isMcpAuthError({ code: 401 })).toBe(true);
+  });
+
+  it('detects a 403 numeric status field', () => {
+    expect(isMcpAuthError(Object.assign(new Error('denied'), { status: 403 }))).toBe(true);
+  });
+
+  it('detects 401 / unauthorized / forbidden in the message', () => {
+    expect(isMcpAuthError(new Error('Request failed with status code 401'))).toBe(true);
+    expect(isMcpAuthError(new Error('Unauthorized'))).toBe(true);
+    expect(isMcpAuthError(new Error('403 Forbidden'))).toBe(true);
+  });
+
+  it('walks the cause chain', () => {
+    expect(
+      isMcpAuthError(withCause('wrapper', Object.assign(new Error('inner'), { status: 401 }))),
+    ).toBe(true);
+  });
+
+  it('returns false for non-auth errors and nullish input', () => {
+    expect(isMcpAuthError(new Error('ECONNREFUSED'))).toBe(false);
+    expect(isMcpAuthError(new Error('500 Internal Server Error'))).toBe(false);
+    expect(isMcpAuthError(undefined)).toBe(false);
+  });
+});
+
+describe('classifyMcpLoadError', () => {
+  it("classifies auth failures as 'auth'", () => {
+    expect(classifyMcpLoadError(new Error('HTTP 403 Forbidden'))).toBe('auth');
+    expect(classifyMcpLoadError({ status: 401 })).toBe('auth');
+  });
+
+  it("classifies network failures as 'connection'", () => {
+    expect(classifyMcpLoadError(new Error('connect ECONNREFUSED 127.0.0.1:3000'))).toBe(
+      'connection',
+    );
+    expect(classifyMcpLoadError(new Error('fetch failed'))).toBe('connection');
+    expect(classifyMcpLoadError(new Error('socket hang up'))).toBe('connection');
+  });
+
+  it("classifies everything else as 'unknown'", () => {
+    expect(classifyMcpLoadError(new Error('tool schema invalid'))).toBe('unknown');
+  });
+});

--- a/packages/ai-proxy/test/mcp-client.test.ts
+++ b/packages/ai-proxy/test/mcp-client.test.ts
@@ -1,6 +1,7 @@
 import type { McpConfiguration } from '../src';
 
 import { tool } from '@langchain/core/tools';
+import { MultiServerMCPClient } from '@langchain/mcp-adapters';
 
 import { McpConnectionError } from '../src';
 import McpClient from '../src/mcp-client';
@@ -485,5 +486,98 @@ describe('McpClient', () => {
         },
       });
     });
+  });
+});
+
+// Additive auth-error classification: loadToolsWithFailures exposes per-server failures alongside
+// the loaded tools so a token holder can tell a revoked token from an unreachable server.
+describe('McpClient.loadToolsWithFailures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const makeTool = (name: string) =>
+    tool(() => {}, { name, description: name, schema: undefined, responseFormat: 'content' });
+
+  const singleServer = (id?: string) =>
+    ({
+      configs: {
+        slack: { transport: 'stdio', command: 'npx', args: [], env: {}, ...(id ? { id } : {}) },
+      },
+    } as unknown as McpConfiguration);
+
+  it('returns the loaded tools and no failures when every server loads', async () => {
+    getToolsMock.mockResolvedValue([makeTool('t1')]);
+
+    const result = await new McpClient(singleServer()).loadToolsWithFailures();
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("classifies a 401 as an 'auth' failure tagged with server and mcpServerId, keeping other tools", async () => {
+    getToolsMock
+      .mockRejectedValueOnce(new Error('Request failed: 401 Unauthorized'))
+      .mockResolvedValueOnce([makeTool('t2')]);
+    const client = new McpClient({
+      configs: {
+        slack: { transport: 'stdio', command: 'npx', args: [], env: {}, id: 'srv-a' },
+        github: { transport: 'stdio', command: 'npx', args: [], env: {} },
+      },
+    } as unknown as McpConfiguration);
+
+    const result = await client.loadToolsWithFailures();
+
+    expect(result.tools).toHaveLength(1);
+    expect(result.failures).toEqual([
+      expect.objectContaining({ server: 'slack', mcpServerId: 'srv-a', kind: 'auth' }),
+    ]);
+  });
+
+  it("classifies a connection error as 'connection', not 'auth'", async () => {
+    getToolsMock.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:3000'));
+
+    const result = await new McpClient(singleServer()).loadToolsWithFailures();
+
+    expect(result.failures[0].kind).toBe('connection');
+  });
+
+  it('logs the aggregated failure summary and does not throw on a per-server failure', async () => {
+    const logger = jest.fn();
+    getToolsMock.mockRejectedValue(new Error('401'));
+
+    const result = await new McpClient(singleServer(), logger).loadToolsWithFailures();
+
+    expect(result.tools).toEqual([]);
+    expect(logger).toHaveBeenCalledWith(
+      'Error',
+      expect.stringContaining('Failed to load tools from 1/1'),
+    );
+  });
+
+  it('loadTools delegates and returns only the tools', async () => {
+    getToolsMock.mockResolvedValue([makeTool('t3')]);
+
+    const tools = await new McpClient(singleServer()).loadTools();
+
+    expect(tools).toHaveLength(1);
+  });
+});
+
+// authType is an executor-side routing hint; like id it must be stripped in the constructor so it
+// never reaches MultiServerMCPClient.
+describe('McpClient constructor — authType stripping', () => {
+  it('strips authType and id, passing only the transport config to MultiServerMCPClient', () => {
+    (MultiServerMCPClient as jest.Mock).mockClear();
+
+    // eslint-disable-next-line no-new
+    new McpClient({
+      configs: {
+        slack: { type: 'http', url: 'https://example.com/mcp', id: 'srv-a', authType: 'oauth2' },
+      },
+    } as unknown as McpConfiguration);
+
+    const passedConfig = (MultiServerMCPClient as jest.Mock).mock.calls[0][0].mcpServers.slack;
+    expect(passedConfig).toEqual({ type: 'http', url: 'https://example.com/mcp' });
   });
 });

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -96,3 +96,7 @@ FOREST_AUTH_SECRET="your-auth-secret" \
 AGENT_URL="https://your-agent-url" \
 npx @forestadmin/workflow-executor --in-memory
 ```
+
+### OAuth2-protected MCP
+
+To exercise the executor's OAuth2-protected MCP path end-to-end, point it at [mcp-oauth-test-server](https://github.com/hercemer42/mcp-oauth-test-server) — a standalone OAuth2 + MCP server that can simulate refresh-token revocation/rotation, consent denial, and upstream 403s.

--- a/packages/workflow-executor/src/adapters/ai-client-adapter.ts
+++ b/packages/workflow-executor/src/adapters/ai-client-adapter.ts
@@ -1,5 +1,11 @@
 import type { AiModelPort, GetModelOptions } from '../ports/ai-model-port';
-import type { AiConfiguration, BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
+import type {
+  AiConfiguration,
+  BaseChatModel,
+  McpServerLoadFailure,
+  RemoteTool,
+  ToolConfig,
+} from '@forestadmin/ai-proxy';
 
 import { AiClient } from '@forestadmin/ai-proxy';
 
@@ -24,6 +30,14 @@ export default class AiClientAdapter implements AiModelPort {
 
   loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
     return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(configs));
+  }
+
+  loadRemoteToolsWithFailures(
+    configs: Record<string, ToolConfig>,
+  ): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }> {
+    return this.callPort('loadRemoteToolsWithFailures', () =>
+      this.aiClient.loadRemoteToolsWithFailures(configs),
+    );
   }
 
   closeConnections(): Promise<void> {

--- a/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
+++ b/packages/workflow-executor/src/adapters/always-error-ai-model-port.ts
@@ -1,5 +1,10 @@
 import type { AiModelPort } from '../ports/ai-model-port';
-import type { BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
+import type {
+  BaseChatModel,
+  McpServerLoadFailure,
+  RemoteTool,
+  ToolConfig,
+} from '@forestadmin/ai-proxy';
 
 import { AiModelPortError } from '../errors';
 
@@ -20,6 +25,13 @@ export default class AlwaysErrorAiModelPort implements AiModelPort {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loadRemoteTools(_configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
     return Promise.resolve([]);
+  }
+
+  loadRemoteToolsWithFailures(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _configs: Record<string, ToolConfig>,
+  ): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }> {
+    return Promise.resolve({ tools: [], failures: [] });
   }
 
   closeConnections(): Promise<void> {

--- a/packages/workflow-executor/src/adapters/server-ai-adapter.ts
+++ b/packages/workflow-executor/src/adapters/server-ai-adapter.ts
@@ -1,5 +1,11 @@
 import type { AiModelPort, GetModelOptions } from '../ports/ai-model-port';
-import type { AiConfiguration, BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
+import type {
+  AiConfiguration,
+  BaseChatModel,
+  McpServerLoadFailure,
+  RemoteTool,
+  ToolConfig,
+} from '@forestadmin/ai-proxy';
 
 import { AiClient } from '@forestadmin/ai-proxy';
 
@@ -36,6 +42,14 @@ export default class ServerAiAdapter implements AiModelPort {
 
   loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]> {
     return this.callPort('loadRemoteTools', () => this.aiClient.loadRemoteTools(configs));
+  }
+
+  loadRemoteToolsWithFailures(
+    configs: Record<string, ToolConfig>,
+  ): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }> {
+    return this.callPort('loadRemoteToolsWithFailures', () =>
+      this.aiClient.loadRemoteToolsWithFailures(configs),
+    );
   }
 
   closeConnections(): Promise<void> {

--- a/packages/workflow-executor/src/adapters/step-outcome-to-update-step-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-outcome-to-update-step-mapper.ts
@@ -32,6 +32,10 @@ export default function toUpdateStepRequest(
     context.selectedOption = outcome.selectedOption;
   }
 
+  if (outcome.type === 'mcp' && outcome.awaitingInputReason !== undefined) {
+    context.awaitingInputReason = outcome.awaitingInputReason;
+  }
+
   const attributes: ServerStepHistoryUpdate = {
     done: outcome.status !== 'awaiting-input',
     context,

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_STEP_TIMEOUT_S,
 } from './defaults';
 import ExecutorHttpServer from './http/executor-http-server';
+import OAuthTokenService from './oauth/token-service';
 import Runner from './runner';
 import SchemaCache from './schema-cache';
 import DatabaseMcpOAuthCredentialsStore from './stores/database-mcp-oauth-credentials-store';
@@ -252,9 +253,23 @@ export function buildDatabaseExecutor(options: DatabaseExecutorOptions): Workflo
   if (mergedOptions.logging === undefined) mergedOptions.logging = false;
   const sequelize = uri ? new Sequelize(uri, mergedOptions) : new Sequelize(mergedOptions);
 
+  const mcpOAuthCredentialsStore = new DatabaseMcpOAuthCredentialsStore({
+    sequelize,
+    schema: mergedOptions.schema,
+  });
+  const credentialEncryption = new CredentialEncryption();
+  // Shares the store + encryption with the deposit endpoint so runtime reads and writes (rotation)
+  // go through the same instance the HTTP server migrates on start.
+  const mcpOAuthTokenService = new OAuthTokenService({
+    store: mcpOAuthCredentialsStore,
+    encryption: credentialEncryption,
+    logger: deps.logger,
+  });
+
   const runner = new Runner({
     ...deps,
     runStore: new DatabaseStore({ sequelize, schema: mergedOptions.schema }),
+    mcpOAuthTokenService,
   });
 
   const server = new ExecutorHttpServer({
@@ -263,11 +278,8 @@ export function buildDatabaseExecutor(options: DatabaseExecutorOptions): Workflo
     authSecret: options.authSecret,
     workflowPort: deps.workflowPort,
     logger: deps.logger,
-    mcpOAuthCredentialsStore: new DatabaseMcpOAuthCredentialsStore({
-      sequelize,
-      schema: mergedOptions.schema,
-    }),
-    credentialEncryption: new CredentialEncryption(),
+    mcpOAuthCredentialsStore,
+    credentialEncryption,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -26,6 +26,7 @@ import {
 } from './defaults';
 import ExecutorHttpServer from './http/executor-http-server';
 import OAuthTokenService from './oauth/token-service';
+import RemoteToolFetcher from './remote-tool-fetcher';
 import Runner from './runner';
 import SchemaCache from './schema-cache';
 import DatabaseMcpOAuthCredentialsStore from './stores/database-mcp-oauth-credentials-store';
@@ -234,6 +235,13 @@ export function buildInMemoryExecutor(options: ExecutorOptions): WorkflowExecuto
     logger: deps.logger,
   });
 
+  const remoteToolFetcher = new RemoteToolFetcher(
+    deps.workflowPort,
+    deps.aiModelPort,
+    deps.logger,
+    mcpOAuthTokenService,
+  );
+
   const runner = new Runner({
     ...deps,
     runStore: new InMemoryStore(),
@@ -248,6 +256,7 @@ export function buildInMemoryExecutor(options: ExecutorOptions): WorkflowExecuto
     logger: deps.logger,
     mcpOAuthCredentialsStore,
     credentialEncryption,
+    remoteToolFetcher,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);
@@ -278,6 +287,13 @@ export function buildDatabaseExecutor(options: DatabaseExecutorOptions): Workflo
     logger: deps.logger,
   });
 
+  const remoteToolFetcher = new RemoteToolFetcher(
+    deps.workflowPort,
+    deps.aiModelPort,
+    deps.logger,
+    mcpOAuthTokenService,
+  );
+
   const runner = new Runner({
     ...deps,
     runStore: new DatabaseStore({ sequelize, schema: mergedOptions.schema }),
@@ -292,6 +308,7 @@ export function buildDatabaseExecutor(options: DatabaseExecutorOptions): Workflo
     logger: deps.logger,
     mcpOAuthCredentialsStore,
     credentialEncryption,
+    remoteToolFetcher,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -257,6 +257,7 @@ export function buildInMemoryExecutor(options: ExecutorOptions): WorkflowExecuto
     mcpOAuthCredentialsStore,
     credentialEncryption,
     remoteToolFetcher,
+    oauthTokenService: mcpOAuthTokenService,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);
@@ -309,6 +310,7 @@ export function buildDatabaseExecutor(options: DatabaseExecutorOptions): Workflo
     mcpOAuthCredentialsStore,
     credentialEncryption,
     remoteToolFetcher,
+    oauthTokenService: mcpOAuthTokenService,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -223,9 +223,21 @@ function createWorkflowExecutor(
 export function buildInMemoryExecutor(options: ExecutorOptions): WorkflowExecutor {
   const deps = buildCommonDependencies(options);
 
+  const mcpOAuthCredentialsStore = new InMemoryMcpOAuthCredentialsStore();
+  const credentialEncryption = new CredentialEncryption();
+  // Shares the store + encryption with the deposit endpoint so runtime reads and writes (rotation)
+  // go through the same instance the HTTP server exposes. In-memory is dev-only: credentials live
+  // only for the process lifetime, but oauth2 steps work end-to-end just like the database executor.
+  const mcpOAuthTokenService = new OAuthTokenService({
+    store: mcpOAuthCredentialsStore,
+    encryption: credentialEncryption,
+    logger: deps.logger,
+  });
+
   const runner = new Runner({
     ...deps,
     runStore: new InMemoryStore(),
+    mcpOAuthTokenService,
   });
 
   const server = new ExecutorHttpServer({
@@ -234,8 +246,8 @@ export function buildInMemoryExecutor(options: ExecutorOptions): WorkflowExecuto
     authSecret: options.authSecret,
     workflowPort: deps.workflowPort,
     logger: deps.logger,
-    mcpOAuthCredentialsStore: new InMemoryMcpOAuthCredentialsStore(),
-    credentialEncryption: new CredentialEncryption(),
+    mcpOAuthCredentialsStore,
+    credentialEncryption,
   });
 
   return createWorkflowExecutor(runner, server, deps.logger);

--- a/packages/workflow-executor/src/defaults.ts
+++ b/packages/workflow-executor/src/defaults.ts
@@ -9,3 +9,6 @@ export const DEFAULT_STOP_TIMEOUT_S = 30;
 export const DEFAULT_MAX_CHAIN_DEPTH = 50;
 export const DEFAULT_SCHEMA_CACHE_TTL_S = 10 * 60;
 export const DEFAULT_LOGGER_LEVEL: LoggerLevel = 'Info';
+// Refresh an OAuth access token this many seconds before it actually expires, so a token never
+// goes stale mid-request between the skew check and the downstream MCP call.
+export const DEFAULT_OAUTH_EXPIRY_SKEW_S = 60;

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -389,6 +389,18 @@ export class OAuthInvalidGrantError extends WorkflowExecutorError {
   }
 }
 
+// The token endpoint is where the executor POSTs the refresh grant (with client credentials), so an
+// unconstrained value is an SSRF vector. A rejected one fails closed (terminal) before any network
+// call, rather than letting an authenticated caller aim the executor at an internal address.
+export class InvalidTokenEndpointError extends WorkflowExecutorError {
+  constructor(reason: string) {
+    super(
+      `Invalid OAuth token endpoint: ${reason}`,
+      'This tool is misconfigured (invalid token endpoint). Contact your administrator.',
+    );
+  }
+}
+
 // Boundary error — the deposit endpoint maps it to a typed HTTP response so the frontend can tell
 // an operator to provision the key, not a generic or re-consent failure.
 export class ExecutorEncryptionKeyMissingError extends Error {

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import type { MalformedRunInfo } from './ports/workflow-port';
 import type { RecordId } from './types/validated/collection';
+import type { AwaitingInputReason } from './types/validated/step-outcome';
 import type { z } from 'zod';
 
 export function causeMessage(error: unknown): string | undefined {
@@ -347,6 +348,44 @@ export class ConfigurationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'ConfigurationError';
+  }
+}
+
+// Carries the typed pause reason so the step executor can emit an awaiting-input outcome (and the
+// orchestrator/front can prompt the user to reconnect) instead of a generic error.
+export class OAuthReauthRequiredError extends WorkflowExecutorError {
+  readonly awaitingInputReason: AwaitingInputReason;
+
+  constructor(
+    mcpServerId: string,
+    awaitingInputReason: AwaitingInputReason = 'needs-oauth-reauth',
+  ) {
+    super(
+      `OAuth re-authentication required for mcpServerId="${mcpServerId}"`,
+      'This tool needs to be reconnected before it can run. Please re-authorize it and try again.',
+    );
+    this.awaitingInputReason = awaitingInputReason;
+  }
+}
+
+// Transient refresh failure (network error, 5xx, malformed response). Surfaces as a retryable step
+// error rather than a re-auth pause — re-authenticating would not fix a temporarily unreachable endpoint.
+export class OAuthRefreshError extends WorkflowExecutorError {
+  constructor(message: string, cause?: unknown) {
+    super(
+      `OAuth token refresh failed: ${message}`,
+      'Could not refresh the connection to this tool. Please try again.',
+    );
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+// The token endpoint rejected the refresh token (RFC 6749 invalid_grant). Internal control-flow
+// signal: the token service catches it to drive the re-read + single-retry, then converts a genuine
+// failure into OAuthReauthRequiredError.
+export class OAuthInvalidGrantError extends WorkflowExecutorError {
+  constructor(detail?: string) {
+    super(`OAuth refresh token rejected${detail ? `: ${detail}` : ''}`);
   }
 }
 

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -472,7 +472,7 @@ export class SourceRecordMissingError extends WorkflowExecutorError {
 
 // Boundary error — surfaces from Runner.start() and is caught at the CLI/HTTP layer, not by step executors.
 export class AgentProbeError extends Error {
-  // Manual `cause` assignment: Error accepts it natively since Node 16.9 but our TS target is ES2020.
+  // Manual `cause` assignment: our ES2020 TS target doesn't type the native Error `cause` option.
   readonly cause?: unknown;
 
   constructor(message: string, options?: { cause?: unknown }) {

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -1,16 +1,22 @@
 import type { ExecutionContext, StepExecutionResult } from '../types/execution-context';
 import type { McpStepExecutionData, McpToolCall } from '../types/step-execution-data';
 import type { McpStepDefinition } from '../types/validated/step-definition';
-import type { RecordStepStatus } from '../types/validated/step-outcome';
+import type { AwaitingInputReason, RecordStepStatus } from '../types/validated/step-outcome';
 import type { RemoteTool } from '@forestadmin/ai-proxy';
 
-import { DynamicStructuredTool, HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
+import {
+  DynamicStructuredTool,
+  HumanMessage,
+  SystemMessage,
+  isMcpAuthError,
+} from '@forestadmin/ai-proxy';
 import { z } from 'zod';
 
 import {
   McpToolInvocationError,
   McpToolNotFoundError,
   NoMcpToolsError,
+  OAuthReauthRequiredError,
   StepStateError,
 } from '../errors';
 import BaseStepExecutor from './base-step-executor';
@@ -28,14 +34,18 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
 
   private readonly mcpServerName?: string;
 
+  private readonly reloadWithFreshAuth?: () => Promise<RemoteTool[]>;
+
   constructor(
     context: ExecutionContext<McpStepDefinition>,
     remoteTools: readonly RemoteTool[],
     mcpServerName?: string,
+    reloadWithFreshAuth?: () => Promise<RemoteTool[]>,
   ) {
     super(context);
     this.remoteTools = remoteTools;
     this.mcpServerName = mcpServerName;
+    this.reloadWithFreshAuth = reloadWithFreshAuth;
   }
 
   protected override getExtraLogContext(): Record<string, unknown> {
@@ -48,6 +58,7 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   protected buildOutcomeResult(outcome: {
     status: RecordStepStatus;
     error?: string;
+    awaitingInputReason?: AwaitingInputReason;
   }): StepExecutionResult {
     return {
       stepOutcome: {
@@ -74,6 +85,22 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   }
 
   protected async doExecute(): Promise<StepExecutionResult> {
+    try {
+      return await this.runStep();
+    } catch (error) {
+      // An unrefreshable OAuth credential pauses the step for re-authentication rather than failing it.
+      if (error instanceof OAuthReauthRequiredError) {
+        return this.buildOutcomeResult({
+          status: 'awaiting-input',
+          awaitingInputReason: error.awaitingInputReason,
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  private async runStep(): Promise<StepExecutionResult> {
     // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<McpStepExecutionData>(
       this.context.incomingPendingData,
@@ -124,13 +151,7 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
         recordId: this.context.baseRecordRef.recordId,
       },
       {
-        operation: async () => {
-          try {
-            return await tool.base.invoke(target.input);
-          } catch (cause) {
-            throw new McpToolInvocationError(target.name, cause);
-          }
-        },
+        operation: () => this.invokeWithReauthRetry(tool, target),
         beforeCall: () =>
           this.context.runStore.saveStepExecution(this.context.runId, {
             ...existingExecution,
@@ -193,6 +214,35 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     }
 
     return this.buildOutcomeResult({ status: 'success' });
+  }
+
+  // No-op for bearer/none steps (no reloadWithFreshAuth). For an OAuth2 step, a 401 on the call means
+  // the token was rejected after listing tools succeeded: force one refresh, rebuild the tool, retry
+  // once. A second 401 pauses the step for re-authentication.
+  private async invokeWithReauthRetry(tool: RemoteTool, target: McpToolCall): Promise<unknown> {
+    try {
+      return await tool.base.invoke(target.input);
+    } catch (cause) {
+      if (!this.reloadWithFreshAuth || !isMcpAuthError(cause)) {
+        throw new McpToolInvocationError(target.name, cause);
+      }
+
+      const refreshedTools = await this.reloadWithFreshAuth();
+      const refreshedTool = refreshedTools.find(
+        t => t.base.name === target.name && t.sourceId === target.sourceId,
+      );
+      if (!refreshedTool) throw new McpToolNotFoundError(target.name);
+
+      try {
+        return await refreshedTool.base.invoke(target.input);
+      } catch (retryCause) {
+        if (isMcpAuthError(retryCause)) {
+          throw new OAuthReauthRequiredError(this.context.stepDefinition.mcpServerId);
+        }
+
+        throw new McpToolInvocationError(target.name, retryCause);
+      }
+    }
   }
 
   private async formatToolResult(tool: McpToolCall, toolResult: unknown): Promise<string | null> {

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -101,7 +101,6 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
   }
 
   private async runStep(): Promise<StepExecutionResult> {
-    // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<McpStepExecutionData>(
       this.context.incomingPendingData,
     );
@@ -112,7 +111,6 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
       );
     }
 
-    // Branches B & C -- First call
     const tools = this.requireTools();
     const { toolName, args } = await this.selectTool(tools);
     const selectedTool = tools.find(t => t.base.name === toolName);
@@ -120,11 +118,9 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     const target: McpToolCall = { name: toolName, sourceId: selectedTool.sourceId, input: args };
 
     if (this.context.stepDefinition.executionType === StepExecutionMode.FullyAutomated) {
-      // Branch B -- direct execution
       return this.executeToolAndPersist(target);
     }
 
-    // Branch C -- Awaiting confirmation
     await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'mcp',
       stepIndex: this.context.stepIndex,

--- a/packages/workflow-executor/src/executors/mcp-step-executor.ts
+++ b/packages/workflow-executor/src/executors/mcp-step-executor.ts
@@ -88,8 +88,11 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
     try {
       return await this.runStep();
     } catch (error) {
-      // An unrefreshable OAuth credential pauses the step for re-authentication rather than failing it.
+      // An unrefreshable OAuth credential pauses the step for re-authentication rather than failing
+      // it. Clear the write-ahead marker so the resumed step is not rejected as interrupted.
       if (error instanceof OAuthReauthRequiredError) {
+        await this.clearReauthPauseState();
+
         return this.buildOutcomeResult({
           status: 'awaiting-input',
           awaitingInputReason: error.awaitingInputReason,
@@ -97,6 +100,22 @@ export default class McpStepExecutor extends BaseStepExecutor<McpStepDefinition>
       }
 
       throw error;
+    }
+  }
+
+  // Keep a confirmation-flow record's approved pendingData (clear only the marker) so resume replays
+  // it; delete a pendingData-less record, which would otherwise mis-route resume into confirmation.
+  private async clearReauthPauseState(): Promise<void> {
+    const existing = await this.findPendingExecution<McpStepExecutionData>('mcp');
+    if (!existing) return;
+
+    if (existing.pendingData) {
+      await this.context.runStore.saveStepExecution(this.context.runId, {
+        ...existing,
+        idempotencyPhase: undefined,
+      });
+    } else {
+      await this.context.runStore.deleteStepExecution(this.context.runId, this.context.stepIndex);
     }
   }
 

--- a/packages/workflow-executor/src/executors/step-executor-factory.ts
+++ b/packages/workflow-executor/src/executors/step-executor-factory.ts
@@ -23,6 +23,7 @@ import type {
 } from '../types/validated/step-definition';
 
 import {
+  OAuthReauthRequiredError,
   StepStateError,
   WorkflowExecutorError,
   causeMessage,
@@ -57,7 +58,7 @@ export default class StepExecutorFactory {
     step: AvailableStepExecution,
     contextConfig: StepContextConfig,
     activityLogPort: ActivityLogPort,
-    fetchRemoteTools: (mcpServerId: string) => Promise<FetchRemoteToolsResult>,
+    fetchRemoteTools: (mcpServerId: string, userId: number) => Promise<FetchRemoteToolsResult>,
     incomingPendingData?: unknown,
   ): Promise<IStepExecutor> {
     try {
@@ -88,11 +89,12 @@ export default class StepExecutorFactory {
 
         case StepType.Mcp: {
           const mcpContext = context as ExecutionContext<McpStepDefinition>;
-          const { tools, mcpServerName } = await fetchRemoteTools(
+          const { tools, mcpServerName, reloadWithFreshAuth } = await fetchRemoteTools(
             mcpContext.stepDefinition.mcpServerId,
+            step.user.id,
           );
 
-          return new McpStepExecutor(mcpContext, tools, mcpServerName);
+          return new McpStepExecutor(mcpContext, tools, mcpServerName, reloadWithFreshAuth);
         }
 
         case StepType.Guidance:
@@ -103,6 +105,29 @@ export default class StepExecutorFactory {
           );
       }
     } catch (error) {
+      // Re-auth required while loading tools is an expected pause, not a failure: emit awaiting-input
+      // with the typed reason so the user can reconnect, rather than erroring the step.
+      if (error instanceof OAuthReauthRequiredError) {
+        contextConfig.logger('Info', 'MCP step paused for OAuth re-authentication', {
+          runId: step.runId,
+          stepId: step.stepId,
+          stepIndex: step.stepIndex,
+          awaitingInputReason: error.awaitingInputReason,
+        });
+
+        return {
+          execute: async (): Promise<StepExecutionResult> => ({
+            stepOutcome: {
+              type: 'mcp',
+              stepId: step.stepId,
+              stepIndex: step.stepIndex,
+              status: 'awaiting-input',
+              awaitingInputReason: error.awaitingInputReason,
+            },
+          }),
+        };
+      }
+
       contextConfig.logger('Error', 'Step execution failed unexpectedly', {
         runId: step.runId,
         stepId: step.stepId,

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -1,4 +1,5 @@
 import type CredentialEncryption from '../crypto/credential-encryption';
+import type OAuthTokenService from '../oauth/token-service';
 import type { Logger } from '../ports/logger-port';
 import type { McpOAuthCredentialsStore } from '../ports/mcp-oauth-credentials-store';
 import type { WorkflowPort } from '../ports/workflow-port';
@@ -44,6 +45,9 @@ export interface ExecutorHttpServerOptions {
   mcpOAuthCredentialsStore: McpOAuthCredentialsStore;
   credentialEncryption: CredentialEncryption;
   remoteToolFetcher: RemoteToolFetcher;
+  // The runtime always provides this (build-workflow-executor); optional so tests that don't
+  // exercise credential deletion don't all have to construct one.
+  oauthTokenService?: OAuthTokenService;
 }
 
 export default class ExecutorHttpServer {
@@ -297,6 +301,9 @@ export default class ExecutorHttpServer {
     const userId = (ctx.state.user as BearerClaims).id;
 
     await store.delete(userId, ctx.params.mcpServerId);
+    // Evict any in-process cached access token so the disconnect is immediate, not deferred until
+    // the cached token expires (the row is gone, but the runtime would otherwise still serve it).
+    this.options.oauthTokenService?.evict(userId, ctx.params.mcpServerId);
     ctx.status = 204;
   }
 

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -290,6 +290,9 @@ export default class ExecutorHttpServer {
       throw err;
     }
 
+    // Evict any cached access token so a reconnect/re-deposit takes effect immediately, instead of
+    // serving the token minted from the previous credential until it expires (mirrors delete).
+    this.options.oauthTokenService?.evict(userId, parsed.data.mcpServerId);
     ctx.status = 200;
     ctx.body = { stored: true };
   }

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -2,6 +2,7 @@ import type CredentialEncryption from '../crypto/credential-encryption';
 import type { Logger } from '../ports/logger-port';
 import type { McpOAuthCredentialsStore } from '../ports/mcp-oauth-credentials-store';
 import type { WorkflowPort } from '../ports/workflow-port';
+import type RemoteToolFetcher from '../remote-tool-fetcher';
 import type Runner from '../runner';
 import type { Server } from 'http';
 
@@ -25,7 +26,11 @@ import {
 } from './mcp-oauth-credentials';
 import serializeStepForWire from './step-serializer';
 import createConsoleLogger from '../adapters/console-logger';
-import { ExecutorEncryptionKeyMissingError, extractErrorMessage } from '../errors';
+import {
+  ExecutorEncryptionKeyMissingError,
+  OAuthReauthRequiredError,
+  extractErrorMessage,
+} from '../errors';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
 const { version } = require('../../package.json') as { version: string };
@@ -38,6 +43,7 @@ export interface ExecutorHttpServerOptions {
   logger?: Logger;
   mcpOAuthCredentialsStore: McpOAuthCredentialsStore;
   credentialEncryption: CredentialEncryption;
+  remoteToolFetcher: RemoteToolFetcher;
 }
 
 export default class ExecutorHttpServer {
@@ -153,7 +159,15 @@ export default class ExecutorHttpServer {
     );
     router.post('/runs/:runId/trigger', this.handleTrigger.bind(this));
 
-    const { mcpOAuthCredentialsStore: credentialsStore, credentialEncryption } = this.options;
+    const {
+      mcpOAuthCredentialsStore: credentialsStore,
+      credentialEncryption,
+      remoteToolFetcher,
+    } = this.options;
+
+    // Design-time tool listing for the MCP-server details page: resolve the caller's vault
+    // credential, refresh, and list the oauth2 server's tools — no workflow run involved.
+    router.get('/list-mcp-tools', ctx => this.handleListMcpTools(ctx, remoteToolFetcher));
 
     router.post('/mcp-oauth-credentials', ctx =>
       this.handleDepositCredentials(ctx, credentialsStore, credentialEncryption),
@@ -284,5 +298,38 @@ export default class ExecutorHttpServer {
 
     await store.delete(userId, ctx.params.mcpServerId);
     ctx.status = 204;
+  }
+
+  // Design-time tool listing: resolve the caller's vault credential for the target oauth2 server,
+  // refresh + inject the Bearer, and return the server's tool definitions. user_id comes from the
+  // validated JWT, so a caller only ever lists with their own stored credential. A missing/dead
+  // credential surfaces as a typed needs-oauth-reauth response (not a generic error or empty list)
+  // so the details page can prompt a reconnect — mirroring the run path's awaiting-input reason.
+  private async handleListMcpTools(ctx: Koa.Context, fetcher: RemoteToolFetcher): Promise<void> {
+    const userId = (ctx.state.user as BearerClaims).id;
+    const { mcpServerId } = ctx.query;
+
+    if (typeof mcpServerId !== 'string' || mcpServerId.length === 0) {
+      throw new BadRequestHttpError('Missing required query parameter "mcpServerId"');
+    }
+
+    try {
+      const { tools } = await fetcher.fetch(mcpServerId, userId);
+      ctx.status = 200;
+      ctx.body = {
+        tools: tools.map(tool => ({ name: tool.base.name, description: tool.base.description })),
+      };
+    } catch (err) {
+      // Set the body directly so the error middleware (which would map this to a generic 400 and
+      // drop the typed reason) doesn't touch it — the frontend needs the reason to prompt reconnect.
+      if (err instanceof OAuthReauthRequiredError) {
+        ctx.status = 409;
+        ctx.body = { awaitingInputReason: err.awaitingInputReason, mcpServerId };
+
+        return;
+      }
+
+      throw err;
+    }
   }
 }

--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -336,6 +336,15 @@ export default class ExecutorHttpServer {
         return;
       }
 
+      // Key-missing is an operator misconfig, not re-consent-resolvable: return the same typed 503
+      // the deposit endpoint uses so the details page shows the admin message, not a generic error.
+      if (err instanceof ExecutorEncryptionKeyMissingError) {
+        ctx.status = 503;
+        ctx.body = { code: err.code };
+
+        return;
+      }
+
       throw err;
     }
   }

--- a/packages/workflow-executor/src/http/mcp-oauth-credentials.ts
+++ b/packages/workflow-executor/src/http/mcp-oauth-credentials.ts
@@ -3,6 +3,8 @@ import type { McpOAuthCredentialInput } from '../ports/mcp-oauth-credentials-sto
 
 import { z } from 'zod';
 
+import assertSafeTokenEndpoint from '../oauth/token-endpoint-url';
+
 // String lengths mirror the DB column limits, so oversized values are rejected here at the boundary
 // rather than at insert. .strict() matters for security: it blocks a body-supplied user id, since
 // identity comes only from the JWT.
@@ -16,7 +18,22 @@ export const depositCredentialsBodySchema = z
       .string()
       .refine(value => !Number.isNaN(Date.parse(value)), { message: 'must be a parseable date' })
       .optional(),
-    tokenEndpoint: z.string().min(1).max(2048),
+    tokenEndpoint: z
+      .string()
+      .min(1)
+      .max(2048)
+      .superRefine((value, ctx) => {
+        // The executor POSTs the refresh grant here, so reject SSRF-prone endpoints at deposit
+        // rather than discovering them at refresh time.
+        try {
+          assertSafeTokenEndpoint(value);
+        } catch (error) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: error instanceof Error ? error.message : 'invalid token endpoint',
+          });
+        }
+      }),
     tokenEndpointAuthMethod: z.string().max(64).optional(),
     scopes: z.string().max(2048).optional(),
   })

--- a/packages/workflow-executor/src/oauth/keyed-mutex.ts
+++ b/packages/workflow-executor/src/oauth/keyed-mutex.ts
@@ -1,0 +1,24 @@
+// Serializes async work per key: callers sharing a key run one at a time (FIFO), while different
+// keys proceed in parallel. Used to collapse concurrent token refreshes for the same (user, server)
+// into a single in-flight refresh within one process.
+export default class KeyedMutex {
+  private readonly tails = new Map<string, Promise<unknown>>();
+
+  async runExclusive<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const result = previous.then(() => task());
+    // Store a non-rejecting tail so the next caller chains regardless of this task's outcome.
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+
+    try {
+      return await result;
+    } finally {
+      // Drop the entry once this was the last queued task for the key, so the map can't grow.
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    }
+  }
+}

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -65,7 +65,7 @@ function buildRequest(params: RefreshGrantParams): {
 export default async function refreshAccessToken(
   params: RefreshGrantParams,
 ): Promise<RefreshGrantResult> {
-  // Defence in depth: deposit validation rejects SSRF-prone endpoints, but a row predating that
+  // Defense in depth: deposit validation rejects SSRF-prone endpoints, but a row predating that
   // validation could still carry one — re-check before the outbound POST. Throws (terminal) rather
   // than reaching the network.
   assertSafeTokenEndpoint(params.tokenEndpoint);

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -77,7 +77,10 @@ export default async function refreshAccessToken(
   let payload: TokenEndpointResponse = {};
 
   try {
-    payload = (await response.json()) as TokenEndpointResponse;
+    const parsed: unknown = await response.json();
+    // A non-object body (e.g. literal null) would make the property reads below throw a TypeError;
+    // keep the {} default so the status checks still surface a typed OAuthRefreshError.
+    if (parsed && typeof parsed === 'object') payload = parsed as TokenEndpointResponse;
   } catch {
     // Non-JSON body — handled by the status checks below.
   }

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -78,8 +78,8 @@ export default async function refreshAccessToken(
 
   try {
     const parsed: unknown = await response.json();
-    // A non-object body (e.g. literal null) would make the property reads below throw a TypeError;
-    // keep the {} default so the status checks still surface a typed OAuthRefreshError.
+    // Ignore a non-object body (e.g. literal null), keeping the {} default so the status checks
+    // below still surface a typed OAuthRefreshError.
     if (parsed && typeof parsed === 'object') payload = parsed as TokenEndpointResponse;
   } catch {
     // Non-JSON body — handled by the status checks below.

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -1,4 +1,5 @@
 import { OAuthInvalidGrantError, OAuthRefreshError } from '../errors';
+import assertSafeTokenEndpoint from './token-endpoint-url';
 
 export interface RefreshGrantParams {
   tokenEndpoint: string;
@@ -64,6 +65,11 @@ function buildRequest(params: RefreshGrantParams): {
 export default async function refreshAccessToken(
   params: RefreshGrantParams,
 ): Promise<RefreshGrantResult> {
+  // Defence in depth: deposit validation rejects SSRF-prone endpoints, but a row predating that
+  // validation could still carry one — re-check before the outbound POST. Throws (terminal) rather
+  // than reaching the network.
+  assertSafeTokenEndpoint(params.tokenEndpoint);
+
   const { headers, body } = buildRequest(params);
 
   let response: Awaited<ReturnType<typeof fetch>>;

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -75,9 +75,21 @@ export default async function refreshAccessToken(
   let response: Awaited<ReturnType<typeof fetch>>;
 
   try {
-    response = await fetch(params.tokenEndpoint, { method: 'POST', headers, body });
+    // Never follow redirects: a 3xx to an internal host would re-send the grant body (refresh
+    // token, plus the client secret in client_secret_post) there and parse its reply as a token —
+    // bypassing the endpoint validation above. Any redirect is treated as a failure.
+    response = await fetch(params.tokenEndpoint, {
+      method: 'POST',
+      headers,
+      body,
+      redirect: 'manual',
+    });
   } catch (cause) {
     throw new OAuthRefreshError('the token endpoint could not be reached', cause);
+  }
+
+  if (response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)) {
+    throw new OAuthRefreshError('the token endpoint attempted a redirect');
   }
 
   let payload: TokenEndpointResponse = {};

--- a/packages/workflow-executor/src/oauth/refresh-grant.ts
+++ b/packages/workflow-executor/src/oauth/refresh-grant.ts
@@ -1,0 +1,108 @@
+import { OAuthInvalidGrantError, OAuthRefreshError } from '../errors';
+
+export interface RefreshGrantParams {
+  tokenEndpoint: string;
+  refreshToken: string;
+  clientId?: string | null;
+  clientSecret?: string | null;
+  tokenEndpointAuthMethod?: string | null;
+  scopes?: string | null;
+}
+
+export interface RefreshGrantResult {
+  accessToken: string;
+  expiresInS?: number;
+  // Present only when the authorization server rotates the refresh token.
+  refreshToken?: string;
+}
+
+interface TokenEndpointResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+  refresh_token?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+}
+
+function buildRequest(params: RefreshGrantParams): {
+  headers: Record<string, string>;
+  body: URLSearchParams;
+} {
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+    accept: 'application/json',
+  };
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: params.refreshToken,
+  });
+
+  if (params.scopes) body.set('scope', params.scopes);
+
+  const { clientId, clientSecret, tokenEndpointAuthMethod } = params;
+
+  if (clientSecret) {
+    if (tokenEndpointAuthMethod === 'client_secret_post') {
+      if (clientId) body.set('client_id', clientId);
+      body.set('client_secret', clientSecret);
+    } else {
+      const credentials = `${encodeURIComponent(clientId ?? '')}:${encodeURIComponent(
+        clientSecret,
+      )}`;
+      headers.authorization = `Basic ${Buffer.from(credentials).toString('base64')}`;
+    }
+  } else if (clientId) {
+    body.set('client_id', clientId);
+  }
+
+  return { headers, body };
+}
+
+// Runs the OAuth2 refresh-token grant (RFC 6749 §6) against the stored token endpoint. Distinguishes
+// a non-retryable invalid_grant (revoked / rotated) from a transient failure so the caller can decide
+// between forcing re-auth and retrying.
+export default async function refreshAccessToken(
+  params: RefreshGrantParams,
+): Promise<RefreshGrantResult> {
+  const { headers, body } = buildRequest(params);
+
+  let response: Awaited<ReturnType<typeof fetch>>;
+
+  try {
+    response = await fetch(params.tokenEndpoint, { method: 'POST', headers, body });
+  } catch (cause) {
+    throw new OAuthRefreshError('the token endpoint could not be reached', cause);
+  }
+
+  let payload: TokenEndpointResponse = {};
+
+  try {
+    payload = (await response.json()) as TokenEndpointResponse;
+  } catch {
+    // Non-JSON body — handled by the status checks below.
+  }
+
+  if (!response.ok) {
+    if (payload.error === 'invalid_grant') {
+      throw new OAuthInvalidGrantError(
+        typeof payload.error_description === 'string' ? payload.error_description : undefined,
+      );
+    }
+
+    throw new OAuthRefreshError(
+      typeof payload.error === 'string'
+        ? payload.error
+        : `the token endpoint returned ${response.status}`,
+    );
+  }
+
+  if (typeof payload.access_token !== 'string' || !payload.access_token) {
+    throw new OAuthRefreshError('the token endpoint response had no access_token');
+  }
+
+  return {
+    accessToken: payload.access_token,
+    expiresInS: typeof payload.expires_in === 'number' ? payload.expires_in : undefined,
+    refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : undefined,
+  };
+}

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -2,16 +2,14 @@ import net from 'net';
 
 import { InvalidTokenEndpointError } from '../errors';
 
-// Constrains the OAuth token endpoint without breaking intended private-provider support:
-//   - scheme must be http(s); in production it must be https (http stays allowed off-prod, since the
-//     local OAuth sim runs on http);
-//   - link-local (incl. cloud metadata, e.g. 169.254.169.254) is never a valid endpoint — blocked
-//     on every environment;
-//   - loopback / the executor host itself is blocked in production (allowed off-prod for the sim);
-//   - RFC1918 private ranges stay allowed — a private OAuth provider refreshes from inside the
-//     customer network by design (see PRD-367).
-// IP-literal hosts cover the direct SSRF the deposit flow enables; hostnames are not DNS-resolved
-// here, as a resolve-then-fetch check is racy (the resolution at fetch time can differ).
+// The token endpoint comes from the deposit body, and the executor POSTs the refresh grant (with
+// client credentials) to it — so an unconstrained value is an SSRF vector. The guard rejects hosts
+// that are never a legitimate endpoint but are prime SSRF targets (loopback, link-local /
+// cloud-metadata) and requires TLS, while deliberately allowing private (RFC1918) hosts: a private
+// OAuth provider reached over the internal network is a supported deployment, so blocking it would
+// break a real use case. http and loopback are relaxed off-production for local development.
+// Only IP literals are inspected — resolving a hostname here would be racy (it can resolve to a
+// different address at fetch time), not safer.
 
 function isProduction(): boolean {
   return process.env.NODE_ENV === 'production';

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -1,0 +1,76 @@
+import net from 'net';
+
+import { InvalidTokenEndpointError } from '../errors';
+
+// Constrains the OAuth token endpoint without breaking intended private-provider support:
+//   - scheme must be http(s); in production it must be https (http stays allowed off-prod, since the
+//     local OAuth sim runs on http);
+//   - link-local (incl. cloud metadata, e.g. 169.254.169.254) is never a valid endpoint — blocked
+//     on every environment;
+//   - loopback / the executor host itself is blocked in production (allowed off-prod for the sim);
+//   - RFC1918 private ranges stay allowed — a private OAuth provider refreshes from inside the
+//     customer network by design (see PRD-367).
+// IP-literal hosts cover the direct SSRF the deposit flow enables; hostnames are not DNS-resolved
+// here, as a resolve-then-fetch check is racy (the resolution at fetch time can differ).
+
+function isProduction(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+function unbracket(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
+function classify(host: string): { loopback: boolean; linkLocal: boolean } {
+  const kind = net.isIP(host);
+
+  if (kind === 4) {
+    const [a, b] = host.split('.').map(Number);
+
+    return { loopback: a === 127, linkLocal: a === 169 && b === 254 };
+  }
+
+  if (kind === 6) {
+    const normalized = host.toLowerCase().split('%')[0]; // drop any zone id
+    const firstHextet = normalized.split(':')[0];
+
+    return {
+      loopback: normalized === '::1' || normalized === '0:0:0:0:0:0:0:1',
+      linkLocal: /^fe[89ab]/.test(firstHextet), // fe80::/10
+    };
+  }
+
+  // Not an IP literal — only the obvious local alias is treated as loopback; other hostnames are
+  // left to the scheme rule (not resolved).
+  return { loopback: host.toLowerCase() === 'localhost', linkLocal: false };
+}
+
+export default function assertSafeTokenEndpoint(raw: string): void {
+  let url: URL;
+
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new InvalidTokenEndpointError('it is not a valid absolute URL');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new InvalidTokenEndpointError('it must use http or https');
+  }
+
+  const { loopback, linkLocal } = classify(unbracket(url.hostname));
+
+  if (linkLocal) {
+    throw new InvalidTokenEndpointError('it points at a link-local / metadata address');
+  }
+
+  if (isProduction()) {
+    if (url.protocol !== 'https:') {
+      throw new InvalidTokenEndpointError('it must use https');
+    }
+
+    if (loopback) {
+      throw new InvalidTokenEndpointError('it points at the executor host (loopback)');
+    }
+  }
+}

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -21,16 +21,39 @@ function unbracket(hostname: string): string {
   return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
 }
 
+function classifyIpv4(host: string): { loopback: boolean; linkLocal: boolean } {
+  const [a, b] = host.split('.').map(Number);
+
+  return { loopback: a === 127, linkLocal: a === 169 && b === 254 }; // 127.0.0.0/8, 169.254.0.0/16
+}
+
+// Returns the embedded IPv4 of an IPv4-mapped IPv6 address (otherwise null). The WHATWG URL parser
+// normalizes `::ffff:127.0.0.1` to the hex form `::ffff:7f00:1`, which would otherwise dodge the
+// IPv4 loopback/link-local checks and still reach the executor's loopback / metadata interface.
+function embeddedIpv4(host: string): string | null {
+  const tail = host.toLowerCase().match(/^::ffff:(.+)$/)?.[1];
+  if (!tail) return null;
+
+  if (net.isIPv4(tail)) return tail;
+
+  const hex = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hex) return null;
+
+  const hi = parseInt(hex[1], 16); // high 16 bits → first two octets
+  const lo = parseInt(hex[2], 16); // low 16 bits → last two octets
+
+  return `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${lo % 256}`;
+}
+
 function classify(host: string): { loopback: boolean; linkLocal: boolean } {
   const kind = net.isIP(host);
 
-  if (kind === 4) {
-    const [a, b] = host.split('.').map(Number);
-
-    return { loopback: a === 127, linkLocal: a === 169 && b === 254 };
-  }
+  if (kind === 4) return classifyIpv4(host);
 
   if (kind === 6) {
+    const mapped = embeddedIpv4(host);
+    if (mapped) return classifyIpv4(mapped);
+
     const normalized = host.toLowerCase().split('%')[0]; // drop any zone id
     const firstHextet = normalized.split(':')[0];
 

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -19,10 +19,16 @@ function unbracket(hostname: string): string {
   return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
 }
 
-function classifyIpv4(host: string): { loopback: boolean; linkLocal: boolean } {
+type HostClass = { loopback: boolean; linkLocal: boolean; unspecified: boolean };
+
+function classifyIpv4(host: string): HostClass {
   const [a, b] = host.split('.').map(Number);
 
-  return { loopback: a === 127, linkLocal: a === 169 && b === 254 }; // 127.0.0.0/8, 169.254.0.0/16
+  return {
+    loopback: a === 127, // 127.0.0.0/8
+    linkLocal: a === 169 && b === 254, // 169.254.0.0/16
+    unspecified: a === 0, // 0.0.0.0/8 — "this host"; connects to loopback on Linux
+  };
 }
 
 // Returns the embedded IPv4 of an IPv4-mapped IPv6 address (otherwise null). The WHATWG URL parser
@@ -43,7 +49,7 @@ function embeddedIpv4(host: string): string | null {
   return `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${lo % 256}`;
 }
 
-function classify(host: string): { loopback: boolean; linkLocal: boolean } {
+function classify(host: string): HostClass {
   const kind = net.isIP(host);
 
   if (kind === 4) return classifyIpv4(host);
@@ -58,12 +64,13 @@ function classify(host: string): { loopback: boolean; linkLocal: boolean } {
     return {
       loopback: normalized === '::1' || normalized === '0:0:0:0:0:0:0:1',
       linkLocal: /^fe[89ab]/.test(firstHextet), // fe80::/10
+      unspecified: normalized === '::' || normalized === '0:0:0:0:0:0:0:0',
     };
   }
 
   // Not an IP literal — only the obvious local alias is treated as loopback; other hostnames are
   // left to the scheme rule (not resolved).
-  return { loopback: host.toLowerCase() === 'localhost', linkLocal: false };
+  return { loopback: host.toLowerCase() === 'localhost', linkLocal: false, unspecified: false };
 }
 
 export default function assertSafeTokenEndpoint(raw: string): void {
@@ -79,7 +86,11 @@ export default function assertSafeTokenEndpoint(raw: string): void {
     throw new InvalidTokenEndpointError('it must use http or https');
   }
 
-  const { loopback, linkLocal } = classify(unbracket(url.hostname));
+  const { loopback, linkLocal, unspecified } = classify(unbracket(url.hostname));
+
+  if (unspecified) {
+    throw new InvalidTokenEndpointError('it points at the unspecified address (0.0.0.0 / ::)');
+  }
 
   if (linkLocal) {
     throw new InvalidTokenEndpointError('it points at a link-local / metadata address');

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -68,9 +68,15 @@ function classify(host: string): HostClass {
     };
   }
 
-  // Not an IP literal — only the obvious local alias is treated as loopback; other hostnames are
-  // left to the scheme rule (not resolved).
-  return { loopback: host.toLowerCase() === 'localhost', linkLocal: false, unspecified: false };
+  // Not an IP literal. Reject the reserved loopback names — bare `localhost`, the `.localhost` TLD
+  // (RFC 6761), and their trailing-dot FQDN forms — since they resolve to loopback. Other hostnames
+  // are left to the scheme rule; their DNS is not resolved here (a hostname pointed at an internal
+  // IP is the filtering-agent's job, not this string check).
+  return {
+    loopback: /^localhost\.?$|\.localhost\.?$/.test(host.toLowerCase()),
+    linkLocal: false,
+    unspecified: false,
+  };
 }
 
 export default function assertSafeTokenEndpoint(raw: string): void {

--- a/packages/workflow-executor/src/oauth/token-endpoint-url.ts
+++ b/packages/workflow-executor/src/oauth/token-endpoint-url.ts
@@ -7,12 +7,15 @@ import { InvalidTokenEndpointError } from '../errors';
 // that are never a legitimate endpoint but are prime SSRF targets (loopback, link-local /
 // cloud-metadata) and requires TLS, while deliberately allowing private (RFC1918) hosts: a private
 // OAuth provider reached over the internal network is a supported deployment, so blocking it would
-// break a real use case. http and loopback are relaxed off-production for local development.
-// Only IP literals are inspected — resolving a hostname here would be racy (it can resolve to a
-// different address at fetch time), not safer.
+// break a real use case. http and loopback are relaxed only when NODE_ENV explicitly opts in
+// (development/test) — see isRelaxedEnv. Only IP literals are inspected — resolving a hostname here
+// would be racy (it can resolve to a different address at fetch time), not safer.
 
-function isProduction(): boolean {
-  return process.env.NODE_ENV === 'production';
+// Fail closed: the strict rules (https + no loopback) apply everywhere UNLESS NODE_ENV explicitly
+// opts into the local-dev relaxation. An unset or misspelled NODE_ENV stays strict, so a
+// misconfigured deploy can't silently allow loopback targets or cleartext http.
+function isRelaxedEnv(): boolean {
+  return process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
 }
 
 function unbracket(hostname: string): string {
@@ -102,7 +105,7 @@ export default function assertSafeTokenEndpoint(raw: string): void {
     throw new InvalidTokenEndpointError('it points at a link-local / metadata address');
   }
 
-  if (isProduction()) {
+  if (!isRelaxedEnv()) {
     if (url.protocol !== 'https:') {
       throw new InvalidTokenEndpointError('it must use https');
     }

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -1,8 +1,10 @@
 import type { RefreshGrantParams, RefreshGrantResult } from './refresh-grant';
 import type CredentialEncryption from '../crypto/credential-encryption';
 import type { Logger } from '../ports/logger-port';
-import type { StoredMcpOAuthCredential } from '../stores/mcp-oauth-credentials-store';
-import type McpOAuthCredentialsStore from '../stores/mcp-oauth-credentials-store';
+import type {
+  McpOAuthCredentialsStore,
+  StoredMcpOAuthCredential,
+} from '../ports/mcp-oauth-credentials-store';
 
 import { DEFAULT_OAUTH_EXPIRY_SKEW_S } from '../defaults';
 import { OAuthInvalidGrantError, OAuthReauthRequiredError } from '../errors';

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -186,7 +186,9 @@ export default class OAuthTokenService {
     try {
       const encrypted = this.encryption.encrypt(refreshToken);
 
-      await this.store.upsert({
+      // Id-scoped so a disconnect (or disconnect + re-authorize) after the grant read leaves an
+      // absent or different row — the rotated-token write-back then can't resurrect or clobber it.
+      await this.store.updateIfPresent(credential.id, {
         userId: credential.userId,
         mcpServerId: credential.mcpServerId,
         refreshTokenEnc: encrypted.ciphertext,

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -78,6 +78,12 @@ export default class OAuthTokenService {
     });
   }
 
+  // Drop the cached access token for a (user, server). Called on credential delete so a disconnect
+  // takes effect immediately, instead of the executor serving the cached token until it expires.
+  evict(userId: number, mcpServerId: string): void {
+    this.cache.delete(`${userId}:${mcpServerId}`);
+  }
+
   private readCache(key: string): string | undefined {
     const entry = this.cache.get(key);
     if (!entry || entry.expiresAtMs === undefined) return undefined;

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -7,7 +7,11 @@ import type {
 } from '../ports/mcp-oauth-credentials-store';
 
 import { DEFAULT_OAUTH_EXPIRY_SKEW_S } from '../defaults';
-import { OAuthInvalidGrantError, OAuthReauthRequiredError } from '../errors';
+import {
+  ExecutorEncryptionKeyMissingError,
+  OAuthInvalidGrantError,
+  OAuthReauthRequiredError,
+} from '../errors';
 import KeyedMutex from './keyed-mutex';
 import defaultRefreshAccessToken from './refresh-grant';
 
@@ -145,17 +149,28 @@ export default class OAuthTokenService {
     }
   }
 
+  // Decrypt happens here. A decrypt failure with the key PRESENT (auth-tag mismatch — the row was
+  // encrypted under a since-rotated/hard-swapped key, or is corrupt) is recoverable: re-consent
+  // re-deposits under the current key, so surface it as needs-oauth-reauth. A missing key
+  // (ExecutorEncryptionKeyMissingError) is an operator misconfig, not re-consent-resolvable, so it
+  // propagates as a terminal error (a re-deposit would just 503 at the deposit endpoint).
   private toGrantParams(credential: StoredMcpOAuthCredential): RefreshGrantParams {
-    return {
-      tokenEndpoint: credential.tokenEndpoint,
-      refreshToken: this.encryption.decrypt(credential.refreshTokenEnc),
-      clientId: credential.clientId,
-      clientSecret: credential.clientSecretEnc
-        ? this.encryption.decrypt(credential.clientSecretEnc)
-        : null,
-      tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
-      scopes: credential.scopes,
-    };
+    try {
+      return {
+        tokenEndpoint: credential.tokenEndpoint,
+        refreshToken: this.encryption.decrypt(credential.refreshTokenEnc),
+        clientId: credential.clientId,
+        clientSecret: credential.clientSecretEnc
+          ? this.encryption.decrypt(credential.clientSecretEnc)
+          : null,
+        tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
+        scopes: credential.scopes,
+      };
+    } catch (error) {
+      if (error instanceof ExecutorEncryptionKeyMissingError) throw error;
+
+      throw new OAuthReauthRequiredError(credential.mcpServerId);
+    }
   }
 
   private async persistRotatedRefreshToken(
@@ -175,7 +190,6 @@ export default class OAuthTokenService {
         tokenEndpoint: credential.tokenEndpoint,
         tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
         scopes: credential.scopes,
-        encKeyVersion: encrypted.encKeyVersion,
       });
     } catch (error) {
       // A failed write-back is not fatal: the access token just obtained is valid. The next refresh

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -198,8 +198,9 @@ export default class OAuthTokenService {
         scopes: credential.scopes,
       });
     } catch (error) {
-      // A failed write-back is not fatal: the access token just obtained is valid. The next refresh
-      // would hit invalid_grant and recover via the re-read path.
+      // A failed write-back is not fatal: the access token just obtained is valid for this call.
+      // The rotated refresh token is lost, so a later refresh forces re-authentication — the safe
+      // fallback, and better than failing the current operation over a transient write error.
       this.logger?.('Error', 'Failed to persist rotated MCP OAuth refresh token', {
         mcpServerId: credential.mcpServerId,
         error: error instanceof Error ? error.message : String(error),

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -1,0 +1,178 @@
+import type { RefreshGrantParams, RefreshGrantResult } from './refresh-grant';
+import type CredentialEncryption from '../crypto/credential-encryption';
+import type { Logger } from '../ports/logger-port';
+import type { StoredMcpOAuthCredential } from '../stores/mcp-oauth-credentials-store';
+import type McpOAuthCredentialsStore from '../stores/mcp-oauth-credentials-store';
+
+import { DEFAULT_OAUTH_EXPIRY_SKEW_S } from '../defaults';
+import { OAuthInvalidGrantError, OAuthReauthRequiredError } from '../errors';
+import KeyedMutex from './keyed-mutex';
+import defaultRefreshAccessToken from './refresh-grant';
+
+interface CachedToken {
+  accessToken: string;
+  // Absent when the grant omitted expires_in: the token is used once but never served from cache.
+  expiresAtMs?: number;
+}
+
+export interface OAuthTokenServiceOptions {
+  store: McpOAuthCredentialsStore;
+  encryption: CredentialEncryption;
+  logger?: Logger;
+  expirySkewS?: number;
+  refreshAccessToken?: (params: RefreshGrantParams) => Promise<RefreshGrantResult>;
+  now?: () => number;
+}
+
+// Acquires an MCP OAuth access token for a (user, server): serves a cached token until it nears
+// expiry, otherwise runs the refresh-token grant under a per-key mutex (one in-flight refresh per
+// user+server in this process) and recovers from a concurrent refresh-token rotation via a single
+// re-read + retry. A missing credential or a genuinely rejected refresh raises
+// OAuthReauthRequiredError so the step pauses for re-authentication.
+export default class OAuthTokenService {
+  private readonly store: McpOAuthCredentialsStore;
+  private readonly encryption: CredentialEncryption;
+  private readonly logger?: Logger;
+  private readonly expirySkewMs: number;
+  private readonly refreshAccessToken: (params: RefreshGrantParams) => Promise<RefreshGrantResult>;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, CachedToken>();
+  private readonly mutex = new KeyedMutex();
+
+  constructor(options: OAuthTokenServiceOptions) {
+    this.store = options.store;
+    this.encryption = options.encryption;
+    this.logger = options.logger;
+    this.expirySkewMs = (options.expirySkewS ?? DEFAULT_OAUTH_EXPIRY_SKEW_S) * 1000;
+    this.refreshAccessToken = options.refreshAccessToken ?? defaultRefreshAccessToken;
+    this.now = options.now ?? Date.now;
+  }
+
+  async getAccessToken(
+    userId: number,
+    mcpServerId: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<string> {
+    const key = `${userId}:${mcpServerId}`;
+    const forceRefresh = options?.forceRefresh ?? false;
+
+    if (!forceRefresh) {
+      const cached = this.readCache(key);
+      if (cached) return cached;
+    }
+
+    return this.mutex.runExclusive(key, async () => {
+      // Re-check inside the lock: a concurrent caller may have just refreshed for this key.
+      if (!forceRefresh) {
+        const cached = this.readCache(key);
+        if (cached) return cached;
+      }
+
+      return this.refreshAndCache(userId, mcpServerId, key);
+    });
+  }
+
+  private readCache(key: string): string | undefined {
+    const entry = this.cache.get(key);
+    if (!entry || entry.expiresAtMs === undefined) return undefined;
+    if (this.now() >= entry.expiresAtMs - this.expirySkewMs) return undefined;
+
+    return entry.accessToken;
+  }
+
+  private async refreshAndCache(userId: number, mcpServerId: string, key: string): Promise<string> {
+    const credential = await this.store.get(userId, mcpServerId);
+    if (!credential) throw new OAuthReauthRequiredError(mcpServerId);
+
+    const result = await this.runGrantWithRotationRetry(credential, userId, mcpServerId);
+
+    this.cache.set(key, {
+      accessToken: result.accessToken,
+      expiresAtMs:
+        result.expiresInS !== undefined ? this.now() + result.expiresInS * 1000 : undefined,
+    });
+
+    if (result.refreshToken) {
+      await this.persistRotatedRefreshToken(credential, result.refreshToken);
+    }
+
+    return result.accessToken;
+  }
+
+  // On invalid_grant a peer instance likely rotated the refresh token out from under us: re-read the
+  // row and retry once with the current token. A second invalid_grant — or an unchanged token, which
+  // means no peer rotated it — is a genuine revocation and forces re-auth.
+  private async runGrantWithRotationRetry(
+    credential: StoredMcpOAuthCredential,
+    userId: number,
+    mcpServerId: string,
+  ): Promise<RefreshGrantResult> {
+    try {
+      return await this.refreshAccessToken(this.toGrantParams(credential));
+    } catch (error) {
+      if (!(error instanceof OAuthInvalidGrantError)) throw error;
+
+      // A peer rotated the refresh token iff the stored value changed since we read it.
+      const latest = await this.store.get(userId, mcpServerId);
+      const wasRotated =
+        latest !== null &&
+        latest.refreshTokenEnc.toString('base64') !== credential.refreshTokenEnc.toString('base64');
+
+      if (!latest || !wasRotated) {
+        throw new OAuthReauthRequiredError(mcpServerId);
+      }
+
+      try {
+        return await this.refreshAccessToken(this.toGrantParams(latest));
+      } catch (retryError) {
+        if (retryError instanceof OAuthInvalidGrantError) {
+          throw new OAuthReauthRequiredError(mcpServerId);
+        }
+
+        throw retryError;
+      }
+    }
+  }
+
+  private toGrantParams(credential: StoredMcpOAuthCredential): RefreshGrantParams {
+    return {
+      tokenEndpoint: credential.tokenEndpoint,
+      refreshToken: this.encryption.decrypt(credential.refreshTokenEnc),
+      clientId: credential.clientId,
+      clientSecret: credential.clientSecretEnc
+        ? this.encryption.decrypt(credential.clientSecretEnc)
+        : null,
+      tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
+      scopes: credential.scopes,
+    };
+  }
+
+  private async persistRotatedRefreshToken(
+    credential: StoredMcpOAuthCredential,
+    refreshToken: string,
+  ): Promise<void> {
+    const encrypted = this.encryption.encrypt(refreshToken);
+
+    try {
+      await this.store.upsert({
+        userId: credential.userId,
+        mcpServerId: credential.mcpServerId,
+        refreshTokenEnc: encrypted.ciphertext,
+        clientId: credential.clientId,
+        clientSecretEnc: credential.clientSecretEnc,
+        clientSecretExpiresAt: credential.clientSecretExpiresAt,
+        tokenEndpoint: credential.tokenEndpoint,
+        tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod,
+        scopes: credential.scopes,
+        encKeyVersion: encrypted.encKeyVersion,
+      });
+    } catch (error) {
+      // A failed write-back is not fatal: the access token just obtained is valid. The next refresh
+      // would hit invalid_grant and recover via the re-read path.
+      this.logger?.('Error', 'Failed to persist rotated MCP OAuth refresh token', {
+        mcpServerId: credential.mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -183,9 +183,9 @@ export default class OAuthTokenService {
     credential: StoredMcpOAuthCredential,
     refreshToken: string,
   ): Promise<void> {
-    const encrypted = this.encryption.encrypt(refreshToken);
-
     try {
+      const encrypted = this.encryption.encrypt(refreshToken);
+
       await this.store.upsert({
         userId: credential.userId,
         mcpServerId: credential.mcpServerId,

--- a/packages/workflow-executor/src/oauth/token-service.ts
+++ b/packages/workflow-executor/src/oauth/token-service.ts
@@ -84,7 +84,11 @@ export default class OAuthTokenService {
     const credential = await this.store.get(userId, mcpServerId);
     if (!credential) throw new OAuthReauthRequiredError(mcpServerId);
 
-    const result = await this.runGrantWithRotationRetry(credential, userId, mcpServerId);
+    const { result, credential: grantedCredential } = await this.runGrantWithRotationRetry(
+      credential,
+      userId,
+      mcpServerId,
+    );
 
     this.cache.set(key, {
       accessToken: result.accessToken,
@@ -93,22 +97,25 @@ export default class OAuthTokenService {
     });
 
     if (result.refreshToken) {
-      await this.persistRotatedRefreshToken(credential, result.refreshToken);
+      await this.persistRotatedRefreshToken(grantedCredential, result.refreshToken);
     }
 
     return result.accessToken;
   }
 
   // On invalid_grant a peer instance likely rotated the refresh token out from under us: re-read the
-  // row and retry once with the current token. A second invalid_grant — or an unchanged token, which
-  // means no peer rotated it — is a genuine revocation and forces re-auth.
+  // row and retry once with the current token; a second invalid_grant (or an unchanged token) is a
+  // genuine revocation and forces re-auth. Returns the credential whose token produced the grant so
+  // the caller writes the rotated token back onto that (current) row, not the stale one.
   private async runGrantWithRotationRetry(
     credential: StoredMcpOAuthCredential,
     userId: number,
     mcpServerId: string,
-  ): Promise<RefreshGrantResult> {
+  ): Promise<{ result: RefreshGrantResult; credential: StoredMcpOAuthCredential }> {
     try {
-      return await this.refreshAccessToken(this.toGrantParams(credential));
+      const result = await this.refreshAccessToken(this.toGrantParams(credential));
+
+      return { result, credential };
     } catch (error) {
       if (!(error instanceof OAuthInvalidGrantError)) throw error;
 
@@ -123,7 +130,9 @@ export default class OAuthTokenService {
       }
 
       try {
-        return await this.refreshAccessToken(this.toGrantParams(latest));
+        const result = await this.refreshAccessToken(this.toGrantParams(latest));
+
+        return { result, credential: latest };
       } catch (retryError) {
         if (retryError instanceof OAuthInvalidGrantError) {
           throw new OAuthReauthRequiredError(mcpServerId);

--- a/packages/workflow-executor/src/ports/ai-model-port.ts
+++ b/packages/workflow-executor/src/ports/ai-model-port.ts
@@ -1,4 +1,9 @@
-import type { BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
+import type {
+  BaseChatModel,
+  McpServerLoadFailure,
+  RemoteTool,
+  ToolConfig,
+} from '@forestadmin/ai-proxy';
 
 export interface GetModelOptions {
   aiConfigName?: string;
@@ -8,5 +13,10 @@ export interface GetModelOptions {
 export interface AiModelPort {
   getModel(options?: GetModelOptions): BaseChatModel;
   loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]>;
+  // Loads tools and exposes per-server failures classified by cause (auth vs connection), so the
+  // OAuth path can tell a revoked token from an unreachable server. Default consumers use loadRemoteTools.
+  loadRemoteToolsWithFailures(
+    configs: Record<string, ToolConfig>,
+  ): Promise<{ tools: RemoteTool[]; failures: McpServerLoadFailure[] }>;
   closeConnections(): Promise<void>;
 }

--- a/packages/workflow-executor/src/ports/mcp-oauth-credentials-store.ts
+++ b/packages/workflow-executor/src/ports/mcp-oauth-credentials-store.ts
@@ -24,5 +24,8 @@ export interface McpOAuthCredentialsStore {
   close(logger?: Logger): Promise<void>;
   get(userId: number, mcpServerId: string): Promise<StoredMcpOAuthCredential | null>;
   upsert(credential: McpOAuthCredentialInput): Promise<void>;
+  // Update-only by the row id the caller read: never inserts, and no-ops if that row is gone or was
+  // re-created with a new id — so a stale write-back can't resurrect or clobber a credential.
+  updateIfPresent(id: number, credential: McpOAuthCredentialInput): Promise<void>;
   delete(userId: number, mcpServerId: string): Promise<void>;
 }

--- a/packages/workflow-executor/src/ports/run-store.ts
+++ b/packages/workflow-executor/src/ports/run-store.ts
@@ -6,4 +6,5 @@ export interface RunStore {
   close(logger?: Logger): Promise<void>;
   getStepExecutions(runId: string): Promise<StepExecutionData[]>;
   saveStepExecution(runId: string, stepExecution: StepExecutionData): Promise<void>;
+  deleteStepExecution(runId: string, stepIndex: number): Promise<void>;
 }

--- a/packages/workflow-executor/src/remote-tool-fetcher.ts
+++ b/packages/workflow-executor/src/remote-tool-fetcher.ts
@@ -6,7 +6,7 @@ import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
 import { injectOauthTokens } from '@forestadmin/ai-proxy';
 
-import { ConfigurationError, OAuthReauthRequiredError } from './errors';
+import { OAuthReauthRequiredError } from './errors';
 
 const OAUTH2_AUTH_TYPE = 'oauth2';
 
@@ -35,13 +35,13 @@ export default class RemoteToolFetcher {
   private readonly workflowPort: WorkflowPort;
   private readonly aiModelPort: AiModelPort;
   private readonly logger: Logger;
-  private readonly oauthTokenService?: OAuthTokenService;
+  private readonly oauthTokenService: OAuthTokenService;
 
   constructor(
     workflowPort: WorkflowPort,
     aiModelPort: AiModelPort,
     logger: Logger,
-    oauthTokenService?: OAuthTokenService,
+    oauthTokenService: OAuthTokenService,
   ) {
     this.workflowPort = workflowPort;
     this.aiModelPort = aiModelPort;
@@ -77,13 +77,6 @@ export default class RemoteToolFetcher {
     mcpServerId: string,
     userId: number,
   ): Promise<FetchRemoteToolsResult> {
-    if (!this.oauthTokenService) {
-      throw new ConfigurationError(
-        `OAuth-protected MCP server "${mcpServerId}" requires the database-backed executor ` +
-          `(no credential store is configured)`,
-      );
-    }
-
     const tokenService = this.oauthTokenService;
 
     const attemptLoad = async (

--- a/packages/workflow-executor/src/remote-tool-fetcher.ts
+++ b/packages/workflow-executor/src/remote-tool-fetcher.ts
@@ -1,7 +1,14 @@
+import type OAuthTokenService from './oauth/token-service';
 import type { AiModelPort } from './ports/ai-model-port';
 import type { Logger } from './ports/logger-port';
 import type { WorkflowPort } from './ports/workflow-port';
 import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
+
+import { injectOauthTokens } from '@forestadmin/ai-proxy';
+
+import { ConfigurationError, OAuthReauthRequiredError } from './errors';
+
+const OAUTH2_AUTH_TYPE = 'oauth2';
 
 // Match by config.id, not by Record key: server names can collide across configs.
 export function scopeConfigsToServer(
@@ -11,23 +18,38 @@ export function scopeConfigsToServer(
   return Object.fromEntries(Object.entries(configs).filter(([, cfg]) => cfg.id === mcpServerId));
 }
 
+function readAuthType(config: ToolConfig | undefined): string | undefined {
+  return (config as { authType?: string } | undefined)?.authType;
+}
+
 export interface FetchRemoteToolsResult {
   tools: RemoteTool[];
   mcpServerName?: string;
+  // Present only for OAuth2 servers: re-mints the token (forced refresh) and reloads the tools, so
+  // the executor can retry once after an upstream 401 on a tool call. Throws OAuthReauthRequiredError
+  // when the credential can no longer be refreshed.
+  reloadWithFreshAuth?: () => Promise<RemoteTool[]>;
 }
 
 export default class RemoteToolFetcher {
   private readonly workflowPort: WorkflowPort;
   private readonly aiModelPort: AiModelPort;
   private readonly logger: Logger;
+  private readonly oauthTokenService?: OAuthTokenService;
 
-  constructor(workflowPort: WorkflowPort, aiModelPort: AiModelPort, logger: Logger) {
+  constructor(
+    workflowPort: WorkflowPort,
+    aiModelPort: AiModelPort,
+    logger: Logger,
+    oauthTokenService?: OAuthTokenService,
+  ) {
     this.workflowPort = workflowPort;
     this.aiModelPort = aiModelPort;
     this.logger = logger;
+    this.oauthTokenService = oauthTokenService;
   }
 
-  async fetch(mcpServerId: string): Promise<FetchRemoteToolsResult> {
+  async fetch(mcpServerId: string, userId: number): Promise<FetchRemoteToolsResult> {
     const configs = await this.workflowPort.getMcpServerConfigs();
     const scoped = scopeConfigsToServer(configs, mcpServerId);
     const [mcpServerName] = Object.keys(scoped);
@@ -36,11 +58,65 @@ export default class RemoteToolFetcher {
 
     if (Object.keys(scoped).length === 0) return { tools: [], mcpServerName };
 
-    const tools = await this.aiModelPort.loadRemoteTools(scoped);
+    if (readAuthType(scoped[mcpServerName]) === OAUTH2_AUTH_TYPE) {
+      return this.fetchOAuthTools(scoped, mcpServerName, mcpServerId, userId);
+    }
 
+    const tools = await this.aiModelPort.loadRemoteTools(scoped);
     this.errorOnPartialLoadFailure(scoped, tools, mcpServerId, mcpServerName);
 
     return { tools, mcpServerName };
+  }
+
+  // OAuth2 path: acquire a per-user access token, inject it as a Bearer header, then list tools.
+  // Tool listing is the first authenticated call, so an auth failure here forces one token refresh
+  // and a single retry; a still-failing load is a genuine re-auth case.
+  private async fetchOAuthTools(
+    scoped: Record<string, ToolConfig>,
+    mcpServerName: string,
+    mcpServerId: string,
+    userId: number,
+  ): Promise<FetchRemoteToolsResult> {
+    if (!this.oauthTokenService) {
+      throw new ConfigurationError(
+        `OAuth-protected MCP server "${mcpServerId}" requires the database-backed executor ` +
+          `(no credential store is configured)`,
+      );
+    }
+
+    const tokenService = this.oauthTokenService;
+
+    const attemptLoad = async (
+      forceRefresh: boolean,
+    ): Promise<{ tools: RemoteTool[]; hasAuthFailure: boolean }> => {
+      const token = await tokenService.getAccessToken(userId, mcpServerId, { forceRefresh });
+      const injected =
+        injectOauthTokens({
+          configs: scoped,
+          tokensByMcpServerName: { [mcpServerName]: `Bearer ${token}` },
+        }) ?? scoped;
+      const { tools, failures } = await this.aiModelPort.loadRemoteToolsWithFailures(injected);
+
+      return { tools, hasAuthFailure: failures.some(failure => failure.kind === 'auth') };
+    };
+
+    const reloadWithFreshAuth = async (): Promise<RemoteTool[]> => {
+      const attempt = await attemptLoad(true);
+      if (attempt.hasAuthFailure) throw new OAuthReauthRequiredError(mcpServerId);
+      this.errorOnPartialLoadFailure(scoped, attempt.tools, mcpServerId, mcpServerName);
+
+      return attempt.tools;
+    };
+
+    const initial = await attemptLoad(false);
+
+    if (initial.hasAuthFailure) {
+      return { tools: await reloadWithFreshAuth(), mcpServerName, reloadWithFreshAuth };
+    }
+
+    this.errorOnPartialLoadFailure(scoped, initial.tools, mcpServerId, mcpServerName);
+
+    return { tools: initial.tools, mcpServerName, reloadWithFreshAuth };
   }
 
   // Distinguish "no configs at all" (deployment misconfig) from "configs exist but none match"

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -51,9 +51,9 @@ export interface RunnerConfig {
   // Max number of ADDITIONAL steps auto-chained via /update-step response before yielding to the
   // next poll cycle (counted after the initial step). 0 disables chaining entirely. Default 50.
   maxChainDepth?: number;
-  // Wired only by the database-backed executor; absent in-memory, where the fetcher raises a
-  // ConfigurationError for oauth2 steps.
-  mcpOAuthTokenService?: OAuthTokenService;
+  // Per-user OAuth access-token service for oauth2 MCP steps. Wired by both the in-memory and
+  // database executors, sharing the credential store the HTTP deposit endpoint writes to.
+  mcpOAuthTokenService: OAuthTokenService;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -1,4 +1,5 @@
 import type { StepContextConfig } from './executors/step-executor-factory';
+import type OAuthTokenService from './oauth/token-service';
 import type { ActivityLogPortFactory } from './ports/activity-log-port';
 import type { AgentPort } from './ports/agent-port';
 import type { AiModelPort } from './ports/ai-model-port';
@@ -50,6 +51,9 @@ export interface RunnerConfig {
   // Max number of ADDITIONAL steps auto-chained via /update-step response before yielding to the
   // next poll cycle (counted after the initial step). 0 disables chaining entirely. Default 50.
   maxChainDepth?: number;
+  // Wired only by the database-backed executor; absent in-memory, where the fetcher raises a
+  // ConfigurationError for oauth2 steps.
+  mcpOAuthTokenService?: OAuthTokenService;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
@@ -70,6 +74,7 @@ export default class Runner {
       config.workflowPort,
       config.aiModelPort,
       this.logger,
+      config.mcpOAuthTokenService,
     );
   }
 
@@ -313,7 +318,7 @@ export default class Runner {
           currentStep,
           this.contextConfig,
           this.config.activityLogPortFactory.forRun(currentToken),
-          mcpServerId => this.remoteToolFetcher.fetch(mcpServerId),
+          (mcpServerId, userId) => this.remoteToolFetcher.fetch(mcpServerId, userId),
           currentIncomingData,
         );
         result = await executor.execute();

--- a/packages/workflow-executor/src/stores/database-mcp-oauth-credentials-store.ts
+++ b/packages/workflow-executor/src/stores/database-mcp-oauth-credentials-store.ts
@@ -196,6 +196,31 @@ export default class DatabaseMcpOAuthCredentialsStore implements McpOAuthCredent
     });
   }
 
+  async updateIfPresent(id: number, credential: McpOAuthCredentialInput): Promise<void> {
+    // Single atomic UPDATE … WHERE id — affects zero rows if that row was deleted or re-created.
+    await this.sequelize.query(
+      `UPDATE ${this.tableReference} SET ` +
+        'refresh_token_enc = :refreshTokenEnc, client_id = :clientId, ' +
+        'client_secret_enc = :clientSecretEnc, client_secret_expires_at = :clientSecretExpiresAt, ' +
+        'token_endpoint = :tokenEndpoint, token_endpoint_auth_method = :tokenEndpointAuthMethod, ' +
+        'scopes = :scopes, updated_at = :now ' +
+        'WHERE id = :id',
+      {
+        replacements: {
+          id,
+          refreshTokenEnc: credential.refreshTokenEnc,
+          clientId: credential.clientId ?? null,
+          clientSecretEnc: credential.clientSecretEnc ?? null,
+          clientSecretExpiresAt: credential.clientSecretExpiresAt ?? null,
+          tokenEndpoint: credential.tokenEndpoint,
+          tokenEndpointAuthMethod: credential.tokenEndpointAuthMethod ?? null,
+          scopes: credential.scopes ?? null,
+          now: new Date(),
+        },
+      },
+    );
+  }
+
   async delete(userId: number, mcpServerId: string): Promise<void> {
     await this.sequelize.query(
       `DELETE FROM ${this.tableReference} WHERE user_id = :userId AND mcp_server_id = :mcpServerId`,

--- a/packages/workflow-executor/src/stores/database-store.ts
+++ b/packages/workflow-executor/src/stores/database-store.ts
@@ -159,6 +159,15 @@ export default class DatabaseStore implements RunStore {
     });
   }
 
+  async deleteStepExecution(runId: string, stepIndex: number): Promise<void> {
+    return this.callPort('deleteStepExecution', async () => {
+      await this.sequelize.query(
+        `DELETE FROM ${this.tableReference} WHERE run_id = :runId AND step_index = :stepIndex`,
+        { replacements: { runId, stepIndex } },
+      );
+    });
+  }
+
   async close(logger?: Logger): Promise<void> {
     return this.callPort('close', async () => {
       try {

--- a/packages/workflow-executor/src/stores/in-memory-mcp-oauth-credentials-store.ts
+++ b/packages/workflow-executor/src/stores/in-memory-mcp-oauth-credentials-store.ts
@@ -32,6 +32,15 @@ export default class InMemoryMcpOAuthCredentialsStore implements McpOAuthCredent
     this.nextId += 1;
   }
 
+  async updateIfPresent(id: number, credential: McpOAuthCredentialInput): Promise<void> {
+    const key = InMemoryMcpOAuthCredentialsStore.key(credential.userId, credential.mcpServerId);
+    const existing = this.data.get(key);
+    // Only update the exact row the caller read; a re-created row has a new id, so skip it.
+    if (!existing || existing.id !== id) return;
+
+    this.data.set(key, { ...credential, id });
+  }
+
   async delete(userId: number, mcpServerId: string): Promise<void> {
     this.data.delete(InMemoryMcpOAuthCredentialsStore.key(userId, mcpServerId));
   }

--- a/packages/workflow-executor/src/stores/in-memory-store.ts
+++ b/packages/workflow-executor/src/stores/in-memory-store.ts
@@ -41,6 +41,12 @@ export default class InMemoryStore implements RunStore {
     });
   }
 
+  async deleteStepExecution(runId: string, stepIndex: number): Promise<void> {
+    return this.callPort('deleteStepExecution', async () => {
+      this.data.get(runId)?.delete(stepIndex);
+    });
+  }
+
   private async callPort<T>(operation: string, fn: () => Promise<T>): Promise<T> {
     try {
       return await fn();

--- a/packages/workflow-executor/src/types/validated/step-outcome.ts
+++ b/packages/workflow-executor/src/types/validated/step-outcome.ts
@@ -9,6 +9,12 @@ export type BaseStepStatus = z.infer<typeof BaseStepStatusSchema>;
 export const RecordStepStatusSchema = z.enum(['success', 'error', 'awaiting-input']);
 export type RecordStepStatus = z.infer<typeof RecordStepStatusSchema>;
 
+// Typed reason for an awaiting-input pause the user must resolve out of band. The field name is
+// `awaitingInputReason` (the orchestrator renamed it from `reason`); the Forest server validates it
+// and the front reads it to prompt the matching action.
+export const AwaitingInputReasonSchema = z.enum(['needs-oauth-reauth']);
+export type AwaitingInputReason = z.infer<typeof AwaitingInputReasonSchema>;
+
 export type StepStatus = BaseStepStatus | RecordStepStatus;
 
 /**
@@ -48,6 +54,8 @@ export const McpStepOutcomeSchema = z
     ...baseOutcomeFields,
     type: z.literal('mcp'),
     status: RecordStepStatusSchema,
+    /** Present when status is 'awaiting-input' because the step paused for re-authentication. */
+    awaitingInputReason: AwaitingInputReasonSchema.optional(),
   })
   .strict();
 export type McpStepOutcome = z.infer<typeof McpStepOutcomeSchema>;

--- a/packages/workflow-executor/src/types/validated/step-outcome.ts
+++ b/packages/workflow-executor/src/types/validated/step-outcome.ts
@@ -9,9 +9,8 @@ export type BaseStepStatus = z.infer<typeof BaseStepStatusSchema>;
 export const RecordStepStatusSchema = z.enum(['success', 'error', 'awaiting-input']);
 export type RecordStepStatus = z.infer<typeof RecordStepStatusSchema>;
 
-// Typed reason for an awaiting-input pause the user must resolve out of band. The field name is
-// `awaitingInputReason` (the orchestrator renamed it from `reason`); the Forest server validates it
-// and the front reads it to prompt the matching action.
+// Typed reason for an awaiting-input pause the user must resolve out of band: the Forest server
+// validates it and the front reads it to prompt the matching action.
 export const AwaitingInputReasonSchema = z.enum(['needs-oauth-reauth']);
 export type AwaitingInputReason = z.infer<typeof AwaitingInputReasonSchema>;
 

--- a/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
@@ -2,12 +2,14 @@ import AiClientAdapter from '../../src/adapters/ai-client-adapter';
 
 const mockGetModel = jest.fn().mockReturnValue({ invoke: jest.fn() });
 const mockLoadRemoteTools = jest.fn().mockResolvedValue([]);
+const mockLoadRemoteToolsWithFailures = jest.fn().mockResolvedValue({ tools: [], failures: [] });
 const mockCloseConnections = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('@forestadmin/ai-proxy', () => ({
   AiClient: jest.fn().mockImplementation(() => ({
     getModel: mockGetModel,
     loadRemoteTools: mockLoadRemoteTools,
+    loadRemoteToolsWithFailures: mockLoadRemoteToolsWithFailures,
     closeConnections: mockCloseConnections,
   })),
 }));
@@ -42,6 +44,15 @@ describe('AiClientAdapter', () => {
     await adapter.loadRemoteTools(configs);
 
     expect(mockLoadRemoteTools).toHaveBeenCalledWith(configs);
+  });
+
+  it('delegates loadRemoteToolsWithFailures to AiClient', async () => {
+    const adapter = new AiClientAdapter([]);
+    const configs = {};
+
+    await adapter.loadRemoteToolsWithFailures(configs);
+
+    expect(mockLoadRemoteToolsWithFailures).toHaveBeenCalledWith(configs);
   });
 
   it('delegates closeConnections to AiClient', async () => {

--- a/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
+++ b/packages/workflow-executor/test/adapters/always-error-ai-model-port.test.ts
@@ -32,6 +32,15 @@ describe('AlwaysErrorAiModelPort', () => {
     });
   });
 
+  describe('loadRemoteToolsWithFailures', () => {
+    it('returns no tools and no failures', async () => {
+      await expect(port.loadRemoteToolsWithFailures({} as never)).resolves.toEqual({
+        tools: [],
+        failures: [],
+      });
+    });
+  });
+
   describe('closeConnections', () => {
     it('resolves without error', async () => {
       await expect(port.closeConnections()).resolves.toBeUndefined();

--- a/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
@@ -2,6 +2,7 @@ import ServerAiAdapter from '../../src/adapters/server-ai-adapter';
 
 const mockGetModel = jest.fn().mockReturnValue({ id: 'fake-model' });
 const mockLoadRemoteTools = jest.fn().mockResolvedValue([]);
+const mockLoadRemoteToolsWithFailures = jest.fn().mockResolvedValue({ tools: [], failures: [] });
 const mockCloseConnections = jest.fn().mockResolvedValue(undefined);
 const mockAiClientConstructor = jest.fn();
 
@@ -12,6 +13,7 @@ jest.mock('@forestadmin/ai-proxy', () => ({
     return {
       getModel: mockGetModel,
       loadRemoteTools: mockLoadRemoteTools,
+      loadRemoteToolsWithFailures: mockLoadRemoteToolsWithFailures,
       closeConnections: mockCloseConnections,
     };
   }),
@@ -129,6 +131,17 @@ describe('ServerAiAdapter', () => {
 
       expect(mockLoadRemoteTools).toHaveBeenCalledWith(configs);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('loadRemoteToolsWithFailures', () => {
+    it('delegates to internal AiClient with the given configs', async () => {
+      const configs = {};
+
+      const result = await adapter.loadRemoteToolsWithFailures(configs);
+
+      expect(mockLoadRemoteToolsWithFailures).toHaveBeenCalledWith(configs);
+      expect(result).toEqual({ tools: [], failures: [] });
     });
   });
 

--- a/packages/workflow-executor/test/adapters/step-outcome-to-update-step-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-outcome-to-update-step-mapper.test.ts
@@ -179,4 +179,50 @@ describe('toUpdateStepRequest', () => {
 
     expect(body.stepUpdate.stepIndex).toBe(7);
   });
+
+  describe('awaitingInputReason propagation', () => {
+    it('puts awaitingInputReason in the update-step context (done=false) when an mcp step pauses for reauth', () => {
+      const outcome: StepOutcome = {
+        type: 'mcp',
+        stepId: 'step-1',
+        stepIndex: 4,
+        status: 'awaiting-input',
+        awaitingInputReason: 'needs-oauth-reauth',
+      };
+
+      const body = toUpdateStepRequest('42', outcome);
+
+      expect(body.stepUpdate.attributes).toEqual({
+        done: false,
+        context: { status: 'awaiting-input', awaitingInputReason: 'needs-oauth-reauth' },
+      });
+      expect(body.executionStatus).toEqual({ type: 'awaiting-input' });
+    });
+
+    it('omits awaitingInputReason for an awaiting-input pause without a reason', () => {
+      const outcome: StepOutcome = {
+        type: 'mcp',
+        stepId: 'step-1',
+        stepIndex: 0,
+        status: 'awaiting-input',
+      };
+
+      const body = toUpdateStepRequest('42', outcome);
+
+      expect(body.stepUpdate.attributes.context).toEqual({ status: 'awaiting-input' });
+    });
+
+    it('omits awaitingInputReason for a success outcome', () => {
+      const outcome: StepOutcome = {
+        type: 'mcp',
+        stepId: 'step-1',
+        stepIndex: 0,
+        status: 'success',
+      };
+
+      const body = toUpdateStepRequest('42', outcome);
+
+      expect(body.stepUpdate.attributes.context).toEqual({ status: 'success' });
+    });
+  });
 });

--- a/packages/workflow-executor/test/build-workflow-executor.test.ts
+++ b/packages/workflow-executor/test/build-workflow-executor.test.ts
@@ -3,6 +3,7 @@ import { buildDatabaseExecutor, buildInMemoryExecutor } from '../src/build-workf
 import CredentialEncryption from '../src/crypto/credential-encryption';
 import { DEFAULT_SCHEMA_CACHE_TTL_S } from '../src/defaults';
 import ExecutorHttpServer from '../src/http/executor-http-server';
+import OAuthTokenService from '../src/oauth/token-service';
 import Runner from '../src/runner';
 import SchemaCache from '../src/schema-cache';
 import DatabaseMcpOAuthCredentialsStore from '../src/stores/database-mcp-oauth-credentials-store';
@@ -68,6 +69,14 @@ describe('buildInMemoryExecutor', () => {
         mcpOAuthCredentialsStore: expect.any(InMemoryMcpOAuthCredentialsStore),
         credentialEncryption: expect.any(CredentialEncryption),
       }),
+    );
+  });
+
+  it('wires an OAuth token service into the in-memory runner', () => {
+    buildInMemoryExecutor(BASE_OPTIONS);
+
+    expect(MockedRunner).toHaveBeenCalledWith(
+      expect.objectContaining({ mcpOAuthTokenService: expect.any(OAuthTokenService) }),
     );
   });
 

--- a/packages/workflow-executor/test/errors.test.ts
+++ b/packages/workflow-executor/test/errors.test.ts
@@ -2,6 +2,9 @@ import {
   AiModelPortError,
   InvalidPendingDataError,
   NoMcpToolsError,
+  OAuthInvalidGrantError,
+  OAuthReauthRequiredError,
+  OAuthRefreshError,
   PendingDataNotFoundError,
   extractErrorMessage,
 } from '../src/errors';
@@ -141,5 +144,36 @@ describe('InvalidPendingDataError', () => {
     const err = new InvalidPendingDataError([]);
 
     expect(err.userMessage).toBe('The request body is invalid.');
+  });
+});
+
+describe('OAuthReauthRequiredError', () => {
+  it("defaults awaitingInputReason to 'needs-oauth-reauth' and names the server in the technical message", () => {
+    const err = new OAuthReauthRequiredError('srv-1');
+
+    expect(err.awaitingInputReason).toBe('needs-oauth-reauth');
+    expect(err.message).toMatch(/srv-1/);
+  });
+
+  it('keeps the user-facing message free of the internal server id', () => {
+    const err = new OAuthReauthRequiredError('srv-1');
+
+    expect(err.userMessage).not.toMatch(/srv-1/);
+  });
+});
+
+describe('OAuthRefreshError', () => {
+  it('prefixes the technical message and stores the cause', () => {
+    const cause = new Error('5xx');
+    const err = new OAuthRefreshError('endpoint unreachable', cause);
+
+    expect(err.message).toMatch(/endpoint unreachable/);
+    expect(err.cause).toBe(cause);
+  });
+});
+
+describe('OAuthInvalidGrantError', () => {
+  it('includes the detail when provided', () => {
+    expect(new OAuthInvalidGrantError('token expired').message).toMatch(/token expired/);
   });
 });

--- a/packages/workflow-executor/test/executors/base-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/base-step-executor.test.ts
@@ -98,6 +98,7 @@ function makeMockRunStore(stepExecutions: StepExecutionData[] = []): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue(stepExecutions),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/packages/workflow-executor/test/executors/condition-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/condition-step-executor.test.ts
@@ -31,6 +31,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/executors/guidance-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/guidance-step-executor.test.ts
@@ -20,6 +20,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -130,6 +130,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -8,7 +8,7 @@ import type { McpStepDefinition } from '../../src/types/validated/step-definitio
 
 import RemoteTool from '@forestadmin/ai-proxy/src/remote-tool';
 
-import { RunStorePortError, StepStateError } from '../../src/errors';
+import { OAuthReauthRequiredError, RunStorePortError, StepStateError } from '../../src/errors';
 import ActivityLog from '../../src/executors/activity-log';
 import AgentWithLog from '../../src/executors/agent-with-log';
 import McpStepExecutor from '../../src/executors/mcp-step-executor';
@@ -1135,5 +1135,115 @@ describe('McpStepExecutor', () => {
         expect.objectContaining({ mcpServerId: 'id-missing', mcpServerName: undefined }),
       );
     });
+  });
+});
+
+// The executor's OAuth responsibility is the tool-call 401 retry and the re-auth pause mapping.
+// authType identification, the credential lookup, list-tools retry and Bearer injection live in
+// RemoteToolFetcher / StepExecutorFactory and are covered by their own suites.
+describe('McpStepExecutor — OAuth2 tool-call re-authentication', () => {
+  const authError = () => new Error('Request failed with status 401');
+
+  function makeAutomated(invoke: jest.Mock) {
+    const tool = new MockRemoteTool({
+      name: 'send_notification',
+      sourceId: 'mcp-server-1',
+      invoke,
+    });
+    const { model } = makeMockModel('send_notification', { message: 'Hello' });
+    const context = makeContext({
+      model,
+      stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+    });
+
+    return { tool, context };
+  }
+
+  it('force-refreshes, rebuilds the tool, and retries once when the call returns 401', async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+    const freshInvoke = jest.fn().mockResolvedValue('ok-after-refresh');
+    const freshTool = new MockRemoteTool({
+      name: 'send_notification',
+      sourceId: 'mcp-server-1',
+      invoke: freshInvoke,
+    });
+    const reloadWithFreshAuth = jest.fn().mockResolvedValue([freshTool]);
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome.status).toBe('success');
+    expect(reloadWithFreshAuth).toHaveBeenCalledTimes(1);
+    expect(freshInvoke).toHaveBeenCalledWith({ message: 'Hello' });
+  });
+
+  it("pauses with awaiting-input/'needs-oauth-reauth' when the credential can no longer be refreshed", async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+    const reloadWithFreshAuth = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('srv'));
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome).toMatchObject({
+      status: 'awaiting-input',
+      awaitingInputReason: 'needs-oauth-reauth',
+    });
+  });
+
+  it("pauses with 'needs-oauth-reauth' when the retried call still returns 401", async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+    const freshTool = new MockRemoteTool({
+      name: 'send_notification',
+      sourceId: 'mcp-server-1',
+      invoke: jest.fn().mockRejectedValue(authError()),
+    });
+    const reloadWithFreshAuth = jest.fn().mockResolvedValue([freshTool]);
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome).toMatchObject({
+      status: 'awaiting-input',
+      awaitingInputReason: 'needs-oauth-reauth',
+    });
+    expect(reloadWithFreshAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh for a non-auth tool error — surfaces it as a step error', async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(new Error('boom')));
+    const reloadWithFreshAuth = jest.fn();
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome.status).toBe('error');
+    expect(reloadWithFreshAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh on a 401 for a bearer/none step (no reload hook)', async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+
+    const result = await new McpStepExecutor(context, [tool], 'srv').execute();
+
+    expect(result.stepOutcome.status).toBe('error');
+  });
+
+  it('surfaces a non-auth error from the retried call as a step error (not a reauth pause)', async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+    const freshTool = new MockRemoteTool({
+      name: 'send_notification',
+      sourceId: 'mcp-server-1',
+      invoke: jest.fn().mockRejectedValue(new Error('downstream 500')),
+    });
+    const reloadWithFreshAuth = jest.fn().mockResolvedValue([freshTool]);
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome.status).toBe('error');
+  });
+
+  it('errors when the refreshed tool set no longer contains the selected tool', async () => {
+    const { tool, context } = makeAutomated(jest.fn().mockRejectedValue(authError()));
+    const reloadWithFreshAuth = jest.fn().mockResolvedValue([]);
+
+    const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
+
+    expect(result.stepOutcome.status).toBe('error');
   });
 });

--- a/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/mcp-step-executor.test.ts
@@ -14,6 +14,7 @@ import AgentWithLog from '../../src/executors/agent-with-log';
 import McpStepExecutor from '../../src/executors/mcp-step-executor';
 import SchemaCache from '../../src/schema-cache';
 import SchemaResolver from '../../src/schema-resolver';
+import InMemoryStore from '../../src/stores/in-memory-store';
 import { StepExecutionMode, StepType } from '../../src/types/validated/step-definition';
 
 // ---------------------------------------------------------------------------
@@ -58,6 +59,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -1245,5 +1247,165 @@ describe('McpStepExecutor — OAuth2 tool-call re-authentication', () => {
     const result = await new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth).execute();
 
     expect(result.stepOutcome.status).toBe('error');
+  });
+});
+
+// On a re-auth pause the executor clears the 'executing' write-ahead marker so the resumed step is
+// not rejected as interrupted; the failed tool call still surfaces as a failed audit-log entry.
+describe('McpStepExecutor — re-auth pause hardening', () => {
+  const authError = () => new Error('Request failed with status 401');
+
+  // A FullyAutomated step whose tool call 401s and whose refresh cannot recover → re-auth pause.
+  function pauseFor(runStore: ReturnType<typeof makeMockRunStore> | InMemoryStore) {
+    const tool = new MockRemoteTool({
+      name: 'send_notification',
+      sourceId: 'mcp-server-1',
+      invoke: jest.fn().mockRejectedValue(authError()),
+    });
+    const reloadWithFreshAuth = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('srv'));
+    const context = makeContext({
+      runStore: runStore as RunStore,
+      stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+    });
+
+    return new McpStepExecutor(context, [tool], 'srv', reloadWithFreshAuth);
+  }
+
+  describe('idempotency phase cleared on the re-auth pause path', () => {
+    it('does not leave the step execution marked executing after pausing for re-auth', async () => {
+      // GIVEN a real store so the persisted write-ahead marker is observable.
+      const store = new InMemoryStore();
+
+      // WHEN the step pauses for re-authentication.
+      const result = await pauseFor(store).execute();
+
+      // THEN it pauses, and the 'executing' marker written by beforeCall must not survive — else
+      // a resume would read a stale marker.
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      const persisted = await store.getStepExecutions('run-1');
+      const mcpExecution = persisted.find(execution => execution.stepIndex === 0) as
+        | McpStepExecutionData
+        | undefined;
+      expect(mcpExecution?.idempotencyPhase).not.toBe('executing');
+    });
+
+    it('resumes to success after a re-auth pause instead of failing as interrupted', async () => {
+      // GIVEN a step that paused for re-auth, persisting its state in a shared store.
+      const store = new InMemoryStore();
+      const pause = await pauseFor(store).execute();
+      expect(pause.stepOutcome.status).toBe('awaiting-input');
+
+      // WHEN the user reconnects and the step is re-dispatched against the same store, with the
+      // tool now succeeding.
+      const reconnectedTool = new MockRemoteTool({
+        name: 'send_notification',
+        sourceId: 'mcp-server-1',
+        invoke: jest.fn().mockResolvedValue('ok-after-reconnect'),
+      });
+      const resumeContext = makeContext({
+        runStore: store,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const resumed = await new McpStepExecutor(resumeContext, [reconnectedTool], 'srv').execute();
+
+      // THEN checkIdempotency must not throw StepStateError on the stale 'executing' marker; the
+      // step runs to success.
+      expect(resumed.stepOutcome.status).toBe('success');
+    });
+
+    it('preserves the approved pendingData on a confirmation-flow re-auth pause so resume replays it', async () => {
+      // GIVEN a confirmation-flow step with a user-approved tool call already persisted.
+      const store = new InMemoryStore();
+      await store.saveStepExecution('run-1', {
+        type: 'mcp',
+        stepIndex: 0,
+        pendingData: {
+          name: 'send_notification',
+          sourceId: 'mcp-server-1',
+          input: { message: 'Hello' },
+        },
+        userConfirmation: { userConfirmed: true },
+      } as McpStepExecutionData);
+      const tool = new MockRemoteTool({
+        name: 'send_notification',
+        sourceId: 'mcp-server-1',
+        invoke: jest.fn().mockRejectedValue(authError()),
+      });
+      const reloadWithFreshAuth = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('srv'));
+      const context = makeContext({ runStore: store });
+
+      // WHEN the approved call 401s and cannot re-auth.
+      const result = await new McpStepExecutor(
+        context,
+        [tool],
+        'srv',
+        reloadWithFreshAuth,
+      ).execute();
+
+      // THEN the marker is cleared but the approved call is kept, so a resume replays it rather than
+      // re-selecting a tool.
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      const persisted = (await store.getStepExecutions('run-1')).find(e => e.stepIndex === 0) as
+        | McpStepExecutionData
+        | undefined;
+      expect(persisted?.idempotencyPhase).not.toBe('executing');
+      expect(persisted?.pendingData).toEqual({
+        name: 'send_notification',
+        sourceId: 'mcp-server-1',
+        input: { message: 'Hello' },
+      });
+    });
+
+    it('surfaces a store error from the re-auth cleanup as a step error, not a stuck pause', async () => {
+      // GIVEN cleanup that fails — a left-behind 'executing' marker would make the pause
+      // non-resumable, so the failure must surface as an error rather than a stuck awaiting-input.
+      const store = new InMemoryStore();
+      jest
+        .spyOn(store, 'deleteStepExecution')
+        .mockRejectedValue(new RunStorePortError('deleteStepExecution', new Error('store down')));
+
+      // WHEN a FullyAutomated step pauses for re-auth (no pendingData → cleanup goes via delete).
+      const result = await pauseFor(store).execute();
+
+      // THEN the store failure propagates to a step error instead of a non-resumable pause.
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('The step state could not be accessed. Please retry.');
+    });
+  });
+
+  describe('re-auth pause surfaces the tool-call failure in the audit log', () => {
+    it('marks the activity-log entry failed while the step pauses for re-auth', async () => {
+      // GIVEN an activity-log port we can inspect.
+      const activityLogPort = {
+        createPending: jest.fn().mockResolvedValue({ id: 'log-1', index: '0' }),
+        markSucceeded: jest.fn().mockResolvedValue(undefined),
+        markFailed: jest.fn().mockResolvedValue(undefined),
+      };
+      const tool = new MockRemoteTool({
+        name: 'send_notification',
+        sourceId: 'mcp-server-1',
+        invoke: jest.fn().mockRejectedValue(authError()),
+      });
+      const reloadWithFreshAuth = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('srv'));
+      const context = makeContext({
+        activityLogPort,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      // WHEN the step pauses for re-authentication.
+      const result = await new McpStepExecutor(
+        context,
+        [tool],
+        'srv',
+        reloadWithFreshAuth,
+      ).execute();
+
+      // THEN the failed tool call is audited as failed, while the step itself pauses (not errors).
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(activityLogPort.createPending).toHaveBeenCalledTimes(1);
+      expect(activityLogPort.markFailed).toHaveBeenCalledTimes(1);
+      expect(activityLogPort.markSucceeded).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -72,6 +72,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/executors/step-executor-factory.test.ts
+++ b/packages/workflow-executor/test/executors/step-executor-factory.test.ts
@@ -1,0 +1,102 @@
+import type { StepContextConfig } from '../../src/executors/step-executor-factory';
+import type { ActivityLogPort } from '../../src/ports/activity-log-port';
+import type { AvailableStepExecution } from '../../src/types/execution-context';
+
+import { OAuthReauthRequiredError } from '../../src/errors';
+import StepExecutorFactory from '../../src/executors/step-executor-factory';
+import SchemaCache from '../../src/schema-cache';
+import { StepExecutionMode, StepType } from '../../src/types/validated/step-definition';
+
+const activityLogPort = {
+  createPending: jest.fn().mockResolvedValue({ id: 'log-1', index: '0' }),
+  markSucceeded: jest.fn().mockResolvedValue(undefined),
+  markFailed: jest.fn().mockResolvedValue(undefined),
+} as unknown as ActivityLogPort;
+
+function makeStep(): AvailableStepExecution {
+  return {
+    runId: 'run-1',
+    stepId: 'step-1',
+    stepIndex: 0,
+    collectionId: 'col-1',
+    baseRecordRef: { collectionName: 'customers', recordId: [1], stepIndex: 0 },
+    stepDefinition: {
+      type: StepType.Mcp,
+      executionType: StepExecutionMode.FullyAutomated,
+      mcpServerId: 'srv-1',
+    },
+    previousSteps: [],
+    user: {
+      id: 7,
+      email: 'a@b.com',
+      firstName: 'A',
+      lastName: 'B',
+      team: 't',
+      renderingId: 1,
+      role: 'admin',
+      permissionLevel: 'admin',
+      tags: {},
+    },
+  } as unknown as AvailableStepExecution;
+}
+
+function makeContextConfig(): StepContextConfig {
+  return {
+    aiModelPort: { getModel: jest.fn().mockReturnValue({}) },
+    agentPort: {},
+    workflowPort: {},
+    runStore: {},
+    schemaCache: new SchemaCache(),
+    logger: jest.fn(),
+  } as unknown as StepContextConfig;
+}
+
+describe('StepExecutorFactory.create — MCP OAuth re-auth', () => {
+  it('maps OAuthReauthRequiredError from tool loading to an awaiting-input outcome with the typed reason', async () => {
+    const fetchRemoteTools = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('srv-1'));
+
+    const executor = await StepExecutorFactory.create(
+      makeStep(),
+      makeContextConfig(),
+      activityLogPort,
+      fetchRemoteTools,
+    );
+    const result = await executor.execute();
+
+    expect(result.stepOutcome).toEqual({
+      type: 'mcp',
+      stepId: 'step-1',
+      stepIndex: 0,
+      status: 'awaiting-input',
+      awaitingInputReason: 'needs-oauth-reauth',
+    });
+  });
+
+  it('maps a generic tool-loading failure to an error outcome (no awaitingInputReason)', async () => {
+    const fetchRemoteTools = jest.fn().mockRejectedValue(new Error('kaboom'));
+
+    const executor = await StepExecutorFactory.create(
+      makeStep(),
+      makeContextConfig(),
+      activityLogPort,
+      fetchRemoteTools,
+    );
+    const result = await executor.execute();
+
+    expect(result.stepOutcome.status).toBe('error');
+    expect(result.stepOutcome).not.toHaveProperty('awaitingInputReason');
+  });
+
+  it('passes the step user id to the tool fetcher', async () => {
+    const fetchRemoteTools = jest.fn().mockResolvedValue({ tools: [], mcpServerName: 'srv' });
+
+    await StepExecutorFactory.create(
+      makeStep(),
+      makeContextConfig(),
+      activityLogPort,
+      fetchRemoteTools,
+    );
+
+    expect(fetchRemoteTools).toHaveBeenCalledWith('srv-1', 7);
+  });
+});

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -84,6 +84,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -77,6 +77,7 @@ function makeMockRunStore(overrides: Partial<RunStore> = {}): RunStore {
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '../../src/ports/logger-port';
 import type { McpOAuthCredentialsStore } from '../../src/ports/mcp-oauth-credentials-store';
 import type { WorkflowPort } from '../../src/ports/workflow-port';
+import type RemoteToolFetcher from '../../src/remote-tool-fetcher';
 import type Runner from '../../src/runner';
 
 import jsonwebtoken from 'jsonwebtoken';
@@ -48,6 +49,12 @@ function createMockWorkflowPort(overrides: Partial<WorkflowPort> = {}): Workflow
   } as unknown as WorkflowPort;
 }
 
+function createMockFetcher(): RemoteToolFetcher {
+  return {
+    fetch: jest.fn().mockResolvedValue({ tools: [], mcpServerName: undefined }),
+  } as unknown as RemoteToolFetcher;
+}
+
 function createServer(
   overrides: {
     runner?: Runner;
@@ -55,6 +62,7 @@ function createServer(
     logger?: jest.MockedFunction<Logger>;
     mcpOAuthCredentialsStore?: McpOAuthCredentialsStore;
     credentialEncryption?: CredentialEncryption;
+    remoteToolFetcher?: RemoteToolFetcher;
   } = {},
 ) {
   return new ExecutorHttpServer({
@@ -66,6 +74,7 @@ function createServer(
     mcpOAuthCredentialsStore:
       overrides.mcpOAuthCredentialsStore ?? new InMemoryMcpOAuthCredentialsStore(),
     credentialEncryption: overrides.credentialEncryption ?? new CredentialEncryption(),
+    remoteToolFetcher: overrides.remoteToolFetcher ?? createMockFetcher(),
   });
 }
 
@@ -82,6 +91,7 @@ describe('ExecutorHttpServer', () => {
         logger,
         mcpOAuthCredentialsStore: { init } as unknown as McpOAuthCredentialsStore,
         credentialEncryption: {} as unknown as CredentialEncryption,
+        remoteToolFetcher: createMockFetcher(),
       });
 
       await server.start();

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -21,7 +21,7 @@
 import jsonwebtoken from 'jsonwebtoken';
 import request from 'supertest';
 
-import { ExecutorEncryptionKeyMissingError } from '../../src/errors';
+import { ExecutorEncryptionKeyMissingError, OAuthReauthRequiredError } from '../../src/errors';
 import ExecutorHttpServer from '../../src/http/executor-http-server';
 
 const AUTH_SECRET = 'test-auth-secret';
@@ -71,6 +71,10 @@ function createMockEncryption() {
   };
 }
 
+function createMockFetcher() {
+  return { fetch: jest.fn().mockResolvedValue({ tools: [], mcpServerName: undefined }) };
+}
+
 function createServer(overrides: Record<string, unknown> = {}) {
   return new ExecutorHttpServer({
     port: 0,
@@ -79,6 +83,7 @@ function createServer(overrides: Record<string, unknown> = {}) {
     workflowPort: createMockWorkflowPort(),
     mcpOAuthCredentialsStore: createMockStore(),
     credentialEncryption: createMockEncryption(),
+    remoteToolFetcher: createMockFetcher(),
     ...overrides,
   } as never);
 }
@@ -424,5 +429,73 @@ describe('DELETE /mcp-oauth-credentials/:mcpServerId', () => {
 
     expect(response.status).toBe(401);
     expect(store.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /list-mcp-tools', () => {
+  const toolDef = (name: string, description: string) => ({ base: { name, description } });
+
+  it('returns 401 when no token is provided', async () => {
+    const server = createServer();
+
+    const response = await request(server.callback).get('/list-mcp-tools?mcpServerId=mcp-server-1');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lists the tools for (token user, mcpServerId), resolving the vault credential', async () => {
+    const fetcher = {
+      fetch: jest.fn().mockResolvedValue({
+        tools: [toolDef('search', 'Search things'), toolDef('create', 'Create a thing')],
+        mcpServerName: 'srv',
+      }),
+    };
+    const server = createServer({ remoteToolFetcher: fetcher });
+    const token = signToken({ id: 7 });
+
+    const response = await request(server.callback)
+      .get('/list-mcp-tools?mcpServerId=mcp-server-1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    // user_id comes from the validated JWT (7), never the request.
+    expect(fetcher.fetch).toHaveBeenCalledWith('mcp-server-1', 7);
+    expect(response.body).toEqual({
+      tools: [
+        { name: 'search', description: 'Search things' },
+        { name: 'create', description: 'Create a thing' },
+      ],
+    });
+  });
+
+  it('returns 400 when mcpServerId is missing', async () => {
+    const fetcher = { fetch: jest.fn() };
+    const server = createServer({ remoteToolFetcher: fetcher });
+    const token = signToken({ id: 7 });
+
+    const response = await request(server.callback)
+      .get('/list-mcp-tools')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(400);
+    expect(fetcher.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a typed needs-oauth-reauth (409) when the credential is missing or unrefreshable', async () => {
+    const fetcher = {
+      fetch: jest.fn().mockRejectedValue(new OAuthReauthRequiredError('mcp-server-1')),
+    };
+    const server = createServer({ remoteToolFetcher: fetcher });
+    const token = signToken({ id: 7 });
+
+    const response = await request(server.callback)
+      .get('/list-mcp-tools?mcpServerId=mcp-server-1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({
+      awaitingInputReason: 'needs-oauth-reauth',
+      mcpServerId: 'mcp-server-1',
+    });
   });
 });

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -55,6 +55,7 @@ function createMockStore() {
   return {
     init: jest.fn().mockResolvedValue(undefined),
     upsert: jest.fn().mockResolvedValue(undefined),
+    updateIfPresent: jest.fn().mockResolvedValue(undefined),
     get: jest.fn().mockResolvedValue(null),
     delete: jest.fn().mockResolvedValue(undefined),
     close: jest.fn().mockResolvedValue(undefined),

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -514,4 +514,19 @@ describe('GET /list-mcp-tools', () => {
       mcpServerId: 'mcp-server-1',
     });
   });
+
+  it('returns the typed 503 executor_encryption_key_missing when the key is absent', async () => {
+    const fetcher = {
+      fetch: jest.fn().mockRejectedValue(new ExecutorEncryptionKeyMissingError()),
+    };
+    const server = createServer({ remoteToolFetcher: fetcher });
+    const token = signToken({ id: 7 });
+
+    const response = await request(server.callback)
+      .get('/list-mcp-tools?mcpServerId=mcp-server-1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({ code: 'executor_encryption_key_missing' });
+  });
 });

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -153,6 +153,20 @@ describe('POST /mcp-oauth-credentials', () => {
       );
     });
 
+    it('evicts any cached access token on deposit so a reconnect takes effect immediately', async () => {
+      const tokenService = createMockTokenService();
+      const server = createServer({ oauthTokenService: tokenService });
+      const token = signToken({ id: 7 });
+
+      const response = await request(server.callback)
+        .post('/mcp-oauth-credentials')
+        .set('Authorization', `Bearer ${token}`)
+        .send(validBody);
+
+      expect(response.status).toBe(200);
+      expect(tokenService.evict).toHaveBeenCalledWith(7, 'mcp-server-1');
+    });
+
     it('rejects a body that tries to supply a user id (the token is the only source)', async () => {
       const store = createMockStore();
       const server = createServer({ mcpOAuthCredentialsStore: store });

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -75,6 +75,10 @@ function createMockFetcher() {
   return { fetch: jest.fn().mockResolvedValue({ tools: [], mcpServerName: undefined }) };
 }
 
+function createMockTokenService() {
+  return { evict: jest.fn() };
+}
+
 function createServer(overrides: Record<string, unknown> = {}) {
   return new ExecutorHttpServer({
     port: 0,
@@ -404,6 +408,18 @@ describe('DELETE /mcp-oauth-credentials/:mcpServerId', () => {
     expect(response.status).toBe(204);
     expect(response.body).toEqual({});
     expect(store.delete).toHaveBeenCalledWith(7, 'mcp-server-1');
+  });
+
+  it('evicts the in-process cached access token so the disconnect takes effect immediately', async () => {
+    const oauthTokenService = createMockTokenService();
+    const server = createServer({ oauthTokenService });
+    const token = signToken({ id: 7 });
+
+    await request(server.callback)
+      .delete('/mcp-oauth-credentials/mcp-server-1')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(oauthTokenService.evict).toHaveBeenCalledWith(7, 'mcp-server-1');
   });
 
   it("does not delete another user's credential", async () => {

--- a/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
+++ b/packages/workflow-executor/test/http/mcp-oauth-credentials-route.test.ts
@@ -327,6 +327,20 @@ describe('POST /mcp-oauth-credentials', () => {
       expect(store.upsert).not.toHaveBeenCalled();
     });
 
+    it('returns 400 when tokenEndpoint points at a link-local / metadata address (SSRF guard)', async () => {
+      const store = createMockStore();
+      const server = createServer({ mcpOAuthCredentialsStore: store });
+      const token = signToken({ id: 1 });
+
+      const response = await request(server.callback)
+        .post('/mcp-oauth-credentials')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ ...validBody, tokenEndpoint: 'http://169.254.169.254/latest/meta-data' });
+
+      expect(response.status).toBe(400);
+      expect(store.upsert).not.toHaveBeenCalled();
+    });
+
     it('returns 400 when a field has the wrong type', async () => {
       const store = createMockStore();
       const server = createServer({ mcpOAuthCredentialsStore: store });

--- a/packages/workflow-executor/test/integration/workflow-execution.test.ts
+++ b/packages/workflow-executor/test/integration/workflow-execution.test.ts
@@ -13,6 +13,7 @@ import createConsoleLogger from '../../src/adapters/console-logger';
 import CredentialEncryption from '../../src/crypto/credential-encryption';
 import ExecutorHttpServer from '../../src/http/executor-http-server';
 import OAuthTokenService from '../../src/oauth/token-service';
+import RemoteToolFetcher from '../../src/remote-tool-fetcher';
 import Runner from '../../src/runner';
 import SchemaCache from '../../src/schema-cache';
 import InMemoryMcpOAuthCredentialsStore from '../../src/stores/in-memory-mcp-oauth-credentials-store';
@@ -224,6 +225,13 @@ function createIntegrationSetup(overrides?: {
     mcpOAuthTokenService,
   });
 
+  const remoteToolFetcher = new RemoteToolFetcher(
+    workflowPort,
+    aiClient,
+    createConsoleLogger(),
+    mcpOAuthTokenService,
+  );
+
   const server = new ExecutorHttpServer({
     port: 0,
     runner,
@@ -231,6 +239,7 @@ function createIntegrationSetup(overrides?: {
     workflowPort,
     mcpOAuthCredentialsStore,
     credentialEncryption,
+    remoteToolFetcher,
   });
 
   return { runner, server, workflowPort, agentPort, runStore, aiClient, model };

--- a/packages/workflow-executor/test/integration/workflow-execution.test.ts
+++ b/packages/workflow-executor/test/integration/workflow-execution.test.ts
@@ -9,8 +9,10 @@ import jsonwebtoken from 'jsonwebtoken';
 import request from 'supertest';
 import { z } from 'zod';
 
+import createConsoleLogger from '../../src/adapters/console-logger';
 import CredentialEncryption from '../../src/crypto/credential-encryption';
 import ExecutorHttpServer from '../../src/http/executor-http-server';
+import OAuthTokenService from '../../src/oauth/token-service';
 import Runner from '../../src/runner';
 import SchemaCache from '../../src/schema-cache';
 import InMemoryMcpOAuthCredentialsStore from '../../src/stores/in-memory-mcp-oauth-credentials-store';
@@ -194,6 +196,13 @@ function createIntegrationSetup(overrides?: {
   const agentPort = overrides?.agentPort ?? createMockAgentPort();
   const runStore = new InMemoryStore();
   const schemaCache = new SchemaCache();
+  const mcpOAuthCredentialsStore = new InMemoryMcpOAuthCredentialsStore();
+  const credentialEncryption = new CredentialEncryption();
+  const mcpOAuthTokenService = new OAuthTokenService({
+    store: mcpOAuthCredentialsStore,
+    encryption: credentialEncryption,
+    logger: createConsoleLogger(),
+  });
 
   const runner = new Runner({
     agentPort,
@@ -212,6 +221,7 @@ function createIntegrationSetup(overrides?: {
     pollingIntervalS: overrides?.pollingIntervalS ?? 60,
     envSecret: ENV_SECRET,
     authSecret: AUTH_SECRET,
+    mcpOAuthTokenService,
   });
 
   const server = new ExecutorHttpServer({
@@ -219,8 +229,8 @@ function createIntegrationSetup(overrides?: {
     runner,
     authSecret: AUTH_SECRET,
     workflowPort,
-    mcpOAuthCredentialsStore: new InMemoryMcpOAuthCredentialsStore(),
-    credentialEncryption: new CredentialEncryption(),
+    mcpOAuthCredentialsStore,
+    credentialEncryption,
   });
 
   return { runner, server, workflowPort, agentPort, runStore, aiClient, model };

--- a/packages/workflow-executor/test/oauth/keyed-mutex.test.ts
+++ b/packages/workflow-executor/test/oauth/keyed-mutex.test.ts
@@ -1,0 +1,79 @@
+import KeyedMutex from '../../src/oauth/keyed-mutex';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('KeyedMutex', () => {
+  describe('runExclusive', () => {
+    it('returns the value the task resolves with', async () => {
+      const mutex = new KeyedMutex();
+
+      await expect(mutex.runExclusive('k', async () => 42)).resolves.toBe(42);
+    });
+
+    it('runs tasks sharing a key one at a time, in order', async () => {
+      const mutex = new KeyedMutex();
+      const events: string[] = [];
+      const first = deferred<void>();
+
+      const firstRun = mutex.runExclusive('user:1', async () => {
+        events.push('first:start');
+        await first.promise;
+        events.push('first:end');
+      });
+
+      const secondRun = mutex.runExclusive('user:1', async () => {
+        events.push('second:start');
+      });
+
+      // The second task must not start while the first holds the key.
+      await Promise.resolve();
+      expect(events).toEqual(['first:start']);
+
+      first.resolve();
+      await Promise.all([firstRun, secondRun]);
+
+      expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+    });
+
+    it('runs tasks for different keys concurrently', async () => {
+      const mutex = new KeyedMutex();
+      const events: string[] = [];
+      const blocker = deferred<void>();
+
+      const blocked = mutex.runExclusive('user:1', async () => {
+        events.push('a:start');
+        await blocker.promise;
+      });
+      const other = mutex.runExclusive('user:2', async () => {
+        events.push('b:start');
+      });
+
+      await other;
+      // 'user:2' completed without waiting for the still-blocked 'user:1'.
+      expect(events).toEqual(['a:start', 'b:start']);
+
+      blocker.resolve();
+      await blocked;
+    });
+
+    it('lets a later task on the same key run after an earlier task rejects', async () => {
+      const mutex = new KeyedMutex();
+
+      const failed = mutex.runExclusive('user:1', async () => {
+        throw new Error('boom');
+      });
+
+      await expect(failed).rejects.toThrow('boom');
+      await expect(mutex.runExclusive('user:1', async () => 'ok')).resolves.toBe('ok');
+    });
+  });
+});

--- a/packages/workflow-executor/test/oauth/refresh-grant.test.ts
+++ b/packages/workflow-executor/test/oauth/refresh-grant.test.ts
@@ -1,4 +1,8 @@
-import { OAuthInvalidGrantError, OAuthRefreshError } from '../../src/errors';
+import {
+  InvalidTokenEndpointError,
+  OAuthInvalidGrantError,
+  OAuthRefreshError,
+} from '../../src/errors';
 import refreshAccessToken from '../../src/oauth/refresh-grant';
 
 function mockResponse(options: {
@@ -33,6 +37,14 @@ describe('refreshAccessToken', () => {
 
     return { url, headers: init.headers as Record<string, string>, body };
   }
+
+  it('rejects a link-local token endpoint without making a request (SSRF guard)', async () => {
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'http://169.254.169.254/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(InvalidTokenEndpointError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 
   it('posts a refresh_token grant with the refresh token to the token endpoint', async () => {
     fetchSpy.mockResolvedValue(

--- a/packages/workflow-executor/test/oauth/refresh-grant.test.ts
+++ b/packages/workflow-executor/test/oauth/refresh-grant.test.ts
@@ -46,6 +46,33 @@ describe('refreshAccessToken', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('sends the request with redirect:manual so redirects are never followed', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' });
+
+    expect(fetchSpy.mock.calls[0][1].redirect).toBe('manual');
+  });
+
+  it('rejects a redirect response without following it or reading the body (SSRF via redirect)', async () => {
+    const jsonSpy = jest.fn();
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 302,
+      type: 'opaqueredirect',
+      json: jsonSpy,
+    } as unknown as Response);
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+
+    // The grant body (refresh token / client secret) must not be re-sent nor the reply parsed.
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
   it('posts a refresh_token grant with the refresh token to the token endpoint', async () => {
     fetchSpy.mockResolvedValue(
       mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),

--- a/packages/workflow-executor/test/oauth/refresh-grant.test.ts
+++ b/packages/workflow-executor/test/oauth/refresh-grant.test.ts
@@ -49,6 +49,18 @@ describe('refreshAccessToken', () => {
     expect(body.get('refresh_token')).toBe('rt-1');
   });
 
+  it('throws OAuthRefreshError (not a TypeError) when the token endpoint body is literal null', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve(null),
+    } as unknown as Response);
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+  });
+
   it('sends client credentials via Basic auth for client_secret_basic (the default with a secret)', async () => {
     fetchSpy.mockResolvedValue(
       mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),

--- a/packages/workflow-executor/test/oauth/refresh-grant.test.ts
+++ b/packages/workflow-executor/test/oauth/refresh-grant.test.ts
@@ -1,0 +1,198 @@
+import { OAuthInvalidGrantError, OAuthRefreshError } from '../../src/errors';
+import refreshAccessToken from '../../src/oauth/refresh-grant';
+
+function mockResponse(options: {
+  ok: boolean;
+  status: number;
+  payload?: unknown;
+  nonJson?: boolean;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status,
+    json: options.nonJson
+      ? () => Promise.reject(new Error('not json'))
+      : () => Promise.resolve(options.payload ?? {}),
+  } as unknown as Response;
+}
+
+describe('refreshAccessToken', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function lastRequest() {
+    const [url, init] = fetchSpy.mock.calls[0];
+    const body = init.body as URLSearchParams;
+
+    return { url, headers: init.headers as Record<string, string>, body };
+  }
+
+  it('posts a refresh_token grant with the refresh token to the token endpoint', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' });
+
+    const { url, body, headers } = lastRequest();
+    expect(url).toBe('https://idp/token');
+    expect(fetchSpy.mock.calls[0][1].method).toBe('POST');
+    expect(headers['content-type']).toBe('application/x-www-form-urlencoded');
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('rt-1');
+  });
+
+  it('sends client credentials via Basic auth for client_secret_basic (the default with a secret)', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+      clientId: 'cid',
+      clientSecret: 'secret',
+    });
+
+    const { headers, body } = lastRequest();
+    expect(headers.authorization).toBe(`Basic ${Buffer.from('cid:secret').toString('base64')}`);
+    expect(body.get('client_secret')).toBeNull();
+  });
+
+  it('sends client credentials in the body for client_secret_post', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      tokenEndpointAuthMethod: 'client_secret_post',
+    });
+
+    const { headers, body } = lastRequest();
+    expect(headers.authorization).toBeUndefined();
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('secret');
+  });
+
+  it('sends only client_id for a public client (no secret)', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+      clientId: 'cid',
+    });
+
+    const { headers, body } = lastRequest();
+    expect(headers.authorization).toBeUndefined();
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBeNull();
+  });
+
+  it('includes the scope parameter only when scopes are provided', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at' } }),
+    );
+
+    await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+      scopes: 'a b',
+    });
+    expect(lastRequest().body.get('scope')).toBe('a b');
+
+    fetchSpy.mockClear();
+    await refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' });
+    expect(lastRequest().body.get('scope')).toBeNull();
+  });
+
+  it('returns the access token, expiry, and a rotated refresh token on success', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        payload: { access_token: 'at-1', expires_in: 3600, refresh_token: 'rt-2' },
+      }),
+    );
+
+    const result = await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+    });
+
+    expect(result).toEqual({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
+  });
+
+  it('leaves expiresInS undefined when the response omits expires_in', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { access_token: 'at-1' } }),
+    );
+
+    const result = await refreshAccessToken({
+      tokenEndpoint: 'https://idp/token',
+      refreshToken: 'rt-1',
+    });
+
+    expect(result.expiresInS).toBeUndefined();
+    expect(result.refreshToken).toBeUndefined();
+  });
+
+  it('throws OAuthInvalidGrantError when the endpoint returns error invalid_grant', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: false, status: 400, payload: { error: 'invalid_grant' } }),
+    );
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthInvalidGrantError);
+  });
+
+  it('throws OAuthRefreshError for a non-invalid_grant error response', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: false, status: 400, payload: { error: 'invalid_client' } }),
+    );
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+  });
+
+  it('throws OAuthRefreshError on a 5xx from the token endpoint', async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 503, nonJson: true }));
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+  });
+
+  it('throws OAuthRefreshError when the endpoint is unreachable', async () => {
+    fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+  });
+
+  it('throws OAuthRefreshError when a 200 response carries no access_token', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, payload: { token_type: 'bearer' } }),
+    );
+
+    await expect(
+      refreshAccessToken({ tokenEndpoint: 'https://idp/token', refreshToken: 'rt-1' }),
+    ).rejects.toBeInstanceOf(OAuthRefreshError);
+  });
+});

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -102,6 +102,15 @@ describe('assertSafeTokenEndpoint', () => {
       ).not.toThrow();
     });
 
+    it('rejects trailing-dot IP literals (URL parsing normalizes the dot before classification)', () => {
+      expect(() => assertSafeTokenEndpoint('https://127.0.0.1./token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://169.254.169.254./token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
     it('rejects an IPv4-mapped IPv6 loopback (e.g. ::ffff:127.0.0.1)', () => {
       expect(() => assertSafeTokenEndpoint('https://[::ffff:127.0.0.1]/token')).toThrow(
         InvalidTokenEndpointError,

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -47,6 +47,12 @@ describe('assertSafeTokenEndpoint', () => {
         InvalidTokenEndpointError,
       );
     });
+
+    it('rejects an IPv4-mapped IPv6 metadata address (e.g. ::ffff:169.254.169.254)', () => {
+      expect(() => assertSafeTokenEndpoint('http://[::ffff:169.254.169.254]/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
   });
 
   describe('in production', () => {
@@ -68,6 +74,12 @@ describe('assertSafeTokenEndpoint', () => {
         InvalidTokenEndpointError,
       );
       expect(() => assertSafeTokenEndpoint('https://[::1]/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('rejects an IPv4-mapped IPv6 loopback (e.g. ::ffff:127.0.0.1)', () => {
+      expect(() => assertSafeTokenEndpoint('https://[::ffff:127.0.0.1]/token')).toThrow(
         InvalidTokenEndpointError,
       );
     });

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -126,4 +126,31 @@ describe('assertSafeTokenEndpoint', () => {
       expect(() => assertSafeTokenEndpoint('https://idp.example.com/oauth/token')).not.toThrow();
     });
   });
+
+  describe('fails closed on a non-explicit environment', () => {
+    it('applies the strict rules when NODE_ENV is unset (not silently relaxed)', () => {
+      delete process.env.NODE_ENV;
+      expect(() => assertSafeTokenEndpoint('http://idp.example.com/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://127.0.0.1/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('applies the strict rules when NODE_ENV is an unexpected value (e.g. misspelled)', () => {
+      process.env.NODE_ENV = 'produciton';
+      expect(() => assertSafeTokenEndpoint('http://idp.example.com/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://localhost/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('relaxes only for an explicit development/test opt-in', () => {
+      process.env.NODE_ENV = 'test';
+      expect(() => assertSafeTokenEndpoint('http://127.0.0.1:9101/token')).not.toThrow();
+    });
+  });
 });

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -87,6 +87,21 @@ describe('assertSafeTokenEndpoint', () => {
       );
     });
 
+    it('rejects loopback hostname aliases (localhost. and the .localhost TLD)', () => {
+      expect(() => assertSafeTokenEndpoint('https://localhost./token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://foo.localhost/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('does not over-block a real domain that merely contains "localhost"', () => {
+      expect(() =>
+        assertSafeTokenEndpoint('https://auth.localhost.example.com/token'),
+      ).not.toThrow();
+    });
+
     it('rejects an IPv4-mapped IPv6 loopback (e.g. ::ffff:127.0.0.1)', () => {
       expect(() => assertSafeTokenEndpoint('https://[::ffff:127.0.0.1]/token')).toThrow(
         InvalidTokenEndpointError,

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -53,6 +53,15 @@ describe('assertSafeTokenEndpoint', () => {
         InvalidTokenEndpointError,
       );
     });
+
+    it('rejects the unspecified address, which routes to loopback (0.0.0.0 / ::)', () => {
+      expect(() => assertSafeTokenEndpoint('https://0.0.0.0/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://[::]/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
   });
 
   describe('in production', () => {

--- a/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
+++ b/packages/workflow-executor/test/oauth/token-endpoint-url.test.ts
@@ -1,0 +1,84 @@
+import { InvalidTokenEndpointError } from '../../src/errors';
+import assertSafeTokenEndpoint from '../../src/oauth/token-endpoint-url';
+
+describe('assertSafeTokenEndpoint', () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  describe('any environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+    });
+
+    it('accepts an https endpoint with a public host', () => {
+      expect(() => assertSafeTokenEndpoint('https://idp.example.com/oauth/token')).not.toThrow();
+    });
+
+    it('accepts http on loopback off-production (the local OAuth sim)', () => {
+      expect(() => assertSafeTokenEndpoint('http://127.0.0.1:9100/token')).not.toThrow();
+      expect(() => assertSafeTokenEndpoint('http://localhost:9100/token')).not.toThrow();
+    });
+
+    it('rejects a value that is not a valid absolute URL', () => {
+      expect(() => assertSafeTokenEndpoint('not a url')).toThrow(InvalidTokenEndpointError);
+    });
+
+    it('rejects a non-http(s) scheme', () => {
+      expect(() => assertSafeTokenEndpoint('file:///etc/passwd')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('ftp://idp/token')).toThrow(InvalidTokenEndpointError);
+    });
+
+    it('rejects a link-local / cloud-metadata address even off-production', () => {
+      expect(() => assertSafeTokenEndpoint('http://169.254.169.254/latest/meta-data')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://169.254.169.254/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('rejects an IPv6 link-local address', () => {
+      expect(() => assertSafeTokenEndpoint('http://[fe80::1]/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+  });
+
+  describe('in production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    it('requires https (rejects http)', () => {
+      expect(() => assertSafeTokenEndpoint('http://idp.example.com/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('rejects loopback (the executor host itself)', () => {
+      expect(() => assertSafeTokenEndpoint('https://127.0.0.1/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://localhost/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+      expect(() => assertSafeTokenEndpoint('https://[::1]/token')).toThrow(
+        InvalidTokenEndpointError,
+      );
+    });
+
+    it('still allows a private RFC1918 host over https (private providers are supported)', () => {
+      expect(() => assertSafeTokenEndpoint('https://10.0.0.5/token')).not.toThrow();
+      expect(() => assertSafeTokenEndpoint('https://192.168.1.10:8443/token')).not.toThrow();
+    });
+
+    it('accepts a public https endpoint', () => {
+      expect(() => assertSafeTokenEndpoint('https://idp.example.com/oauth/token')).not.toThrow();
+    });
+  });
+});

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -1,0 +1,300 @@
+import type CredentialEncryption from '../../src/crypto/credential-encryption';
+import type { RefreshGrantParams, RefreshGrantResult } from '../../src/oauth/refresh-grant';
+import type McpOAuthCredentialsStore from '../../src/stores/mcp-oauth-credentials-store';
+import type { StoredMcpOAuthCredential } from '../../src/stores/mcp-oauth-credentials-store';
+
+import {
+  OAuthInvalidGrantError,
+  OAuthReauthRequiredError,
+  OAuthRefreshError,
+} from '../../src/errors';
+import OAuthTokenService from '../../src/oauth/token-service';
+
+const USER_ID = 7;
+const SERVER_ID = 'srv-1';
+
+function makeCredential(
+  overrides: Partial<StoredMcpOAuthCredential> = {},
+): StoredMcpOAuthCredential {
+  return {
+    id: 1,
+    userId: USER_ID,
+    mcpServerId: SERVER_ID,
+    refreshTokenEnc: Buffer.from('enc-rt-1'),
+    clientId: 'cid',
+    clientSecretEnc: Buffer.from('enc-secret'),
+    clientSecretExpiresAt: null,
+    tokenEndpoint: 'https://idp/token',
+    tokenEndpointAuthMethod: 'client_secret_basic',
+    scopes: 'a b',
+    encKeyVersion: 1,
+    ...overrides,
+  };
+}
+
+function setup(options?: {
+  credential?: StoredMcpOAuthCredential | null;
+  refresh?: jest.Mock<Promise<RefreshGrantResult>, [RefreshGrantParams]>;
+  expirySkewS?: number;
+}) {
+  const credential = options?.credential === undefined ? makeCredential() : options.credential;
+  const get = jest.fn().mockResolvedValue(credential);
+  const upsert = jest.fn().mockResolvedValue(undefined);
+  const store = { get, upsert } as unknown as McpOAuthCredentialsStore;
+
+  const decrypt = jest.fn((buf: Buffer) => `decrypted:${buf.toString()}`);
+  const encrypt = jest.fn((plain: string) => ({
+    ciphertext: Buffer.from(`enc:${plain}`),
+    encKeyVersion: 2,
+  }));
+  const encryption = { decrypt, encrypt } as unknown as CredentialEncryption;
+
+  const refresh =
+    options?.refresh ?? jest.fn().mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600 });
+
+  let clock = 1_000_000;
+  const now = () => clock;
+
+  const service = new OAuthTokenService({
+    store,
+    encryption,
+    refreshAccessToken: refresh,
+    expirySkewS: options?.expirySkewS ?? 60,
+    now,
+  });
+
+  return {
+    service,
+    get,
+    upsert,
+    decrypt,
+    encrypt,
+    refresh,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+describe('OAuthTokenService.getAccessToken', () => {
+  describe('acquisition', () => {
+    it('looks up the credential by user and server, refreshes, and returns the access token', async () => {
+      const { service, get, refresh } = setup();
+
+      const token = await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(token).toBe('at-1');
+      expect(get).toHaveBeenCalledWith(USER_ID, SERVER_ID);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('decrypts the refresh token and client secret and passes the stored endpoint to the grant', async () => {
+      const { service, refresh } = setup();
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(refresh).toHaveBeenCalledWith({
+        tokenEndpoint: 'https://idp/token',
+        refreshToken: 'decrypted:enc-rt-1',
+        clientId: 'cid',
+        clientSecret: 'decrypted:enc-secret',
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        scopes: 'a b',
+      });
+    });
+
+    it('passes a null client secret to the grant when none is stored', async () => {
+      const { service, refresh } = setup({ credential: makeCredential({ clientSecretEnc: null }) });
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(refresh).toHaveBeenCalledWith(expect.objectContaining({ clientSecret: null }));
+    });
+
+    it('raises OAuthReauthRequiredError and never refreshes when no credential is stored', async () => {
+      const { service, refresh } = setup({ credential: null });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        OAuthReauthRequiredError,
+      );
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('propagates a transient refresh failure without converting it to a re-auth pause', async () => {
+      const refresh = jest.fn().mockRejectedValue(new OAuthRefreshError('5xx'));
+      const { service } = setup({ refresh });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        OAuthRefreshError,
+      );
+    });
+  });
+
+  describe('expiry-skew cache', () => {
+    it('serves the cached token on a second call within the skew window', async () => {
+      const { service, refresh } = setup();
+
+      const first = await service.getAccessToken(USER_ID, SERVER_ID);
+      const second = await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(first).toBe(second);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes again once the token is within the skew window of expiry', async () => {
+      const { service, refresh, advance } = setup({ expirySkewS: 60 });
+
+      await service.getAccessToken(USER_ID, SERVER_ID); // expires_in 3600s, skew 60s
+      advance((3600 - 60) * 1000); // now exactly at the skew threshold
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache a token when the grant omits expires_in', async () => {
+      const refresh = jest.fn().mockResolvedValue({ accessToken: 'at-1' });
+      const { service } = setup({ refresh });
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+
+    it('forceRefresh bypasses a still-valid cached token', async () => {
+      const { service, refresh } = setup();
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+      await service.getAccessToken(USER_ID, SERVER_ID, { forceRefresh: true });
+
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches independently per (user, server)', async () => {
+      const { service, refresh } = setup();
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+      await service.getAccessToken(USER_ID, 'other-server');
+
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('refresh-token rotation', () => {
+    it('persists the rotated refresh token, encrypted, when the grant returns a new one', async () => {
+      const refresh = jest
+        .fn()
+        .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
+      const { service, upsert, encrypt } = setup({ refresh });
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(encrypt).toHaveBeenCalledWith('rt-2');
+      expect(upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: USER_ID,
+          mcpServerId: SERVER_ID,
+          refreshTokenEnc: Buffer.from('enc:rt-2'),
+          encKeyVersion: 2,
+        }),
+      );
+    });
+
+    it('does not write back when the grant returns no new refresh token', async () => {
+      const { service, upsert } = setup();
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(upsert).not.toHaveBeenCalled();
+    });
+
+    it('still returns the token when the rotation write-back fails', async () => {
+      const refresh = jest
+        .fn()
+        .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
+      const { service, upsert } = setup({ refresh });
+      (upsert as jest.Mock).mockRejectedValue(new Error('db down'));
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).resolves.toBe('at-1');
+    });
+  });
+
+  describe('invalid_grant — concurrent rotation recovery', () => {
+    it('re-reads the credential and retries once with the rotated token', async () => {
+      const rotated = makeCredential({ refreshTokenEnc: Buffer.from('enc-rt-rotated') });
+      const get = jest.fn().mockResolvedValueOnce(makeCredential()).mockResolvedValueOnce(rotated);
+      const refresh = jest
+        .fn()
+        .mockRejectedValueOnce(new OAuthInvalidGrantError())
+        .mockResolvedValueOnce({ accessToken: 'at-after-retry', expiresInS: 3600 });
+
+      const service = new OAuthTokenService({
+        store: { get, upsert: jest.fn() } as unknown as McpOAuthCredentialsStore,
+        encryption: {
+          decrypt: (buf: Buffer) => `decrypted:${buf.toString()}`,
+          encrypt: jest.fn(),
+        } as unknown as CredentialEncryption,
+        refreshAccessToken: refresh,
+      });
+
+      const token = await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(token).toBe('at-after-retry');
+      expect(refresh).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ refreshToken: 'decrypted:enc-rt-rotated' }),
+      );
+    });
+
+    it('raises OAuthReauthRequiredError when the re-read shows the same (unrotated) token', async () => {
+      const refresh = jest.fn().mockRejectedValue(new OAuthInvalidGrantError());
+      const { service } = setup({ refresh });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        OAuthReauthRequiredError,
+      );
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('raises OAuthReauthRequiredError when the retry also returns invalid_grant', async () => {
+      const rotated = makeCredential({ refreshTokenEnc: Buffer.from('enc-rt-rotated') });
+      const get = jest.fn().mockResolvedValueOnce(makeCredential()).mockResolvedValueOnce(rotated);
+      const refresh = jest.fn().mockRejectedValue(new OAuthInvalidGrantError());
+
+      const service = new OAuthTokenService({
+        store: { get, upsert: jest.fn() } as unknown as McpOAuthCredentialsStore,
+        encryption: {
+          decrypt: (buf: Buffer) => buf.toString(),
+          encrypt: jest.fn(),
+        } as unknown as CredentialEncryption,
+        refreshAccessToken: refresh,
+      });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        OAuthReauthRequiredError,
+      );
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('serialization', () => {
+    it('collapses concurrent requests for the same (user, server) into a single refresh', async () => {
+      let resolveRefresh!: (value: RefreshGrantResult) => void;
+      const refresh = jest.fn().mockReturnValue(
+        new Promise<RefreshGrantResult>(resolve => {
+          resolveRefresh = resolve;
+        }),
+      );
+      const { service } = setup({ refresh });
+
+      const a = service.getAccessToken(USER_ID, SERVER_ID);
+      const b = service.getAccessToken(USER_ID, SERVER_ID);
+      resolveRefresh({ accessToken: 'at-shared', expiresInS: 3600 });
+
+      await expect(a).resolves.toBe('at-shared');
+      await expect(b).resolves.toBe('at-shared');
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -247,6 +247,33 @@ describe('OAuthTokenService.getAccessToken', () => {
       );
     });
 
+    it('persists the rotated token onto the re-read credential fields, not the stale ones', async () => {
+      const original = makeCredential({ scopes: 'a b' });
+      const latest = makeCredential({
+        refreshTokenEnc: Buffer.from('enc-rt-rotated'),
+        scopes: 'a b c',
+      });
+      const get = jest.fn().mockResolvedValueOnce(original).mockResolvedValueOnce(latest);
+      const upsert = jest.fn().mockResolvedValue(undefined);
+      const refresh = jest
+        .fn()
+        .mockRejectedValueOnce(new OAuthInvalidGrantError())
+        .mockResolvedValueOnce({ accessToken: 'at', expiresInS: 3600, refreshToken: 'rt-3' });
+
+      const service = new OAuthTokenService({
+        store: { get, upsert } as unknown as McpOAuthCredentialsStore,
+        encryption: {
+          decrypt: (buf: Buffer) => buf.toString(),
+          encrypt: () => ({ ciphertext: Buffer.from('enc:rt-3'), encKeyVersion: 2 }),
+        } as unknown as CredentialEncryption,
+        refreshAccessToken: refresh,
+      });
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ scopes: 'a b c' }));
+    });
+
     it('raises OAuthReauthRequiredError when the re-read shows the same (unrotated) token', async () => {
       const refresh = jest.fn().mockRejectedValue(new OAuthInvalidGrantError());
       const { service } = setup({ refresh });

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../src/ports/mcp-oauth-credentials-store';
 
 import {
+  ExecutorEncryptionKeyMissingError,
   OAuthInvalidGrantError,
   OAuthReauthRequiredError,
   OAuthRefreshError,
@@ -29,7 +30,6 @@ function makeCredential(
     tokenEndpoint: 'https://idp/token',
     tokenEndpointAuthMethod: 'client_secret_basic',
     scopes: 'a b',
-    encKeyVersion: 1,
     ...overrides,
   };
 }
@@ -47,7 +47,6 @@ function setup(options?: {
   const decrypt = jest.fn((buf: Buffer) => `decrypted:${buf.toString()}`);
   const encrypt = jest.fn((plain: string) => ({
     ciphertext: Buffer.from(`enc:${plain}`),
-    encKeyVersion: 2,
   }));
   const encryption = { decrypt, encrypt } as unknown as CredentialEncryption;
 
@@ -198,7 +197,6 @@ describe('OAuthTokenService.getAccessToken', () => {
           userId: USER_ID,
           mcpServerId: SERVER_ID,
           refreshTokenEnc: Buffer.from('enc:rt-2'),
-          encKeyVersion: 2,
         }),
       );
     });
@@ -266,7 +264,7 @@ describe('OAuthTokenService.getAccessToken', () => {
         store: { get, upsert } as unknown as McpOAuthCredentialsStore,
         encryption: {
           decrypt: (buf: Buffer) => buf.toString(),
-          encrypt: () => ({ ciphertext: Buffer.from('enc:rt-3'), encKeyVersion: 2 }),
+          encrypt: () => ({ ciphertext: Buffer.from('enc:rt-3') }),
         } as unknown as CredentialEncryption,
         refreshAccessToken: refresh,
       });
@@ -324,6 +322,51 @@ describe('OAuthTokenService.getAccessToken', () => {
       await expect(a).resolves.toBe('at-shared');
       await expect(b).resolves.toBe('at-shared');
       expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('decrypt failure classification', () => {
+    it('surfaces a decrypt failure with the key present as needs-oauth-reauth (recoverable)', async () => {
+      const service = new OAuthTokenService({
+        store: {
+          get: jest.fn().mockResolvedValue(makeCredential()),
+          upsert: jest.fn(),
+        } as unknown as McpOAuthCredentialsStore,
+        encryption: {
+          // A since-rotated/hard-swapped key fails GCM auth-tag verification with a generic error.
+          decrypt: () => {
+            throw new Error('Unsupported state or unable to authenticate data');
+          },
+          encrypt: jest.fn(),
+        } as unknown as CredentialEncryption,
+        refreshAccessToken: jest.fn(),
+      });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        OAuthReauthRequiredError,
+      );
+    });
+
+    it('rethrows a missing-key error as terminal, never reaching the grant', async () => {
+      const refreshAccessToken = jest.fn();
+      const service = new OAuthTokenService({
+        store: {
+          get: jest.fn().mockResolvedValue(makeCredential()),
+          upsert: jest.fn(),
+        } as unknown as McpOAuthCredentialsStore,
+        encryption: {
+          decrypt: () => {
+            throw new ExecutorEncryptionKeyMissingError();
+          },
+          encrypt: jest.fn(),
+        } as unknown as CredentialEncryption,
+        refreshAccessToken,
+      });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).rejects.toBeInstanceOf(
+        ExecutorEncryptionKeyMissingError,
+      );
+      expect(refreshAccessToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -1,6 +1,7 @@
 import type CredentialEncryption from '../../src/crypto/credential-encryption';
 import type { RefreshGrantParams, RefreshGrantResult } from '../../src/oauth/refresh-grant';
 import type {
+  McpOAuthCredentialInput,
   McpOAuthCredentialsStore,
   StoredMcpOAuthCredential,
 } from '../../src/ports/mcp-oauth-credentials-store';
@@ -42,7 +43,8 @@ function setup(options?: {
   const credential = options?.credential === undefined ? makeCredential() : options.credential;
   const get = jest.fn().mockResolvedValue(credential);
   const upsert = jest.fn().mockResolvedValue(undefined);
-  const store = { get, upsert } as unknown as McpOAuthCredentialsStore;
+  const updateIfPresent = jest.fn().mockResolvedValue(undefined);
+  const store = { get, upsert, updateIfPresent } as unknown as McpOAuthCredentialsStore;
 
   const decrypt = jest.fn((buf: Buffer) => `decrypted:${buf.toString()}`);
   const encrypt = jest.fn((plain: string) => ({
@@ -68,6 +70,7 @@ function setup(options?: {
     service,
     get,
     upsert,
+    updateIfPresent,
     decrypt,
     encrypt,
     refresh,
@@ -200,12 +203,13 @@ describe('OAuthTokenService.getAccessToken', () => {
       const refresh = jest
         .fn()
         .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
-      const { service, upsert, encrypt } = setup({ refresh });
+      const { service, updateIfPresent, encrypt } = setup({ refresh });
 
       await service.getAccessToken(USER_ID, SERVER_ID);
 
       expect(encrypt).toHaveBeenCalledWith('rt-2');
-      expect(upsert).toHaveBeenCalledWith(
+      expect(updateIfPresent).toHaveBeenCalledWith(
+        1,
         expect.objectContaining({
           userId: USER_ID,
           mcpServerId: SERVER_ID,
@@ -215,19 +219,19 @@ describe('OAuthTokenService.getAccessToken', () => {
     });
 
     it('does not write back when the grant returns no new refresh token', async () => {
-      const { service, upsert } = setup();
+      const { service, updateIfPresent } = setup();
 
       await service.getAccessToken(USER_ID, SERVER_ID);
 
-      expect(upsert).not.toHaveBeenCalled();
+      expect(updateIfPresent).not.toHaveBeenCalled();
     });
 
     it('still returns the token when the rotation write-back fails', async () => {
       const refresh = jest
         .fn()
         .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
-      const { service, upsert } = setup({ refresh });
-      (upsert as jest.Mock).mockRejectedValue(new Error('db down'));
+      const { service, updateIfPresent } = setup({ refresh });
+      (updateIfPresent as jest.Mock).mockRejectedValue(new Error('db down'));
 
       await expect(service.getAccessToken(USER_ID, SERVER_ID)).resolves.toBe('at-1');
     });
@@ -236,13 +240,13 @@ describe('OAuthTokenService.getAccessToken', () => {
       const refresh = jest
         .fn()
         .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
-      const { service, encrypt, upsert } = setup({ refresh });
+      const { service, encrypt, updateIfPresent } = setup({ refresh });
       (encrypt as jest.Mock).mockImplementation(() => {
         throw new Error('key unavailable');
       });
 
       await expect(service.getAccessToken(USER_ID, SERVER_ID)).resolves.toBe('at-1');
-      expect(upsert).not.toHaveBeenCalled();
+      expect(updateIfPresent).not.toHaveBeenCalled();
     });
   });
 
@@ -280,14 +284,14 @@ describe('OAuthTokenService.getAccessToken', () => {
         scopes: 'a b c',
       });
       const get = jest.fn().mockResolvedValueOnce(original).mockResolvedValueOnce(latest);
-      const upsert = jest.fn().mockResolvedValue(undefined);
+      const updateIfPresent = jest.fn().mockResolvedValue(undefined);
       const refresh = jest
         .fn()
         .mockRejectedValueOnce(new OAuthInvalidGrantError())
         .mockResolvedValueOnce({ accessToken: 'at', expiresInS: 3600, refreshToken: 'rt-3' });
 
       const service = new OAuthTokenService({
-        store: { get, upsert } as unknown as McpOAuthCredentialsStore,
+        store: { get, upsert: jest.fn(), updateIfPresent } as unknown as McpOAuthCredentialsStore,
         encryption: {
           decrypt: (buf: Buffer) => buf.toString(),
           encrypt: () => ({ ciphertext: Buffer.from('enc:rt-3') }),
@@ -297,7 +301,7 @@ describe('OAuthTokenService.getAccessToken', () => {
 
       await service.getAccessToken(USER_ID, SERVER_ID);
 
-      expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ scopes: 'a b c' }));
+      expect(updateIfPresent).toHaveBeenCalledWith(1, expect.objectContaining({ scopes: 'a b c' }));
     });
 
     it('raises OAuthReauthRequiredError when the re-read shows the same (unrotated) token', async () => {
@@ -394,5 +398,44 @@ describe('OAuthTokenService.getAccessToken', () => {
       );
       expect(refreshAccessToken).not.toHaveBeenCalled();
     });
+  });
+});
+
+// A disconnect (DELETE) landing between the grant read and the write-back must not re-create the
+// row: the atomic update-only path leaves a deleted credential deleted, not silently resurrected.
+describe('OAuthTokenService — concurrent disconnect during refresh write-back', () => {
+  it('does not resurrect a credential deleted between the snapshot read and the rotated-token write-back', async () => {
+    // GIVEN a stored credential and a refresh that rotates the token while a concurrent disconnect
+    // (the row is DELETED) lands before the write-back; updateIfPresent updates only an existing row.
+    let current: StoredMcpOAuthCredential | null = makeCredential();
+    const store = {
+      get: jest.fn(async () => current),
+      updateIfPresent: jest.fn(async (id: number, credential: McpOAuthCredentialInput) => {
+        if (current && current.id === id) current = { ...credential, id };
+      }),
+      delete: jest.fn(async () => {
+        current = null;
+      }),
+    } as unknown as McpOAuthCredentialsStore;
+
+    const refresh = jest.fn(async () => {
+      // The disconnect lands after refreshAndCache's snapshot read, before persistRotatedRefreshToken.
+      await store.delete(USER_ID, SERVER_ID);
+
+      return { accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rotated-rt' };
+    });
+
+    const encryption = {
+      decrypt: (buf: Buffer) => buf.toString(),
+      encrypt: (plain: string) => ({ ciphertext: Buffer.from(`enc:${plain}`) }),
+    } as unknown as CredentialEncryption;
+
+    const service = new OAuthTokenService({ store, encryption, refreshAccessToken: refresh });
+
+    // WHEN a token is acquired, triggering the refresh and the rotated-token write-back.
+    await service.getAccessToken(USER_ID, SERVER_ID);
+
+    // THEN the deleted credential must stay deleted — the write-back must not recreate it.
+    expect(await store.get(USER_ID, SERVER_ID)).toBeNull();
   });
 });

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -142,6 +142,19 @@ describe('OAuthTokenService.getAccessToken', () => {
       expect(refresh).toHaveBeenCalledTimes(1);
     });
 
+    it('evict drops the cached token so the next acquire refreshes again', async () => {
+      const { service, refresh } = setup();
+
+      await service.getAccessToken(USER_ID, SERVER_ID);
+      await service.getAccessToken(USER_ID, SERVER_ID);
+      expect(refresh).toHaveBeenCalledTimes(1); // second call served from cache
+
+      service.evict(USER_ID, SERVER_ID);
+      await service.getAccessToken(USER_ID, SERVER_ID);
+
+      expect(refresh).toHaveBeenCalledTimes(2); // cache dropped → refreshed again
+    });
+
     it('refreshes again once the token is within the skew window of expiry', async () => {
       const { service, refresh, advance } = setup({ expirySkewS: 60 });
 

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -1,7 +1,9 @@
 import type CredentialEncryption from '../../src/crypto/credential-encryption';
 import type { RefreshGrantParams, RefreshGrantResult } from '../../src/oauth/refresh-grant';
-import type McpOAuthCredentialsStore from '../../src/stores/mcp-oauth-credentials-store';
-import type { StoredMcpOAuthCredential } from '../../src/stores/mcp-oauth-credentials-store';
+import type {
+  McpOAuthCredentialsStore,
+  StoredMcpOAuthCredential,
+} from '../../src/ports/mcp-oauth-credentials-store';
 
 import {
   OAuthInvalidGrantError,

--- a/packages/workflow-executor/test/oauth/token-service.test.ts
+++ b/packages/workflow-executor/test/oauth/token-service.test.ts
@@ -231,6 +231,19 @@ describe('OAuthTokenService.getAccessToken', () => {
 
       await expect(service.getAccessToken(USER_ID, SERVER_ID)).resolves.toBe('at-1');
     });
+
+    it('still returns the token when encrypting the rotated refresh token throws', async () => {
+      const refresh = jest
+        .fn()
+        .mockResolvedValue({ accessToken: 'at-1', expiresInS: 3600, refreshToken: 'rt-2' });
+      const { service, encrypt, upsert } = setup({ refresh });
+      (encrypt as jest.Mock).mockImplementation(() => {
+        throw new Error('key unavailable');
+      });
+
+      await expect(service.getAccessToken(USER_ID, SERVER_ID)).resolves.toBe('at-1');
+      expect(upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('invalid_grant — concurrent rotation recovery', () => {

--- a/packages/workflow-executor/test/remote-tool-fetcher.test.ts
+++ b/packages/workflow-executor/test/remote-tool-fetcher.test.ts
@@ -4,7 +4,7 @@ import type { Logger } from '../src/ports/logger-port';
 import type { WorkflowPort } from '../src/ports/workflow-port';
 import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
-import { ConfigurationError, OAuthReauthRequiredError } from '../src/errors';
+import { OAuthReauthRequiredError } from '../src/errors';
 import RemoteToolFetcher, { scopeConfigsToServer } from '../src/remote-tool-fetcher';
 
 const USER_ID = 1;
@@ -39,11 +39,16 @@ function makeFetcher(overrides?: {
   const workflowPort = { ...createMockWorkflowPort(), ...overrides?.workflowPort };
   const aiModelPort = { ...createMockAiModelPort(), ...overrides?.aiModelPort };
   const logger = overrides?.logger ?? createMockLogger();
+  const tokenService =
+    overrides?.tokenService ??
+    ({
+      getAccessToken: jest.fn().mockResolvedValue('access-token'),
+    } as unknown as OAuthTokenService);
   const fetcher = new RemoteToolFetcher(
     workflowPort as unknown as WorkflowPort,
     aiModelPort as unknown as AiModelPort,
     logger,
-    overrides?.tokenService,
+    tokenService,
   );
 
   return { fetcher, workflowPort, aiModelPort, logger };
@@ -334,16 +339,6 @@ describe('RemoteToolFetcher.fetch — OAuth2 servers', () => {
     });
     expect(result.tools).toEqual([tool]);
     expect(typeof result.reloadWithFreshAuth).toBe('function');
-  });
-
-  it('throws ConfigurationError when no token service is wired (in-memory executor)', async () => {
-    const { fetcher } = makeFetcher({
-      workflowPort: {
-        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
-      },
-    });
-
-    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toBeInstanceOf(ConfigurationError);
   });
 
   it('force-refreshes and retries list-tools once on an auth failure, then succeeds', async () => {

--- a/packages/workflow-executor/test/remote-tool-fetcher.test.ts
+++ b/packages/workflow-executor/test/remote-tool-fetcher.test.ts
@@ -1,16 +1,25 @@
+import type OAuthTokenService from '../src/oauth/token-service';
 import type { AiModelPort } from '../src/ports/ai-model-port';
 import type { Logger } from '../src/ports/logger-port';
 import type { WorkflowPort } from '../src/ports/workflow-port';
 import type { RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
+import { ConfigurationError, OAuthReauthRequiredError } from '../src/errors';
 import RemoteToolFetcher, { scopeConfigsToServer } from '../src/remote-tool-fetcher';
+
+const USER_ID = 1;
+
+type AiModelMethods = Pick<AiModelPort, 'loadRemoteTools' | 'loadRemoteToolsWithFailures'>;
 
 function createMockWorkflowPort(): jest.Mocked<Pick<WorkflowPort, 'getMcpServerConfigs'>> {
   return { getMcpServerConfigs: jest.fn().mockResolvedValue({}) };
 }
 
-function createMockAiModelPort(): jest.Mocked<Pick<AiModelPort, 'loadRemoteTools'>> {
-  return { loadRemoteTools: jest.fn().mockResolvedValue([]) };
+function createMockAiModelPort(): jest.Mocked<AiModelMethods> {
+  return {
+    loadRemoteTools: jest.fn().mockResolvedValue([]),
+    loadRemoteToolsWithFailures: jest.fn().mockResolvedValue({ tools: [], failures: [] }),
+  };
 }
 
 function createMockLogger(): jest.MockedFunction<Logger> {
@@ -23,8 +32,9 @@ function makeRemoteTool(sourceId: string, mcpServerId?: string): RemoteTool {
 
 function makeFetcher(overrides?: {
   workflowPort?: Partial<jest.Mocked<Pick<WorkflowPort, 'getMcpServerConfigs'>>>;
-  aiModelPort?: Partial<jest.Mocked<Pick<AiModelPort, 'loadRemoteTools'>>>;
+  aiModelPort?: Partial<jest.Mocked<AiModelMethods>>;
   logger?: jest.MockedFunction<Logger>;
+  tokenService?: OAuthTokenService;
 }) {
   const workflowPort = { ...createMockWorkflowPort(), ...overrides?.workflowPort };
   const aiModelPort = { ...createMockAiModelPort(), ...overrides?.aiModelPort };
@@ -33,6 +43,7 @@ function makeFetcher(overrides?: {
     workflowPort as unknown as WorkflowPort,
     aiModelPort as unknown as AiModelPort,
     logger,
+    overrides?.tokenService,
   );
 
   return { fetcher, workflowPort, aiModelPort, logger };
@@ -40,6 +51,15 @@ function makeFetcher(overrides?: {
 
 const cfg = (id: string | undefined): ToolConfig =>
   ({ id, url: 'https://x.example', type: 'http' as const, headers: {} } as unknown as ToolConfig);
+
+const oauthCfg = (id: string): ToolConfig =>
+  ({
+    id,
+    authType: 'oauth2',
+    url: 'https://x.example',
+    type: 'http' as const,
+    headers: {},
+  } as unknown as ToolConfig);
 
 // ---------------------------------------------------------------------------
 // scopeConfigsToServer (pure)
@@ -82,7 +102,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await fetcher.fetch('id-A');
+    await fetcher.fetch('id-A', USER_ID);
 
     expect(aiModelPort.loadRemoteTools).toHaveBeenCalledWith({ 'srv-a': cfg('id-A') });
   });
@@ -92,7 +112,7 @@ describe('RemoteToolFetcher.fetch', () => {
       workflowPort: { getMcpServerConfigs: jest.fn().mockResolvedValue({}) },
     });
 
-    const result = await fetcher.fetch('id-A');
+    const result = await fetcher.fetch('id-A', USER_ID);
 
     expect(result).toEqual({ tools: [], mcpServerName: undefined });
     expect(aiModelPort.loadRemoteTools).not.toHaveBeenCalled();
@@ -107,7 +127,7 @@ describe('RemoteToolFetcher.fetch', () => {
       aiModelPort: { loadRemoteTools: jest.fn().mockResolvedValue(remoteTools) },
     });
 
-    const result = await fetcher.fetch('id-A');
+    const result = await fetcher.fetch('id-A', USER_ID);
 
     expect(result).toEqual({ tools: remoteTools, mcpServerName: 'srv-a' });
   });
@@ -121,7 +141,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await fetcher.fetch('id-missing');
+    await fetcher.fetch('id-missing', USER_ID);
 
     expect(logger).toHaveBeenCalledWith(
       'Warn',
@@ -139,7 +159,7 @@ describe('RemoteToolFetcher.fetch', () => {
       workflowPort: { getMcpServerConfigs: jest.fn().mockResolvedValue({}) },
     });
 
-    await fetcher.fetch('id-A');
+    await fetcher.fetch('id-A', USER_ID);
 
     expect(logger).toHaveBeenCalledWith(
       'Warn',
@@ -160,7 +180,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await fetcher.fetch('id-A');
+    await fetcher.fetch('id-A', USER_ID);
 
     expect(logger.mock.calls.find(c => c[0] === 'Warn')).toBeUndefined();
   });
@@ -173,7 +193,7 @@ describe('RemoteToolFetcher.fetch', () => {
       aiModelPort: { loadRemoteTools: jest.fn().mockResolvedValue([]) },
     });
 
-    await fetcher.fetch('id-A');
+    await fetcher.fetch('id-A', USER_ID);
 
     expect(logger).toHaveBeenCalledWith('Error', 'MCP servers failed to load tools', {
       requestedMcpServerId: 'id-A',
@@ -192,7 +212,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await fetcher.fetch('id-A');
+    await fetcher.fetch('id-A', USER_ID);
 
     expect(logger.mock.calls.find(c => c[0] === 'Error')).toBeUndefined();
   });
@@ -214,7 +234,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await fetcher.fetch('id-zendesk');
+    await fetcher.fetch('id-zendesk', USER_ID);
 
     expect(logger.mock.calls.find(c => c[0] === 'Error')).toBeUndefined();
   });
@@ -232,7 +252,7 @@ describe('RemoteToolFetcher.fetch', () => {
       aiModelPort: { loadRemoteTools: jest.fn().mockResolvedValue([]) },
     });
 
-    await fetcher.fetch('id-zendesk');
+    await fetcher.fetch('id-zendesk', USER_ID);
 
     expect(logger).toHaveBeenCalledWith('Error', 'MCP servers failed to load tools', {
       requestedMcpServerId: 'id-zendesk',
@@ -250,7 +270,7 @@ describe('RemoteToolFetcher.fetch', () => {
       aiModelPort: { loadRemoteTools: jest.fn().mockResolvedValue(remoteTools) },
     });
 
-    const result = await fetcher.fetch('id-A');
+    const result = await fetcher.fetch('id-A', USER_ID);
 
     expect(result.tools).toBe(remoteTools);
   });
@@ -265,7 +285,7 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await expect(fetcher.fetch('id-A')).rejects.toThrow('MCP unreachable');
+    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toThrow('MCP unreachable');
     expect(logger.mock.calls.find(c => c[0] === 'Error')).toBeUndefined();
   });
 
@@ -276,7 +296,142 @@ describe('RemoteToolFetcher.fetch', () => {
       },
     });
 
-    await expect(fetcher.fetch('id-A')).rejects.toThrow('orchestrator down');
+    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toThrow('orchestrator down');
     expect(aiModelPort.loadRemoteTools).not.toHaveBeenCalled();
+  });
+});
+
+describe('RemoteToolFetcher.fetch — OAuth2 servers', () => {
+  const makeTokenService = (getAccessToken: jest.Mock): OAuthTokenService =>
+    ({ getAccessToken } as unknown as OAuthTokenService);
+
+  const authFailure = {
+    server: 'srv-a',
+    mcpServerId: 'id-A',
+    kind: 'auth',
+    error: new Error('401'),
+  };
+
+  it('acquires a token, injects it as a Bearer header, and returns the loaded tools + a reload hook', async () => {
+    const tool = makeRemoteTool('srv-a', 'id-A');
+    const getAccessToken = jest.fn().mockResolvedValue('tok-1');
+    const loadRemoteToolsWithFailures = jest
+      .fn()
+      .mockResolvedValue({ tools: [tool], failures: [] });
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+      aiModelPort: { loadRemoteToolsWithFailures },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    const result = await fetcher.fetch('id-A', USER_ID);
+
+    expect(getAccessToken).toHaveBeenCalledWith(USER_ID, 'id-A', { forceRefresh: false });
+    expect(loadRemoteToolsWithFailures).toHaveBeenCalledWith({
+      'srv-a': expect.objectContaining({ headers: { Authorization: 'Bearer tok-1' } }),
+    });
+    expect(result.tools).toEqual([tool]);
+    expect(typeof result.reloadWithFreshAuth).toBe('function');
+  });
+
+  it('throws ConfigurationError when no token service is wired (in-memory executor)', async () => {
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+    });
+
+    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toBeInstanceOf(ConfigurationError);
+  });
+
+  it('force-refreshes and retries list-tools once on an auth failure, then succeeds', async () => {
+    const tool = makeRemoteTool('srv-a', 'id-A');
+    const getAccessToken = jest.fn().mockResolvedValue('tok');
+    const loadRemoteToolsWithFailures = jest
+      .fn()
+      .mockResolvedValueOnce({ tools: [], failures: [authFailure] })
+      .mockResolvedValueOnce({ tools: [tool], failures: [] });
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+      aiModelPort: { loadRemoteToolsWithFailures },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    const result = await fetcher.fetch('id-A', USER_ID);
+
+    expect(getAccessToken).toHaveBeenNthCalledWith(1, USER_ID, 'id-A', { forceRefresh: false });
+    expect(getAccessToken).toHaveBeenNthCalledWith(2, USER_ID, 'id-A', { forceRefresh: true });
+    expect(result.tools).toEqual([tool]);
+  });
+
+  it('raises OAuthReauthRequiredError when the auth failure persists after a forced refresh', async () => {
+    const getAccessToken = jest.fn().mockResolvedValue('tok');
+    const loadRemoteToolsWithFailures = jest
+      .fn()
+      .mockResolvedValue({ tools: [], failures: [authFailure] });
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+      aiModelPort: { loadRemoteToolsWithFailures },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+  });
+
+  it('propagates OAuthReauthRequiredError from token acquisition (no stored credential)', async () => {
+    const getAccessToken = jest.fn().mockRejectedValue(new OAuthReauthRequiredError('id-A'));
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    await expect(fetcher.fetch('id-A', USER_ID)).rejects.toBeInstanceOf(OAuthReauthRequiredError);
+  });
+
+  it('reloadWithFreshAuth forces a refresh and returns freshly-authed tools', async () => {
+    const tool = makeRemoteTool('srv-a', 'id-A');
+    const getAccessToken = jest.fn().mockResolvedValue('tok');
+    const loadRemoteToolsWithFailures = jest
+      .fn()
+      .mockResolvedValue({ tools: [tool], failures: [] });
+    const { fetcher } = makeFetcher({
+      workflowPort: {
+        getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': oauthCfg('id-A') }),
+      },
+      aiModelPort: { loadRemoteToolsWithFailures },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    const { reloadWithFreshAuth } = await fetcher.fetch('id-A', USER_ID);
+    if (!reloadWithFreshAuth) throw new Error('expected reloadWithFreshAuth to be defined');
+    getAccessToken.mockClear();
+    const reloaded = await reloadWithFreshAuth();
+
+    expect(getAccessToken).toHaveBeenCalledWith(USER_ID, 'id-A', { forceRefresh: true });
+    expect(reloaded).toEqual([tool]);
+  });
+
+  it('leaves the token service untouched for a bearer/none server', async () => {
+    const getAccessToken = jest.fn();
+    const tool = makeRemoteTool('srv-a', 'id-A');
+    const { fetcher, aiModelPort } = makeFetcher({
+      workflowPort: { getMcpServerConfigs: jest.fn().mockResolvedValue({ 'srv-a': cfg('id-A') }) },
+      aiModelPort: { loadRemoteTools: jest.fn().mockResolvedValue([tool]) },
+      tokenService: makeTokenService(getAccessToken),
+    });
+
+    const result = await fetcher.fetch('id-A', USER_ID);
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(aiModelPort.loadRemoteTools).toHaveBeenCalled();
+    expect(result.reloadWithFreshAuth).toBeUndefined();
   });
 });

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -80,6 +80,7 @@ function createMockRunStore(overrides: Partial<RunStore> = {}): jest.Mocked<RunS
     close: jest.fn().mockResolvedValue(undefined),
     getStepExecutions: jest.fn().mockResolvedValue([]),
     saveStepExecution: jest.fn().mockResolvedValue(undefined),
+    deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   } as jest.Mocked<RunStore>;
 }
@@ -106,6 +107,7 @@ function createRunnerConfig(
       close: jest.fn().mockResolvedValue(undefined),
       getStepExecutions: jest.fn().mockResolvedValue([]),
       saveStepExecution: jest.fn().mockResolvedValue(undefined),
+      deleteStepExecution: jest.fn().mockResolvedValue(undefined),
     } as unknown as RunStore,
     pollingIntervalS: POLLING_INTERVAL_S,
     aiModelPort: createMockAiClient() as unknown as AiModelPort,

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1,4 +1,5 @@
 import type { StepContextConfig } from '../src/executors/step-executor-factory';
+import type OAuthTokenService from '../src/oauth/token-service';
 import type { AgentPort } from '../src/ports/agent-port';
 import type { AiModelPort } from '../src/ports/ai-model-port';
 import type { Logger } from '../src/ports/logger-port';
@@ -120,6 +121,9 @@ function createRunnerConfig(
     schemaCache: new SchemaCache(),
     envSecret: VALID_ENV_SECRET,
     authSecret: VALID_AUTH_SECRET,
+    mcpOAuthTokenService: {
+      getAccessToken: jest.fn().mockResolvedValue('access-token'),
+    } as unknown as OAuthTokenService,
     ...overrides,
   };
 }

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1711,7 +1711,7 @@ describe('StepExecutorFactory.create — factory', () => {
       fetchRemoteTools,
     );
     expect(executor).toBeInstanceOf(McpStepExecutor);
-    expect(fetchRemoteTools).toHaveBeenCalledWith('srv-42');
+    expect(fetchRemoteTools).toHaveBeenCalledWith('srv-42', 1);
     expect(
       (
         executor as unknown as { getExtraLogContext(): Record<string, unknown> }

--- a/packages/workflow-executor/test/stores/database-mcp-oauth-credentials-store.test.ts
+++ b/packages/workflow-executor/test/stores/database-mcp-oauth-credentials-store.test.ts
@@ -169,6 +169,36 @@ describe('DatabaseMcpOAuthCredentialsStore (SQLite)', () => {
     });
   });
 
+  describe('updateIfPresent', () => {
+    it('updates the row matching the given id in place', async () => {
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('old') }));
+      const { id } = unwrap(await store.get(42, 'mcp-server-1'));
+
+      await store.updateIfPresent(id, makeCredential({ refreshTokenEnc: Buffer.from('rotated') }));
+
+      const row = unwrap(await store.get(42, 'mcp-server-1'));
+      expect(row.refreshTokenEnc.toString()).toBe('rotated');
+    });
+
+    it('does not insert a row when none exists for the key', async () => {
+      await store.updateIfPresent(1, makeCredential());
+
+      expect(await store.get(42, 'mcp-server-1')).toBeNull();
+    });
+
+    it('does not touch a row that was re-created with a different id', async () => {
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('old') }));
+      const staleId = unwrap(await store.get(42, 'mcp-server-1')).id;
+      await store.delete(42, 'mcp-server-1');
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('reauthorized') }));
+
+      await store.updateIfPresent(staleId, makeCredential({ refreshTokenEnc: Buffer.from('rot') }));
+
+      const row = unwrap(await store.get(42, 'mcp-server-1'));
+      expect(row.refreshTokenEnc.toString()).toBe('reauthorized');
+    });
+  });
+
   describe('isolation', () => {
     it('keeps credentials for the same server but different users separate', async () => {
       await store.upsert(makeCredential({ userId: 1, refreshTokenEnc: Buffer.from('user-1') }));

--- a/packages/workflow-executor/test/stores/database-store.test.ts
+++ b/packages/workflow-executor/test/stores/database-store.test.ts
@@ -27,6 +27,32 @@ describe('DatabaseStore (SQLite)', () => {
     await store.close();
   });
 
+  it('clears the step execution for a given (runId, stepIndex)', async () => {
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+
+    await store.deleteStepExecution('run-1', 0);
+
+    expect(await store.getStepExecutions('run-1')).toEqual([]);
+  });
+
+  it('leaves other steps in the same run untouched when clearing one step', async () => {
+    const kept = makeStepExecution({ stepIndex: 1, type: 'read-record' } as never);
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+    await store.saveStepExecution('run-1', kept);
+
+    await store.deleteStepExecution('run-1', 0);
+
+    expect(await store.getStepExecutions('run-1')).toEqual([kept]);
+  });
+
+  it('is a no-op when no execution exists for that (runId, stepIndex)', async () => {
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+
+    await store.deleteStepExecution('run-1', 99);
+
+    expect((await store.getStepExecutions('run-1')).map(s => s.stepIndex)).toEqual([0]);
+  });
+
   it('returns empty array for unknown runId', async () => {
     const result = await store.getStepExecutions('unknown');
     expect(result).toEqual([]);

--- a/packages/workflow-executor/test/stores/in-memory-mcp-oauth-credentials-store.test.ts
+++ b/packages/workflow-executor/test/stores/in-memory-mcp-oauth-credentials-store.test.ts
@@ -86,6 +86,38 @@ describe('InMemoryMcpOAuthCredentialsStore', () => {
     });
   });
 
+  describe('updateIfPresent', () => {
+    it('updates the row matching the given id in place', async () => {
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('old') }));
+      const { id } = unwrap(await store.get(42, 'mcp-server-1'));
+
+      await store.updateIfPresent(id, makeCredential({ refreshTokenEnc: Buffer.from('rotated') }));
+
+      expect(unwrap(await store.get(42, 'mcp-server-1')).refreshTokenEnc.toString()).toBe(
+        'rotated',
+      );
+    });
+
+    it('does not insert when the row is absent', async () => {
+      await store.updateIfPresent(1, makeCredential());
+
+      expect(await store.get(42, 'mcp-server-1')).toBeNull();
+    });
+
+    it('does not touch a row that was re-created with a different id', async () => {
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('old') }));
+      const staleId = unwrap(await store.get(42, 'mcp-server-1')).id;
+      await store.delete(42, 'mcp-server-1');
+      await store.upsert(makeCredential({ refreshTokenEnc: Buffer.from('reauthorized') }));
+
+      await store.updateIfPresent(staleId, makeCredential({ refreshTokenEnc: Buffer.from('rot') }));
+
+      expect(unwrap(await store.get(42, 'mcp-server-1')).refreshTokenEnc.toString()).toBe(
+        'reauthorized',
+      );
+    });
+  });
+
   describe('isolation', () => {
     it('keeps entries for different users and servers separate', async () => {
       await store.upsert(makeCredential({ userId: 1, refreshTokenEnc: Buffer.from('user-1') }));

--- a/packages/workflow-executor/test/stores/in-memory-store.test.ts
+++ b/packages/workflow-executor/test/stores/in-memory-store.test.ts
@@ -19,6 +19,32 @@ describe('InMemoryStore', () => {
     store = new InMemoryStore();
   });
 
+  it('clears the step execution for a given (runId, stepIndex)', async () => {
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+
+    await store.deleteStepExecution('run-1', 0);
+
+    expect(await store.getStepExecutions('run-1')).toEqual([]);
+  });
+
+  it('leaves other steps in the same run untouched when clearing one step', async () => {
+    const kept = makeStepExecution({ stepIndex: 1, type: 'read-record' } as never);
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+    await store.saveStepExecution('run-1', kept);
+
+    await store.deleteStepExecution('run-1', 0);
+
+    expect(await store.getStepExecutions('run-1')).toEqual([kept]);
+  });
+
+  it('is a no-op when no execution exists for that (runId, stepIndex)', async () => {
+    await store.saveStepExecution('run-1', makeStepExecution({ stepIndex: 0 }));
+
+    await store.deleteStepExecution('run-1', 99);
+
+    expect((await store.getStepExecutions('run-1')).map(s => s.stepIndex)).toEqual([0]);
+  });
+
   it('returns empty array for unknown runId', async () => {
     const result = await store.getStepExecutions('unknown');
     expect(result).toEqual([]);

--- a/packages/workflow-executor/test/types/step-outcome.test.ts
+++ b/packages/workflow-executor/test/types/step-outcome.test.ts
@@ -1,5 +1,8 @@
 import { StepType } from '../../src/types/validated/step-definition';
-import { stepTypeToOutcomeType } from '../../src/types/validated/step-outcome';
+import {
+  McpStepOutcomeSchema,
+  stepTypeToOutcomeType,
+} from '../../src/types/validated/step-outcome';
 
 describe('stepTypeToOutcomeType', () => {
   it('maps Condition to condition', () => {
@@ -32,5 +35,45 @@ describe('stepTypeToOutcomeType', () => {
 
   it('falls through to record for an unknown future step type', () => {
     expect(stepTypeToOutcomeType('future-step-type' as StepType)).toBe('record');
+  });
+});
+
+describe('McpStepOutcomeSchema — awaitingInputReason', () => {
+  const base = { type: 'mcp' as const, stepId: 'step-1', stepIndex: 0 };
+
+  it("accepts an awaiting-input outcome carrying awaitingInputReason 'needs-oauth-reauth'", () => {
+    const parsed = McpStepOutcomeSchema.parse({
+      ...base,
+      status: 'awaiting-input',
+      awaitingInputReason: 'needs-oauth-reauth',
+    });
+
+    expect(parsed.awaitingInputReason).toBe('needs-oauth-reauth');
+  });
+
+  it('allows awaitingInputReason to be omitted', () => {
+    const parsed = McpStepOutcomeSchema.parse({ ...base, status: 'awaiting-input' });
+
+    expect(parsed.awaitingInputReason).toBeUndefined();
+  });
+
+  it('rejects an unknown awaitingInputReason value', () => {
+    expect(() =>
+      McpStepOutcomeSchema.parse({
+        ...base,
+        status: 'awaiting-input',
+        awaitingInputReason: 'nope',
+      }),
+    ).toThrow();
+  });
+
+  it("rejects the legacy 'reason' key under the strict schema", () => {
+    expect(() =>
+      McpStepOutcomeSchema.parse({
+        ...base,
+        status: 'awaiting-input',
+        reason: 'needs-oauth-reauth',
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## What & why
Executor-side runtime use of stored OAuth credentials for OAuth2-protected MCP servers (PRD-367, PR2). At an `oauth2` MCP step the executor looks up the stored credential by `(user, server)`, runs a refresh-token grant against the stored `token_endpoint` behind an expiry-skew cache, injects the Bearer token before connecting, retries once on an upstream 401 (covering both list-tools and the tool call), and pauses the step `awaiting-input` with `awaitingInputReason: needs-oauth-reauth` when there is no usable credential or the refresh is rejected. Bearer/none steps are unchanged.

## Stacked PR / deploy ordering
- Based on `feat/prd-367-pr1-executor-oauth-credentials` (PR #1619), not `main`: PR2 depends on PR1's credential store / encryption / deposit endpoint, which is not yet merged. Review the diff against that branch.
- Behaviour stays dormant until the Forest server serves `authType` + accepts the typed `awaitingInputReason` (PR1.5) and the frontend ships (PR3) — deploy the orchestrator first. Safe to deploy alone: the oauth2 path only activates once `authType=oauth2` is served; bearer/none is unchanged.

## Notable choices (large-PR annotation)
- Serialization (option B): in-process mutex + DB re-read + single retry on `invalid_grant`, not a Postgres row lock — the executor and token endpoints can sit behind a client VPN, so no DB lock is held across the refresh HTTP call. Row lock is the documented hardening path if a strict reuse-detection provider plus real cross-process contention appears.
- Executor isolation: the executor gains only a re-loadable tool source (`reloadWithFreshAuth`) plus a typed `OAuthReauthRequiredError -> awaiting-input` mapping; all token/credential/HTTP logic stays behind `RemoteToolFetcher` and the new OAuth token service.
- Shared `@forestadmin/ai-proxy` change (consumed by the agent too) is additive-only (new `loadToolsWithFailures` / `loadRemoteToolsWithFailures` + `mcp-auth-error` export) plus behaviour-preserving delegation; `authType` is stripped in the `McpClient` constructor like `id`.
- In-memory executor (dev-only) raises a `ConfigurationError` for oauth2 steps (no credential store wired).

## Tests
294 tests across the touched suites (ai-proxy 59 + workflow-executor 235); build, lint, tsc clean; >=90% line/stmt coverage on changed files.

## Known limitation
A re-auth at tool-call time leaves the step at `idempotencyPhase=executing`, so it needs a manual retry after re-auth; the common list-tools-time re-auth (pre-executor) resumes cleanly.

Part of PRD-367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add stored OAuth credential support for MCP steps in workflow executor
> - Introduces `OAuthTokenService` to retrieve, cache, and refresh OAuth access tokens per (userId, mcpServerId), with per-key serialization via a new `KeyedMutex` and rotation-aware retry logic.
> - Adds `refreshAccessToken` and `assertSafeTokenEndpoint` to perform the OAuth2 refresh-token grant and validate token endpoints against SSRF risks before any network call.
> - Updates `RemoteToolFetcher.fetch` to inject Bearer tokens for OAuth2 MCP servers, detect auth failures, and retry once with a forced refresh before surfacing `OAuthReauthRequiredError`.
> - Updates `McpStepExecutor` and `StepExecutorFactory` so auth failures during tool invocation produce an `awaiting-input` outcome with reason `needs-oauth-reauth` instead of failing the step.
> - Adds a `GET /list-mcp-tools` HTTP endpoint for design-time tool listing, with typed 409/503 responses for reauth and missing encryption key cases.
> - `POST /mcp-oauth-credentials` now validates `tokenEndpoint` safety at deposit time; `DELETE` now evicts cached tokens immediately.
> - Risk: `Runner` and `ExecutorHttpServer` constructor signatures have changed to require OAuth-related dependencies.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1665 opened
>
> - Prevented OAuth refresh token flow from following redirects and restricted token endpoint URL validation to enforce HTTPS and reject loopback addresses in non-development/non-test environments [5f1c6f3]
> - Evicted cached OAuth access tokens when credentials are upserted for a user and MCP server pair [5f1c6f3]
> - Modified `McpStepExecutor.doExecute` to clear the write-ahead idempotency phase marker when an `OAuthReauthRequiredError` is caught by calling a new `clearReauthPauseState` method that either re-saves the step execution with the phase cleared (if `pendingData` exists) or deletes the step execution entirely (if no `pendingData` exists) [9d48e40]
> - Changed `OAuthTokenService.persistRotatedRefreshToken` to use `store.updateIfPresent` instead of `store.upsert` when writing back rotated refresh tokens [9d48e40]
> - Added `updateIfPresent` method to `McpOAuthCredentialsStore` interface and implemented it in `DatabaseMcpOAuthCredentialsStore` and `InMemoryMcpOAuthCredentialsStore` [9d48e40]
> - Added `deleteStepExecution` method to `RunStore` interface and implemented it in `DatabaseStore` and `InMemoryStore` [9d48e40]
> - Added comprehensive test suite 'McpStepExecutor — re-auth pause hardening' in `mcp-step-executor.test.ts` validating re-auth pause behavior [9d48e40]
> - Updated all test mock factories across executor and service test files to include `deleteStepExecution` and `updateIfPresent` mocks [9d48e40]
> - Added tests for `updateIfPresent` in `database-mcp-oauth-credentials-store.test.ts` and `in-memory-mcp-oauth-credentials-store.test.ts` verifying in-place updates, no-insert behavior when absent, and no-update behavior when the row was re-created with a new id [9d48e40]
> - Added tests for `deleteStepExecution` in `database-store.test.ts` and `in-memory-store.test.ts` ensuring step deletion, preservation of other steps, and no-op behavior when the target step does not exist [9d48e40]
> - Updated token-service tests to assert `updateIfPresent` is called instead of `upsert` for refresh token rotation and added a test ensuring credentials deleted between read and write-back are not resurrected [9d48e40]
> - Added subsection 'OAuth2-protected MCP' to `workflow-executor` README describing how to exercise the executor's OAuth2-protected MCP path using `mcp-oauth-test-server` [9d48e40]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9d48e40. 9 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->