### PR TITLE
feat(workflow-executor): save AI reasoning in update-record steps

### DIFF
--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,9 +1,5 @@
 import type { StepExecutionResult } from '../types/execution-context';
-import type {
-  FieldWithValue,
-  FieldWithValueAndReasoning,
-  UpdateRecordStepExecutionData,
-} from '../types/step-execution-data';
+import type { FieldWithValue, UpdateRecordStepExecutionData } from '../types/step-execution-data';
 import type { CollectionSchema, FieldSchema, RecordRef } from '../types/validated/collection';
 import type { UpdateRecordStepDefinition } from '../types/validated/step-definition';
 
@@ -125,7 +121,7 @@ function coerceFieldValue(
   return parsed.data;
 }
 
-interface UpdateTarget extends FieldWithValueAndReasoning {
+interface UpdateTarget extends FieldWithValue {
   selectedRecordRef: RecordRef;
 }
 
@@ -293,7 +289,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
   private async selectFieldAndValue(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<{ fieldName: string; value: unknown; reasoning: string }> {
+  ): Promise<{ reasoning: string; fieldName: string; value: unknown }> {
     const tool = this.buildUpdateFieldTool(schema);
     const messages = [
       this.buildContextMessage(),
@@ -306,13 +302,13 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     ];
 
     const { input } = await this.invokeWithTool<{
-      input: { fieldName: string; value: unknown; reasoning: string };
+      input: { reasoning: string; fieldName: string; value: unknown };
     }>(messages, tool);
 
     return {
+      reasoning: input.reasoning,
       fieldName: this.resolveAiFieldName(schema, input.fieldName),
       value: input.value,
-      reasoning: input.reasoning,
     };
   }
 
@@ -327,16 +323,17 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     }
 
     type FieldObject = z.ZodObject<{
+      reasoning: z.ZodString;
       fieldName: z.ZodLiteral<string>;
       value: z.ZodNullable<z.ZodTypeAny>;
-      reasoning: z.ZodString;
     }>;
 
+    // `reasoning` first so the AI reasons toward the choice instead of justifying it afterwards.
     const fieldObjects = nonRelationFields.map(f =>
       z.object({
+        reasoning: z.string().describe('Why this field and value were chosen'),
         fieldName: z.literal(f.displayName),
         value: buildZodSchemaForField(f, schema.collectionName).nullable(),
-        reasoning: z.string().describe('Why this field and value were chosen'),
       }),
     ) as FieldObject[];
 

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -1,5 +1,9 @@
 import type { StepExecutionResult } from '../types/execution-context';
-import type { FieldWithValue, UpdateRecordStepExecutionData } from '../types/step-execution-data';
+import type {
+  FieldWithValue,
+  FieldWithValueAndReasoning,
+  UpdateRecordStepExecutionData,
+} from '../types/step-execution-data';
 import type { CollectionSchema, FieldSchema, RecordRef } from '../types/validated/collection';
 import type { UpdateRecordStepDefinition } from '../types/validated/step-definition';
 
@@ -121,7 +125,7 @@ function coerceFieldValue(
   return parsed.data;
 }
 
-interface UpdateTarget extends FieldWithValue {
+interface UpdateTarget extends FieldWithValueAndReasoning {
   selectedRecordRef: RecordRef;
 }
 
@@ -208,9 +212,10 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     }
 
     const recordedField = preRecordedArgs?.fieldName;
-    const { fieldName, value } =
+    // Pre-recorded args bypass the AI, so there is no reasoning to persist on that path.
+    const { fieldName, value, reasoning } =
       recordedField !== undefined
-        ? { fieldName: recordedField, value: preRecordedArgs?.value }
+        ? { fieldName: recordedField, value: preRecordedArgs?.value, reasoning: undefined }
         : await this.selectFieldAndValue(schema, step.prompt);
     const field = this.findFieldByTechnicalName(schema, fieldName);
 
@@ -223,6 +228,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       displayName: field.displayName,
       name: field.fieldName,
       value,
+      reasoning,
     };
 
     // Branch B -- fully automated execution
@@ -238,6 +244,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
         displayName: target.displayName,
         name: target.name,
         value: target.value,
+        reasoning: target.reasoning,
       },
       selectedRecordRef: target.selectedRecordRef,
     });
@@ -250,7 +257,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     target: UpdateTarget,
     existingExecution?: UpdateRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
