### PR TITLE
fix(workflow-executor): accept LOG_LEVEL case-insensitively

### DIFF
--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -43,8 +43,6 @@ function parsePositiveIntEnv(name: string, raw: string | undefined): number | un
 function parseLoggerLevelEnv(raw: string | undefined): LoggerLevel | undefined {
   if (!raw) return undefined;
 
-  // Accept any case (e.g. "info" from an env shared with other services) and
-  // normalize to the canonical Debug/Info/Warn/Error form before validating.
   const normalized = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
   const parsed = LOGGER_LEVEL_SCHEMA.safeParse(normalized);
 

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -43,7 +43,10 @@ function parsePositiveIntEnv(name: string, raw: string | undefined): number | un
 function parseLoggerLevelEnv(raw: string | undefined): LoggerLevel | undefined {
   if (!raw) return undefined;
 
-  const parsed = LOGGER_LEVEL_SCHEMA.safeParse(raw);
+  // Accept any case (e.g. "info" from an env shared with other services) and
+  // normalize to the canonical Debug/Info/Warn/Error form before validating.
+  const normalized = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase();
+  const parsed = LOGGER_LEVEL_SCHEMA.safeParse(normalized);
 
   if (!parsed.success) {
     throw new ConfigurationError(

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -324,7 +324,19 @@ describe('readEnvConfig', () => {
     expect(config.executorOptions.loggerLevel).toBe('Info');
   });
 
-  it.each(['debug', 'info', 'trace', 'fatal', 'verbose', 'xxx'])(
+  it.each([
+    ['info', 'Info'],
+    ['INFO', 'Info'],
+    ['debug', 'Debug'],
+    ['WARN', 'Warn'],
+    ['error', 'Error'],
+  ] as const)('parses case-insensitive LOG_LEVEL=%s into %s', (input, expected) => {
+    const config = readEnvConfig({ ...baseEnv, LOG_LEVEL: input }, args);
+
+    expect(config.executorOptions.loggerLevel).toBe(expected);
+  });
+
+  it.each(['trace', 'fatal', 'verbose', 'xxx'])(
     'throws ConfigurationError on invalid LOG_LEVEL=%s',
     value => {
       expect(() => readEnvConfig({ ...baseEnv, LOG_LEVEL: value }, args)).toThrow(


### PR DESCRIPTION
## Problem

When the executor runs alongside other services sharing an environment/secret, `LOG_LEVEL` is often set in lowercase (e.g. `info`). The CLI validated it against a strict `Debug | Info | Warn | Error` enum, so `info` threw `ConfigurationError` **at startup** → the process exits → the container never serves (deploy goes unhealthy, 100% 5xx).

Hit in real life deploying the executor as a Beanstalk service: the shared `staging/env-vars` secret sets `LOG_LEVEL=info`, crashing the executor on boot.

## Fix

`parseLoggerLevelEnv` now normalizes the raw value to canonical case (`raw[0].toUpperCase() + rest.toLowerCase()`) before validating. So `info`, `INFO`, `debug`, `WARN`, … are accepted and mapped to `Info`/`Debug`/`Warn`; genuinely unknown levels (`trace`, `verbose`, …) still throw the same `ConfigurationError`.

## Tests

- New: `info`/`INFO`/`debug`/`WARN`/`error` parse to the canonical level.
- Updated: the "throws on invalid" cases no longer include `debug`/`info` (now valid); `trace`/`fatal`/`verbose`/`xxx` still throw.
- Full `cli.test.ts` green (68 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept `LOG_LEVEL` env var case-insensitively in workflow-executor
> Normalizes the `LOG_LEVEL` value in `parseLoggerLevelEnv` by capitalizing the first character and lowercasing the rest before validating against the schema, so values like `info`, `INFO`, or `Warn` are all accepted. Tests are updated to cover the new case-insensitive behavior and remove previously invalid cases that are now valid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c9c5c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->