### PR TITLE
fix(workflow): save ai reasoning in loadRelatedRecord steps

### DIFF
--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -1,7 +1,6 @@
 import type { StepExecutionResult } from '../types/execution-context';
 import type {
   LoadRelatedRecordCandidate,
-  LoadRelatedRecordPendingData,
   LoadRelatedRecordStepExecutionData,
   RelationRef,
 } from '../types/step-execution-data';
@@ -9,7 +8,6 @@ import type {
   CollectionSchema,
   FieldSchema,
   RecordData,
-  RecordId,
   RecordRef,
 } from '../types/validated/collection';
 import type { LoadRelatedRecordStepDefinition } from '../types/validated/step-definition';
@@ -95,10 +93,13 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     );
 
     if (pending) {
-      const conf = pending.userConfirmation;
+      const { userConfirmation } = pending;
 
-      if (conf?.userConfirmed === undefined && conf?.fieldName !== undefined) {
-        return this.refreshCandidatesForField(pending, conf.fieldName);
+      if (
+        userConfirmation?.userConfirmed === undefined &&
+        userConfirmation?.fieldName !== undefined
+      ) {
+        return this.refreshCandidatesForField(pending, userConfirmation.fieldName);
       }
 
       return this.handleConfirmationFlow<LoadRelatedRecordStepExecutionData>(pending, async exec =>
@@ -478,13 +479,14 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     // Carry the AI reasoning into executionResult only when the user kept the AI's suggestion
     // intact — both the relation and the record. A change to either makes the reasoning
     // (which justified the original record) misleading, so it is dropped.
-    const clearReasoning =
-      userConfirmation &&
-      (userConfirmation.fieldName !== pendingData.suggestedField.name ||
-        JSON.stringify(userConfirmation.selectedRecordId) !==
+    const suggestionChanged =
+      (userConfirmation?.fieldName &&
+        userConfirmation.fieldName !== pendingData.suggestedField.name) ||
+      (userConfirmation?.selectedRecordId &&
+        JSON.stringify(userConfirmation?.selectedRecordId) !==
           JSON.stringify(pendingData.suggestedRecord?.recordId));
 
-    const recordWithReasoning: RecordWithReasoning = clearReasoning
+    const recordWithReasoning: RecordWithReasoning = suggestionChanged
       ? { record }
       : {
           record,

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -1,6 +1,7 @@
 import type { StepExecutionResult } from '../types/execution-context';
 import type {
   LoadRelatedRecordCandidate,
+  LoadRelatedRecordPendingData,
   LoadRelatedRecordStepExecutionData,
   RelationRef,
 } from '../types/step-execution-data';
@@ -8,6 +9,7 @@ import type {
   CollectionSchema,
   FieldSchema,
   RecordData,
+  RecordId,
   RecordRef,
 } from '../types/validated/collection';
 import type { LoadRelatedRecordStepDefinition } from '../types/validated/step-definition';
@@ -68,6 +70,15 @@ interface RelationCandidate {
   record: RecordRef;
   schema: CollectionSchema;
   field: FieldSchema & { relatedCollectionName: string };
+}
+
+// A resolved record plus the AI justifications behind it (HasMany only — xToOne and
+// BelongsToMany run no AI). Persisted into executionResult in fully-automated mode.
+interface RecordWithReasoning {
+  record: RecordRef;
+  suggestedFields?: string[];
+  fieldsReasoning?: string;
+  reasoning?: string;
 }
 
 // Followable = has a static target (relatedCollectionName) or is a polymorphic relation resolvable
@@ -363,21 +374,20 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
   /** Branch B: fully automated. xToOne loads the linked record; HasMany ranks candidates via AI; BelongsToMany takes the first. */
   private async resolveAndLoadAutomatic(target: RelationTarget): Promise<StepExecutionResult> {
-    const record = await this.fetchRecordForRelation(target);
+    const recordWithReasoning = await this.fetchRecordForRelation(target);
 
-    return this.persistAndReturn(record, target, undefined);
+    return this.persistAndReturn(recordWithReasoning, target, undefined);
   }
 
-  private async fetchRecordForRelation(target: RelationTarget): Promise<RecordRef> {
+  private async fetchRecordForRelation(target: RelationTarget): Promise<RecordWithReasoning> {
     if (target.relationType === 'BelongsTo' || target.relationType === 'HasOne') {
-      return this.fetchXToOneRecordRef(target);
+      return {
+        record: await this.fetchXToOneRecordRef(target),
+        reasoning: 'single related record',
+      };
     }
 
-    if (target.relationType === 'HasMany') {
-      return this.selectBestRelatedRecord(target);
-    }
-
-    return this.fetchFirstCandidate(target);
+    return this.selectBestRelatedRecord(target);
   }
 
   private async fetchXToOneRecordRef(target: RelationTarget): Promise<RecordRef> {
@@ -465,7 +475,29 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       stepIndex: this.context.stepIndex,
     };
 
-    return this.persistAndReturn(record, { selectedRecordRef, name, displayName }, execution);
+    // Carry the AI reasoning into executionResult only when the user kept the AI's suggestion
+    // intact — both the relation and the record. A change to either makes the reasoning
+    // (which justified the original record) misleading, so it is dropped.
+    const clearReasoning =
+      userConfirmation &&
+      (userConfirmation.fieldName !== pendingData.suggestedField.name ||
+        JSON.stringify(userConfirmation.selectedRecordId) !==
+          JSON.stringify(pendingData.suggestedRecord?.recordId));
+
+    const recordWithReasoning: RecordWithReasoning = clearReasoning
+      ? { record }
+      : {
+          record,
+          suggestedFields: pendingData.suggestedFields,
+          fieldsReasoning: pendingData.fieldsReasoning,
+          reasoning: pendingData.reasoning,
+        };
+
+    return this.persistAndReturn(
+      recordWithReasoning,
+      { selectedRecordRef, name, displayName },
+      execution,
+    );
   }
 
   private async selectBestFromRelatedData(
@@ -523,14 +555,20 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   }
 
   /** HasMany + fully automated execution: fetch top 50, then AI calls to select the best record. */
-  private async selectBestRelatedRecord(target: RelationTarget): Promise<RecordRef> {
-    const { relatedData, bestIndex } = await this.selectBestFromRelatedData(target, 50);
+  private async selectBestRelatedRecord(target: RelationTarget): Promise<RecordWithReasoning> {
+    const { relatedData, bestIndex, suggestedFields, fieldsReasoning, reasoning } =
+      await this.selectBestFromRelatedData(target, 50);
 
     if (relatedData.length === 0) {
       throw new RelatedRecordNotFoundError(target.selectedRecordRef.collectionName, target.name);
     }
 
-    return this.toRecordRef(relatedData[bestIndex]);
+    return {
+      record: this.toRecordRef(relatedData[bestIndex]),
+      suggestedFields,
+      fieldsReasoning,
+      reasoning,
+    };
   }
 
   private async fetchFirstCandidate(target: RelationTarget): Promise<RecordRef> {
@@ -570,7 +608,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
   /** Persists the loaded record ref and returns a success outcome. */
   private async persistAndReturn(
-    record: RecordRef,
+    recordWithReasoning: RecordWithReasoning,
     target: Pick<RelationTarget, 'selectedRecordRef' | 'name' | 'displayName'>,
     existingExecution: LoadRelatedRecordStepExecutionData | undefined,
   ): Promise<StepExecutionResult> {
@@ -581,7 +619,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       type: 'load-related-record',
       stepIndex: this.context.stepIndex,
       executionParams: { displayName, name },
-      executionResult: { relation: { name, displayName }, record },
+      executionResult: { relation: { name, displayName }, ...recordWithReasoning },
       selectedRecordRef,
     });
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -571,27 +571,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     };
   }
 
-  private async fetchFirstCandidate(target: RelationTarget): Promise<RecordRef> {
-    const candidates = await this.fetchCandidates(target, 1);
-
-    return candidates[0];
-  }
-
-  private async fetchCandidates(
-    target: Pick<RelationTarget, 'selectedRecordRef' | 'name' | 'relatedCollectionName'>,
-    limit: number,
-  ): Promise<RecordRef[]> {
-    const { selectedRecordRef, name } = target;
-    const relatedSchema = await this.getCollectionSchema(target.relatedCollectionName);
-    const relatedData = await this.fetchRelatedData(target, relatedSchema, limit);
-
-    if (relatedData.length === 0) {
-      throw new RelatedRecordNotFoundError(selectedRecordRef.collectionName, name);
-    }
-
-    return relatedData.map(r => this.toRecordRef(r));
-  }
-
   private async fetchRelatedData(
     target: Pick<RelationTarget, 'selectedRecordRef' | 'name'>,
     relatedSchema: CollectionSchema,

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -109,7 +109,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const schema = await this.getCollectionSchema(execution.selectedRecordRef.collectionName);
     const target = await this.buildTarget(schema, fieldName, execution.selectedRecordRef);
-    const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
+    const { availableRecordIds, suggestedRecord, suggestedFields, fieldsReasoning, reasoning } =
+      await this.collectCandidateIds(target);
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
       ...execution,
@@ -119,6 +120,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         suggestedField: { name: target.name, displayName: target.displayName },
         availableRecordIds,
         suggestedRecord,
+        suggestedFields,
+        fieldsReasoning,
+        reasoning,
       },
     });
 
@@ -284,7 +288,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   ): Promise<StepExecutionResult> {
     const { selectedRecordRef, name, displayName } = target;
 
-    const { availableRecordIds, suggestedRecord } = await this.collectCandidateIds(target);
+    const { availableRecordIds, suggestedRecord, suggestedFields, fieldsReasoning, reasoning } =
+      await this.collectCandidateIds(target);
 
     const availableFields: RelationRef[] = sourceSchema.fields
       .filter(isFollowableRelation)
@@ -298,6 +303,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         suggestedField: { name, displayName },
         availableRecordIds,
         suggestedRecord,
+        suggestedFields,
+        fieldsReasoning,
+        reasoning,
       },
       selectedRecordRef,
     });
