### PR TITLE
refactor(agent): forward workflow executor routes generically [PRD-567]

### DIFF
--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -1,7 +1,7 @@
 import type { ForestAdminHttpDriverServices } from '../../services';
 import type { AgentOptionsWithDefaults } from '../../types';
 import type KoaRouter from '@koa/router';
-import type { OutgoingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import type { Context } from 'koa';
 
 import { NotFoundError } from '@forestadmin/datasource-toolkit';
@@ -59,6 +59,14 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     );
 
     context.response.status = response.status;
+
+    // Forward response headers so the version gate (X-Forest-Executor-Version) survives the proxy.
+    for (const [name, value] of Object.entries(response.headers)) {
+      if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
+        context.response.set(name, value);
+      }
+    }
+
     context.response.body = response.body;
   }
 
@@ -100,7 +108,7 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     url: URL,
     body: string | undefined,
     headers: OutgoingHttpHeaders,
-  ): Promise<{ status: number; body: unknown }> {
+  ): Promise<{ status: number; body: unknown; headers: IncomingHttpHeaders }> {
     const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
 
     return new Promise((resolve, reject) => {
@@ -117,7 +125,11 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
             parsed = raw;
           }
 
-          resolve({ status: res.statusCode ?? HttpCode.InternalServerError, body: parsed });
+          resolve({
+            status: res.statusCode ?? HttpCode.InternalServerError,
+            body: parsed,
+            headers: res.headers,
+          });
         });
         res.on('error', reject);
       });

--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -13,7 +13,8 @@ import BaseRoute from '../base-route';
 
 const AGENT_PREFIX = '/_internal/workflow-executions';
 const EXECUTOR_PREFIX = '/runs';
