### PR TITLE
docs(mcp-server): add Quick Setup section for non-developers

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -4,9 +4,7 @@ Model Context Protocol (MCP) server for Forest Admin with OAuth authentication s
 
 ## Quick Setup
 
-### Without a local database (30 seconds)
-
-If you already have a Forest Admin project, start the MCP server immediately — no installation, no database:
+Start the MCP server in seconds — no installation required:
 
 ```bash
 FOREST_ENV_SECRET="your-env-secret" \
@@ -25,52 +23,6 @@ http://localhost:3931/mcp
 1. Open [app.forestadmin.com](https://app.forestadmin.com) → your project
 2. Go to **Settings** → **Environments** → click your environment
 3. Copy the **Environment secret** (`FOREST_ENV_SECRET`) and the **Auth secret** (`FOREST_AUTH_SECRET`)
-
----
-
-### With a local database
-
-If you want the MCP server to query your own database, you need a Forest Admin agent running locally.
-
-**1. Create an agent project** (one-time setup):
-
-```bash
-mkdir my-forest-agent && cd my-forest-agent
-npm init -y
-npm install @forestadmin/agent @forestadmin/datasource-sql
-```
-
-**2. Create `agent.js`:**
-
-```javascript
-const { createAgent } = require('@forestadmin/agent');
-const { createSqlDatasource } = require('@forestadmin/datasource-sql');
-
-createAgent({
-  envSecret: process.env.FOREST_ENV_SECRET,
-  authSecret: process.env.FOREST_AUTH_SECRET,
-  isProduction: false,
-  loggerLevel: 'Info',
-})
-  .addDataSource(
-    createSqlDatasource(process.env.DATABASE_URL), // e.g. postgres://user:pass@localhost:5432/mydb
-  )
-  .start();
-```
-
-> For MongoDB use `@forestadmin/datasource-mongo`, for Mongoose use `@forestadmin/datasource-mongoose`.
-
-**3. Start both:**
-
-```bash
-# Terminal 1 — agent (port 3351 by default)
-FOREST_ENV_SECRET="..." FOREST_AUTH_SECRET="..." DATABASE_URL="postgres://..." node agent.js
-
-# Terminal 2 — MCP server (port 3931)
-FOREST_ENV_SECRET="..." FOREST_AUTH_SECRET="..." npx @forestadmin/mcp-server
-```
-
-The MCP server routes requests through the Forest Admin cloud to your local agent, which queries your database. No data ever leaves your infrastructure.
 
 ---
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -2,6 +2,78 @@
 
 Model Context Protocol (MCP) server for Forest Admin with OAuth authentication support.
 
+## Quick Setup
+
+### Without a local database (30 seconds)
+
+If you already have a Forest Admin project, start the MCP server immediately — no installation, no database:
+
+```bash
+FOREST_ENV_SECRET="your-env-secret" \
+FOREST_AUTH_SECRET="your-auth-secret" \
+npx @forestadmin/mcp-server
+```
+
+The server starts on port `3931`. Point your MCP client (Claude Desktop, Cursor, etc.) to:
+
+```
+http://localhost:3931/mcp
+```
+
+**Where to find your credentials:**
+
+1. Open [app.forestadmin.com](https://app.forestadmin.com) → your project
+2. Go to **Settings** → **Environments** → click your environment
+3. Copy the **Environment secret** (`FOREST_ENV_SECRET`) and the **Auth secret** (`FOREST_AUTH_SECRET`)
+
+---
+
+### With a local database
+
+If you want the MCP server to query your own database, you need a Forest Admin agent running locally.
+
+**1. Create an agent project** (one-time setup):
+
+```bash
+mkdir my-forest-agent && cd my-forest-agent
+npm init -y
+npm install @forestadmin/agent @forestadmin/datasource-sql
+```
+
+**2. Create `agent.js`:**
+
+```javascript
+const { createAgent } = require('@forestadmin/agent');
+const { createSqlDatasource } = require('@forestadmin/datasource-sql');
+
+createAgent({
+  envSecret: process.env.FOREST_ENV_SECRET,
+  authSecret: process.env.FOREST_AUTH_SECRET,
+  isProduction: false,
+  loggerLevel: 'Info',
+})
+  .addDataSource(
+    createSqlDatasource(process.env.DATABASE_URL), // e.g. postgres://user:pass@localhost:5432/mydb
+  )
+  .start();
+```
+
+> For MongoDB use `@forestadmin/datasource-mongo`, for Mongoose use `@forestadmin/datasource-mongoose`.
+
+**3. Start both:**
+
+```bash
+# Terminal 1 — agent (port 3351 by default)
+FOREST_ENV_SECRET="..." FOREST_AUTH_SECRET="..." DATABASE_URL="postgres://..." node agent.js
+
+# Terminal 2 — MCP server (port 3931)
+FOREST_ENV_SECRET="..." FOREST_AUTH_SECRET="..." npx @forestadmin/mcp-server
+```
+
+The MCP server routes requests through the Forest Admin cloud to your local agent, which queries your database. No data ever leaves your infrastructure.
+
+---
+
 ## Overview
 
 This MCP server provides HTTP REST API access to Forest Admin operations, enabling AI assistants and other MCP clients to interact with your Forest Admin data through a standardized protocol.


### PR DESCRIPTION
## Summary

- Adds a **Quick Setup** section at the top of `packages/mcp-server/README.md`
- Two guided paths:
  - **Without a local database** (30 seconds): just `npx @forestadmin/mcp-server` with credentials from the Forest Admin UI
  - **With a local database**: step-by-step agent setup (`npm install`, `agent.js`, two-terminal start)
- Includes credentials location (Settings → Environments) and the MCP endpoint URL for client config

## Test plan

- [ ] README renders correctly on GitHub
- [ ] `npx` command in "without database" section matches the actual package bin name (`forest-mcp-server`)
- [ ] Agent example code compiles (uses public API: `createAgent`, `createSqlDatasource`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Quick Setup section to mcp-server README for non-developers
> Adds a new 'Quick Setup' section to [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1678/files#diff-46a7a23fdaae3bf8011f1ddca552c21b774309bc427c931469d104619efa28a8) explaining how to start the MCP server via `npx`, including required environment variables, the default port, and the MCP endpoint URL. Also includes steps to locate environment and auth secrets in the Forest Admin UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f18234f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->