### PR TITLE
fix(workflow-executor): coerce numeric-string bearer id to number

### DIFF
--- a/packages/workflow-executor/src/http/bearer-claims.ts
+++ b/packages/workflow-executor/src/http/bearer-claims.ts
@@ -3,8 +3,9 @@ import { z } from 'zod';
 // Claims we require from the decoded bearer JWT payload (ctx.state.user). Non-strict on purpose:
 // jsonwebtoken adds standard claims (iat/exp) and Forest may send extra ones — strict would reject
 // every real token. Only `id` is consumed downstream (handleTrigger + hasRunAccess → ?userId=).
-// `.int()` rejects NaN/Infinity/floats (a user id is an integer) — preserves the invariant the
-// previous Number.isFinite guard enforced.
-export const BearerClaimsSchema = z.object({ id: z.number().int() });
+// `z.coerce` because Forest sends the user id as a numeric string ("245"); coercing then validating
+// integer/positive preserves the previous `Number(rawId)` + `Number.isFinite` behavior and rejects
+// null/empty (→ 0) and non-numeric ids.
+export const BearerClaimsSchema = z.object({ id: z.coerce.number().int().positive() });
 
 export type BearerClaims = z.infer<typeof BearerClaimsSchema>;

--- a/packages/workflow-executor/test/http/bearer-claims.test.ts
+++ b/packages/workflow-executor/test/http/bearer-claims.test.ts
@@ -7,6 +7,13 @@ describe('BearerClaimsSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('coerces a numeric string id (Forest sends the user id as a string) to a number', () => {
+    const result = BearerClaimsSchema.safeParse({ id: '245' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.id).toBe(245);
+  });
+
   it('tolerates standard JWT claims and extra Forest claims (not strict)', () => {
     // jsonwebtoken adds iat/exp to the decoded payload — a strict schema would wrongly reject it.
     const result = BearerClaimsSchema.safeParse({


### PR DESCRIPTION
## What

`BearerClaimsSchema` now coerces the bearer JWT `id` claim before validating it (`z.coerce.number().int().positive()`).

## Why

The PRD-508 zod refactor replaced the previous `Number(rawId)` + `Number.isFinite` guard with a strict `z.number().int()`. Forest sends the user id as a **numeric string** (e.g. `"245"`), so every authenticated run request started failing:

```
warn Bearer token has invalid claims method="GET" path="/runs/245" issues=[{"path":["id"],"code":"invalid_type"}]
```

## How

`z.coerce.number().int().positive()` restores the old behavior and is stricter on edge cases:

- `"245"` → `245` ✓ (downstream `?userId=` stays correct — `ctx.state.user.id` becomes the coerced number)
- `null` / `""` → `0` → rejected by `.positive()`
- `"user-42"` → `NaN` → rejected
- `1.5` → rejected

## Tests

- New case asserting a numeric-string id is accepted and coerced to a number.
- Existing rejection cases (null, non-numeric, non-integer, missing) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coerce numeric-string bearer `id` to number in `BearerClaimsSchema`
> Updates the `id` field in [bearer-claims.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1669/files#diff-bf4c1916b408ea1bccef6de0232eb8b1d5cc0cf757cfbeb97a476c5b74db720a) from `z.number().int()` to `z.coerce.number().int().positive()`, so JWT bearer tokens with a string-encoded numeric ID are accepted. Adds a `positive()` constraint, so IDs that coerce to 0 or a negative integer are now rejected. Risk: `null` and empty string inputs previously passed the old schema if somehow typed incorrectly; they now coerce to 0 and are explicitly rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7778529.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->