### PR TITLE
feat(plugin-audit-trail): filter record history by changed fields

### DIFF
--- a/packages/agent/src/routes/access/audit-trail.ts
+++ b/packages/agent/src/routes/access/audit-trail.ts
@@ -17,6 +17,7 @@ type AuditHistoryFilters = {
   userIds?: number[];
   startTimestamp?: string;
   endTimestamp?: string;
+  fields?: string[];
 };
 
 export default class AuditTrailRoute extends CollectionRoute {
@@ -30,7 +31,7 @@ export default class AuditTrailRoute extends CollectionRoute {
     const { store } = this.options.auditTrail;
     const { skip, limit } = AuditTrailRoute.parsePagination(context);
     const order = AuditTrailRoute.parseSort(context);
-    const { userIds, startTimestamp, endTimestamp } = AuditTrailRoute.parseFilters(context);
+    const { userIds, startTimestamp, endTimestamp, fields } = AuditTrailRoute.parseFilters(context);
 
     // context.params.id is already Forest's packed id, the form the audit store keys on.
     const filters = {
@@ -39,6 +40,7 @@ export default class AuditTrailRoute extends CollectionRoute {
       ...(userIds && { userIds }),
       ...(startTimestamp && { startTimestamp }),
       ...(endTimestamp && { endTimestamp }),
+      ...(fields && { fields }),
     };
 
     // `count` reflects the active filters (not the absolute total) and is independent of the page.
@@ -94,6 +96,7 @@ export default class AuditTrailRoute extends CollectionRoute {
         'start',
       ),
       endTimestamp: AuditTrailRoute.parseDateBoundary(query.endDate?.toString(), timezone, 'end'),
+      fields: AuditTrailRoute.parseFields(query.fields?.toString()),
     };
   }
 
@@ -108,6 +111,17 @@ export default class AuditTrailRoute extends CollectionRoute {
       .map(token => Number.parseInt(token, 10));
 
     return ids.length > 0 ? ids : undefined;
+  }
+
+  private static parseFields(raw?: string): string[] | undefined {
+    if (!raw) return undefined;
+
+    const fields = raw
+      .split(',')
+      .map(token => token.trim())
+      .filter(token => token.length > 0);
+
+    return fields.length > 0 ? fields : undefined;
   }
 
   // `startDate` / `endDate` accept a bare day (`YYYY-MM-DD`) or a wall-clock datetime

--- a/packages/agent/test/routes/access/audit-trail.test.ts
+++ b/packages/agent/test/routes/access/audit-trail.test.ts
@@ -198,6 +198,81 @@ describe('AuditTrailRoute', () => {
     );
   });
 
