### PR TITLE
feat(plugin-audit-trail): audit writes from inside smart actions

### DIFF
--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -272,7 +272,7 @@ export default class CollectionCustomizer<
 
   /**
    * Like {@link addHook} but also fires for writes initiated from inside a smart action
-   * (`context.collection.update`/`create`/`delete`). Intended for instrumentation plugins.
+   * (`context.collection.update`/`create`/`delete`). Used by the audit-trail plugin.
    */
   addInternalHook<P extends HookPosition, T extends HookType>(
     position: P,

--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -271,6 +271,28 @@ export default class CollectionCustomizer<
   }
 
   /**
+   * Register a hook on the decorator layer that sits *below* the action decorator.
+   *
+   * Unlike {@link addHook}, hooks registered here also fire for writes initiated from inside a
+   * smart action (`context.collection.update`/`create`/`delete`) — those start at the action
+   * layer and would otherwise skip the public hook layer above it.
+   *
+   * Intended for instrumentation plugins (audit-trail, logging, etc.). Application code should
+   * keep using {@link addHook}.
+   */
+  addInternalHook<P extends HookPosition, T extends HookType>(
+    position: P,
+    type: T,
+    handler: HookHandler<HooksContext<S, N>[P][T]>,
+  ): this {
+    return this.pushCustomization(async () => {
+      this.stack.internalHook
+        .getCollection(this.name)
+        .addHook(position, type, handler as unknown as HookHandler<HooksContext[P][T]>);
+    });
+  }
+
+  /**
    * Add a many to one relation to the collection
    * @param name name of the new relation
    * @param foreignCollection name of the targeted collection

--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -271,14 +271,8 @@ export default class CollectionCustomizer<
   }
 
   /**
-   * Register a hook on the decorator layer that sits *below* the action decorator.
-   *
-   * Unlike {@link addHook}, hooks registered here also fire for writes initiated from inside a
-   * smart action (`context.collection.update`/`create`/`delete`) — those start at the action
-   * layer and would otherwise skip the public hook layer above it.
-   *
-   * Intended for instrumentation plugins (audit-trail, logging, etc.). Application code should
-   * keep using {@link addHook}.
+   * Like {@link addHook} but also fires for writes initiated from inside a smart action
+   * (`context.collection.update`/`create`/`delete`). Intended for instrumentation plugins.
    */
   addInternalHook<P extends HookPosition, T extends HookType>(
     position: P,

--- a/packages/datasource-customizer/src/decorators/decorators-stack-base.ts
+++ b/packages/datasource-customizer/src/decorators/decorators-stack-base.ts
@@ -34,9 +34,6 @@ export default abstract class DecoratorsStackBase {
   earlyComputed: DataSourceDecorator<ComputedCollectionDecorator>;
   earlyOpEmulate: DataSourceDecorator<OperatorsEmulateCollectionDecorator>;
   hook: DataSourceDecorator<HookCollectionDecorator>;
-  // Hooks installed here observe writes from both the UI and from inside smart actions, because
-  // this layer sits below `action` in the decorator stack. The public `hook` layer is above
-  // `action`, so it misses writes that originate from `context.collection.update(...)`.
   internalHook: DataSourceDecorator<HookCollectionDecorator>;
   lateComputed: DataSourceDecorator<ComputedCollectionDecorator>;
   lateOpEmulate: DataSourceDecorator<OperatorsEmulateCollectionDecorator>;

--- a/packages/datasource-customizer/src/decorators/decorators-stack-base.ts
+++ b/packages/datasource-customizer/src/decorators/decorators-stack-base.ts
@@ -34,6 +34,10 @@ export default abstract class DecoratorsStackBase {
   earlyComputed: DataSourceDecorator<ComputedCollectionDecorator>;
   earlyOpEmulate: DataSourceDecorator<OperatorsEmulateCollectionDecorator>;
   hook: DataSourceDecorator<HookCollectionDecorator>;
+  // Hooks installed here observe writes from both the UI and from inside smart actions, because
+  // this layer sits below `action` in the decorator stack. The public `hook` layer is above
+  // `action`, so it misses writes that originate from `context.collection.update(...)`.
+  internalHook: DataSourceDecorator<HookCollectionDecorator>;
   lateComputed: DataSourceDecorator<ComputedCollectionDecorator>;
   lateOpEmulate: DataSourceDecorator<OperatorsEmulateCollectionDecorator>;
   publication: PublicationDataSourceDecorator;
@@ -64,6 +68,7 @@ export default abstract class DecoratorsStackBase {
       earlyComputed: this.earlyComputed,
       earlyOpEmulate: this.earlyOpEmulate,
       hook: this.hook,
+      internalHook: this.internalHook,
       lateComputed: this.lateComputed,
       lateOpEmulate: this.lateOpEmulate,
       publication: this.publication,
@@ -86,6 +91,7 @@ export default abstract class DecoratorsStackBase {
     this.earlyComputed = stack.earlyComputed;
     this.earlyOpEmulate = stack.earlyOpEmulate;
     this.hook = stack.hook;
+    this.internalHook = stack.internalHook;
     this.lateComputed = stack.lateComputed;
     this.lateOpEmulate = stack.lateOpEmulate;
     this.publication = stack.publication;

--- a/packages/datasource-customizer/src/decorators/decorators-stack-no-code.ts
+++ b/packages/datasource-customizer/src/decorators/decorators-stack-no-code.ts
@@ -4,6 +4,7 @@ import { DataSourceDecorator } from '@forestadmin/datasource-toolkit';
 
 import ActionCollectionDecorator from './actions/collection';
 import DecoratorsStackBase from './decorators-stack-base';
+import HookCollectionDecorator from './hook/collection';
 import SchemaCollectionDecorator from './schema/collection';
 import ValidationCollectionDecorator from './validation/collection';
 
@@ -15,6 +16,7 @@ export default class DecoratorsStackNoCode extends DecoratorsStackBase {
     // We only need those for the No Code use cases.
 
     /* eslint-disable no-multi-assign */
+    last = this.internalHook = new DataSourceDecorator(last, HookCollectionDecorator);
     last = this.action = new DataSourceDecorator(last, ActionCollectionDecorator);
     last = this.schema = new DataSourceDecorator(last, SchemaCollectionDecorator);
     last = this.validation = new DataSourceDecorator(last, ValidationCollectionDecorator);

--- a/packages/datasource-customizer/src/decorators/decorators-stack.ts
+++ b/packages/datasource-customizer/src/decorators/decorators-stack.ts
@@ -52,6 +52,10 @@ export default class DecoratorsStack extends DecoratorsStackBase {
 
     // Step 3: Access to all fields AND emulated capabilities
     last = this.chart = new ChartDataSourceDecorator(last);
+    // `internalHook` sits *below* `action` so writes emitted from inside a smart action
+    // (`context.collection.update/create/delete`) still pass through it. The public `hook`
+    // decorator below is above `action` and would miss those writes.
+    last = this.internalHook = new DataSourceDecorator(last, HookCollectionDecorator);
     last = this.action = new DataSourceDecorator(last, ActionCollectionDecorator);
     last = this.schema = new DataSourceDecorator(last, SchemaCollectionDecorator);
     last = this.write = new WriteDataSourceDecorator(last);

--- a/packages/datasource-customizer/src/decorators/decorators-stack.ts
+++ b/packages/datasource-customizer/src/decorators/decorators-stack.ts
@@ -52,9 +52,7 @@ export default class DecoratorsStack extends DecoratorsStackBase {
 
     // Step 3: Access to all fields AND emulated capabilities
     last = this.chart = new ChartDataSourceDecorator(last);
-    // `internalHook` sits *below* `action` so writes emitted from inside a smart action
-    // (`context.collection.update/create/delete`) still pass through it. The public `hook`
-    // decorator below is above `action` and would miss those writes.
+    // Below `action` so writes emitted from inside a smart action also traverse it.
     last = this.internalHook = new DataSourceDecorator(last, HookCollectionDecorator);
     last = this.action = new DataSourceDecorator(last, ActionCollectionDecorator);
     last = this.schema = new DataSourceDecorator(last, SchemaCollectionDecorator);

--- a/packages/plugin-audit-trail/src/audit-trail.ts
+++ b/packages/plugin-audit-trail/src/audit-trail.ts
@@ -166,7 +166,7 @@ function instrumentCollection(
       newValues: redactValues(newValues, redactedFields),
     });
 
-  collection.addHook('After', 'Create', async (context: HookAfterCreateContext) => {
+  collection.addInternalHook('After', 'Create', async (context: HookAfterCreateContext) => {
     await Promise.all(
       context.records.map(record =>
         emit(context.caller, 'create', toRecordId(record, primaryKeys), {}, pick(record, columns)),
@@ -174,12 +174,12 @@ function instrumentCollection(
     );
   });
 
-  collection.addHook('Before', 'Update', async (context: HookBeforeUpdateContext) => {
+  collection.addInternalHook('Before', 'Update', async (context: HookBeforeUpdateContext) => {
     const before = await context.collection.list(context.filter as never, projection as never[]);
     pendingSnapshots.set(context.filter, before as RecordData[]);
   });
 
-  collection.addHook('After', 'Update', async (context: HookBeforeUpdateContext) => {
+  collection.addInternalHook('After', 'Update', async (context: HookBeforeUpdateContext) => {
     const before = pendingSnapshots.get(context.filter) ?? [];
     pendingSnapshots.delete(context.filter);
 
@@ -201,12 +201,12 @@ function instrumentCollection(
     );
   });
 
-  collection.addHook('Before', 'Delete', async (context: HookBeforeDeleteContext) => {
+  collection.addInternalHook('Before', 'Delete', async (context: HookBeforeDeleteContext) => {
     const before = await context.collection.list(context.filter as never, projection as never[]);
     pendingSnapshots.set(context.filter, before as RecordData[]);
   });
 
-  collection.addHook('After', 'Delete', async (context: HookBeforeDeleteContext) => {
+  collection.addInternalHook('After', 'Delete', async (context: HookBeforeDeleteContext) => {
     const before = pendingSnapshots.get(context.filter) ?? [];
     pendingSnapshots.delete(context.filter);
 

--- a/packages/plugin-audit-trail/test/audit-trail.test.ts
+++ b/packages/plugin-audit-trail/test/audit-trail.test.ts
@@ -46,7 +46,7 @@ function fakeCollection(
   const collection = {
     name,
     schema,
-    addHook: (position: string, type: string, handler: Handler) => {
+    addInternalHook: (position: string, type: string, handler: Handler) => {
       handlers.set(`${position}:${type}`, handler);
     },
   };

--- a/packages/plugin-audit-trail/test/integration.test.ts
+++ b/packages/plugin-audit-trail/test/integration.test.ts
@@ -181,6 +181,50 @@ describe('auditTrail against a real DataSourceCustomizer stack', () => {
     });
   });
 
+  it('captures updates triggered from inside a smart action', async () => {
+    const store = new InMemoryAuditStore();
+    const customizer = new DataSourceCustomizer();
+    customizer.addDataSource(async () => {
+      const dataSource = new BaseDataSource();
+      dataSource.addCollection(new AccountsCollection(dataSource));
+
+      return dataSource;
+    });
+    customizer.customizeCollection('accounts', accounts => {
+      accounts.addAction('Mark closed', {
+        scope: 'Bulk',
+        execute: async context => {
+          await context.collection.update(context.filter, { status: 'closed' });
+        },
+      });
+    });
+    customizer.use(auditTrail, { store });
+
+    const dataSource = await customizer.getDataSource(() => {});
+    const collection = dataSource.getCollection('accounts');
+    await collection.create(caller('r-seed'), [
+      { status: 'open', name: 'Acme' },
+      { status: 'pending', name: 'Globex' },
+    ]);
+
+    await collection.execute(caller('r-action'), 'Mark closed', {}, new Filter({}));
+
+    const first = store.listByRecord({ collection: 'accounts', recordId: '1' });
+    const second = store.listByRecord({ collection: 'accounts', recordId: '2' });
+    expect(first[first.length - 1]).toMatchObject({
+      operation: 'update',
+      correlationKey: 'r-action',
+      previousValues: { status: 'open' },
+      newValues: { status: 'closed' },
+    });
+    expect(second[second.length - 1]).toMatchObject({
+      operation: 'update',
+      correlationKey: 'r-action',
+      previousValues: { status: 'pending' },
+      newValues: { status: 'closed' },
+    });
+  });
+
   it('groups a bulk update under one correlation key, one row per matched record', async () => {
     const { store, collection } = await buildCollection();
     await collection.create(caller('r-create'), [


### PR DESCRIPTION
## Summary
- Smart actions call `context.collection.update/create/delete`, which enter the decorator stack at the `ActionCollectionDecorator` and travel inward. The plugin's CRUD hooks were registered on the public `HookCollectionDecorator`, which sits *above* the action layer, so action-initiated writes were never audited.
- Introduce an `internalHook` layer (a second `HookCollectionDecorator`) wired between `chart` and `action`, exposed via `CollectionCustomizer.addInternalHook`. UI writes (top-down) and action writes (action layer, going inward) both pass through it.
- Audit-trail plugin now uses `addInternalHook`, so the five CRUD hooks fire for both origins. An integration test executes a `Bulk` smart action and asserts the resulting audit rows.

## Test plan
- [x] `yarn workspace @forestadmin/plugin-audit-trail test` (78/78, includes new "captures updates triggered from inside a smart action" case)
- [x] `yarn workspace @forestadmin/datasource-customizer test` (850/850 — stack ordering invariants intact)
- [x] `yarn workspace @forestadmin/plugin-audit-trail lint` / `yarn workspace @forestadmin/datasource-customizer lint` (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Audit writes triggered from inside smart actions in the audit trail plugin
> - Adds `addInternalHook` to `CollectionCustomizer` and a new `internalHook` decorator stage in the stack, positioned before the action decorator so hooks fire for writes made inside smart actions.
> - Updates the audit trail plugin's `instrumentCollection` to register its create/update/delete hooks via `addInternalHook` instead of `addHook`, so audit records are emitted for smart action-initiated writes.
> - Adds an integration test that executes a bulk smart action and asserts audit entries are captured with the correct `correlationKey`, previous values, and new values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 216ec87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->