### PR TITLE
Revert "fix(workflow): save ai reasoning in loadRelatedRecord steps (#1668)"

### DIFF
--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -109,8 +109,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const schema = await this.getCollectionSchema(execution.selectedRecordRef.collectionName);
     const target = await this.buildTarget(schema, fieldName, execution.selectedRecordRef);
-    const { availableRecordIds, suggestedRecord, suggestedFields, fieldsReasoning, reasoning } =
-      await this.collectCandidateIds(target);
+    const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
       ...execution,
@@ -120,9 +119,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         suggestedField: { name: target.name, displayName: target.displayName },
         availableRecordIds,
         suggestedRecord,
-        suggestedFields,
-        fieldsReasoning,
-        reasoning,
       },
     });
 
@@ -288,8 +284,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   ): Promise<StepExecutionResult> {
     const { selectedRecordRef, name, displayName } = target;
 
-    const { availableRecordIds, suggestedRecord, suggestedFields, fieldsReasoning, reasoning } =
-      await this.collectCandidateIds(target);
+    const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
 
     const availableFields: RelationRef[] = sourceSchema.fields
       .filter(isFollowableRelation)
@@ -303,9 +298,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         suggestedField: { name, displayName },
         availableRecordIds,
         suggestedRecord,
-        suggestedFields,
-        fieldsReasoning,
-        reasoning,
       },
       selectedRecordRef,
     });
@@ -315,10 +307,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
   private async collectCandidateIds(target: RelationTarget): Promise<{
     availableRecordIds: LoadRelatedRecordCandidate[];
-    suggestedFields?: string[];
-    fieldsReasoning?: string;
     suggestedRecord?: LoadRelatedRecordCandidate;
-    reasoning?: string;
   }> {
     if (target.relationType === 'BelongsTo' || target.relationType === 'HasOne') {
       const candidate = await this.fetchXToOneCandidate(target);
@@ -328,8 +317,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         : { availableRecordIds: [] };
     }
 
-    const { relatedData, bestIndex, relatedSchema, suggestedFields, fieldsReasoning, reasoning } =
-      await this.selectBestFromRelatedData(target, 50);
+    const { relatedData, bestIndex, relatedSchema } = await this.selectBestFromRelatedData(
+      target,
+      50,
+    );
 
     if (relatedData.length === 0) {
       return { availableRecordIds: [] };
@@ -345,10 +336,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     return {
       availableRecordIds: relatedData.map(toCandidate),
-      suggestedFields,
-      fieldsReasoning,
       suggestedRecord: toCandidate(relatedData[bestIndex]),
-      reasoning,
     };
   }
 
@@ -475,8 +463,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     relatedData: RecordData[];
     bestIndex: number;
     suggestedFields: string[];
-    fieldsReasoning?: string;
-    reasoning?: string;
     relatedSchema: CollectionSchema;
   }> {
     const relatedSchema = await this.getCollectionSchema(target.relatedCollectionName);
@@ -510,16 +496,17 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       };
     }
 
-    const { fieldNames: suggestedFields, reasoning: fieldsReasoning } =
-      await this.selectRelevantFields(relatedSchema, this.context.stepDefinition.prompt);
-
-    const { recordIndex: bestIndex, reasoning } = await this.selectBestRecordIndex(
+    const suggestedFields = await this.selectRelevantFields(
+      relatedSchema,
+      this.context.stepDefinition.prompt,
+    );
+    const bestIndex = await this.selectBestRecordIndex(
       relatedData,
       suggestedFields,
       this.context.stepDefinition.prompt,
     );
 
-    return { relatedData, bestIndex, suggestedFields, fieldsReasoning, reasoning, relatedSchema };
+    return { relatedData, bestIndex, suggestedFields, relatedSchema };
   }
 
   /** HasMany + fully automated execution: fetch top 50, then AI calls to select the best record. */
