### PR TITLE
feat(workflow-executor): persist update-record AI reasoning in result

### DIFF
--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -122,6 +122,16 @@ function coerceFieldValue(
   return parsed.data;
 }
 
+// Field values are primitives, strings, or arrays of those (Json is stored as a string), so a
+// recursive primitive/array compare is enough — no plain objects to deep-compare.
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => valuesEqual(item, b[i]));
+  }
+
+  return a === b;
+}
+
 interface UpdateTarget extends FieldWithValue {
   selectedRecordRef: RecordRef;
   reasoning?: string;
@@ -156,19 +166,24 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
         // A user override of `null` (clearing the field) must win over the AI suggestion, so
         // distinguish "no override" (undefined) from "override to null".
         const overrideValue = userConfirmation?.value;
-        const valueOverridden = overrideValue !== undefined;
-        const rawValue = valueOverridden ? overrideValue : pendingData!.value;
+        const hasOverride = overrideValue !== undefined;
+        const rawValue = hasOverride ? overrideValue : pendingData!.value;
 
-        const target: UpdateTarget = {
-          selectedRecordRef,
-          ...pendingData!,
-          // The value comes from an `unknown` HTTP value (may be a boolean or array), so coerce
-          // it to the field's native type before updating. Idempotent on already-typed values.
-          value: await this.coerceOverride(selectedRecordRef, pendingData, rawValue),
-        };
+        // The value comes from an `unknown` HTTP value (may be a boolean or array), so coerce
+        // it to the field's native type before updating. Idempotent on already-typed values.
+        const value = await this.coerceOverride(selectedRecordRef, pendingData, rawValue);
 
-        // The AI reasoning justifies the AI value; drop it when the user picked their own.
-        if (valueOverridden) target.reasoning = undefined;
+        const target: UpdateTarget = { selectedRecordRef, ...pendingData!, value };
+
+        // Keep the reasoning when the written value matches the AI suggestion, drop it otherwise.
+        if (hasOverride) {
+          const aiValue = await this.coerceOverride(
+            selectedRecordRef,
+            pendingData,
+            pendingData!.value,
+          );
+          if (!valuesEqual(value, aiValue)) target.reasoning = undefined;
+        }
 
         return this.resolveAndUpdate(target, exec);
       });

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -10,6 +10,7 @@ import {
   FieldNotFoundError,
   FieldTypeMissingError,
   InvalidPreRecordedArgsError,
+  MalformedToolCallError,
   NoWritableFieldsError,
   StepStateError,
 } from '../errors';
@@ -123,6 +124,7 @@ function coerceFieldValue(
 
 interface UpdateTarget extends FieldWithValue {
   selectedRecordRef: RecordRef;
+  reasoning?: string;
 }
 
 export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateRecordStepDefinition> {
@@ -153,8 +155,9 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
         const { selectedRecordRef, pendingData, userConfirmation } = exec;
         // A user override of `null` (clearing the field) must win over the AI suggestion, so
         // distinguish "no override" (undefined) from "override to null".
-        const rawValue =
-          userConfirmation?.value !== undefined ? userConfirmation.value : pendingData!.value;
+        const overrideValue = userConfirmation?.value;
+        const valueOverridden = overrideValue !== undefined;
+        const rawValue = valueOverridden ? overrideValue : pendingData!.value;
 
         const target: UpdateTarget = {
           selectedRecordRef,
@@ -163,6 +166,9 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
           // it to the field's native type before updating. Idempotent on already-typed values.
           value: await this.coerceOverride(selectedRecordRef, pendingData, rawValue),
         };
+
+        // The AI reasoning justifies the AI value; drop it when the user picked their own.
+        if (valueOverridden) target.reasoning = undefined;
 
         return this.resolveAndUpdate(target, exec);
       });
@@ -208,9 +214,10 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     }
 
     const recordedField = preRecordedArgs?.fieldName;
-    const { fieldName, value } =
+    // Pre-recorded args bypass the AI, so there is no reasoning on that path.
+    const { fieldName, value, reasoning } =
       recordedField !== undefined
-        ? { fieldName: recordedField, value: preRecordedArgs?.value }
+        ? { fieldName: recordedField, value: preRecordedArgs?.value, reasoning: undefined }
         : await this.selectFieldAndValue(schema, step.prompt);
     const field = this.findFieldByTechnicalName(schema, fieldName);
 