-    const { selectedRecordRef, displayName, name, value } = target;
+    const { selectedRecordRef, displayName, name, value, reasoning } = target;
 
     const updated = await this.context.agent.updateRecord(
       {
@@ -274,7 +281,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       ...existingExecution,
       type: 'update-record',
       stepIndex: this.context.stepIndex,
-      executionParams: { displayName, name, value },
+      executionParams: { displayName, name, value, reasoning },
       executionResult: { updatedValues: updated.values },
       selectedRecordRef,
       idempotencyPhase: 'done',
@@ -286,7 +293,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
   private async selectFieldAndValue(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<{ fieldName: string; value: unknown }> {
+  ): Promise<{ fieldName: string; value: unknown; reasoning: string }> {
     const tool = this.buildUpdateFieldTool(schema);
     const messages = [
       this.buildContextMessage(),
@@ -305,6 +312,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     return {
       fieldName: this.resolveAiFieldName(schema, input.fieldName),
       value: input.value,
+      reasoning: input.reasoning,
     };
   }
 

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -39,11 +39,7 @@ export interface FieldRef {
   displayName: string;
 }
 
-export type FieldWithValue = FieldRef & { value: unknown };
-
-// AI-suggested field/value plus the reasoning behind the choice. `reasoning` is privacy-sensitive
-// (AI internals) so it lives in StepExecutionData only — never in the StepOutcome sent upstream.
-export type FieldWithValueAndReasoning = FieldWithValue & { reasoning?: string };
+export type FieldWithValue = FieldRef & { value: unknown; reasoning?: string };
 
 // -- Read Record --
 
@@ -70,10 +66,10 @@ export interface UpdateRecordStepExecutionData
   extends MutatingStepExecutionData,
     WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
-  executionParams?: FieldWithValueAndReasoning;
+  executionParams?: FieldWithValue;
   // User confirmed → values returned by updateRecord. User rejected → skipped.
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
-  pendingData?: FieldWithValueAndReasoning;
+  pendingData?: FieldWithValue;
   selectedRecordRef: RecordRef;
 }
 

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -41,6 +41,10 @@ export interface FieldRef {
 
 export type FieldWithValue = FieldRef & { value: unknown };
 
+// AI-suggested field/value plus the reasoning behind the choice. `reasoning` is privacy-sensitive
+// (AI internals) so it lives in StepExecutionData only — never in the StepOutcome sent upstream.
+export type FieldWithValueAndReasoning = FieldWithValue & { reasoning?: string };
+
 // -- Read Record --
 
 export interface FieldReadSuccess extends FieldRef {
@@ -66,10 +70,10 @@ export interface UpdateRecordStepExecutionData
   extends MutatingStepExecutionData,
     WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
-  executionParams?: FieldWithValue;
+  executionParams?: FieldWithValueAndReasoning;
   // User confirmed → values returned by updateRecord. User rejected → skipped.
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
-  pendingData?: FieldWithValue;
+  pendingData?: FieldWithValueAndReasoning;
   selectedRecordRef: RecordRef;
 }
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -224,7 +224,12 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
-          executionParams: { displayName: 'Status', name: 'status', value: 'active' },
+          executionParams: {
+            displayName: 'Status',
+            name: 'status',
+            value: 'active',
+            reasoning: 'User requested status change',
+          },
           executionResult: { updatedValues },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
@@ -410,7 +415,12 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
-          pendingData: { displayName: 'Status', name: 'status', value: 'active' },
+          pendingData: {
+            displayName: 'Status',
+            name: 'status',
+            value: 'active',
+            reasoning: 'User requested status change',
+          },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
             recordId: [42],
@@ -789,6 +799,7 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Order Status',
             name: 'status',
             value: 'shipped',
+            reasoning: 'Mark as shipped',
           },
           selectedRecordRef: expect.objectContaining({
             recordId: [99],


### PR DESCRIPTION
## Description

Persist the AI's reasoning for the field/value it selects when running an `update-record` step. The reasoning is now stored in `StepExecutionData` (in `executionParams` and `pendingData`), so it is available for later display and auditing.

Reasoning is privacy-sensitive (AI internals), so it lives **only** in `StepExecutionData` — persisted client-side in the `RunStore` — and is never included in the `StepOutcome` sent upstream to the orchestrator.

## Changes

- Add `FieldWithValueAndReasoning` type (`FieldWithValue` + optional `reasoning`) and use it for `UpdateRecordStepExecutionData.executionParams` / `pendingData`.
- Thread the AI-returned `reasoning` through `UpdateRecordStepExecutor` for the direct, awaiting-input, and multi-record selection paths.
- Pre-recorded args bypass the AI, so no reasoning is persisted on that path (`reasoning: undefined`).
- Update tests to assert the reasoning is persisted across all execution paths.

## Tests

All 81 tests in `update-record-step-executor.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Save AI reasoning in update-record workflow step executions
> - Adds a `reasoning` string to `UpdateRecordStepExecutor` so the AI model's rationale is captured alongside field name and value during update-record steps.
> - Updates `buildUpdateFieldTool` to include `reasoning` as the first field in the tool's Zod schema, requiring the model to provide it.
> - Persists `reasoning` in `pendingData` for awaiting-input executions and in `executionParams` for completed executions in the run store.
> - Extends the `FieldWithValue` type in [step-execution-data.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1671/files#diff-7c687de53bb6a7544d145eaf135f79eb6665ca9f14337016748699238ce1f40f) with an optional `reasoning?: string` property.
> - Pre-recorded (non-AI) arg paths set `reasoning` to `undefined`, bypassing AI reasoning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 573a154.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->