@@ -641,12 +628,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   private async selectRelevantFields(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<{ fieldNames: string[]; reasoning: string }> {
+  ): Promise<string[]> {
     const nonRelationFields = schema.fields.filter(f => !f.isRelationship);
 
-    if (nonRelationFields.length === 0) {
-      return { fieldNames: [], reasoning: 'No field is available' };
-    }
+    if (nonRelationFields.length === 0) return [];
 
     // Use displayName in both the enum and the prompt for consistency — the AI sees human-readable
     // names throughout. Results are mapped back to technical fieldNames before returning.
@@ -656,7 +641,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       name: 'select-fields',
       description: 'Select the most relevant fields to identify the right record.',
       schema: z.object({
-        reasoning: z.string().describe('Why these fields seems relevant to choose the record'),
         fieldNames: z
           .array(z.enum(displayNames))
           .min(1)
@@ -670,7 +654,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const messages = [
       this.buildContextMessage(),
-      ...(await this.buildPreviousStepsMessages()),
       new SystemMessage(SELECT_FIELDS_SYSTEM_PROMPT),
       new SystemMessage(
         `The related records are from the "${schema.collectionDisplayName}" collection. ` +
@@ -679,9 +662,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       new HumanMessage(`**Request**: ${prompt ?? 'Select the most relevant record.'}`),
     ];
 
-    const { fieldNames: selectedDisplayNames, reasoning } = await this.invokeWithTool<{
+    const { fieldNames: selectedDisplayNames } = await this.invokeWithTool<{
       fieldNames: string[];
-      reasoning: string;
     }>(messages, tool);
 
     // Zod's .min(1) shapes the prompt but is NOT validated against the AI response.
@@ -694,11 +676,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     // Map display names back to technical field names — values in RecordData are keyed by fieldName.
     // .max() shapes the prompt only (not validated against the response), so cap explicitly.
-    const fieldNames = selectedDisplayNames
+    return selectedDisplayNames
       .slice(0, MAX_RELEVANT_FIELDS)
       .map(dn => nonRelationFields.find(f => f.displayName === dn)?.fieldName ?? dn);
-
-    return { fieldNames, reasoning };
   }
 
   /** AI call 2 for HasMany: selects the best record by index from the candidate list. */
@@ -706,7 +686,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     candidates: RecordData[],
     fieldNames: string[],
     prompt: string | undefined,
-  ): Promise<{ recordIndex: number; reasoning: string }> {
+  ): Promise<number> {
     const filteredCandidates = candidates.map((c, i) => {
       const entries = Object.entries(c.values).filter(
         ([k]) => fieldNames.length === 0 || fieldNames.includes(k),
@@ -745,29 +725,28 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       name: 'select-record-by-content',
       description: 'Select the most relevant related record by its index.',
       schema: z.object({
-        reasoning: z.string().describe('Why this record was chosen'),
         recordIndex: z
           .number()
           .int()
           .min(0)
           .max(maxIndex)
           .describe(`0-based index of the most relevant record (0 to ${maxIndex})`),
+        reasoning: z.string().describe('Why this record was chosen'),
       }),
       func: undefined,
     });
 
     const messages = [
       this.buildContextMessage(),
-      ...(await this.buildPreviousStepsMessages()),
       new SystemMessage(SELECT_RECORD_SYSTEM_PROMPT),
       new SystemMessage(`Candidates:\n${lines.join('\n')}`),
       new HumanMessage(`**Request**: ${prompt ?? 'Select the most relevant record.'}`),
     ];
 
-    const { recordIndex, reasoning } = await this.invokeWithTool<{
-      recordIndex: number;
-      reasoning: string;
-    }>(messages, tool);
+    const { recordIndex } = await this.invokeWithTool<{ recordIndex: number; reasoning: string }>(
+      messages,
+      tool,
+    );
 
     // NOTE: The Zod schema's .min(0).max(maxIndex) shapes the tool prompt only — it is NOT
     // validated against the AI response. This guard is the sole runtime enforcement.
@@ -777,7 +756,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       );
     }
 
-    return { recordIndex, reasoning };
+    return recordIndex;
   }
 
   private toRecordRef(data: RecordData): RecordRef {

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -141,12 +141,6 @@ export interface LoadRelatedRecordPendingData {
   availableRecordIds: LoadRelatedRecordCandidate[];
   // Absent when the relation has no linked record(s): the list is empty and there's nothing to suggest.
   suggestedRecord?: LoadRelatedRecordCandidate;
-  // Technical names of the fields the AI judged most relevant to identify the record.
-  suggestedFields?: string[];
-  // AI justification for the selected fields (selectRelevantFields).
-  fieldsReasoning?: string;
-  // AI justification for the suggested record (selectBestRecordIndex).
-  reasoning?: string;
 }
 
 export interface LoadRelatedRecordStepExecutionData

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -1063,13 +1063,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
           ],
         })
         .mockResolvedValueOnce({
-          tool_calls: [
-            {
-              name: 'select-fields',
-              args: { fieldNames: ['City'], reasoning: 'City identifies the address' },
-              id: 'c2',
-            },
-          ],
+          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
         })
         .mockResolvedValueOnce({
           tool_calls: [
@@ -1110,9 +1104,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
             suggestedField: { name: 'address', displayName: 'Address' },
             availableRecordIds: [cand([1]), cand([2])],
             suggestedRecord: cand([2]), // record at index 1
-            suggestedFields: ['city'],
-            fieldsReasoning: 'City identifies the address',
-            reasoning: 'Lyon is best',
           },
         }),
       );