@@ -307,7 +315,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
   private async collectCandidateIds(target: RelationTarget): Promise<{
     availableRecordIds: LoadRelatedRecordCandidate[];
+    suggestedFields?: string[];
+    fieldsReasoning?: string;
     suggestedRecord?: LoadRelatedRecordCandidate;
+    reasoning?: string;
   }> {
     if (target.relationType === 'BelongsTo' || target.relationType === 'HasOne') {
       const candidate = await this.fetchXToOneCandidate(target);
@@ -317,10 +328,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
         : { availableRecordIds: [] };
     }
 
-    const { relatedData, bestIndex, relatedSchema } = await this.selectBestFromRelatedData(
-      target,
-      50,
-    );
+    const { relatedData, bestIndex, relatedSchema, suggestedFields, fieldsReasoning, reasoning } =
+      await this.selectBestFromRelatedData(target, 50);
 
     if (relatedData.length === 0) {
       return { availableRecordIds: [] };
@@ -336,7 +345,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     return {
       availableRecordIds: relatedData.map(toCandidate),
+      suggestedFields,
+      fieldsReasoning,
       suggestedRecord: toCandidate(relatedData[bestIndex]),
+      reasoning,
     };
   }
 
@@ -463,6 +475,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     relatedData: RecordData[];
     bestIndex: number;
     suggestedFields: string[];
+    fieldsReasoning?: string;
+    reasoning?: string;
     relatedSchema: CollectionSchema;
   }> {
     const relatedSchema = await this.getCollectionSchema(target.relatedCollectionName);
@@ -496,17 +510,16 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       };
     }
 