@@ -223,6 +230,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       displayName: field.displayName,
       name: field.fieldName,
       value,
+      reasoning,
     };
 
     // Branch B -- fully automated execution
@@ -238,6 +246,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
         displayName: target.displayName,
         name: target.name,
         value: target.value,
+        reasoning: target.reasoning,
       },
       selectedRecordRef: target.selectedRecordRef,
     });
@@ -250,7 +259,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     target: UpdateTarget,
     existingExecution?: UpdateRecordStepExecutionData,
   ): Promise<StepExecutionResult> {
-    const { selectedRecordRef, displayName, name, value } = target;
+    const { selectedRecordRef, displayName, name, value, reasoning } = target;
 
     const updated = await this.context.agent.updateRecord(
       {
@@ -275,7 +284,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       type: 'update-record',
       stepIndex: this.context.stepIndex,
       executionParams: { displayName, name, value },
-      executionResult: { updatedValues: updated.values },
+      executionResult: { updatedValues: updated.values, ...(reasoning ? { reasoning } : {}) },
       selectedRecordRef,
       idempotencyPhase: 'done',
     });
@@ -286,7 +295,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
   private async selectFieldAndValue(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<{ fieldName: string; value: unknown }> {
+  ): Promise<{ fieldName: string; value: unknown; reasoning?: string }> {
     const tool = this.buildUpdateFieldTool(schema);
     const messages = [
       this.buildContextMessage(),
@@ -298,13 +307,23 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       new HumanMessage(`**Request**: ${prompt ?? 'Update the relevant field.'}`),
     ];
 
-    const { input } = await this.invokeWithTool<{
-      input: { fieldName: string; value: unknown; reasoning: string };
-    }>(messages, tool);
+    type FieldSelection = { reasoning?: string; fieldName?: string; value?: unknown };
+    const args = await this.invokeWithTool<FieldSelection & { input?: FieldSelection }>(
+      messages,
+      tool,
+    );
+
+    // Some models omit the `input` wrapper and return the field object at the top level.
+    const selection = args.input ?? args;
+
+    if (selection.fieldName === undefined) {
+      throw new MalformedToolCallError('update-record-field', 'no field was selected');
+    }
 
     return {
-      fieldName: this.resolveAiFieldName(schema, input.fieldName),
-      value: input.value,
+      fieldName: this.resolveAiFieldName(schema, selection.fieldName),
+      value: selection.value,
+      reasoning: selection.reasoning,
     };
   }
 
@@ -319,16 +338,17 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     }
 
     type FieldObject = z.ZodObject<{
+      reasoning: z.ZodString;
       fieldName: z.ZodLiteral<string>;
       value: z.ZodNullable<z.ZodTypeAny>;
-      reasoning: z.ZodString;
     }>;
 
+    // `reasoning` first so the AI reasons toward the choice instead of justifying it afterwards.
     const fieldObjects = nonRelationFields.map(f =>
       z.object({
+        reasoning: z.string().describe('Why this field and value were chosen'),
         fieldName: z.literal(f.displayName),
         value: buildZodSchemaForField(f, schema.collectionName).nullable(),
-        reasoning: z.string().describe('Why this field and value were chosen'),
       }),
     ) as FieldObject[];
 

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -67,7 +67,7 @@ export interface UpdateRecordStepExecutionData
     WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
   executionParams?: FieldWithValue;
-  // `reasoning` is absent when the user overrode the AI value (the choice is then theirs).
+  // `reasoning` is absent when the user changed the AI value to a different one.
   executionResult?:
     | { updatedValues: Record<string, unknown>; reasoning?: string }
     | { skipped: true };

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -67,9 +67,11 @@ export interface UpdateRecordStepExecutionData
     WithUserConfirmation<UpdateRecordConfirmation> {
   type: 'update-record';
   executionParams?: FieldWithValue;
-  // User confirmed → values returned by updateRecord. User rejected → skipped.
-  executionResult?: { updatedValues: Record<string, unknown> } | { skipped: true };
-  pendingData?: FieldWithValue;
+  // `reasoning` is absent when the user overrode the AI value (the choice is then theirs).
+  executionResult?:
+    | { updatedValues: Record<string, unknown>; reasoning?: string }
+    | { skipped: true };
+  pendingData?: FieldWithValue & { reasoning?: string };
   selectedRecordRef: RecordRef;
 }
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -225,13 +225,60 @@ describe('UpdateRecordStepExecutor', () => {
           type: 'update-record',
           stepIndex: 0,
           executionParams: { displayName: 'Status', name: 'status', value: 'active' },
-          executionResult: { updatedValues },
+          executionResult: { updatedValues, reasoning: 'User requested status change' },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
             recordId: [42],
           }),
         }),
       );