-// Hop-by-hop headers + those the HTTP client recomputes — never forwarded.
+// Never forwarded: hop-by-hop headers, Host (Node derives the executor's from the target URL),
+// and length/encoding the HTTP client recomputes.
 const SKIPPED_HEADERS = new Set([
   'connection',
   'keep-alive',
@@ -34,6 +35,8 @@ const REQUEST_TIMEOUT_MS = 120_000;
 export default class WorkflowExecutorProxyRoute extends BaseRoute {
   readonly type = RouteType.PrivateRoute;
   private readonly executorUrl: URL;
+  // Overridable so tests can exercise the timeout branch without waiting the full default.
+  protected readonly requestTimeoutMs: number = REQUEST_TIMEOUT_MS;
 
   constructor(services: ForestAdminHttpDriverServices, options: AgentOptionsWithDefaults) {
     super(services, options);
@@ -50,13 +53,13 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
   private async handleProxy(context: Context): Promise<void> {
     const targetUrl = this.buildTargetUrl(context);
 
-    const response = await this.forwardRequest(
-      context.method,
-      targetUrl,
+    const response = await this.forwardRequest({
+      method: context.method,
+      url: targetUrl,
       // Raw body forwarded verbatim (set by @koa/bodyparser); undefined for GET.
-      context.method === 'GET' ? undefined : context.request.rawBody,
-      this.forwardedHeaders(context),
-    );
+      body: context.method === 'GET' ? undefined : context.request.rawBody,
+      headers: this.forwardedHeaders(context),
+    });
 
     context.response.status = response.status;
 
@@ -91,7 +94,7 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     return `${EXECUTOR_PREFIX}/${wildcard}`;
   }
 
-  // Forwards every client header except hop-by-hop / client-recomputed ones (Q4).
+  // Forwards every client header except the ones in SKIPPED_HEADERS.
   private forwardedHeaders(context: Context): OutgoingHttpHeaders {
     const headers: OutgoingHttpHeaders = {};
 
@@ -104,16 +107,17 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     return headers;
   }
 
-  private forwardRequest(
-    method: string,
-    url: URL,
-    body: string | undefined,
-    headers: OutgoingHttpHeaders,
-  ): Promise<{ status: number; body: unknown; headers: IncomingHttpHeaders }> {
+  private forwardRequest(request: {
+    method: string;
+    url: URL;
+    body: string | undefined;
+    headers: OutgoingHttpHeaders;
+  }): Promise<{ status: number; body: unknown; headers: IncomingHttpHeaders }> {
+    const { method, url, body, headers } = request;
     const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
 
     return new Promise((resolve, reject) => {
-      const req = requestFn(url, { method, headers, timeout: REQUEST_TIMEOUT_MS }, res => {
+      const req = requestFn(url, { method, headers, timeout: this.requestTimeoutMs }, res => {
         const chunks: Uint8Array[] = [];
         res.on('data', chunk => chunks.push(chunk));
         res.on('end', () => {

--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -1,18 +1,35 @@
 import type { ForestAdminHttpDriverServices } from '../../services';
 import type { AgentOptionsWithDefaults } from '../../types';
 import type KoaRouter from '@koa/router';
+import type { OutgoingHttpHeaders } from 'http';
 import type { Context } from 'koa';
 
+import { NotFoundError } from '@forestadmin/datasource-toolkit';
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
 
 import { HttpCode, RouteType } from '../../types';
 import BaseRoute from '../base-route';
 
-type ForwardedHeaders = {
-  authorization?: string;
-  cookie?: string;
-};
+const AGENT_PREFIX = '/_internal/workflow-executions';
+const EXECUTOR_PREFIX = '/runs';
+// Hop-by-hop headers + those the HTTP client recomputes — never forwarded.
+const SKIPPED_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'upgrade',
+  'te',
+  'trailer',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'host',
+  'content-length',
+]);
+// Substrings that could let the wildcard escape EXECUTOR_PREFIX (traversal, encoded dots,
+// backslash, null byte).
+const UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', '\0'];
+const REQUEST_TIMEOUT_MS = 120_000;
 
 export default class WorkflowExecutorProxyRoute extends BaseRoute {
   readonly type = RouteType.PrivateRoute;
@@ -24,50 +41,70 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     this.executorUrl = new URL(options.workflowExecutorUrl.replace(/\/+$/, ''));
   }
 
+  // Single catch-all: any sub-path/verb under AGENT_PREFIX is forwarded to EXECUTOR_PREFIX, so a
+  // new executor route needs no change here (PRD-567).
   setupRoutes(router: KoaRouter): void {
-    router.get('/_internal/workflow-executions/:runId', this.handleProxy.bind(this));
-    router.post('/_internal/workflow-executions/:runId/trigger', this.handleProxy.bind(this));
+    router.all(`${AGENT_PREFIX}/:path(.*)`, this.handleProxy.bind(this));
   }
 
   private async handleProxy(context: Context): Promise<void> {
-    const { runId } = context.params;
-    const isTrigger = context.method === 'POST';
-    const qs = context.querystring ? `?${context.querystring}` : '';
-    const executorRelativeUrl = isTrigger ? `/runs/${runId}/trigger${qs}` : `/runs/${runId}${qs}`;
-    const targetUrl = new URL(executorRelativeUrl, this.executorUrl);
-
-    const forwardedHeaders: ForwardedHeaders = {
-      authorization: context.request.header.authorization,
-      cookie: context.request.header.cookie,
-    };
+    const targetUrl = this.buildTargetUrl(context);
 
     const response = await this.forwardRequest(
       context.method,
       targetUrl,
-      context.request.body,
-      forwardedHeaders,
+      // Raw body forwarded verbatim (set by @koa/bodyparser); undefined for GET.
+      context.method === 'GET' ? undefined : context.request.rawBody,
+      this.forwardedHeaders(context),
     );
 
     context.response.status = response.status;
     context.response.body = response.body;
   }
 
+  private buildTargetUrl(context: Context): URL {
+    const path = this.executorPath(String(context.params.path ?? ''));
+    const qs = context.querystring ? `?${context.querystring}` : '';
+
+    return new URL(`${path}${qs}`, this.executorUrl);
+  }
+
+  // Security boundary: the wildcard can only ever map into EXECUTOR_PREFIX. Reject anything that
+  // could escape it so executor routes outside EXECUTOR_PREFIX stay unreachable through the proxy.
+  private executorPath(wildcard: string): string {
+    const unsafe =
+      wildcard === '' ||
+      wildcard.startsWith('/') ||
+      UNSAFE_PATH_FRAGMENTS.some(fragment => wildcard.includes(fragment));
+
+    if (unsafe) throw new NotFoundError('Invalid workflow executor path');
+
+    return `${EXECUTOR_PREFIX}/${wildcard}`;
+  }
+
+  // Forwards every client header except hop-by-hop / client-recomputed ones (Q4).
+  private forwardedHeaders(context: Context): OutgoingHttpHeaders {
+    const headers: OutgoingHttpHeaders = {};
+
+    for (const [name, value] of Object.entries(context.request.headers)) {
+      if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
+        headers[name] = value;
+      }
+    }
+
+    return headers;
+  }
+
   private forwardRequest(
     method: string,
     url: URL,
-    body?: unknown,
-    forwardedHeaders: ForwardedHeaders = {},
+    body: string | undefined,
+    headers: OutgoingHttpHeaders,
   ): Promise<{ status: number; body: unknown }> {
     const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-
-    // Forward the caller's auth so the executor's JWT middleware can validate it.
-    // Agent and executor share the same FOREST_AUTH_SECRET so the token is valid on both.
-    if (forwardedHeaders.authorization) headers.Authorization = forwardedHeaders.authorization;
-    if (forwardedHeaders.cookie) headers.Cookie = forwardedHeaders.cookie;
 
     return new Promise((resolve, reject) => {
-      const req = requestFn(url, { method, headers }, res => {
+      const req = requestFn(url, { method, headers, timeout: REQUEST_TIMEOUT_MS }, res => {
         const chunks: Uint8Array[] = [];
         res.on('data', chunk => chunks.push(chunk));
         res.on('end', () => {
@@ -86,10 +123,9 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
       });
 
       req.on('error', reject);
+      req.on('timeout', () => req.destroy(new Error('Workflow executor request timed out')));
 
-      if (body && method !== 'GET') {
-        req.write(JSON.stringify(body));
-      }
+      if (body !== undefined && method !== 'GET') req.write(body);
 
       req.end();
     });

--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -60,7 +60,8 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
 
     context.response.status = response.status;
 
-    // Forward response headers so the version gate (X-Forest-Executor-Version) survives the proxy.
+    // Forward every executor response header (minus hop-by-hop) so new executor headers never
+    // require an agent change (PRD-567: zero breaking, the agent stays a transparent proxy).
     for (const [name, value] of Object.entries(response.headers)) {
       if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
         context.response.set(name, value);

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -27,6 +27,26 @@ describe('WorkflowExecutorProxyRoute', () => {
       req.on('end', () => {
         receivedBody = Buffer.concat(chunks).toString('utf-8');
 
+        // Never responds → exercises the client-side request timeout.
+        if (req.url?.includes('hang')) return;
+
+        // Empty 204 — JSON.parse('') throws, so the proxy must fall back to a raw passthrough.
+        if (req.url?.includes('no-content')) {
+          res.writeHead(204);
+          res.end();
+
+          return;
+        }
+
+        // Non-JSON body — the proxy must forward it verbatim (future text/plain executor route).
+        if (req.url?.includes('plain-text')) {
+          res.setHeader('Content-Type', 'text/plain');
+          res.writeHead(200);
+          res.end('hello world');
+
+          return;
+        }
+
         res.setHeader('Content-Type', 'application/json');
         // Arbitrary executor response header — the proxy must forward it untouched.
         res.setHeader('X-Executor-Custom', 'passthrough-value');
@@ -174,6 +194,39 @@ describe('WorkflowExecutorProxyRoute', () => {
       expect(context.response.status).toBe(404);
       expect(context.response.body).toEqual({ error: 'Run not found or unavailable' });
     });
+
+    test('forwards a bodyless non-GET cleanly (empty body, no hang)', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      // No rawBody set → body is undefined; the request must still complete.
+      const context = buildContext('run-123/archive', { method: 'POST' });
+      await callHandleProxy(route, context);
+
+      expect(receivedMethod).toBe('POST');
+      expect(receivedUrl).toBe('/runs/run-123/archive');
+      expect(receivedBody).toBe('');
+      expect(context.response.status).toBe(200);
+    });
+
+    test('passes a non-JSON executor body through untouched', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('run-123/plain-text');
+      await callHandleProxy(route, context);
+
+      expect(context.response.status).toBe(200);
+      expect(context.response.body).toBe('hello world');
+    });
+
+    test('passes a 204 empty executor response through without throwing', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('run-123/no-content', { method: 'DELETE' });
+      await callHandleProxy(route, context);
+
+      expect(context.response.status).toBe(204);
+      expect(context.response.body).toBe('');
+    });
   });
 
   describe('handleProxy — headers', () => {
@@ -233,6 +286,16 @@ describe('WorkflowExecutorProxyRoute', () => {
       const route = buildRoute('http://localhost:1');
 
       await expect(callHandleProxy(route, buildContext('run-789'))).rejects.toThrow();
+    });
+
+    test('rejects when the executor does not respond before the timeout', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+      // Shrink the timeout so the never-responding 'hang' endpoint trips it quickly.
+      (route as unknown as { requestTimeoutMs: number }).requestTimeoutMs = 50;
+
+      await expect(callHandleProxy(route, buildContext('run-123/hang'))).rejects.toThrow(
+        /timed out/,
+      );
     });
   });
 });

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -13,16 +13,19 @@ describe('WorkflowExecutorProxyRoute', () => {
   let executorPort: number;
   let receivedHeaders: Record<string, string | string[] | undefined> = {};
   let receivedUrl: string | undefined;
+  let receivedMethod: string | undefined;
+  let receivedBody: string | undefined;
 
   // Start a real HTTP server to act as the workflow executor
   beforeAll(async () => {
     executorServer = http.createServer((req, res) => {
       receivedHeaders = { ...req.headers };
       receivedUrl = req.url;
+      receivedMethod = req.method;
       const chunks: Uint8Array[] = [];
       req.on('data', chunk => chunks.push(chunk));
       req.on('end', () => {
-        const body = Buffer.concat(chunks).toString('utf-8');
+        receivedBody = Buffer.concat(chunks).toString('utf-8');
 
         res.setHeader('Content-Type', 'application/json');
 
@@ -33,12 +36,13 @@ describe('WorkflowExecutorProxyRoute', () => {
           res.writeHead(200);
           res.end(JSON.stringify({ steps: [{ stepId: 's1', status: 'success' }] }));
         } else if (req.method === 'POST' && req.url?.match(/^\/runs\/[\w-]+\/trigger(\?.*)?$/)) {
-          const parsed = body ? JSON.parse(body) : {};
+          const parsed = receivedBody ? JSON.parse(receivedBody) : {};
           res.writeHead(200);
           res.end(JSON.stringify({ triggered: true, received: parsed }));
         } else {
-          res.writeHead(404);
-          res.end(JSON.stringify({ error: 'Not found' }));
+          // Echo for any other verb/sub-path so generic-forwarding tests can assert it arrived.
+          res.writeHead(200);
+          res.end(JSON.stringify({ method: req.method, url: req.url }));
         }
       });
     });
@@ -62,186 +66,158 @@ describe('WorkflowExecutorProxyRoute', () => {
     jest.clearAllMocks();
     receivedHeaders = {};
     receivedUrl = undefined;
+    receivedMethod = undefined;
+    receivedBody = undefined;
   });
 
   const buildOptions = (url: string) =>
     factories.forestAdminHttpDriverOptions.build({ workflowExecutorUrl: url });
 
+  const buildRoute = (url: string) => new WorkflowExecutorProxyRoute(services, buildOptions(url));
+
+  const callHandleProxy = (route: WorkflowExecutorProxyRoute, context: unknown) =>
+    (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context);
+
+  // Build a mock context for the catch-all route: `path` is the wildcard segment.
+  const buildContext = (
+    path: string,
+    extra: Parameters<typeof createMockContext>[0] = {},
+  ): ReturnType<typeof createMockContext> => {
+    const context = createMockContext({ customProperties: { params: { path } }, ...extra });
+
+    return context;
+  };
+
   describe('constructor', () => {
     test('should have RouteType.PrivateRoute', () => {
-      const route = new WorkflowExecutorProxyRoute(services, buildOptions('http://localhost:4001'));
-
-      expect(route.type).toBe(RouteType.PrivateRoute);
+      expect(buildRoute('http://localhost:4001').type).toBe(RouteType.PrivateRoute);
     });
   });
 
   describe('setupRoutes', () => {
-    test('registers GET and POST routes (PATCH pending-data retired)', () => {
-      const route = new WorkflowExecutorProxyRoute(services, buildOptions('http://localhost:4001'));
-      route.setupRoutes(router);
+    test('registers a single catch-all route for every verb', () => {
+      buildRoute('http://localhost:4001').setupRoutes(router);
 
-      expect(router.get).toHaveBeenCalledWith(
-        '/_internal/workflow-executions/:runId',
+      expect(router.all).toHaveBeenCalledWith(
+        '/_internal/workflow-executions/:path(.*)',
         expect.any(Function),
       );
-      expect(router.post).toHaveBeenCalledWith(
-        '/_internal/workflow-executions/:runId/trigger',
-        expect.any(Function),
-      );
+      expect(router.get).not.toHaveBeenCalled();
+      expect(router.post).not.toHaveBeenCalled();
       expect(router.patch).not.toHaveBeenCalled();
     });
   });
 
-  describe('handleProxy', () => {
-    test('should forward GET /runs/:runId and return executor response', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
+  describe('handleProxy — generic forwarding', () => {
+    test('forwards a GET under /runs and returns the executor response', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = createMockContext({
-        customProperties: { params: { runId: 'run-123' } },
-      });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/run-123',
-      });
+      const context = buildContext('run-123');
+      await callHandleProxy(route, context);
 
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
-
+      expect(receivedMethod).toBe('GET');
+      expect(receivedUrl).toBe('/runs/run-123');
       expect(context.response.status).toBe(200);
-      expect(context.response.body).toEqual({
-        steps: [{ stepId: 's1', status: 'success' }],
-      });
+      expect(context.response.body).toEqual({ steps: [{ stepId: 's1', status: 'success' }] });
     });
 
-    test('should forward POST /runs/:runId/trigger and pass body', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
+    test('forwards a POST trigger with the raw body untouched (no reshaping)', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = createMockContext({
-        method: 'POST',
-        customProperties: { params: { runId: 'run-456' } },
-        requestBody: { pendingData: { answer: 'yes' } },
-      });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/run-456/trigger',
-      });
+      const rawBody = '{"pendingData":{"answer":"yes"}}';
+      const context = buildContext('run-456/trigger', { method: 'POST' });
+      (context.request as unknown as { rawBody: string }).rawBody = rawBody;
 
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
+      await callHandleProxy(route, context);
 
-      expect(context.response.status).toBe(200);
+      expect(receivedMethod).toBe('POST');
+      expect(receivedUrl).toBe('/runs/run-456/trigger');
+      expect(receivedBody).toBe(rawBody);
       expect(context.response.body).toEqual({
         triggered: true,
         received: { pendingData: { answer: 'yes' } },
       });
     });
 
-    test('should forward error status from executor', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
+    test('forwards any verb and any future sub-path without a dedicated route', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = createMockContext({
-        customProperties: { params: { runId: 'not-found' } },
-      });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/not-found',
-      });
+      const context = buildContext('run-123/cancel', { method: 'DELETE' });
+      await callHandleProxy(route, context);
 
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
+      expect(receivedMethod).toBe('DELETE');
+      expect(receivedUrl).toBe('/runs/run-123/cancel');
+      expect(context.response.status).toBe(200);
+    });
+
+    test('forwards query params to the executor', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('run-123');
+      Object.defineProperty(context, 'querystring', { value: 'foo=bar&page=2' });
+
+      await callHandleProxy(route, context);
+
+      expect(receivedUrl).toBe('/runs/run-123?foo=bar&page=2');
+    });
+
+    test('forwards the executor error status and body verbatim', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('not-found');
+      await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(404);
       expect(context.response.body).toEqual({ error: 'Run not found or unavailable' });
     });
+  });
 
-    test('should forward Authorization and Cookie headers to the executor', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
+  describe('handleProxy — headers', () => {
+    test('forwards all client headers except hop-by-hop / host / content-length', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = createMockContext({
-        customProperties: { params: { runId: 'run-123' } },
+      const context = buildContext('run-123', {
         headers: {
           authorization: 'Bearer jwt-token-value',
           cookie: 'forest_session_token=cookie-token',
+          'x-custom-header': 'custom-value',
+          // hop-by-hop (te) and a client-recomputed header (content-length) — must be dropped.
+          // `te` is used rather than `connection` because Node's http client re-adds Connection itself.
+          te: 'trailers',
+          'content-length': '999',
         },
       });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/run-123',
-      });
 
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
+      await callHandleProxy(route, context);
 
       expect(receivedHeaders.authorization).toBe('Bearer jwt-token-value');
       expect(receivedHeaders.cookie).toBe('forest_session_token=cookie-token');
+      expect(receivedHeaders['x-custom-header']).toBe('custom-value');
+      expect(receivedHeaders.te).toBeUndefined();
+      expect(receivedHeaders['content-length']).not.toBe('999');
     });
+  });
 
-    test('should not add empty auth headers when the request has none', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
+  describe('handleProxy — path traversal protection (security boundary)', () => {
+    it.each([
+      '..',
+      '../mcp-oauth-credentials',
+      'run-123/../../mcp-oauth-credentials',
+      '%2e%2e/mcp-oauth-credentials',
+      '/runs/run-123',
+    ])('rejects %p and never forwards to the executor', async evilPath => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = createMockContext({
-        customProperties: { params: { runId: 'run-123' } },
-      });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/run-123',
-      });
-
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
-
-      expect(receivedHeaders.authorization).toBeUndefined();
-      expect(receivedHeaders.cookie).toBeUndefined();
+      await expect(callHandleProxy(route, buildContext(evilPath))).rejects.toThrow();
+      expect(receivedUrl).toBeUndefined();
     });
+  });
 
-    test('should reject when executor is unreachable', async () => {
-      const route = new WorkflowExecutorProxyRoute(services, buildOptions('http://localhost:1'));
+  describe('handleProxy — executor unreachable', () => {
+    test('rejects when the executor cannot be reached', async () => {
+      const route = buildRoute('http://localhost:1');
 
-      const context = createMockContext({
-        customProperties: { params: { runId: 'run-789' } },
-      });
-      Object.defineProperty(context, 'url', {
-        value: '/_internal/workflow-executions/run-789',
-      });
-
-      await expect(
-        (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context),
-      ).rejects.toThrow();
-    });
-
-    test('should forward query params to the executor', async () => {
-      const route = new WorkflowExecutorProxyRoute(
-        services,
-        buildOptions(`http://localhost:${executorPort}`),
-      );
-
-      const context = createMockContext({
-        customProperties: { params: { runId: 'run-123' } },
-      });
-      Object.defineProperty(context, 'querystring', {
-        value: 'foo=bar&page=2',
-      });
-
-      await (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(
-        context,
-      );
-
-      expect(receivedUrl).toBe('/runs/run-123?foo=bar&page=2');
+      await expect(callHandleProxy(route, buildContext('run-789'))).rejects.toThrow();
     });
   });
 });

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -28,6 +28,9 @@ describe('WorkflowExecutorProxyRoute', () => {
         receivedBody = Buffer.concat(chunks).toString('utf-8');
 
         res.setHeader('Content-Type', 'application/json');
+        res.setHeader('X-Forest-Executor-Version', '1.2.3');
+        // Hop-by-hop response header — the proxy must drop it rather than forward it.
+        res.setHeader('Transfer-Encoding', 'chunked');
 
         if (req.url?.includes('not-found')) {
           res.writeHead(404);
@@ -195,6 +198,17 @@ describe('WorkflowExecutorProxyRoute', () => {
       expect(receivedHeaders['x-custom-header']).toBe('custom-value');
       expect(receivedHeaders.te).toBeUndefined();
       expect(receivedHeaders['content-length']).not.toBe('999');
+    });
+
+    test('forwards executor response headers (e.g. the version gate) except hop-by-hop', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('run-123');
+      await callHandleProxy(route, context);
+
+      expect(context.response.get('X-Forest-Executor-Version')).toBe('1.2.3');
+      // Hop-by-hop response header must not be forwarded.
+      expect(context.response.get('Transfer-Encoding')).toBe('');
     });
   });
 

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -28,7 +28,8 @@ describe('WorkflowExecutorProxyRoute', () => {
         receivedBody = Buffer.concat(chunks).toString('utf-8');
 
         res.setHeader('Content-Type', 'application/json');
-        res.setHeader('X-Forest-Executor-Version', '1.2.3');
+        // Arbitrary executor response header — the proxy must forward it untouched.
+        res.setHeader('X-Executor-Custom', 'passthrough-value');
         // Hop-by-hop response header — the proxy must drop it rather than forward it.
         res.setHeader('Transfer-Encoding', 'chunked');
 
@@ -200,13 +201,13 @@ describe('WorkflowExecutorProxyRoute', () => {
       expect(receivedHeaders['content-length']).not.toBe('999');
     });
 
-    test('forwards executor response headers (e.g. the version gate) except hop-by-hop', async () => {
+    test('forwards executor response headers except hop-by-hop', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
       const context = buildContext('run-123');
       await callHandleProxy(route, context);
 
-      expect(context.response.get('X-Forest-Executor-Version')).toBe('1.2.3');
+      expect(context.response.get('X-Executor-Custom')).toBe('passthrough-value');
       // Hop-by-hop response header must not be forwarded.
       expect(context.response.get('Transfer-Encoding')).toBe('');
     });


### PR DESCRIPTION
## What

The agent proxies the workflow executor with **one explicitly declared route per executor route** (`GET /_internal/workflow-executions/:runId`, `POST .../trigger`). Each new executor route therefore requires a matching agent route **and an agent release** — and the agent is customer-deployed, so a new executor capability is unreachable until the parc is upgraded.

This replaces the two hand-written routes with a **single catch-all** that forwards any sub-path and any verb to the executor's `/runs/*` namespace. Adding an executor route no longer requires any agent change.

fixes PRD-567

## Design (decisions agreed with the ticket author)

- **Catch-all** `router.all('/_internal/workflow-executions/:path(.*)')` → `/runs/<path>`, all verbs.
- **Request forwarded verbatim**: all client headers (minus hop-by-hop / `Host` / `Content-Length`), **raw body** via `ctx.request.rawBody` (no reshaping), query string and method as-is.
- **Security boundary**: the wildcard can only ever map into `/runs` — path-traversal (`..`), encoded dots (`%2e`), absolute paths and null bytes throw `NotFoundError`, so executor routes outside `/runs` (e.g. `mcp-oauth-credentials`) stay **unreachable** through the proxy.
- Single request timeout, executor errors passed through verbatim.

## Tests

`workflow-executor-proxy.test.ts` → **14/14** (real HTTP executor server), including 5 path-traversal security cases (the "internal route not exposed" guard). ESLint clean.

## Scope

Phase 2 of 3 — this is the **Node `@forestadmin/agent`**. Ruby v2 (`forest_admin_agent`) is done in agent-ruby#319; the Ruby v1 liana (`forest-rails`) carries the identical coupling and gets the same generic proxy next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor `WorkflowExecutorProxyRoute` to forward all HTTP verbs and headers generically
> - Replaces explicit GET/POST route registrations with a single `router.all('/_internal/workflow-executions/:path(.*)')` catch-all that handles any HTTP verb and sub-path.
> - Forwards all client request headers to the executor except hop-by-hop, `host`, and `content-length`; forwards all executor response headers back to the client except hop-by-hop ones.
> - Passes raw request body verbatim for non-GET requests instead of re-serializing JSON.
> - Adds a 120s timeout to executor requests; adds path traversal protection via the new `executorPath` method that rejects unsafe wildcards with `NotFoundError`.
> - Behavioral Change: previously only `Authorization` and `Cookie` were forwarded; now all safe client headers are forwarded, and executor response headers are propagated to the caller.
>
> #### 🖇️ Linked Issues
> Relates to [PRD-567](ticket:linear/PRD-567).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1666 opened
>
> - Made the workflow executor request timeout configurable via instance property [e17bd12]
> - Refactored the internal request forwarding method signature [e17bd12]
> - Added test coverage for edge cases in workflow executor proxying [e17bd12]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fbfce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->