-    const suggestedFields = await this.selectRelevantFields(
-      relatedSchema,
-      this.context.stepDefinition.prompt,
-    );
-    const bestIndex = await this.selectBestRecordIndex(
+    const { fieldNames: suggestedFields, reasoning: fieldsReasoning } =
+      await this.selectRelevantFields(relatedSchema, this.context.stepDefinition.prompt);
+
+    const { recordIndex: bestIndex, reasoning } = await this.selectBestRecordIndex(
       relatedData,
       suggestedFields,
       this.context.stepDefinition.prompt,
     );
 
-    return { relatedData, bestIndex, suggestedFields, relatedSchema };
+    return { relatedData, bestIndex, suggestedFields, fieldsReasoning, reasoning, relatedSchema };
   }
 
   /** HasMany + fully automated execution: fetch top 50, then AI calls to select the best record. */
@@ -628,10 +641,12 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   private async selectRelevantFields(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<string[]> {
+  ): Promise<{ fieldNames: string[]; reasoning: string }> {
     const nonRelationFields = schema.fields.filter(f => !f.isRelationship);
 
-    if (nonRelationFields.length === 0) return [];
+    if (nonRelationFields.length === 0) {
+      return { fieldNames: [], reasoning: 'No field is available' };
+    }
 
     // Use displayName in both the enum and the prompt for consistency — the AI sees human-readable
     // names throughout. Results are mapped back to technical fieldNames before returning.
@@ -641,6 +656,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       name: 'select-fields',
       description: 'Select the most relevant fields to identify the right record.',
       schema: z.object({
+        reasoning: z.string().describe('Why these fields seems relevant to choose the record'),
         fieldNames: z
           .array(z.enum(displayNames))
           .min(1)
@@ -654,6 +670,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     const messages = [
       this.buildContextMessage(),
+      ...(await this.buildPreviousStepsMessages()),
       new SystemMessage(SELECT_FIELDS_SYSTEM_PROMPT),
       new SystemMessage(
         `The related records are from the "${schema.collectionDisplayName}" collection. ` +
@@ -662,8 +679,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       new HumanMessage(`**Request**: ${prompt ?? 'Select the most relevant record.'}`),
     ];
 
-    const { fieldNames: selectedDisplayNames } = await this.invokeWithTool<{
+    const { fieldNames: selectedDisplayNames, reasoning } = await this.invokeWithTool<{
       fieldNames: string[];
+      reasoning: string;
     }>(messages, tool);
 
     // Zod's .min(1) shapes the prompt but is NOT validated against the AI response.
@@ -676,9 +694,11 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
 
     // Map display names back to technical field names — values in RecordData are keyed by fieldName.
     // .max() shapes the prompt only (not validated against the response), so cap explicitly.
-    return selectedDisplayNames
+    const fieldNames = selectedDisplayNames
       .slice(0, MAX_RELEVANT_FIELDS)
       .map(dn => nonRelationFields.find(f => f.displayName === dn)?.fieldName ?? dn);
+
+    return { fieldNames, reasoning };
   }
 
   /** AI call 2 for HasMany: selects the best record by index from the candidate list. */
@@ -686,7 +706,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     candidates: RecordData[],
     fieldNames: string[],
     prompt: string | undefined,
-  ): Promise<number> {
+  ): Promise<{ recordIndex: number; reasoning: string }> {
     const filteredCandidates = candidates.map((c, i) => {
       const entries = Object.entries(c.values).filter(
         ([k]) => fieldNames.length === 0 || fieldNames.includes(k),
@@ -725,28 +745,29 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       name: 'select-record-by-content',
       description: 'Select the most relevant related record by its index.',
       schema: z.object({
+        reasoning: z.string().describe('Why this record was chosen'),
         recordIndex: z
           .number()
           .int()
           .min(0)
           .max(maxIndex)
           .describe(`0-based index of the most relevant record (0 to ${maxIndex})`),
-        reasoning: z.string().describe('Why this record was chosen'),
       }),
       func: undefined,
     });
 
     const messages = [
       this.buildContextMessage(),
+      ...(await this.buildPreviousStepsMessages()),
       new SystemMessage(SELECT_RECORD_SYSTEM_PROMPT),
       new SystemMessage(`Candidates:\n${lines.join('\n')}`),
       new HumanMessage(`**Request**: ${prompt ?? 'Select the most relevant record.'}`),
     ];
 
-    const { recordIndex } = await this.invokeWithTool<{ recordIndex: number; reasoning: string }>(
-      messages,
-      tool,
-    );
+    const { recordIndex, reasoning } = await this.invokeWithTool<{
+      recordIndex: number;
+      reasoning: string;
+    }>(messages, tool);
 
     // NOTE: The Zod schema's .min(0).max(maxIndex) shapes the tool prompt only — it is NOT
     // validated against the AI response. This guard is the sole runtime enforcement.
@@ -756,7 +777,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       );
     }
 
-    return recordIndex;
+    return { recordIndex, reasoning };
   }
 
   private toRecordRef(data: RecordData): RecordRef {

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -141,6 +141,12 @@ export interface LoadRelatedRecordPendingData {
   availableRecordIds: LoadRelatedRecordCandidate[];
   // Absent when the relation has no linked record(s): the list is empty and there's nothing to suggest.
   suggestedRecord?: LoadRelatedRecordCandidate;
+  // Technical names of the fields the AI judged most relevant to identify the record.
+  suggestedFields?: string[];
+  // AI justification for the selected fields (selectRelevantFields).
+  fieldsReasoning?: string;
+  // AI justification for the suggested record (selectBestRecordIndex).
+  reasoning?: string;
 }
 
 export interface LoadRelatedRecordStepExecutionData

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -18,12 +18,6 @@ interface MutatingStepExecutionData extends BaseStepExecutionData {
   idempotencyPhase?: 'executing' | 'done';
 }
 
-// Validated POST body stored alongside `pendingData` (AI suggestion) so executors
-// can read user input without overwriting the AI suggestion.
-export interface WithUserConfirmation<T extends Record<string, unknown> = Record<string, unknown>> {
-  userConfirmation?: T;
-}
-
 // -- Condition --
 
 export interface ConditionStepExecutionData extends BaseStepExecutionData {
@@ -62,15 +56,14 @@ export interface ReadRecordStepExecutionData extends BaseStepExecutionData {
 
 // -- Update Record --
 
-export interface UpdateRecordStepExecutionData
-  extends MutatingStepExecutionData,
-    WithUserConfirmation<UpdateRecordConfirmation> {
+export interface UpdateRecordStepExecutionData extends MutatingStepExecutionData {
   type: 'update-record';
   executionParams?: FieldWithValue;
   // User confirmed → values returned by updateRecord. User rejected → skipped.
   executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
   pendingData?: FieldWithValue;
   selectedRecordRef: RecordRef;
+  userConfirmation?: UpdateRecordConfirmation;
 }
 
 // -- Trigger Action --
@@ -87,14 +80,13 @@ export interface RelationRef {
   displayName: string;
 }
 
-export interface TriggerRecordActionStepExecutionData
-  extends MutatingStepExecutionData,
-    WithUserConfirmation<TriggerActionConfirmation> {
+export interface TriggerRecordActionStepExecutionData extends MutatingStepExecutionData {
   type: 'trigger-action';
   executionParams?: ActionRef;
   executionResult?: { success: true; actionResult: unknown } | { skipped: true };
   pendingData?: ActionRef;
   selectedRecordRef: RecordRef;
+  userConfirmation?: TriggerActionConfirmation;
 }
 
 // -- Mcp --
@@ -109,15 +101,14 @@ export interface McpToolCall extends McpToolRef {
   input: Record<string, unknown>;
 }
 
-export interface McpStepExecutionData
-  extends MutatingStepExecutionData,
-    WithUserConfirmation<McpConfirmation> {
+export interface McpStepExecutionData extends MutatingStepExecutionData {
   type: 'mcp';
   executionParams?: McpToolCall;
   executionResult?:
     | { success: true; toolResult: unknown; formattedResponse?: string }
     | { skipped: true };
   pendingData?: McpToolCall;
+  userConfirmation?: McpConfirmation;
 }
 
 // -- Generic AI Task (fallback for untyped steps) --
@@ -149,14 +140,21 @@ export interface LoadRelatedRecordPendingData {
   reasoning?: string;
 }
 
-export interface LoadRelatedRecordStepExecutionData
-  extends BaseStepExecutionData,
-    WithUserConfirmation<LoadRelatedRecordConfirmation> {
+export interface LoadRelatedRecordStepExecutionData extends BaseStepExecutionData {
   type: 'load-related-record';
   pendingData?: LoadRelatedRecordPendingData;
   selectedRecordRef: RecordRef;
   executionParams?: RelationRef;
-  executionResult?: { relation: RelationRef; record: RecordRef } | { skipped: true };
+  executionResult?:
+    | {
+        relation: RelationRef;
+        record: RecordRef;
+        suggestedFields?: string[];
+        fieldsReasoning?: string;
+        reasoning?: string;
+      }
+    | { skipped: true };
+  userConfirmation?: LoadRelatedRecordConfirmation;
 }
 
 // -- Guidance --

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -818,11 +818,11 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  // BelongsToMany falls through to the same to-many candidate path as the default
-  // branch (neither xToOne nor HasMany). Routes through fetchFirstCandidate ->
-  // fetchCandidates -> getRelatedData with limit: 1, then picks the first row.
+  // BelongsToMany routes through the to-many ranking path (selectBestRelatedRecord ->
+  // selectBestFromRelatedData -> getRelatedData with limit: 50). A single candidate short-circuits
+  // the AI ranking (bestIndex 0) but still goes through the limit-50 fetch.
   describe('executionType=FullyAutomated: BelongsToMany — load direct (Branch B)', () => {
-    it('fetches 1 related record via /relationships and returns success', async () => {
+    it('fetches related records via /relationships and returns success', async () => {
       const belongsToManySchema = makeCollectionSchema({
         fields: [
           {
@@ -849,13 +849,13 @@ describe('LoadRelatedRecordStepExecutor', () => {
       const result = await executor.execute();
 
       expect(result.stepOutcome.status).toBe('success');
-      // To-many path: /relationships call with limit: 1, no parent-record projection.
+      // To-many ranking path: /relationships call with limit: 50, no parent-record projection.
       expect(agentPort.getRelatedData).toHaveBeenCalledWith(
         expect.objectContaining({
           collection: 'customers',
           id: [42],
           relation: 'tags',
-          limit: 1,
+          limit: 50,
           relatedSchema: expect.objectContaining({ collectionName: 'tags' }),
         }),
         expect.objectContaining({ id: 1 }),
@@ -871,7 +871,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    // fetchCandidates throws RelatedRecordNotFoundError when the agent returns an
+    // selectBestRelatedRecord throws RelatedRecordNotFoundError when the agent returns an
     // empty list. Same user-facing message as the other empty-result paths.
     it('returns error when getRelatedData returns an empty array', async () => {
       const belongsToManySchema = makeCollectionSchema({

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -1063,7 +1063,13 @@ describe('LoadRelatedRecordStepExecutor', () => {
           ],
         })
         .mockResolvedValueOnce({
-          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
+          tool_calls: [
+            {
+              name: 'select-fields',
+              args: { fieldNames: ['City'], reasoning: 'City identifies the address' },
+              id: 'c2',
+            },
+          ],
         })
         .mockResolvedValueOnce({
           tool_calls: [
@@ -1104,6 +1110,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
             suggestedField: { name: 'address', displayName: 'Address' },
             availableRecordIds: [cand([1]), cand([2])],
             suggestedRecord: cand([2]), // record at index 1
+            suggestedFields: ['city'],
+            fieldsReasoning: 'City identifies the address',
+            reasoning: 'Lyon is best',
           },
         }),
       );
@@ -2865,6 +2874,115 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       const messages = mockModel.invoke.mock.calls[0][0];
       expect(messages[0].content).toContain('Step title: "Load the customer order"');
+    });
+
+    // HasMany triggers select-fields (call 1) and select-record-by-content (call 2) after
+    // select-relation-to-follow (call 0). The previous-steps summary must reach all three so
+    // the AI picks fields/record using earlier answers, not just the relation choice.
+    it('includes previous steps summary in select-fields and select-record-by-content messages', async () => {
+      const relatedData: RecordData[] = [
+        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
+        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
+      ];
+      const agentPort = makeMockAgentPort(relatedData);
+
+      const addressesSchema = makeCollectionSchema({
+        collectionName: 'addresses',
+        collectionDisplayName: 'Addresses',
+        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
+      });
+
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-relation-to-follow',
+              args: {
+                relation: relationOption({
+                  recordId: [42],
+                  relationDisplayName: 'Address',
+                  relatedCollectionName: 'addresses',
+                }),
+                reasoning: 'Load address',
+              },
+              id: 'c1',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-fields',
+              args: { fieldNames: ['City'], reasoning: 'City identifies the address' },
+              id: 'c2',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record-by-content',
+              args: { recordIndex: 1, reasoning: 'Lyon is best' },
+              id: 'c3',
+            },
+          ],
+        });
+      const bindTools = jest.fn().mockReturnValue({ invoke });
+      const model = { bindTools } as unknown as ExecutionContext['model'];
+
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'condition',
+            stepIndex: 0,
+            executionParams: { answer: 'Yes', reasoning: 'Approved' },
+          },
+        ]),
+      });
+      const context = makeContext({
+        model,
+        agentPort,
+        runStore,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema(),
+          addresses: addressesSchema,
+        }),
+        previousSteps: [
+          {
+            stepDefinition: {
+              type: StepType.Condition,
+              executionType: StepExecutionMode.Manual,
+              options: ['Yes', 'No'],
+              prompt: 'Should we proceed?',
+            },
+            stepOutcome: {
+              type: 'condition',
+              stepId: 'prev-step',
+              stepIndex: 0,
+              status: 'success',
+            },
+          },
+        ],
+      });
+
+      await new LoadRelatedRecordStepExecutor({
+        ...context,
+        stepId: 'load-2',
+        stepIndex: 1,
+      }).execute();
+
+      expect(invoke).toHaveBeenCalledTimes(3);
+
+      // Leading SystemMessages (context + previous-steps summary + system prompts) are merged
+      // into messages[0] before invoke, so the summary lives there — not at a separate index.
+      const selectFieldsMessages = invoke.mock.calls[1][0];
+      expect(selectFieldsMessages[0].content).toContain('Should we proceed?');
+      expect(selectFieldsMessages[0].content).toContain('"answer":"Yes"');
+
+      const selectRecordMessages = invoke.mock.calls[2][0];
+      expect(selectRecordMessages[0].content).toContain('Should we proceed?');
+      expect(selectRecordMessages[0].content).toContain('"answer":"Yes"');
     });
   });
 


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Save AI reasoning in `loadRelatedRecord` step execution results
> - Adds `suggestedFields`, `fieldsReasoning`, and `reasoning` fields to `LoadRelatedRecordStepExecutionData` execution results and `LoadRelatedRecordPendingData`, so downstream consumers can access AI justification for record and field selection.
> - `selectRelevantFields` and `selectBestRecordIndex` now require the AI to return a reasoning string; both prompts include a previous steps summary for context.
> - `BelongsToMany` relations no longer short-circuit to the first candidate — they now follow the same ranking path as `HasMany` (with limit 50).
> - When a user deviates from the AI suggestion during confirmation, reasoning is dropped from the result; if the user accepts the suggestion, reasoning and `suggestedFields` are preserved.
> - Removes the generic `WithUserConfirmation` interface in favor of direct `userConfirmation?` properties on each step execution data type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be15908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->