### PR TITLE
fix(demo fintech ds): allow multiple restart

### DIFF
--- a/packages/datasource-demo-fintech/src/index.ts
+++ b/packages/datasource-demo-fintech/src/index.ts
@@ -7,6 +7,7 @@ import type {
 
 import { DataSourceCustomizer } from '@forestadmin/datasource-customizer';
 import { createSqlDataSource } from '@forestadmin/datasource-sql';
+import { rm } from 'fs/promises';
 
 import customizeAmlAlerts from './customizations/aml_alerts';
 import customizeCards from './customizations/cards';
@@ -98,6 +99,7 @@ async function buildSeededSqlDataSource(
   restartAgent: () => Promise<void>,
 ): Promise<DataSource> {
   const storage = 'db.sqlite';
+  await rm(storage, { force: true });
 
   await seed(storage);
 

--- a/packages/datasource-demo-fintech/test/index.test.ts
+++ b/packages/datasource-demo-fintech/test/index.test.ts
@@ -1,7 +1,22 @@
+import type { Logger } from '@forestadmin/datasource-toolkit';
+
 import { createDemoFintechDataSource } from '../src/index';
 
 describe('createDemoFintechDataSource', () => {
   it('should not crash', () => {
     expect(() => createDemoFintechDataSource()).not.toThrow();
+  });
+
+  it('should rebuild a fresh database on each boot without failing on existing tables', async () => {
+    const logger: Logger = () => {};
+
+    const restartAgent = jest.fn().mockResolvedValue(undefined);
+
+    // The data source seeds a persistent SQLite file lazily, when the factory runs.
+    // A second boot must drop the leftover database instead of failing on
+    // `createTable` for tables that already exist.
+    await createDemoFintechDataSource()(logger, restartAgent);
+
+    await expect(createDemoFintechDataSource()(logger, restartAgent)).resolves.toBeDefined();
   });
 });


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildSeededSqlDataSource` to support multiple restarts in the demo fintech datasource
> Deletes the existing `db.sqlite` file before seeding by calling `rm(storage, { force: true })`, ensuring a fresh database is created on each boot. Previously, restarting would fail because SQLite table creation statements were re-run against an existing database. A test covering two consecutive initializations is also added in [index.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1681/files#diff-baac47333fcb85f94d54b927581ecd49e62523d9e9e86b861e9caa45bf448a32).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d38f567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->