### PR TITLE
fix(agent): explicit error when workflow executor URL is not configured

### DIFF
--- a/packages/agent/src/routes/index.ts
+++ b/packages/agent/src/routes/index.ts
@@ -174,8 +174,8 @@ function getAiRoutes(options: Options, services: Services, aiRouter: AiRouter | 
 }
 
 function getWorkflowExecutorRoutes(options: Options, services: Services): BaseRoute[] {
-  if (!options.workflowExecutorUrl) return [];
-
+  // Always mount the route so that hitting it without `workflowExecutorUrl` configured
+  // returns an explicit error to the client instead of a bare 404.
   return [new WorkflowExecutorProxyRoute(services, options)];
 }
 

--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -3,6 +3,7 @@ import type { AgentOptionsWithDefaults } from '../../types';
 import type KoaRouter from '@koa/router';
 import type { Context } from 'koa';
 
+import { InternalServerError } from '@forestadmin/datasource-toolkit';
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
 
@@ -16,12 +17,14 @@ type ForwardedHeaders = {
 
 export default class WorkflowExecutorProxyRoute extends BaseRoute {
   readonly type = RouteType.PrivateRoute;
-  private readonly executorUrl: URL;
+  private readonly executorUrl: URL | null;
 
   constructor(services: ForestAdminHttpDriverServices, options: AgentOptionsWithDefaults) {
     super(services, options);
     // Remove trailing slash for clean URL joining
-    this.executorUrl = new URL(options.workflowExecutorUrl.replace(/\/+$/, ''));
+    this.executorUrl = options.workflowExecutorUrl
+      ? new URL(options.workflowExecutorUrl.replace(/\/+$/, ''))
+      : null;
   }
 
   setupRoutes(router: KoaRouter): void {
@@ -30,6 +33,12 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
   }
 
   private async handleProxy(context: Context): Promise<void> {
+    if (!this.executorUrl) {
+      throw new InternalServerError(
+        'The workflow executor is not configured on this agent: the `workflowExecutorUrl` option is missing.',
+      );
+    }
+
     const { runId } = context.params;
     const isTrigger = context.method === 'POST';
     const qs = context.querystring ? `?${context.querystring}` : '';

--- a/packages/agent/test/routes/index.test.ts
+++ b/packages/agent/test/routes/index.test.ts
@@ -68,8 +68,12 @@ describe('Route index', () => {
     expect(NATIVE_QUERY_ROUTES_CTOR).toEqual([DataSourceNativeQueryRoute]);
   });
 
+  const WORKFLOW_EXECUTOR_ROUTE_SIZE = 1;
   const BASE_ROUTE_SIZE =
-    ROOT_ROUTES_CTOR.length + CAPABILITIES_ROUTES_CTOR.length + NATIVE_QUERY_ROUTES_CTOR.length;
+    ROOT_ROUTES_CTOR.length +
+    CAPABILITIES_ROUTES_CTOR.length +
+    NATIVE_QUERY_ROUTES_CTOR.length +
+    WORKFLOW_EXECUTOR_ROUTE_SIZE;
 
   describe('makeRoutes', () => {
     describe('when a data source without relations', () => {

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -73,6 +73,16 @@ describe('WorkflowExecutorProxyRoute', () => {
 
       expect(route.type).toBe(RouteType.PrivateRoute);
     });
+
+    test('should not throw when workflowExecutorUrl is not configured', () => {
+      expect(
+        () =>
+          new WorkflowExecutorProxyRoute(
+            services,
+            factories.forestAdminHttpDriverOptions.build({ workflowExecutorUrl: null }),
+          ),
+      ).not.toThrow();
+    });
   });
 
   describe('setupRoutes', () => {
@@ -222,6 +232,24 @@ describe('WorkflowExecutorProxyRoute', () => {
       await expect(
         (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context),
       ).rejects.toThrow();
+    });
+
+    test('should throw an explicit error when workflowExecutorUrl is not configured', async () => {
+      const route = new WorkflowExecutorProxyRoute(
+        services,
+        factories.forestAdminHttpDriverOptions.build({ workflowExecutorUrl: null }),
+      );
+
+      const context = createMockContext({
+        customProperties: { params: { runId: 'run-123' } },
+      });
+      Object.defineProperty(context, 'url', {
+        value: '/_internal/workflow-executions/run-123',
+      });
+
+      await expect(
+        (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context),
+      ).rejects.toThrow('The workflow executor is not configured on this agent');
     });
 
     test('should forward query params to the executor', async () => {


### PR DESCRIPTION
## Problem

When the agent receives a request on the workflow-executor proxy routes
(`GET /_internal/workflow-executions/:runId`, `POST .../trigger`) but the
`workflowExecutorUrl` option is **not** configured, the route was simply never
mounted. The client got a bare koa **404 with an empty body** — indistinguishable
from a real "run not found" coming from the executor, and giving no hint that the
agent is actually misconfigured.

This came up debugging a staging agent where the deploying app didn't pass
`workflowExecutorUrl`: every workflow request 404'd with no actionable signal in
the browser console or the agent logs.

## Change

- Mount the proxy route **unconditionally** ([routes/index.ts](packages/agent/src/routes/index.ts)).
- In the handler, if `workflowExecutorUrl` is missing, throw an
  `InternalServerError` with an explicit message
  (`The workflow executor is not configured on this agent: the workflowExecutorUrl option is missing.`).
  The agent's error-handling middleware turns this into a **500 with a clear
  `detail`** for the client (instead of a silent 404), and logs it at `Error` level.

The constructor now tolerates a null URL instead of throwing at boot.

## Tests

- `handleProxy` throws an explicit error when `workflowExecutorUrl` is not set.
- Constructor does not throw when the option is null.
- `BASE_ROUTE_SIZE` updated since the route is always mounted now.
- Existing proxy-forwarding tests unchanged and passing (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Throw explicit error when workflow executor URL is not configured
> - The workflow executor route in [workflow-executor-proxy.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1689/files#diff-8c9b2f16246bf46a886e58b2c764c83fa21e38fa53935e6f6209b0e3f57980fd) now accepts a null `executorUrl` instead of requiring a valid URL at construction time.
> - Routes in [index.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1689/files#diff-62f344f57fa71527d87986bb707f662100b456e88c946118958d201bb8f9f993) always register the `WorkflowExecutorProxyRoute`, regardless of whether `workflowExecutorUrl` is set.
> - When the handler is invoked without a configured URL, it throws an `InternalServerError` with a descriptive message instead of returning a 404.
> - Behavioral Change: previously, missing `workflowExecutorUrl` caused the route to be absent (404); now the route exists and returns a 500 with an explicit message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da6e08e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->