@@ -2874,115 +2865,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       const messages = mockModel.invoke.mock.calls[0][0];
       expect(messages[0].content).toContain('Step title: "Load the customer order"');
-    });
-
-    // HasMany triggers select-fields (call 1) and select-record-by-content (call 2) after
-    // select-relation-to-follow (call 0). The previous-steps summary must reach all three so
-    // the AI picks fields/record using earlier answers, not just the relation choice.
-    it('includes previous steps summary in select-fields and select-record-by-content messages', async () => {
-      const relatedData: RecordData[] = [
-        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
-        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
-      ];
-      const agentPort = makeMockAgentPort(relatedData);
-
-      const addressesSchema = makeCollectionSchema({
-        collectionName: 'addresses',
-        collectionDisplayName: 'Addresses',
-        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
-      });
-
-      const invoke = jest
-        .fn()
-        .mockResolvedValueOnce({
-          tool_calls: [
-            {
-              name: 'select-relation-to-follow',
-              args: {
-                relation: relationOption({
-                  recordId: [42],
-                  relationDisplayName: 'Address',
-                  relatedCollectionName: 'addresses',
-                }),
-                reasoning: 'Load address',
-              },
-              id: 'c1',
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          tool_calls: [
-            {
-              name: 'select-fields',
-              args: { fieldNames: ['City'], reasoning: 'City identifies the address' },
-              id: 'c2',
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          tool_calls: [
-            {
-              name: 'select-record-by-content',
-              args: { recordIndex: 1, reasoning: 'Lyon is best' },
-              id: 'c3',
-            },
-          ],
-        });
-      const bindTools = jest.fn().mockReturnValue({ invoke });
-      const model = { bindTools } as unknown as ExecutionContext['model'];
-
-      const runStore = makeMockRunStore({
-        getStepExecutions: jest.fn().mockResolvedValue([
-          {
-            type: 'condition',
-            stepIndex: 0,
-            executionParams: { answer: 'Yes', reasoning: 'Approved' },
-          },
-        ]),
-      });
-      const context = makeContext({
-        model,
-        agentPort,
-        runStore,
-        workflowPort: makeMockWorkflowPort({
-          customers: makeCollectionSchema(),
-          addresses: addressesSchema,
-        }),
-        previousSteps: [
-          {
-            stepDefinition: {
-              type: StepType.Condition,
-              executionType: StepExecutionMode.Manual,
-              options: ['Yes', 'No'],
-              prompt: 'Should we proceed?',
-            },
-            stepOutcome: {
-              type: 'condition',
-              stepId: 'prev-step',
-              stepIndex: 0,
-              status: 'success',
-            },
-          },
-        ],
-      });
-
-      await new LoadRelatedRecordStepExecutor({
-        ...context,
-        stepId: 'load-2',
-        stepIndex: 1,
-      }).execute();
-
-      expect(invoke).toHaveBeenCalledTimes(3);
-
-      // Leading SystemMessages (context + previous-steps summary + system prompts) are merged
-      // into messages[0] before invoke, so the summary lives there — not at a separate index.
-      const selectFieldsMessages = invoke.mock.calls[1][0];
-      expect(selectFieldsMessages[0].content).toContain('Should we proceed?');
-      expect(selectFieldsMessages[0].content).toContain('"answer":"Yes"');
-
-      const selectRecordMessages = invoke.mock.calls[2][0];
-      expect(selectRecordMessages[0].content).toContain('Should we proceed?');
-      expect(selectRecordMessages[0].content).toContain('"answer":"Yes"');
     });
   });
 


### PR DESCRIPTION
This reverts commit 48a7e4763c37c8d4ddcbe7f4af7a0f5197714cbe.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert AI reasoning persistence in `LoadRelatedRecordStepExecutor` pending data
> Reverts #1668, which saved AI metadata (`suggestedFields`, `fieldsReasoning`, `reasoning`) into `pendingData` during `awaiting-input` steps.
>
> - Removes `suggestedFields`, `fieldsReasoning`, and `reasoning` from `LoadRelatedRecordPendingData` in [step-execution-data.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1672/files#diff-7c687de53bb6a7544d145eaf135f79eb6665ca9f14337016748699238ce1f40f) and from all write sites in [load-related-record-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1672/files#diff-128ff9b9f75a54359e7793b4ed6d306700531b6debe78ce56bb4bed1391f3650)
> - `selectRelevantFields` and `selectBestRecordIndex` no longer include previous steps summary in model messages and no longer return reasoning
> - Test expectations updated to match the removed fields; the test asserting previous steps summary in model messages is removed
> - Behavioral Change: any consumers reading `suggestedFields`, `fieldsReasoning`, or `reasoning` from `pendingData` will no longer find those properties
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f77c91f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->