### PR TITLE
feat(workflow-executor): optional database TLS via DATABASE_SSL

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -22,6 +22,7 @@ npm install -g @forestadmin/workflow-executor
 | `FOREST_AUTH_SECRET` | ✓ | — | JWT signing secret (shared with your agent) |
 | `AGENT_URL` | ✓ | — | URL of your running Forest Admin agent |
 | `DATABASE_URL` | ✓* | — | Postgres connection string (*not needed with `--in-memory`) |
+| `DATABASE_SSL` | — | `false` | Set to `true` to connect over TLS (managed databases like RDS often require it). Encrypts without verifying the server certificate. |
 | `HTTP_PORT` | — | `3400` | Port for the executor HTTP server |
 | `FOREST_SERVER_URL` | — | `https://api.forestadmin.com` | Orchestrator URL |
 | `POLLING_INTERVAL_S` | — | `30` | Poll cadence for pending steps |

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -301,8 +301,6 @@ export async function runCli(
         ...config.executorOptions,
         database: {
           uri: config.databaseUrl as string,
-          // Managed databases (RDS, etc.) commonly require TLS. Mirror the agent's
-          // server setup: encrypt without verifying the server certificate.
           ...(config.databaseSsl && {
             dialectOptions: { ssl: { require: true, rejectUnauthorized: false } },
           }),

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -55,6 +55,19 @@ function parseLoggerLevelEnv(raw: string | undefined): LoggerLevel | undefined {
   return parsed.data;
 }
 
+const TRUTHY = ['true', '1', 'yes', 'on'];
+const FALSY = ['false', '0', 'no', 'off'];
+
+function parseBooleanEnv(name: string, raw: string | undefined): boolean {
+  if (!raw) return false;
+
+  const value = raw.trim().toLowerCase();
+  if (TRUTHY.includes(value)) return true;
+  if (FALSY.includes(value)) return false;
+
+  throw new ConfigurationError(`${name} must be a boolean (true/false); got "${raw}"`);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
 const { version } = require('../package.json') as { version: string };
 
@@ -193,7 +206,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
   return {
     executorOptions,
     databaseUrl: env.DATABASE_URL,
-    databaseSsl: env.DATABASE_SSL === 'true',
+    databaseSsl: parseBooleanEnv('DATABASE_SSL', env.DATABASE_SSL),
     mode: args.inMemory ? 'in-memory' : 'database',
   };
 }
@@ -244,7 +257,7 @@ export function printVersion(): void {
 }
 
 export function logStartup(logger: Logger, config: CliConfig): void {
-  const { executorOptions: opts, mode } = config;
+  const { executorOptions: opts, mode, databaseSsl } = config;
   let aiLabel: string;
 
   if (opts.forceAiError) {
@@ -257,6 +270,7 @@ export function logStartup(logger: Logger, config: CliConfig): void {
 
   logger('Info', 'Workflow executor starting', {
     mode,
+    databaseSsl: mode === 'database' ? databaseSsl : undefined,
     forestServerUrl: opts.forestServerUrl ?? DEFAULT_FOREST_SERVER_URL,
     agentUrl: opts.agentUrl,
     httpPort: opts.httpPort,

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -71,6 +71,7 @@ export interface CliArgs {
 export interface CliConfig {
   executorOptions: ExecutorOptions;
   databaseUrl?: string;
+  databaseSsl: boolean;
   mode: 'in-memory' | 'database';
 }
 
@@ -192,6 +193,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
   return {
     executorOptions,
     databaseUrl: env.DATABASE_URL,
+    databaseSsl: env.DATABASE_SSL === 'true',
     mode: args.inMemory ? 'in-memory' : 'database',
   };
 }
@@ -215,6 +217,7 @@ Required environment variables:
   DATABASE_URL        Postgres connection string (not needed with --in-memory)
 
 Optional environment variables:
+  DATABASE_SSL          Set to "true" to connect to the database over TLS (managed DBs like RDS)
   HTTP_PORT              Default: ${DEFAULT_HTTP_PORT}
   FOREST_SERVER_URL      Default: ${DEFAULT_FOREST_SERVER_URL}
   POLLING_INTERVAL_S    Default: ${DEFAULT_POLLING_INTERVAL_S}
@@ -296,7 +299,14 @@ export async function runCli(
     } else {
       const databaseOptions: DatabaseExecutorOptions = {
         ...config.executorOptions,
-        database: { uri: config.databaseUrl as string },
+        database: {
+          uri: config.databaseUrl as string,
+          // Managed databases (RDS, etc.) commonly require TLS. Mirror the agent's
+          // server setup: encrypt without verifying the server certificate.
+          ...(config.databaseSsl && {
+            dialectOptions: { ssl: { require: true, rejectUnauthorized: false } },
+          }),
+        },
       };
       executor = factories.buildDatabase(databaseOptions);
     }

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -165,6 +165,23 @@ describe('readEnvConfig', () => {
     );
   });
 
+  it.each(['true', 'TRUE', 'True', '1', 'yes', 'on'])(
+    'parses DATABASE_SSL=%s as enabled',
+    value => {
+      expect(readEnvConfig({ ...baseEnv, DATABASE_SSL: value }, args).databaseSsl).toBe(true);
+    },
+  );
+
+  it.each(['false', '0', 'no', 'off', ''])('parses DATABASE_SSL=%s as disabled', value => {
+    expect(readEnvConfig({ ...baseEnv, DATABASE_SSL: value }, args).databaseSsl).toBe(false);
+  });
+
+  it('throws ConfigurationError on a non-boolean DATABASE_SSL', () => {
+    expect(() => readEnvConfig({ ...baseEnv, DATABASE_SSL: 'enabled' }, args)).toThrow(
+      'DATABASE_SSL must be a boolean (true/false); got "enabled"',
+    );
+  });
+
   it('parses numeric env vars as numbers', () => {
     const config = readEnvConfig(
       {
@@ -424,6 +441,27 @@ describe('logStartup', () => {
         forestServerUrl: DEFAULT_FOREST_SERVER_URL,
         pollingIntervalS: DEFAULT_POLLING_INTERVAL_S,
       }),
+    );
+  });
+
+  it('reports the database TLS state in database mode', () => {
+    const logger = makeLogger();
+
+    logStartup(logger as never, {
+      mode: 'database',
+      databaseSsl: true,
+      executorOptions: {
+        envSecret: 'e',
+        authSecret: 'a',
+        agentUrl: 'http://agent',
+        httpPort: DEFAULT_HTTP_PORT,
+      },
+    });
+
+    expect(logger).toHaveBeenCalledWith(
+      'Info',
+      'Workflow executor starting',
+      expect.objectContaining({ databaseSsl: true }),
     );
   });
 });

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -154,6 +154,7 @@ describe('readEnvConfig', () => {
 
     expect(config.mode).toBe('database');
     expect(config.databaseUrl).toBe('postgres://u:p@localhost:5432/wfe');
+    expect(config.databaseSsl).toBe(false);
     expect(config.executorOptions).toEqual(
       expect.objectContaining({
         envSecret: 'env-secret',
@@ -407,6 +408,7 @@ describe('logStartup', () => {
 
     logStartup(logger as never, {
       mode: 'database',
+      databaseSsl: false,
       executorOptions: {
         envSecret: 'e',
         authSecret: 'a',
@@ -484,6 +486,28 @@ describe('runCli', () => {
     );
     expect(factories.buildInMemory).not.toHaveBeenCalled();
     expect(executor.start).toHaveBeenCalled();
+  });
+
+  it('enables TLS (no cert verification) on the database when DATABASE_SSL=true', async () => {
+    const { factories } = makeFactories();
+    await runCli([], { ...baseEnv, DATABASE_SSL: 'true' }, factories);
+
+    expect(factories.buildDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: {
+          uri: 'postgres://u:p@localhost:5432/wfe',
+          dialectOptions: { ssl: { require: true, rejectUnauthorized: false } },
+        },
+      }),
+    );
+  });
+
+  it('does not configure database TLS when DATABASE_SSL is unset', async () => {
+    const { factories } = makeFactories();
+    await runCli([], baseEnv, factories);
+
+    const call = (factories.buildDatabase as jest.Mock).mock.calls[0][0];
+    expect(call.database).toEqual({ uri: 'postgres://u:p@localhost:5432/wfe' });
   });
 
   it('injects a JSON logger into executorOptions when --json is set', async () => {


### PR DESCRIPTION
## Problem

Managed databases (AWS RDS, etc.) commonly require TLS. The executor CLI only passed the connection URI to Sequelize with **no SSL option**, so against such a database the connection is rejected at startup:

```
no pg_hba.conf entry for host "…", user "…", database "…", no encryption
```

→ `runStore.init()` (migration) throws → the process exits → the service never becomes healthy. Hit while deploying the executor as a Beanstalk service against the staging RDS (which enforces SSL).

## Fix

Add a `DATABASE_SSL` env var. When enabled, the database connection uses:

```js
dialectOptions: { ssl: { require: true, rejectUnauthorized: false } }
```

i.e. encrypt **without** verifying the server certificate — the same setup the agent's server uses for staging/production RDS, and the standard approach for RDS without bundling the CA. Defaults **off**, so existing non-TLS deployments are unchanged.

### Robust parsing (QA hardening)
`DATABASE_SSL` is parsed leniently — `true` / `1` / `yes` / `on` (case-insensitive) enable it, `false` / `0` / `no` / `off` / unset disable it — and an **unrecognized value throws `ConfigurationError`** rather than silently disabling TLS (the same footgun we just removed for `LOG_LEVEL`).

### Observability
The resolved database TLS state is logged at startup (`databaseSsl` in the "Workflow executor starting" line), so operators can confirm whether the connection is encrypted.

## Tests

`cli.test.ts` — **83 passing**, and `cli-core.ts` at **100% statements / lines / functions** (all changed lines covered):
- `DATABASE_SSL` truthy variants (`true/TRUE/True/1/yes/on`) → enabled.
- Falsy variants (`false/0/no/off/''`) → disabled; unset → disabled.
- Unrecognized value → throws `ConfigurationError`.
- `runCli` with SSL on → `buildDatabase` receives `database.dialectOptions.ssl = { require: true, rejectUnauthorized: false }`; with SSL off → `database` stays `{ uri }`.
- `logStartup` reports `databaseSsl` in database mode.

Documented in the README and `--help`.

## Known limitation (intentional)

`rejectUnauthorized: false` is the only TLS mode offered — it encrypts but does **not** verify the server certificate (MITM exposure). This matches the agent's server setup and is the practical choice for RDS, but there is no `verify-full` / custom-CA option yet. Worth a follow-up for stricter TLS policies. End-to-end TLS is verified at deploy time (no SSL-capable DB in this package's CI; the tests assert wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)