+  test('forwards a comma-separated fields filter to the store', async () => {
+    const { services, dataSource, options, store } = setup();
+    const route = new AuditTrailRoute(services, options, dataSource, 'books');
+    const context = createMockContext({
+      state: { user: { email: 'john.doe@domain.com' } },
+      customProperties: {
+        query: { timezone: 'Europe/Paris', fields: 'title,author' },
+        params: { id: '2' },
+      },
+    });
+
+    await route.handleHistory(context);
+
+    expect(store.listByRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ fields: ['title', 'author'] }),
+    );
+    expect(store.countByRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ fields: ['title', 'author'] }),
+    );
+  });
+
+  test('trims whitespace around field tokens and drops empty ones', async () => {
+    const { services, dataSource, options, store } = setup();
+    const route = new AuditTrailRoute(services, options, dataSource, 'books');
+    const context = createMockContext({
+      state: { user: { email: 'john.doe@domain.com' } },
+      customProperties: {
+        query: { timezone: 'Europe/Paris', fields: ' title , , author ' },
+        params: { id: '2' },
+      },
+    });
+
+    await route.handleHistory(context);
+
+    expect(store.listByRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ fields: ['title', 'author'] }),
+    );
+  });
+
+  test('omits the fields filter when the parameter is empty', async () => {
+    const { services, dataSource, options, store } = setup();
+    const route = new AuditTrailRoute(services, options, dataSource, 'books');
+    const context = createMockContext({
+      state: { user: { email: 'john.doe@domain.com' } },
+      customProperties: {
+        query: { timezone: 'Europe/Paris', fields: '' },
+        params: { id: '2' },
+      },
+    });
+
+    await route.handleHistory(context);
+
+    expect(store.listByRecord).toHaveBeenCalledWith(
+      expect.not.objectContaining({ fields: expect.anything() }),
+    );
+  });
+
+  test('omits the fields filter when every token is whitespace', async () => {
+    const { services, dataSource, options, store } = setup();
+    const route = new AuditTrailRoute(services, options, dataSource, 'books');
+    const context = createMockContext({
+      state: { user: { email: 'john.doe@domain.com' } },
+      customProperties: {
+        query: { timezone: 'Europe/Paris', fields: ' , , ' },
+        params: { id: '2' },
+      },
+    });
+
+    await route.handleHistory(context);
+
+    expect(store.listByRecord).toHaveBeenCalledWith(
+      expect.not.objectContaining({ fields: expect.anything() }),
+    );
+  });
+
   test('converts startDate/endDate to inclusive UTC instants in the request timezone', async () => {
     const { services, dataSource, options, store } = setup();
     const route = new AuditTrailRoute(services, options, dataSource, 'books');

--- a/packages/plugin-audit-trail/src/sql-store.ts
+++ b/packages/plugin-audit-trail/src/sql-store.ts
@@ -82,14 +82,47 @@ export function toRow(record: AuditRecord): Record<string, unknown> {
   };
 }
 
-/** Build the Sequelize `where` clause shared by `listByRecord` and `countByRecord`. */
-function buildWhere({
-  collection,
-  recordId,
-  userIds,
-  startTimestamp,
-  endTimestamp,
-}: AuditHistoryQuery): Record<string | symbol, unknown> {
+function fieldsChangedCondition(sequelize: Sequelize, fields: string[]) {
+  const dialect = sequelize.getDialect();
+
+  if (dialect === 'postgres') {
+    const keys = fields.map(field => sequelize.escape(field)).join(',');
+
+    return Sequelize.literal(
+      `(jsonb_exists_any("previous_values"::jsonb, ARRAY[${keys}]) ` +
+        `OR jsonb_exists_any("new_values"::jsonb, ARRAY[${keys}]))`,
+    );
+  }
+
+  if (dialect === 'sqlite') {
+    const tests = fields.flatMap(field => {
+      const path = sequelize.escape(`$.${field}`);
+
+      return [
+        `json_type(previous_values, ${path}) IS NOT NULL`,
+        `json_type(new_values, ${path}) IS NOT NULL`,
+      ];
+    });
+
+    return Sequelize.literal(`(${tests.join(' OR ')})`);
+  }
+
+  if (dialect === 'mysql' || dialect === 'mariadb') {
+    const paths = fields.map(field => sequelize.escape(`$.${field}`)).join(',');
+
+    return Sequelize.literal(
+      `(JSON_CONTAINS_PATH(previous_values, 'one', ${paths}) ` +
+        `OR JSON_CONTAINS_PATH(new_values, 'one', ${paths}))`,
+    );
+  }
+
+  throw new Error(`Audit-trail "fields" filter is not supported on dialect "${dialect}"`);
+}
+
+function buildWhere(
+  { collection, recordId, userIds, startTimestamp, endTimestamp, fields }: AuditHistoryQuery,
+  sequelize: Sequelize,
+): Record<string | symbol, unknown> {
   const where: Record<string | symbol, unknown> = { collection, recordId };
 
   if (userIds) where.userId = { [Op.in]: userIds };
@@ -98,6 +131,8 @@ function buildWhere({
   if (startTimestamp) timestampRange[Op.gte] = new Date(startTimestamp);
   if (endTimestamp) timestampRange[Op.lte] = new Date(endTimestamp);
   if (Object.getOwnPropertySymbols(timestampRange).length) where.timestamp = timestampRange;
+
+  if (fields?.length) where[Op.and] = [fieldsChangedCondition(sequelize, fields)];
 
   return where;
 }
@@ -135,28 +170,29 @@ export function createSqlAuditStore(options: AuditStorageOptions): {
   const { connectionString, schema = DEFAULT_SCHEMA, tableName = DEFAULT_TABLE } = options;
 
   let sequelize: Sequelize | null = null;
-  let modelPromise: Promise<ModelStatic<Model>> | null = null;
+  let bootstrap: Promise<{ model: ModelStatic<Model>; connection: Sequelize }> | null = null;
 
-  const init = (): Promise<ModelStatic<Model>> => {
-    if (modelPromise) return modelPromise;
+  const init = (): Promise<{ model: ModelStatic<Model>; connection: Sequelize }> => {
+    if (bootstrap) return bootstrap;
 
     const connection = new Sequelize(connectionString, { logging: false });
     sequelize = connection;
-    modelPromise = (async () => {
+    bootstrap = (async () => {
       try {
         await connection.authenticate();
+        const model = await ensureAuditStorage(connection, { schema, tableName });
 
-        return await ensureAuditStorage(connection, { schema, tableName });
+        return { model, connection };
       } catch (error) {
         // Reset so a later call can retry once the database is reachable.
         await connection.close().catch(() => undefined);
         sequelize = null;
-        modelPromise = null;
+        bootstrap = null;
         throw error;
       }
     })();
 
-    return modelPromise;
+    return bootstrap;
   };
 
   return {
@@ -165,18 +201,18 @@ export function createSqlAuditStore(options: AuditStorageOptions): {
         await init();
       },
       async append(record) {
-        const model = await init();
+        const { model } = await init();
         await model.create(toRow(record));
       },
       async listByRecord(query) {
-        const model = await init();
+        const { model, connection } = await init();
         const { skip = 0, limit, order = 'asc' } = query;
         const direction = order === 'desc' ? 'DESC' : 'ASC';
 
         // `id` (insertion order) breaks ties on equal timestamps, keeping the order deterministic
         // and stable across pages regardless of the chosen direction.
         const rows = await model.findAll({
-          where: buildWhere(query),
+          where: buildWhere(query, connection),
           order: [
             ['timestamp', direction],
             ['id', 'ASC'],
@@ -188,12 +224,12 @@ export function createSqlAuditStore(options: AuditStorageOptions): {
         return rows.map(fromRow);
       },
       async countByRecord(query) {
-        const model = await init();
+        const { model, connection } = await init();
 
-        return model.count({ where: buildWhere(query) });
+        return model.count({ where: buildWhere(query, connection) });
       },
       async listByCorrelation({ collection, recordId, correlationKey }) {
-        const model = await init();
+        const { model } = await init();
 
         const rows = await model.findAll({
           where: { collection, recordId, correlationKey },
@@ -208,7 +244,7 @@ export function createSqlAuditStore(options: AuditStorageOptions): {
       async listByCorrelations({ collection, recordId, correlationKeys }) {
         if (!correlationKeys.length) return [];
 
-        const model = await init();
+        const { model } = await init();
 
         const rows = await model.findAll({
           where: { collection, recordId, correlationKey: { [Op.in]: correlationKeys } },
@@ -224,7 +260,7 @@ export function createSqlAuditStore(options: AuditStorageOptions): {
     close: async () => {
       if (sequelize) await sequelize.close();
       sequelize = null;
-      modelPromise = null;
+      bootstrap = null;
     },
   };
 }

--- a/packages/plugin-audit-trail/src/types.ts
+++ b/packages/plugin-audit-trail/src/types.ts
@@ -26,6 +26,7 @@ export type AuditHistoryQuery = {
   startTimestamp?: string;
   /** Keep only entries whose `timestamp` is <= this UTC ISO instant (inclusive). */
   endTimestamp?: string;
+  fields?: string[];
   /** Sort direction on `timestamp` (ties broken by insertion order). Defaults to `'asc'`. */
   order?: 'asc' | 'desc';
 };

--- a/packages/plugin-audit-trail/test/sql-store.test.ts
+++ b/packages/plugin-audit-trail/test/sql-store.test.ts
@@ -215,6 +215,121 @@ describe('createSqlAuditStore (sqlite round-trip)', () => {
     await close();
   });
 
+  it('keeps only entries that touched at least one of the requested fields', async () => {
+    const { store, close } = createSqlAuditStore({ connectionString: 'sqlite::memory:' });
+
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        previousValues: { name: 'a' },
+        newValues: { name: 'b' },
+      }),
+    );
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-02T00:00:00.000Z',
+        previousValues: { email: 'x' },
+        newValues: { email: 'y' },
+      }),
+    );
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-03T00:00:00.000Z',
+        previousValues: { age: 1 },
+        newValues: { age: 2 },
+      }),
+    );
+
+    const history = await store.listByRecord({
+      collection: 'accounts',
+      recordId: '1',
+      fields: ['name', 'email'],
+    });
+
+    expect(history.map(r => r.timestamp)).toEqual([
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-02T00:00:00.000Z',
+    ]);
+
+    await close();
+  });
+
+  it('paginates after applying the fields filter', async () => {
+    const { store, close } = createSqlAuditStore({ connectionString: 'sqlite::memory:' });
+
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        previousValues: { name: 'a' },
+        newValues: { name: 'b' },
+      }),
+    );
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-02T00:00:00.000Z',
+        previousValues: { other: 1 },
+        newValues: { other: 2 },
+      }),
+    );
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-03T00:00:00.000Z',
+        previousValues: { name: 'c' },
+        newValues: { name: 'd' },
+      }),
+    );
+    await store.append(
+      record({
+        recordId: '1',
+        timestamp: '2026-01-04T00:00:00.000Z',
+        previousValues: { name: 'e' },
+        newValues: { name: 'f' },
+      }),
+    );
+
+    const page = await store.listByRecord({
+      collection: 'accounts',
+      recordId: '1',
+      fields: ['name'],
+      skip: 1,
+      limit: 1,
+    });
+
+    expect(page.map(r => r.timestamp)).toEqual(['2026-01-03T00:00:00.000Z']);
+
+    await close();
+  });
+
+  it('counts only entries that touched at least one of the requested fields', async () => {
+    const { store, close } = createSqlAuditStore({ connectionString: 'sqlite::memory:' });
+
+    await store.append(
+      record({ recordId: '1', previousValues: { name: 'a' }, newValues: { name: 'b' } }),
+    );
+    await store.append(
+      record({ recordId: '1', previousValues: { other: 1 }, newValues: { other: 2 } }),
+    );
+    await store.append(
+      record({ recordId: '1', previousValues: { name: 'c' }, newValues: { name: 'd' } }),
+    );
+
+    const count = await store.countByRecord({
+      collection: 'accounts',
+      recordId: '1',
+      fields: ['name'],
+    });
+
+    expect(count).toBe(2);
+
+    await close();
+  });
+
   it('counts only the rows matching the active filters', async () => {
     const { store, close } = createSqlAuditStore({ connectionString: 'sqlite::memory:' });
 


### PR DESCRIPTION
## Summary
- Add a `fields` query param to the audit-trail history route: `GET /_audit-trail/:collection/:id?fields=title,author` keeps only entries whose change involved at least one of the requested fields.
- Push the filter into the SQL `WHERE` clause using dialect-aware JSON key-existence operators (Postgres `jsonb_exists_any`, SQLite `json_type IS NOT NULL`, MySQL/MariaDB `JSON_CONTAINS_PATH`) — single `findAll` / single `count`, no JS-side filtering.
- Refactor `createSqlAuditStore`'s `init()` to return `{ model, connection }` so `buildWhere` gets the dialect without a non-null assertion.

## Test plan
- [x] `yarn jest packages/plugin-audit-trail packages/agent/test/routes/access/audit-trail.test.ts` — 118 tests pass
- [x] `yarn workspace @forestadmin/agent lint` clean (warnings pre-existing on origin)
- [ ] Manual smoke against a Postgres-backed audit log (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add field-based filtering to audit trail record history
> - Adds an optional `fields` query parameter to the audit trail history route, parsed as a comma-separated list of field names (whitespace trimmed, empty tokens dropped).
> - When `fields` is provided, the SQL store applies a dialect-specific JSON condition (`jsonb_exists_any` for Postgres, `json_type` path checks for SQLite, `JSON_CONTAINS_PATH` for MySQL/MariaDB) to restrict results to entries that touched at least one of the requested fields.
> - Both `listByRecord` and `countByRecord` in [sql-store.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1683/files#diff-976c46f51ace1374880e2b390fdb4ab74bf168bba9b59a6cd033bc204fead7ab) respect the filter, so pagination and counts are consistent.
> - Risk: an unsupported Sequelize dialect combined with a non-empty `fields` filter throws a runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b3e017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->