### PR TITLE
feat(workflow-executor): PRD-553 apply build-time filters on 1–n Load Related Record

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -11,7 +11,7 @@ import type {
 import type SchemaCache from '../schema-cache';
 import type { StepUser } from '../types/execution-context';
 import type { RecordData } from '../types/validated/collection';
-import type { ActionEndpointsByCollection } from '@forestadmin/agent-client';
+import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/agent-client';
 
 import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
@@ -109,7 +109,7 @@ export default class AgentClientAgentPort implements AgentPort {
   }
 
   async getRelatedData(
-    { collection, id, relation, relatedSchema, limit, fields }: GetRelatedDataQuery,
+    { collection, id, relation, relatedSchema, limit, fields, filters }: GetRelatedDataQuery,
     user: StepUser,
   ): Promise<RecordData[]> {
     return this.callAgent('getRelatedData', async () => {
@@ -120,6 +120,8 @@ export default class AgentClientAgentPort implements AgentPort {
         .list<Record<string, unknown>>({
           ...(limit !== null && { pagination: { size: limit, number: 1 } }),
           ...(fields?.length && { fields }),
+          // Trusted build-time conditionTree (PRD-553); the agent validates it at query time.
+          ...(filters !== undefined && { filters: filters as SelectOptions['filters'] }),
         });
 
       return rows.map(row => {

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -120,7 +120,6 @@ export default class AgentClientAgentPort implements AgentPort {
         .list<Record<string, unknown>>({
           ...(limit !== null && { pagination: { size: limit, number: 1 } }),
           ...(fields?.length && { fields }),
-          // Trusted build-time conditionTree (PRD-553); the agent validates it at query time.
           ...(filters !== undefined && { filters: filters as SelectOptions['filters'] }),
         });
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -562,6 +562,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       relation: target.name,
       relatedSchema,
       limit,
+      // 1–n only: the build-time filter (PRD-553) narrows the candidate list. xToOne goes through
+      // fetchXToOneCandidate (no list to filter), so it never reaches here.
+      filters: this.context.stepDefinition.preRecordedArgs?.filters,
     });
   }
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -562,8 +562,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       relation: target.name,
       relatedSchema,
       limit,
-      // 1–n only: the build-time filter (PRD-553) narrows the candidate list. xToOne goes through
-      // fetchXToOneCandidate (no list to filter), so it never reaches here.
       filters: this.context.stepDefinition.preRecordedArgs?.filters,
     });
   }

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -17,8 +17,6 @@ export type GetRelatedDataQuery = {
   // record ID and restore original field names without consulting any cache.
   relatedSchema: CollectionSchema;
   fields?: string[];
-  // Build-time filter (PRD-553) forwarded verbatim to the agent. Port stays agnostic of the
-  // filter shape; the adapter casts it to the agent-client's conditionTree type.
   filters?: unknown;
 } & Limit;
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -17,6 +17,9 @@ export type GetRelatedDataQuery = {
   // record ID and restore original field names without consulting any cache.
   relatedSchema: CollectionSchema;
   fields?: string[];
+  // Build-time filter (PRD-553) forwarded verbatim to the agent. Port stays agnostic of the
+  // filter shape; the adapter casts it to the agent-client's conditionTree type.
+  filters?: unknown;
 } & Limit;
 
 // xToOne relations (BelongsTo / HasOne) — the agent does not serve

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -106,6 +106,12 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
       selectedRecordStepId: z.string().optional(),
       /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
+      /**
+       * Build-time filter narrowing the candidate records on a 1–n relation (PRD-553). Forest's
+       * plain conditionTree, forwarded verbatim to the agent (which validates it at query time) —
+       * kept loose here since it's trusted build config, not executor-validated input.
+       */
+      filters: z.unknown().optional(),
     })
     .optional(),
 });

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -106,11 +106,7 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
       selectedRecordStepId: z.string().optional(),
       /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