+    });
+
+    it('handles a model that returns the field selection without the "input" wrapper', async () => {
+      const updatedValues = { status: 'active' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      // Flattened args: no `input` key, the field object is at the top level.
+      const mockModel = makeMockModel({
+        fieldName: 'Status',
+        value: 'active',
+        reasoning: 'User requested status change',
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        { collection: 'customers', id: [42], values: { status: 'active' } },
+        expect.objectContaining({ id: 1 }),
+      );
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          executionParams: { displayName: 'Status', name: 'status', value: 'active' },
+          executionResult: { updatedValues, reasoning: 'User requested status change' },
+        }),
+      );
+    });
+
+    it('returns an error outcome when the model selects no field', async () => {
+      const mockModel = makeMockModel({ reasoning: 'unsure' });
+      const context = makeContext({
+        model: mockModel.model,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
     });
   });
 
@@ -410,7 +457,12 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({
           type: 'update-record',
           stepIndex: 0,
-          pendingData: { displayName: 'Status', name: 'status', value: 'active' },
+          pendingData: {
+            displayName: 'Status',
+            name: 'status',
+            value: 'active',
+            reasoning: 'User requested status change',
+          },
           selectedRecordRef: expect.objectContaining({
             collectionName: 'customers',
             recordId: [42],
@@ -431,6 +483,7 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'active',
+          reasoning: 'User requested status change',
         },
         userConfirmation: { userConfirmed: true },
         selectedRecordRef: makeRecordRef(),
@@ -448,16 +501,18 @@ describe('UpdateRecordStepExecutor', () => {
         { collection: 'customers', id: [42], values: { status: 'active' } },
         expect.objectContaining({ id: 1 }),
       );
+      // Accepted without override → AI reasoning is persisted in the result.
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
         expect.objectContaining({
           type: 'update-record',
           executionParams: { displayName: 'Status', name: 'status', value: 'active' },
-          executionResult: { updatedValues },
+          executionResult: { updatedValues, reasoning: 'User requested status change' },
           pendingData: {
             displayName: 'Status',
             name: 'status',
             value: 'active',
+            reasoning: 'User requested status change',
           },
         }),
       );
@@ -465,8 +520,8 @@ describe('UpdateRecordStepExecutor', () => {
   });
 
   describe('confirmation with user override (Branch A)', () => {
-    it('preserves AI suggestion in pendingData and writes user value to executionParams', async () => {
-      // Persisted state: AI proposed 'inactive', awaiting confirmation.
+    it('writes the user value and drops the now-stale AI reasoning from the result', async () => {
+      // Persisted state: AI proposed 'inactive' with a reasoning, awaiting confirmation.
       const execution: UpdateRecordStepExecutionData = {
         type: 'update-record',
         stepIndex: 0,
@@ -474,6 +529,7 @@ describe('UpdateRecordStepExecutor', () => {
           displayName: 'Status',
           name: 'status',
           value: 'inactive',
+          reasoning: 'AI judged the record inactive',
         },
         selectedRecordRef: makeRecordRef(),
       };
@@ -498,8 +554,8 @@ describe('UpdateRecordStepExecutor', () => {
         expect.objectContaining({ id: 1 }),
       );
 
-      // Final persisted execution must keep AI suggestion in pendingData
-      // and the user value in executionParams.
+      // The AI suggestion + reasoning stays in pendingData, but the result must NOT carry the
+      // reasoning since the written value is the user's, not the AI's.
       const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
       expect(finalSave).toEqual(
         expect.objectContaining({
@@ -508,11 +564,13 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Status',
             name: 'status',
             value: 'inactive', // AI suggestion preserved
+            reasoning: 'AI judged the record inactive',
           }),
           executionParams: { displayName: 'Status', name: 'status', value: 'active' },
           executionResult: { updatedValues },
         }),
       );
+      expect(finalSave.executionResult.reasoning).toBeUndefined();
     });
   });
 
@@ -789,6 +847,7 @@ describe('UpdateRecordStepExecutor', () => {
             displayName: 'Order Status',
             name: 'status',
             value: 'shipped',
+            reasoning: 'Mark as shipped',
           },
           selectedRecordRef: expect.objectContaining({
             recordId: [99],

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -572,6 +572,40 @@ describe('UpdateRecordStepExecutor', () => {
       );
       expect(finalSave.executionResult.reasoning).toBeUndefined();
     });
+
+    it('keeps the AI reasoning when the user re-submits the suggested value unchanged', async () => {
+      const execution: UpdateRecordStepExecutionData = {
+        type: 'update-record',
+        stepIndex: 0,
+        pendingData: {
+          displayName: 'Status',
+          name: 'status',
+          value: 'active',
+          reasoning: 'AI judged the record active',
+        },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const updatedValues = { status: 'active' };
+      const agentPort = makeMockAgentPort(updatedValues);
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      // User confirms echoing the AI value: 'active'.
+      const context = makeContext({
+        agentPort,
+        runStore,
+        incomingPendingData: { userConfirmed: true, value: 'active' },
+      });
+      const executor = new UpdateRecordStepExecutor(context);
+
+      await executor.execute();
+
+      const finalSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(finalSave.executionResult).toEqual({
+        updatedValues,
+        reasoning: 'AI judged the record active',
+      });
+    });
   });
 
   describe('accept-via-PATCH without value override (Branch A)', () => {


### PR DESCRIPTION
## Contexte

Sur le step **update-record**, le reasoning de l'IA était jeté. Cette PR le capture et le persiste de façon auditable, dans le cadre de `feat/ai-explainability-for-compliance`.

## Changements

### Reasoning dans `executionResult`
- Le reasoning IA est persisté dans **`executionResult`** (et non `executionParams`) : il enregistre *pourquoi la valeur écrite a été choisie*.
- Il est **omis quand l'utilisateur override la valeur** à la confirmation — la décision est alors la sienne, pas celle de l'IA (détecté via `userConfirmation.value !== undefined`, fiable car le validateur n'envoie `value` qu'en cas d'override).
- Transporté à travers le flux de confirmation via `pendingData`.
- Reste **client-side**, jamais envoyé dans le `StepOutcome` (frontière de confidentialité respectée).
- Chemin `preRecordedArgs` : pas d'IA → pas de reasoning.

### Fix robustesse `selectFieldAndValue`
- L'outil `update-record-field` enveloppe sa sortie dans `{ input: ... }` (nécessaire pour le cas union). Certains modèles renvoient la sélection **à plat**, ce qui provoquait un `TypeError: Cannot read properties of undefined (reading 'fieldName')`.
- On accepte désormais les deux formes (wrappé **ou** à plat), et on lève un `MalformedToolCallError` clair si aucun champ n'est sélectionné (au lieu d'un crash « Unexpected error »).

## Tests
- Branch B / C / A-accept : reasoning au bon endroit (`executionResult` / `pendingData`).
- Branch A-override : `pendingData` garde le reasoning, **`executionResult` ne le contient pas**.
- Modèle sans wrapper `input` → succès ; modèle sans champ → erreur propre.
- **1058/1058** tests, lint 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist AI reasoning in update-record step execution results
> - The `update-record` step executor now captures and stores the AI's reasoning for field/value selection in both `pendingData` and `executionResult` within the run store.
> - When a user override differs from the AI-suggested value, reasoning is dropped from the saved result; if the override matches, reasoning is retained.
> - The tool schema in `buildUpdateFieldTool` now includes a required `reasoning` field, and `selectFieldAndValue` accepts flattened tool responses (without the `input` wrapper) and throws `MalformedToolCallError` when no field is selected.
> - Behavioral Change: tool call responses no longer require the `input` wrapper, and missing field selection now returns an error outcome instead of failing silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0af434.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->