### PR TITLE
test(workflow-executor): PRD-552 legacy and deterministic Load Related Record coexist

### DIFF
--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3603,8 +3603,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  // PRD-552: legacy prompt-only steps and new deterministic steps must coexist — the same executor
-  // takes the AI path for one and the deterministic (no-AI) path for the other within one run.
   describe('backward compatibility (PRD-552): legacy and deterministic coexist', () => {
     it('runs the AI path for a legacy step and the deterministic path for a configured step', async () => {
       // Legacy prompt-only step → AI selects the relation.

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3635,7 +3635,10 @@ describe('LoadRelatedRecordStepExecutor', () => {
           agentPort: makeMockAgentPort([
             makeRelatedRecordData({ collectionName: 'customers', recordId: [7], values: {} }),
           ]),
-          workflowPort: makeMockWorkflowPort({ customers: makeCollectionSchema(), orders: ordersSchema }),
+          workflowPort: makeMockWorkflowPort({
+            customers: makeCollectionSchema(),
+            orders: ordersSchema,
+          }),
           previousSteps: [makeLoadRelatedPreviousStep(1)],
           stepDefinition: makeStep({
             executionType: StepExecutionMode.FullyAutomated,

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3585,6 +3585,70 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
+  // PRD-552: legacy prompt-only steps and new deterministic steps must coexist — the same executor
+  // takes the AI path for one and the deterministic (no-AI) path for the other within one run.
+  describe('backward compatibility (PRD-552): legacy and deterministic coexist', () => {
+    it('runs the AI path for a legacy step and the deterministic path for a configured step', async () => {
+      // Legacy prompt-only step → AI selects the relation.
+      const legacy = makeMockModel({ relationName: 'Orders', reasoning: 'r' });
+      await new LoadRelatedRecordStepExecutor(
+        makeContext({
+          model: legacy.model,
+          stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+        }),
+      ).execute();
+
+      expect(legacy.bindTools).toHaveBeenCalled();
+
+      // Deterministic step (source + relation pinned) → no relation AI call.
+      const ordersSchema = makeCollectionSchema({
+        collectionName: 'orders',
+        collectionDisplayName: 'Orders',
+        fields: [
+          {
+            fieldName: 'customer',
+            displayName: 'Customer',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            relatedCollectionName: 'customers',
+          },
+        ],
+      });
+      const deterministic = makeMockModel();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 1,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: { collectionName: 'orders', recordId: [99], stepIndex: 1 },
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const result = await new LoadRelatedRecordStepExecutor(
+        makeContext({
+          model: deterministic.model,
+          runStore,
+          agentPort: makeMockAgentPort([
+            makeRelatedRecordData({ collectionName: 'customers', recordId: [7], values: {} }),
+          ]),
+          workflowPort: makeMockWorkflowPort({ customers: makeCollectionSchema(), orders: ordersSchema }),
+          previousSteps: [makeLoadRelatedPreviousStep(1)],
+          stepDefinition: makeStep({
+            executionType: StepExecutionMode.FullyAutomated,
+            preRecordedArgs: { selectedRecordStepId: 'load-1', relationName: 'customer' },
+          }),
+        }),
+      ).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(deterministic.bindTools).not.toHaveBeenCalled();
+    });
+  });
+
   describe('record pool after revision', () => {
     it('re-executes a revised load step from the base record, not from the dead branch record', async () => {
       // Given: the run loaded an owner before the user revised the "Load store" step. The


### PR DESCRIPTION
## Context
Joint backward-compat guard for the Deterministic Load Related Record epic (PRD-471), stacked on #1687 (PRD-551).

## What
An explicit regression test: within one run the same executor takes the **AI path** for a legacy prompt-only step (no `preRecordedArgs`) and the **deterministic no-AI path** for a step with source + relation pinned. Coexistence was already implied by the green suite; this names it as a guard.

## Where the rest of the coexistence is covered
- **Orchestrator** (#8312): step with no `forest:preRecordedArgs` → forwarded unchanged (parser test).
- **Run panel** (#9773): Handle Manually present on legacy, absent on deterministic; field unlocked on legacy.
- **Editor** (#9770): legacy steps render the untouched `guidance` panel (gating).

## Tests
82/82 in the load-related suite (run locally). 

fixes PRD-552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add coexistence test for legacy and deterministic `LoadRelatedRecordStepExecutor` paths
> Adds a test suite in [load-related-record-step-executor.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1688/files#diff-ac728230ca190f664862205507ae80cd2c51bc30da32dfa3e0ccbd36e13f3345) verifying that legacy prompt-only `FullyAutomated` steps call `bindTools` for AI relation selection, while deterministic steps with `preRecordedArgs` and prior execution data skip `bindTools` entirely and load related data directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7412b6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->