-      /**
-       * Build-time filter narrowing the candidate records on a 1–n relation (PRD-553). Forest's
-       * plain conditionTree, forwarded verbatim to the agent (which validates it at query time) —
-       * kept loose here since it's trusted build config, not executor-validated input.
-       */
+      /** 1–n relation filter (conditionTree), forwarded verbatim; loosely typed as it's trusted config the agent validates. */
       filters: z.unknown().optional(),
     })
     .optional(),

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -635,6 +635,65 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('also forwards the filter on the AutomatedWithConfirmation path (the user-facing list)', async () => {
+      const hasManySchema = makeCollectionSchema({
+        fields: [
+          {
+            fieldName: 'address',
+            displayName: 'Address',
+            isRelationship: true,
+            relationType: 'HasMany',
+            relatedCollectionName: 'addresses',
+          },
+        ],
+      });
+      const relatedData: RecordData[] = [
+        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
+        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
+      ];
+      const agentPort = makeMockAgentPort(relatedData);
+      const addressSchema = makeCollectionSchema({
+        collectionName: 'addresses',
+        collectionDisplayName: 'Addresses',
+        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
+      });
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record-by-content',
+              args: { recordIndex: 0, reasoning: 'r' },
+              id: 'c3',
+            },
+          ],
+        });
+      const model = {
+        bindTools: jest.fn().mockReturnValue({ invoke }),
+      } as unknown as ExecutionContext['model'];
+
+      const filters = { field: 'city', operator: 'equal', value: 'Lyon' };
+      const context = makeContext({
+        model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({ customers: hasManySchema, addresses: addressSchema }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.AutomatedWithConfirmation,
+          preRecordedArgs: { relationName: 'address', filters },
+        }),
+      });
+
+      await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(agentPort.getRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', relation: 'address', filters }),
+        expect.anything(),
+      );
+    });
+
     it('skips field-selection AI call when related collection has no non-relation fields', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -576,6 +576,65 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('forwards a build-time filter (PRD-553) to getRelatedData on the 1–n list fetch', async () => {
+      const hasManySchema = makeCollectionSchema({
+        fields: [
+          {
+            fieldName: 'address',
+            displayName: 'Address',
+            isRelationship: true,
+            relationType: 'HasMany',
+            relatedCollectionName: 'addresses',
+          },
+        ],
+      });
+      const relatedData: RecordData[] = [
+        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
+        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
+      ];
+      const agentPort = makeMockAgentPort(relatedData);
+      const addressSchema = makeCollectionSchema({
+        collectionName: 'addresses',
+        collectionDisplayName: 'Addresses',
+        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
+      });
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record-by-content',
+              args: { recordIndex: 0, reasoning: 'r' },
+              id: 'c3',
+            },
+          ],
+        });
+      const model = {
+        bindTools: jest.fn().mockReturnValue({ invoke }),
+      } as unknown as ExecutionContext['model'];
+
+      const filters = { field: 'city', operator: 'equal', value: 'Lyon' };
+      const context = makeContext({
+        model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({ customers: hasManySchema, addresses: addressSchema }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { relationName: 'address', filters },
+        }),
+      });
+
+      await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(agentPort.getRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', relation: 'address', filters }),
+        expect.anything(),
+      );
+    });
+
     it('skips field-selection AI call when related collection has no non-relation fields', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [


### PR DESCRIPTION
## Context
Filter half of PRD-553 (executor), stacked on #1688. Applies the build-time filter the editor sets on a 1–n relation, narrowing the candidate records.

## What
- `preRecordedArgs.filters` added to the executor step-definition schema (`z.unknown().optional()` — trusted build config, forwarded verbatim; the agent validates it).
- Threaded through `GetRelatedDataQuery` → adapter → agent-client `SelectOptions.filters` on the **1–n list fetch** (`fetchRelatedData`). The agent-client already supports `filters`; this is pure wiring.
- **xToOne untouched**: it goes through `getSingleRelatedData` (no list to filter) → 1–1 relations never receive a filter, per PRD.
- Port stays agnostic (`filters?: unknown`); the adapter casts to the agent-client type at the single call site.

## Tests
+1 executor test: HasMany with `preRecordedArgs.filters` → `getRelatedData` called with that `filters`. 1085/1085 pass.

> Base = PRD-552 branch (stacked). Retarget on merge.

fixes PRD-553

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply build-time filters to 1–n Load Related Record step execution
> - Adds an optional `filters` field to `LoadRelatedRecordStepDefinitionSchema.preRecordedArgs` in [step-definition.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1690/files#diff-66dcc667cb1ebecf3964eecfb28391b1cb81e16c853ad79d4f9017172521aea3), accepted as `z.unknown()` and validated by the agent.
> - Extends `GetRelatedDataQuery` in [agent-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1690/files#diff-6a26a0f86a146665060c75502f9eb8cafd3880a779128d5a82d9020b1fab18cf) with an optional `filters?: unknown` field and forwards it through `AgentClientAgentPort.getRelatedData` to the agent client's `relation().list()` call.
> - Updates [load-related-record-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1690/files#diff-128ff9b9f75a54359e7793b4ed6d306700531b6debe78ce56bb4bed1391f3650) to include `preRecordedArgs.filters` in the `getRelatedData` payload when present.
> - Behavioral Change: related record candidates for 1–n steps will now be filtered at fetch time when filters are defined, changing the returned rows compared to the previous unfiltered behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4a72ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->