### PR TITLE
feat(workflow): deterministic + Full AI workflow steps

### DIFF
--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -17,6 +17,38 @@ import ActionFieldRadioGroup from '../action-fields/action-field-radio-group';
 import ActionFieldString from '../action-fields/action-field-string';
 import ActionFieldStringList from '../action-fields/action-field-string-list';
 import ActionLayoutRoot from '../action-layout/action-layout-root';
+import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from '../errors';
+
+// JSON:API error body the agent returns on a rejected action.
+type ActionErrorBody = {
+  errors?: { name?: string; detail?: string; data?: { roleIdsAllowedToApprove?: number[] } }[];
+  data?: { roleIdsAllowedToApprove?: number[] };
+};
+
+// Translate the transport AgentHttpError into a semantic action error so callers route on meaning.
+// Approval gate = 403 CustomActionRequiresApprovalError; form validation = 400/422; else unchanged.
+function toActionError(error: unknown): unknown {
+  if (!(error instanceof AgentHttpError)) return error;
+
+  const body = (error.body ?? {}) as ActionErrorBody;
+  const detail = body.errors?.[0]?.detail;
+  const isApproval =
+    body.errors?.[0]?.name === 'CustomActionRequiresApprovalError' ||
+    !!error.responseText?.includes('CustomActionRequiresApprovalError');
+
+  if (error.status === 403 && isApproval) {
+    return new ActionRequiresApprovalError(
+      detail ?? 'This action requires an approval before it can run.',
+      body.errors?.[0]?.data?.roleIdsAllowedToApprove ?? body.data?.roleIdsAllowedToApprove,
+    );
+  }
+
+  if (error.status === 400 || error.status === 422) {
+    return new ActionFormValidationError(detail ?? 'The action form values were rejected.');
+  }
+
+  return error;
+}
 
 export type BaseActionContext = {
   recordId?: RecordId;
@@ -69,11 +101,15 @@ export default class Action {
       },
     };
 
-    return this.httpRequester.query<{ success: string }>({
-      method: 'post',
-      path: this.actionPath,
-      body: requestBody,
-    });
+    try {
+      return await this.httpRequester.query<{ success: string }>({
+        method: 'post',
+        path: this.actionPath,
+        body: requestBody,
+      });
+    } catch (error) {
+      throw toActionError(error);
+    }
   }
 
   async setFields(fields: Record<string, unknown>): Promise<void> {

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -1,0 +1,26 @@
+/* eslint-disable max-classes-per-file */
+
+// Typed transport error: status + parsed body (JSON:API `{ errors: [...] }` when available, else
+// raw text). Callers read fields directly instead of parsing a stringified message.
+export default class AgentHttpError extends Error {
+  constructor(readonly status: number, readonly body: unknown, readonly responseText?: string) {
+    super(`Agent responded with HTTP ${status}`);
+    this.name = 'AgentHttpError';
+  }
+}
+
+// Semantic action errors: agent-client interprets the failure once so callers route on meaning, not
+// status/body. `message` carries the agent's detail when available.
+export class ActionRequiresApprovalError extends Error {
+  constructor(message: string, readonly roleIdsAllowedToApprove?: number[]) {
+    super(message);
+    this.name = 'ActionRequiresApprovalError';
+  }
+}
+
+export class ActionFormValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ActionFormValidationError';
+  }
+}

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -3,6 +3,18 @@ import type { WriteStream } from 'fs';
 import { Deserializer } from 'jsonapi-serializer';
 import superagent from 'superagent';
 
+import AgentHttpError from './errors';
+
+function parseJson(text: string | undefined): unknown {
+  if (text === undefined) return undefined;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 export default class HttpRequester {
   private readonly deserializer: Deserializer;
 
@@ -60,9 +72,15 @@ export default class HttpRequester {
         return (response.body ?? response.text) as Data;
       }
     } catch (error) {
-      const superagentError = error as { response?: { error?: Record<string, string> } };
-      if (!superagentError.response) throw error;
-      throw new Error(JSON.stringify({ error: superagentError.response.error, body }, null, 4));
+      const res = (error as { response?: { status?: number; body?: unknown; text?: string } })
+        .response;
+      if (!res) throw error; // network/timeout/abort → no HTTP response, propagate raw
+
+      const text = typeof res.text === 'string' ? res.text : undefined;
+      const hasBody =
+        !!res.body && typeof res.body === 'object' && Object.keys(res.body).length > 0;
+
+      throw new AgentHttpError(res.status ?? 0, hasBody ? res.body : parseJson(text), text);
     }
   }
 
@@ -105,13 +123,7 @@ export default class HttpRequester {
   }
 
   static is404Error(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-
-    try {
-      return JSON.parse(error.message)?.error?.status === 404;
-    } catch {
-      return false;
-    }
+    return error instanceof AgentHttpError && error.status === 404;
   }
 
   private buildUrl(path: string): string {

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -8,9 +8,18 @@ import type {
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
 import RemoteAgentClient from './domains/remote-agent-client';
+import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from './errors';
 import HttpRequester from './http-requester';
 
-export { ActionFieldJson, ActionFieldStringList, RemoteAgentClient, HttpRequester };
+export {
+  ActionFieldJson,
+  ActionFieldStringList,
+  RemoteAgentClient,
+  HttpRequester,
+  AgentHttpError,
+  ActionRequiresApprovalError,
+  ActionFormValidationError,
+};
 export type {
   ActionEndpointsByCollection,
   CollectionPermissionsOverride,

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -1,6 +1,7 @@
 import type HttpRequester from '../../src/http-requester';
 
 import FieldFormStates from '../../src/action-fields/field-form-states';
+import AgentHttpError from '../../src/errors';
 
 jest.mock('../../src/http-requester', () => {
   const actual = jest.requireActual('../../src/http-requester');
@@ -278,9 +279,7 @@ describe('FieldFormStates', () => {
         { load: false, change: [] },
       );
 
-      const error404 = new Error(
-        JSON.stringify({ error: { status: 404, text: 'Not Found' }, body: null }),
-      );
+      const error404 = new AgentHttpError(404, null, 'Not Found');
       httpRequester.query.mockRejectedValue(error404);
 
       await formStates.loadInitialState();
@@ -307,9 +306,7 @@ describe('FieldFormStates', () => {
         fallbackFields,
       );
 
-      const error404 = new Error(
-        JSON.stringify({ error: { status: 404, text: 'Not Found' }, body: null }),
-      );
+      const error404 = new AgentHttpError(404, null, 'Not Found');
       httpRequester.query.mockRejectedValue(error404);
 
       await formStates.loadInitialState();
@@ -331,9 +328,7 @@ describe('FieldFormStates', () => {
         { load: false, change: [] },
       );
 
-      const error500 = new Error(
-        JSON.stringify({ error: { status: 500, text: 'Internal Server Error' }, body: null }),
-      );
+      const error500 = new AgentHttpError(500, null, 'Internal Server Error');
       httpRequester.query.mockRejectedValue(error500);
 
       await expect(formStates.loadInitialState()).rejects.toThrow();

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -2,6 +2,7 @@ import type FieldFormStates from '../../src/action-fields/field-form-states';
 import type HttpRequester from '../../src/http-requester';
 
 import Action from '../../src/domains/action';
+import AgentHttpError from '../../src/errors';
 
 jest.mock('../../src/http-requester');
 jest.mock('../../src/action-fields/field-form-states');
@@ -114,6 +115,44 @@ describe('Action', () => {
           },
         },
       });
+    });
+
+    it('should translate a 403 approval rejection into ActionRequiresApprovalError', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [
+            {
+              name: 'CustomActionRequiresApprovalError',
+              detail: 'Needs approval',
+              data: { roleIdsAllowedToApprove: [7, 9] },
+            },
+          ],
+        }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionRequiresApprovalError',
+        message: 'Needs approval',
+        roleIdsAllowedToApprove: [7, 9],
+      });
+    });
+
+    it('should translate a 422 rejection into ActionFormValidationError', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(422, { errors: [{ detail: 'Invalid value' }] }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'Invalid value',
+      });
+    });
+
+    it('should propagate other HTTP errors unchanged', async () => {
+      const error = new AgentHttpError(500, null);
+      httpRequester.query.mockRejectedValue(error);
+
+      await expect(action.execute()).rejects.toBe(error);
     });
   });
 

--- a/packages/agent-client/test/http-requester.test.ts
+++ b/packages/agent-client/test/http-requester.test.ts
@@ -1,5 +1,6 @@
 import superagent from 'superagent';
 
+import AgentHttpError from '../src/errors';
 import HttpRequester from '../src/http-requester';
 
 jest.mock('superagent');
@@ -43,23 +44,20 @@ describe('HttpRequester', () => {
   });
 
   describe('is404Error', () => {
-    it('should return true for a 404 error', () => {
-      const error = new Error(JSON.stringify({ error: { status: 404 }, body: null }));
-      expect(HttpRequester.is404Error(error)).toBe(true);
+    it('should return true for a 404 AgentHttpError', () => {
+      expect(HttpRequester.is404Error(new AgentHttpError(404, null))).toBe(true);
     });
 
-    it('should return false for a 500 error', () => {
-      const error = new Error(JSON.stringify({ error: { status: 500 }, body: null }));
-      expect(HttpRequester.is404Error(error)).toBe(false);
+    it('should return false for a non-404 AgentHttpError', () => {
+      expect(HttpRequester.is404Error(new AgentHttpError(500, null))).toBe(false);
     });
 
     it('should return false for a non-Error', () => {
       expect(HttpRequester.is404Error('not an error')).toBe(false);
     });
 
-    it('should return false for non-JSON error message', () => {
-      const error = new Error('plain text error');
-      expect(HttpRequester.is404Error(error)).toBe(false);
+    it('should return false for a plain Error', () => {
+      expect(HttpRequester.is404Error(new Error('plain text error'))).toBe(false);
     });
   });
 
@@ -239,6 +237,28 @@ describe('HttpRequester', () => {
 
       await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toThrow(
         'Network error',
+      );
+    });
+
+    it('should parse the JSON body from the response text when body is empty', async () => {
+      const error = { response: { status: 422, text: '{"errors":[{"detail":"bad"}]}' } };
+      mockRequest.then = jest.fn((_onFulfilled: any, onRejected: any) =>
+        Promise.resolve(onRejected(error)),
+      );
+
+      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
+        { status: 422, body: { errors: [{ detail: 'bad' }] }, responseText: error.response.text },
+      );
+    });
+
+    it('should fall back to the raw text when it is not valid JSON', async () => {
+      const error = { response: { status: 500, text: 'Internal Server Error' } };
+      mockRequest.then = jest.fn((_onFulfilled: any, onRejected: any) =>
+        Promise.resolve(onRejected(error)),
+      );
+
+      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
+        { status: 500, body: 'Internal Server Error' },
       );
     });
 

--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -1,64 +1,31 @@
-/**
- * Parse JSON:API error text to extract the detail message.
- */
-function parseJsonApiErrorText(text: string): string | null {
-  try {
-    const parsed = JSON.parse(text) as {
-      errors?: Array<{ detail?: string; name?: string }>;
-    };
+import { AgentHttpError } from '@forestadmin/agent-client';
 
-    if (parsed.errors?.[0]?.detail) {
-      return parsed.errors[0].detail;
+// Extract the JSON:API detail message from a parsed body or its raw text.
+function jsonApiDetail(body: unknown, text?: string): string | null {
+  const fromBody = (body as { errors?: Array<{ detail?: string }> })?.errors?.[0]?.detail;
+  if (fromBody) return fromBody;
+
+  if (typeof text === 'string') {
+    try {
+      const parsed = JSON.parse(text) as { errors?: Array<{ detail?: string }> };
+      if (parsed.errors?.[0]?.detail) return parsed.errors[0].detail;
+    } catch {
+      // not JSON:API → fall through
     }
-  } catch {
-    // Ignore parsing failures
   }
 
   return null;
 }
 
-/**
- * Parse error from the agent RPC client.
- * The error structure can vary:
- * - Error with message containing JSON: { error: { text: '{"errors":[{"detail":"..."}]}' } }
- * - Error with message containing JSON: { text: '{"errors":[{"detail":"..."}]}' }
- * - Error with message containing JSON: { message: '...' }
- * - Error with plain string message
- */
+// Turn an agent RPC error into a human-readable message (AgentHttpError detail, else raw message).
 export default function parseAgentError(error: unknown): string | null {
-  try {
-    const err = JSON.parse((error as Error).message) as {
-      error?: { text?: string };
-      text?: string;
-      message?: string;
-    };
-
-    // Try nested error.text first (e.g., { error: { text: '...' } })
-    if (err.error?.text) {
-      const detail = parseJsonApiErrorText(err.error.text);
-
-      if (detail) return detail;
-    }
-
-    // Try direct text property (e.g., { text: '...' })
-    if (err.text) {
-      const detail = parseJsonApiErrorText(err.text);
-
-      if (detail) return detail;
-    }
-
-    // Fallback to message property
-    if (err.message) {
-      return err.message;
-    }
-
-    return null;
-  } catch {
-    // If parsing fails, try to get message directly
-    if (error && typeof error === 'object' && 'message' in error) {
-      return (error as { message: string }).message || null;
-    }
-
-    return null;
+  if (error instanceof AgentHttpError) {
+    return jsonApiDetail(error.body, error.responseText) ?? error.message;
   }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    return (error as { message: string }).message || null;
+  }
+
+  return null;
 }

--- a/packages/mcp-server/test/utils/error-parser.test.ts
+++ b/packages/mcp-server/test/utils/error-parser.test.ts
@@ -1,142 +1,48 @@
+import { AgentHttpError } from '@forestadmin/agent-client';
+
 import parseAgentError from '../../src/utils/error-parser';
 
 describe('parseAgentError', () => {
-  describe('nested error.text structure', () => {
-    it('should parse error with nested error.text containing JSON:API errors', () => {
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError', detail: 'Invalid filters provided' }],
-          }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('Invalid filters provided');
+  it('extracts the JSON:API detail from the parsed body', () => {
+    const error = new AgentHttpError(400, {
+      errors: [{ name: 'ValidationError', detail: 'Invalid filters provided' }],
     });
 
-    it('should return null when error.text has no errors array', () => {
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({ success: false }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+    expect(parseAgentError(error)).toBe('Invalid filters provided');
   });
 
-  describe('direct text property', () => {
-    it('should parse error with direct text property containing JSON:API errors', () => {
-      const errorPayload = {
-        text: JSON.stringify({
-          errors: [{ name: 'ValidationError', detail: 'Direct text error' }],
-        }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
+  it('falls back to parsing responseText when the body is not a parsed object', () => {
+    const error = new AgentHttpError(
+      400,
+      undefined,
+      JSON.stringify({ errors: [{ detail: 'From raw text' }] }),
+    );
 
-      expect(parseAgentError(error)).toBe('Direct text error');
-    });
-
-    it('should return null when text has no errors array', () => {
-      const errorPayload = {
-        text: JSON.stringify({ success: false }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+    expect(parseAgentError(error)).toBe('From raw text');
   });
 
-  describe('message property fallback', () => {
-    it('should use message property from parsed JSON when no text field', () => {
-      const errorPayload = {
-        message: 'Error message from JSON payload',
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('Error message from JSON payload');
-    });
+  it('returns the generic HTTP message when the body has no JSON:API detail', () => {
+    expect(parseAgentError(new AgentHttpError(400, { success: false }))).toBe(
+      'Agent responded with HTTP 400',
+    );
   });
 
-  describe('plain error message fallback', () => {
-    it('should fall back to error.message when message is not valid JSON', () => {
-      const error = new Error('Plain error message');
-
-      expect(parseAgentError(error)).toBe('Plain error message');
-    });
+  it('returns the generic HTTP message for an empty errors array', () => {
+    expect(parseAgentError(new AgentHttpError(422, { errors: [] }))).toBe(
+      'Agent responded with HTTP 422',
+    );
   });
 
-  describe('error priority', () => {
-    it('should prioritize error.text over direct text', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({
-            errors: [{ detail: 'From error.text' }],
-          }),
-        },
-        text: JSON.stringify({
-          errors: [{ detail: 'From direct text' }],
-        }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('From error.text');
-    });
-
-    it('should prioritize text over message', () => {
-      const errorPayload = {
-        text: JSON.stringify({
-          errors: [{ detail: 'From text' }],
-        }),
-        message: 'From message',
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('From text');
-    });
+  it('returns the message of a plain Error', () => {
+    expect(parseAgentError(new Error('Plain error message'))).toBe('Plain error message');
   });
 
-  describe('edge cases', () => {
-    it('should return null for object without message property', () => {
-      const error = { unknownProperty: 'some value' };
+  it('returns null for an object without a message', () => {
+    expect(parseAgentError({ unknownProperty: 'some value' })).toBeNull();
+  });
 
-      expect(parseAgentError(error)).toBeNull();
-    });
-
-    it('should return null for null error', () => {
-      expect(parseAgentError(null)).toBeNull();
-    });
-
-    it('should return null for undefined error', () => {
-      expect(parseAgentError(undefined)).toBeNull();
-    });
-
-    it('should handle empty errors array', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({ errors: [] }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
-
-    it('should handle error without detail property', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError' }],
-          }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+  it('returns null for null/undefined', () => {
+    expect(parseAgentError(null)).toBeNull();
+    expect(parseAgentError(undefined)).toBeNull();
   });
 });

--- a/packages/mcp-server/test/utils/with-activity-log.test.ts
+++ b/packages/mcp-server/test/utils/with-activity-log.test.ts
@@ -3,6 +3,8 @@ import type { Logger } from '../../src/server';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
 
+import { AgentHttpError } from '@forestadmin/agent-client';
+
 import createPendingActivityLog, {
   markActivityLogAsFailed,
   markActivityLogAsSucceeded,
@@ -137,15 +139,11 @@ describe('withActivityLog', () => {
   });
 
   it('should parse agent error and use detail as error message', async () => {
-    const errorPayload = {
-      error: {
-        status: 400,
-        text: JSON.stringify({
-          errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
-        }),
-      },
-    };
-    const operation = jest.fn().mockRejectedValue(new Error(JSON.stringify(errorPayload)));
+    const operation = jest.fn().mockRejectedValue(
+      new AgentHttpError(400, {
+        errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
+      }),
+    );
 
     await expect(
       withActivityLog({
@@ -283,16 +281,9 @@ describe('withActivityLog', () => {
     });
 
     it('should pass parsed agent error detail to errorEnhancer', async () => {
-      // parseAgentError expects an Error with a JSON message containing error details
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
-          }),
-        },
-      };
-      const agentError = new Error(JSON.stringify(errorPayload));
+      const agentError = new AgentHttpError(400, {
+        errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
+      });
       const operation = jest.fn().mockRejectedValue(agentError);
       const errorEnhancer = jest.fn().mockImplementation(msg => Promise.resolve(`Context: ${msg}`));
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -16,7 +16,12 @@ import type { StepUser } from '../types/execution-context';
 import type { RecordData } from '../types/validated/collection';
 import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/agent-client';
 
-import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import {
+  ActionFormValidationError as ClientActionFormValidationError,
+  ActionRequiresApprovalError as ClientActionRequiresApprovalError,
+  HttpRequester,
+  createRemoteAgentClient,
+} from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import {
@@ -29,50 +34,14 @@ import {
   extractErrorMessage,
 } from '../errors';
 
-// The agent-client throws `new Error(JSON.stringify({ error: { status, text }, body }))` on a non-2xx
-// (superagent's toError sets status + text = raw response body). Parse it back to (status, body).
-function parseAgentHttpError(error: unknown): { status?: number; text?: string } {
-  if (!(error instanceof Error)) return {};
-
-  try {
-    const parsed = JSON.parse(error.message) as { error?: { status?: number; text?: string } };
-
-    return { status: parsed.error?.status, text: parsed.error?.text };
-  } catch {
-    return {};
-  }
-}
-
-// The agent rejects an approval-gated action with HTTP 403 CustomActionRequiresApprovalError,
-// carrying roleIdsAllowedToApprove. Pull the roles out of the response body when present.
-function extractRoleIdsAllowedToApprove(text: string): number[] | undefined {
-  try {
-    const body = JSON.parse(text) as {
-      errors?: { data?: { roleIdsAllowedToApprove?: number[] } }[];
-      data?: { roleIdsAllowedToApprove?: number[] };
-    };
-
-    return (
-      body.errors?.[0]?.data?.roleIdsAllowedToApprove ??
-      body.data?.roleIdsAllowedToApprove ??
-      undefined
-    );
-  } catch {
-    return undefined;
-  }
-}
-
-// Map an action `execute()` failure to a typed error so the step executor can route it:
-// approval-403 and validation rejections become distinct fallback-worthy errors; everything else
-// (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
+// Re-wrap agent-client's semantic action error into the executor's domain error (carries userMessage
+// + drives the step fallback). Anything else stays raw → AgentPortError = step error.
 function mapActionExecutionError(action: string, cause: unknown): unknown {
-  const { status, text } = parseAgentHttpError(cause);
-
-  if (status === 403 && text && text.includes('CustomActionRequiresApprovalError')) {
-    return new ActionRequiresApprovalError(action, extractRoleIdsAllowedToApprove(text));
+  if (cause instanceof ClientActionRequiresApprovalError) {
+    return new ActionRequiresApprovalError(action, cause.roleIdsAllowedToApprove);
   }
 
-  if (status === 400 || status === 422) {
+  if (cause instanceof ClientActionFormValidationError) {
     return new ActionFormValidationError(action, cause);
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -11,7 +11,7 @@ import type {
 import type SchemaCache from '../schema-cache';
 import type { StepUser } from '../types/execution-context';
 import type { RecordData } from '../types/validated/collection';
-import type { ActionEndpointsByCollection } from '@forestadmin/agent-client';
+import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/agent-client';
 
 import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
@@ -109,7 +109,7 @@ export default class AgentClientAgentPort implements AgentPort {
   }
 
   async getRelatedData(
-    { collection, id, relation, relatedSchema, limit, fields }: GetRelatedDataQuery,
+    { collection, id, relation, relatedSchema, limit, fields, filters }: GetRelatedDataQuery,
     user: StepUser,
   ): Promise<RecordData[]> {
     return this.callAgent('getRelatedData', async () => {
@@ -120,6 +120,8 @@ export default class AgentClientAgentPort implements AgentPort {
         .list<Record<string, unknown>>({
           ...(limit !== null && { pagination: { size: limit, number: 1 } }),
           ...(fields?.length && { fields }),
+          // Trusted build-time conditionTree (PRD-553); the agent validates it at query time.
+          ...(filters !== undefined && { filters: filters as SelectOptions['filters'] }),
         });
 
       return rows.map(row => {

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -1,7 +1,10 @@
 import type {
+  ActionForm,
+  ActionFormField,
   AgentPort,
   ExecuteActionQuery,
   GetActionFormInfoQuery,
+  GetActionFormQuery,
   GetRecordQuery,
   GetRelatedDataQuery,
   GetSingleRelatedDataQuery,
@@ -17,12 +20,64 @@ import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-clien
 import jsonwebtoken from 'jsonwebtoken';
 
 import {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
   AgentPortError,
   AgentProbeError,
   RecordNotFoundError,
   WorkflowExecutorError,
   extractErrorMessage,
 } from '../errors';
+
+// The agent-client throws `new Error(JSON.stringify({ error: { status, text }, body }))` on a non-2xx
+// (superagent's toError sets status + text = raw response body). Parse it back to (status, body).
+function parseAgentHttpError(error: unknown): { status?: number; text?: string } {
+  if (!(error instanceof Error)) return {};
+
+  try {
+    const parsed = JSON.parse(error.message) as { error?: { status?: number; text?: string } };
+
+    return { status: parsed.error?.status, text: parsed.error?.text };
+  } catch {
+    return {};
+  }
+}
+
+// The agent rejects an approval-gated action with HTTP 403 CustomActionRequiresApprovalError,
+// carrying roleIdsAllowedToApprove. Pull the roles out of the response body when present.
+function extractRoleIdsAllowedToApprove(text: string): number[] | undefined {
+  try {
+    const body = JSON.parse(text) as {
+      errors?: { data?: { roleIdsAllowedToApprove?: number[] } }[];
+      data?: { roleIdsAllowedToApprove?: number[] };
+    };
+
+    return (
+      body.errors?.[0]?.data?.roleIdsAllowedToApprove ??
+      body.data?.roleIdsAllowedToApprove ??
+      undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+// Map an action `execute()` failure to a typed error so the step executor can route it (PRD-509):
+// approval-403 and validation rejections become distinct fallback-worthy errors; everything else
+// (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
+function mapActionExecutionError(action: string, cause: unknown): unknown {
+  const { status, text } = parseAgentHttpError(cause);
+
+  if (status === 403 && text && text.includes('CustomActionRequiresApprovalError')) {
+    return new ActionRequiresApprovalError(action, extractRoleIdsAllowedToApprove(text));
+  }
+
+  if (status === 400 || status === 422) {
+    return new ActionFormValidationError(action, cause);
+  }
+
+  return cause;
+}
 
 function toCamelCase(name: string): string {
   return name.replace(/_([a-zA-Z0-9])/g, (_, c: string) => c.toUpperCase());
@@ -192,7 +247,7 @@ export default class AgentClientAgentPort implements AgentPort {
   }
 
   async executeAction(
-    { collection, action, id }: ExecuteActionQuery,
+    { collection, action, id, values }: ExecuteActionQuery,
     user: StepUser,
   ): Promise<unknown> {
     return this.callAgent('executeAction', async () => {
@@ -200,7 +255,21 @@ export default class AgentClientAgentPort implements AgentPort {
       const recordIds = id?.length ? [id] : [];
       const act = await client.collection(collection).action(action, { recordIds });
 
-      return act.execute();
+      if (values) {
+        // setFields is strict (mirrors MCP execute-action): an unknown field is a config/drift
+        // problem, surfaced as a validation error rather than a silent skip.
+        try {
+          await act.setFields(values);
+        } catch (cause) {
+          throw new ActionFormValidationError(action, cause);
+        }
+      }
+
+      try {
+        return await act.execute();
+      } catch (cause) {
+        throw mapActionExecutionError(action, cause);
+      }
     });
   }
 
@@ -213,6 +282,39 @@ export default class AgentClientAgentPort implements AgentPort {
       const act = await client.collection(collection).action(action, { recordIds: [id] });
 
       return { hasForm: act.getFields().length > 0 };
+    });
+  }
+
+  async getActionForm(
+    { collection, action, id, values }: GetActionFormQuery,
+    user: StepUser,
+  ): Promise<ActionForm> {
+    return this.callAgent('getActionForm', async () => {
+      const client = this.createClient(user);
+      const act = await client.collection(collection).action(action, { recordIds: [id] });
+
+      // Soft-apply so dependent fields are revealed by change hooks; unknown fields (dropped by a
+      // prior hook) come back in skippedFields rather than throwing (mirrors MCP get-action-form).
+      const skippedFields = values ? await act.tryToSetFields(values) : [];
+
+      const fields = act.getFields().map((field): ActionFormField => {
+        const base = {
+          name: field.getName(),
+          type: field.getType(),
+          value: field.getValue(),
+          isRequired: field.isRequired() ?? false,
+        };
+
+        return field.getType() === 'Enum'
+          ? { ...base, enumValues: act.getEnumField(field.getName()).getOptions() ?? undefined }
+          : base;
+      });
+
+      const requiredFields = fields
+        .filter(field => field.isRequired && (field.value === undefined || field.value === null))
+        .map(field => field.name);
+
+      return { fields, canExecute: requiredFields.length === 0, requiredFields, skippedFields };
     });
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -120,7 +120,6 @@ export default class AgentClientAgentPort implements AgentPort {
         .list<Record<string, unknown>>({
           ...(limit !== null && { pagination: { size: limit, number: 1 } }),
           ...(fields?.length && { fields }),
-          // Trusted build-time conditionTree (PRD-553); the agent validates it at query time.
           ...(filters !== undefined && { filters: filters as SelectOptions['filters'] }),
         });
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -62,7 +62,7 @@ function extractRoleIdsAllowedToApprove(text: string): number[] | undefined {
   }
 }
 
-// Map an action `execute()` failure to a typed error so the step executor can route it (PRD-509):
+// Map an action `execute()` failure to a typed error so the step executor can route it:
 // approval-403 and validation rejections become distinct fallback-worthy errors; everything else
 // (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
 function mapActionExecutionError(action: string, cause: unknown): unknown {

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -76,7 +76,9 @@ interface ServerWorkflowTaskUpdateData extends ServerWorkflowTaskBase {
 
 interface ServerWorkflowTaskTriggerAction extends ServerWorkflowTaskBase {
   taskType: ServerTaskTypeEnum.TriggerAction;
+  // Manual is valid for a form-bearing action (PRD-511): pause for the user with no AI prefill.
   executionType:
+    | ServerStepExecutionTypeEnum.Manual
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
 }

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -87,7 +87,7 @@ interface ServerWorkflowTaskLoadRelatedRecord extends ServerWorkflowTaskBase {
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
   // Deterministic build-time config (PRD-471). Validated by the step-definition schema.
-  preRecordedArgs?: { selectedRecordStepIndex?: number; relationName?: string };
+  preRecordedArgs?: { selectedRecordStepId?: string; relationName?: string };
 }
 
 export interface ServerWorkflowTaskMcpServer extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -76,7 +76,7 @@ interface ServerWorkflowTaskUpdateData extends ServerWorkflowTaskBase {
 
 interface ServerWorkflowTaskTriggerAction extends ServerWorkflowTaskBase {
   taskType: ServerTaskTypeEnum.TriggerAction;
-  // Manual is valid for a form-bearing action (PRD-511): pause for the user with no AI prefill.
+  // Manual is valid for a form-bearing action: pause for the user with no AI prefill.
   executionType:
     | ServerStepExecutionTypeEnum.Manual
     | ServerStepExecutionTypeEnum.FullyAutomated
@@ -88,7 +88,7 @@ interface ServerWorkflowTaskLoadRelatedRecord extends ServerWorkflowTaskBase {
   executionType:
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
-  // Deterministic build-time config (PRD-471). Validated by the step-definition schema.
+  // Deterministic build-time config. Validated by the step-definition schema.
   preRecordedArgs?: { selectedRecordStepId?: string; relationName?: string };
 }
 

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -86,6 +86,8 @@ interface ServerWorkflowTaskLoadRelatedRecord extends ServerWorkflowTaskBase {
   executionType:
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
+  // Deterministic build-time config (PRD-471). Validated by the step-definition schema.
+  preRecordedArgs?: { selectedRecordStepIndex?: number; relationName?: string };
 }
 
 export interface ServerWorkflowTaskMcpServer extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -81,6 +81,7 @@ interface ServerWorkflowTaskTriggerAction extends ServerWorkflowTaskBase {
     | ServerStepExecutionTypeEnum.Manual
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
+  preRecordedArgs?: { selectedRecordStepId?: string; actionName?: string };
 }
 
 interface ServerWorkflowTaskLoadRelatedRecord extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -42,6 +42,7 @@ function mapTask(task: ServerWorkflowTask): StepDefinition {
       return LoadRelatedRecordStepDefinitionSchema.parse({
         ...base,
         type: StepType.LoadRelatedRecord,
+        preRecordedArgs: task.preRecordedArgs,
       });
     default:
       throw new InvalidStepDefinitionError(

--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -37,7 +37,11 @@ function mapTask(task: ServerWorkflowTask): StepDefinition {
     case ServerTaskTypeEnum.UpdateData:
       return UpdateRecordStepDefinitionSchema.parse({ ...base, type: StepType.UpdateRecord });
     case ServerTaskTypeEnum.TriggerAction:
-      return TriggerActionStepDefinitionSchema.parse({ ...base, type: StepType.TriggerAction });
+      return TriggerActionStepDefinitionSchema.parse({
+        ...base,
+        type: StepType.TriggerAction,
+        preRecordedArgs: task.preRecordedArgs,
+      });
     case ServerTaskTypeEnum.LoadRelatedRecord:
       return LoadRelatedRecordStepDefinitionSchema.parse({
         ...base,

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -127,7 +127,7 @@ export class UnsupportedActionFormError extends WorkflowExecutorError {
 }
 
 // The action submission was rejected by the agent's server-side validation (bad/missing values),
-// NOT an infra failure (PRD-509). Full AI (PRD-512) treats this as a fallback-to-AI-assisted reason
+// NOT an infra failure. Full AI treats this as a fallback-to-AI-assisted reason
 // so a human can fix the values and resubmit.
 export class ActionFormValidationError extends WorkflowExecutorError {
   constructor(actionName: string, cause?: unknown) {
@@ -140,8 +140,8 @@ export class ActionFormValidationError extends WorkflowExecutorError {
 }
 
 // The action requires an Approval: the agent rejects a programmatic submit upfront with HTTP 403
-// CustomActionRequiresApprovalError (PRD-509). Distinct from a plain permission 403 — Full AI
-// (PRD-512) falls back to AI-assisted so the native front handles the approval flow. The executor
+// CustomActionRequiresApprovalError. Distinct from a plain permission 403 — Full AI
+// falls back to AI-assisted so the native front handles the approval flow. The executor
 // MUST NOT self-sign an approval request.
 export class ActionRequiresApprovalError extends WorkflowExecutorError {
   readonly roleIdsAllowedToApprove?: number[];
@@ -408,7 +408,7 @@ export class InvalidPreRecordedArgsError extends WorkflowExecutorError {
 }
 
 // A "Related to" / "On record" source step ran but loaded no record, so the step that uses it has
-// no source to act on (PRD-550 / PRD-469 "no source record"). Distinct from a bad config — the
+// no source to act on ("no source record"). Distinct from a bad config — the
 // user can continue without. Wording is step-type-neutral (shared by load-related and trigger-action).
 export class SourceRecordMissingError extends WorkflowExecutorError {
   constructor(sourceTitle?: string) {

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -378,6 +378,18 @@ export class InvalidPreRecordedArgsError extends WorkflowExecutorError {
   }
 }
 
+// The "Related to" source step ran but loaded no record, so this step has nothing to load from
+// (PRD-550 "no source record"). Distinct from a bad config — the user can continue without.
+export class SourceRecordMissingError extends WorkflowExecutorError {
+  constructor(sourceTitle?: string) {
+    const from = sourceTitle ? `"${sourceTitle}"` : 'its source step';
+    super(
+      `Source step ${from} loaded no record`,
+      `This step loads from ${from}, but that step didn't load any record, so nothing can be loaded here.`,
+    );
+  }
+}
+
 // Boundary error — surfaces from Runner.start() and is caught at the CLI/HTTP layer, not by step executors.
 export class AgentProbeError extends Error {
   // Manual `cause` assignment: Error accepts it natively since Node 16.9 but our TS target is ES2020.

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -378,14 +378,15 @@ export class InvalidPreRecordedArgsError extends WorkflowExecutorError {
   }
 }
 
-// The "Related to" source step ran but loaded no record, so this step has nothing to load from
-// (PRD-550 "no source record"). Distinct from a bad config — the user can continue without.
+// A "Related to" / "On record" source step ran but loaded no record, so the step that uses it has
+// no source to act on (PRD-550 / PRD-469 "no source record"). Distinct from a bad config — the
+// user can continue without. Wording is step-type-neutral (shared by load-related and trigger-action).
 export class SourceRecordMissingError extends WorkflowExecutorError {
   constructor(sourceTitle?: string) {
     const from = sourceTitle ? `"${sourceTitle}"` : 'its source step';
     super(
       `Source step ${from} loaded no record`,
-      `This step loads from ${from}, but that step didn't load any record, so nothing can be loaded here.`,
+      `This step uses ${from} as its source, but that step didn't load any record.`,
     );
   }
 }

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -126,6 +126,35 @@ export class UnsupportedActionFormError extends WorkflowExecutorError {
   }
 }
 
+// The action submission was rejected by the agent's server-side validation (bad/missing values),
+// NOT an infra failure (PRD-509). Full AI (PRD-512) treats this as a fallback-to-AI-assisted reason
+// so a human can fix the values and resubmit.
+export class ActionFormValidationError extends WorkflowExecutorError {
+  constructor(actionName: string, cause?: unknown) {
+    super(
+      `Action "${actionName}" rejected the submitted form values`,
+      'The submitted form values were rejected. Please review the form and try again.',
+    );
+    this.cause = cause;
+  }
+}
+
+// The action requires an Approval: the agent rejects a programmatic submit upfront with HTTP 403
+// CustomActionRequiresApprovalError (PRD-509). Distinct from a plain permission 403 — Full AI
+// (PRD-512) falls back to AI-assisted so the native front handles the approval flow. The executor
+// MUST NOT self-sign an approval request.
+export class ActionRequiresApprovalError extends WorkflowExecutorError {
+  readonly roleIdsAllowedToApprove?: number[];
+
+  constructor(actionName: string, roleIdsAllowedToApprove?: number[]) {
+    super(
+      `Action "${actionName}" requires an approval and cannot be submitted programmatically`,
+      'This action requires an approval. Please review and submit it manually.',
+    );
+    this.roleIdsAllowedToApprove = roleIdsAllowedToApprove;
+  }
+}
+
 export class RunStorePortError extends UnavailableError {
   constructor(operation: string, cause: unknown) {
     super(

--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -120,7 +120,7 @@ export default class AgentWithLog {
   }
 
   // Unaudited passthrough: reading the form structure (and applying values to reveal dependent
-  // fields via change hooks) is read-only — the actual execution is what gets logged (PRD-509/511).
+  // fields via change hooks) is read-only — the actual execution is what gets logged.
   getActionForm(query: GetActionFormQuery): Promise<ActionForm> {
     return this.agentPort.getActionForm(query, this.user);
   }

--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -1,8 +1,10 @@
 import type ActivityLog from './activity-log';
 import type {
+  ActionForm,
   AgentPort,
   ExecuteActionQuery,
   GetActionFormInfoQuery,
+  GetActionFormQuery,
   GetRecordQuery,
   GetRelatedDataQuery,
   GetSingleRelatedDataQuery,
@@ -115,6 +117,12 @@ export default class AgentWithLog {
   // not a data access, so unlike the methods above it records NO activity-log entry.
   getActionFormInfo(query: GetActionFormInfoQuery): Promise<{ hasForm: boolean }> {
     return this.agentPort.getActionFormInfo(query, this.user);
+  }
+
+  // Unaudited passthrough: reading the form structure (and applying values to reveal dependent
+  // fields via change hooks) is read-only — the actual execution is what gets logged (PRD-509/511).
+  getActionForm(query: GetActionFormQuery): Promise<ActionForm> {
+    return this.agentPort.getActionForm(query, this.user);
   }
 
   // Unaudited passthrough: resolves a polymorphic relation's target type (metadata probe). The

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -21,6 +21,7 @@ import {
   NoRelationshipFieldsError,
   RelatedRecordNotFoundError,
   RelationNotFoundError,
+  SourceRecordMissingError,
   StepStateError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
@@ -218,6 +219,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       ) {
         return execution.executionResult.record;
       }
+
+      // The source step exists but loaded nothing → clear "no source record" message (PRD-550),
+      // distinct from a config pointing at a non-existent step.
+      throw new SourceRecordMissingError(sourceStep.stepDefinition.title);
     }
 
     throw new InvalidPreRecordedArgsError(`No source record found for step "${stepId}"`);

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -24,7 +24,11 @@ import {
   StepStateError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
-import { StepExecutionMode, StepType } from '../types/validated/step-definition';
+import {
+  StepExecutionMode,
+  StepType,
+  WORKFLOW_START_STEP_ID,
+} from '../types/validated/step-definition';
 
 const SELECT_RELATION_SYSTEM_PROMPT = `You are an AI agent loading a related record based on a user request.
 You are given relations to follow, each shown as "<source record> → <relation> (→ <target collection>)".
@@ -147,8 +151,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     const { preRecordedArgs } = this.context.stepDefinition;
 
     const sourceRecords =
-      preRecordedArgs?.selectedRecordStepIndex !== undefined
-        ? [await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepIndex)]
+      preRecordedArgs?.selectedRecordStepId !== undefined
+        ? [await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepId)]
         : await this.getAvailableRecordRefs();
 
     const candidates = await this.buildRelationCandidates(sourceRecords);
@@ -186,21 +190,22 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     };
   }
 
-  // Revise-safe source resolution. The editor's selectedRecordStepIndex references a step by its
-  // original graph position; on a revise, indices shift, so match a previous load-related step on
-  // its own stepIndex OR its originalStepIndex (mirrors resolveStepExecution / getAvailableRecordRefs),
-  // and also accept the workflow-start record. A strict own-index match would wrongly report a valid
-  // chained source as "no source record" after a revise.
-  private async resolveSourceRecordRef(stepIndex: number): Promise<RecordRef> {
-    if (this.context.baseRecordRef.stepIndex === stepIndex) {
+  // Revise-safe source resolution. The "Related to" reference is a stable BPMN step id (or the
+  // WORKFLOW_START_STEP_ID sentinel), not a runtime index — so it survives the index shifts a
+  // revision causes (clones keep their step id) and is knowable by the editor at build time.
+  // previousSteps are already restricted to the live path; in a loop the same id can appear more
+  // than once, so we take the most recent occurrence.
+  private async resolveSourceRecordRef(stepId: string): Promise<RecordRef> {
+    if (stepId === WORKFLOW_START_STEP_ID) {
       return this.context.baseRecordRef;
     }
 
-    const sourceStep = this.context.previousSteps.find(
+    const matches = this.context.previousSteps.filter(
       step =>
         step.stepDefinition.type === StepType.LoadRelatedRecord &&
-        (step.stepOutcome.stepIndex === stepIndex || step.originalStepIndex === stepIndex),
+        step.stepOutcome.stepId === stepId,
     );
+    const sourceStep = matches[matches.length - 1];
 
     if (sourceStep) {
       const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
@@ -215,7 +220,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       }
     }
 
-    throw new InvalidPreRecordedArgsError(`No record found at step index ${stepIndex}`);
+    throw new InvalidPreRecordedArgsError(`No source record found for step "${stepId}"`);
   }
 
   private async buildRelationCandidates(records: RecordRef[]): Promise<RelationCandidate[]> {

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -157,7 +157,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       throw new NoRelationshipFieldsError(sourceRecords[0]?.collectionName ?? 'unknown');
     }
 
-    // Pre-recorded relations are pinned by their stable technical name (PRD-426), matched exactly.
+    // Pre-recorded relations are pinned by their stable technical name, matched exactly.
     const pinned = preRecordedArgs?.relationName;
     const eligible = pinned ? candidates.filter(c => c.field.fieldName === pinned) : candidates;
 
@@ -463,7 +463,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     }
 
     // The final record stays AI-suggested + user-confirmed — only the source + relation are
-    // pinned deterministically (PRD-471). Index-based record pinning was removed (not revise-safe).
+    // pinned deterministically. Index-based record pinning was removed (not revise-safe).
     const suggestedFields = await this.selectRelevantFields(
       relatedSchema,
       this.context.stepDefinition.prompt,

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -78,6 +78,7 @@ function isFollowableRelation(field: FieldSchema): boolean {
 
 export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<LoadRelatedRecordStepDefinition> {
   protected async doExecute(): Promise<StepExecutionResult> {
+    // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<LoadRelatedRecordStepExecutionData>(
       this.context.incomingPendingData,
     );
@@ -94,6 +95,7 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       );
     }
 
+    // Branches B & C -- First call
     return this.handleFirstCall();
   }
 
@@ -127,10 +129,12 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     const { stepDefinition: step } = this.context;
     const target = await this.resolveTarget();
 
+    // Branch B -- fully automated execution
     if (step.executionType === StepExecutionMode.FullyAutomated) {
       return this.resolveAndLoadAutomatic(target);
     }
 
+    // Branch C -- pre-fetch candidates, await user confirmation
     const sourceSchema = await this.getCollectionSchema(target.selectedRecordRef.collectionName);
 
     return this.saveAndAwaitInput(target, sourceSchema);

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -562,6 +562,9 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       relation: target.name,
       relatedSchema,
       limit,
+      // 1–n only: the build-time filter (PRD-553) narrows the candidate list. xToOne goes through
+      // fetchXToOneCandidate (no list to filter), so it never reaches here.
+      filters: this.context.stepDefinition.preRecordedArgs?.filters,
     });
   }
 

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -78,7 +78,6 @@ function isFollowableRelation(field: FieldSchema): boolean {
 
 export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<LoadRelatedRecordStepDefinition> {
   protected async doExecute(): Promise<StepExecutionResult> {
-    // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<LoadRelatedRecordStepExecutionData>(
       this.context.incomingPendingData,
     );
@@ -95,7 +94,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       );
     }
 
-    // Branches B & C -- First call
     return this.handleFirstCall();
   }
 
@@ -129,12 +127,10 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     const { stepDefinition: step } = this.context;
     const target = await this.resolveTarget();
 
-    // Branch B -- fully automated execution
     if (step.executionType === StepExecutionMode.FullyAutomated) {
       return this.resolveAndLoadAutomatic(target);
     }
 
-    // Branch C -- pre-fetch candidates, await user confirmation
     const sourceSchema = await this.getCollectionSchema(target.selectedRecordRef.collectionName);
 
     return this.saveAndAwaitInput(target, sourceSchema);

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -21,15 +21,10 @@ import {
   NoRelationshipFieldsError,
   RelatedRecordNotFoundError,
   RelationNotFoundError,
-  SourceRecordMissingError,
   StepStateError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
-import {
-  StepExecutionMode,
-  StepType,
-  WORKFLOW_START_STEP_ID,
-} from '../types/validated/step-definition';
+import { StepExecutionMode } from '../types/validated/step-definition';
 
 const SELECT_RELATION_SYSTEM_PROMPT = `You are an AI agent loading a related record based on a user request.
 You are given relations to follow, each shown as "<source record> → <relation> (→ <target collection>)".
@@ -189,43 +184,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       relationType: field.relationType,
       relatedCollectionName: field.relatedCollectionName,
     };
-  }
-
-  // Revise-safe source resolution. The "Related to" reference is a stable BPMN step id (or the
-  // WORKFLOW_START_STEP_ID sentinel), not a runtime index — so it survives the index shifts a
-  // revision causes (clones keep their step id) and is knowable by the editor at build time.
-  // previousSteps are already restricted to the live path; in a loop the same id can appear more
-  // than once, so we take the most recent occurrence.
-  private async resolveSourceRecordRef(stepId: string): Promise<RecordRef> {
-    if (stepId === WORKFLOW_START_STEP_ID) {
-      return this.context.baseRecordRef;
-    }
-
-    const matches = this.context.previousSteps.filter(
-      step =>
-        step.stepDefinition.type === StepType.LoadRelatedRecord &&
-        step.stepOutcome.stepId === stepId,
-    );
-    const sourceStep = matches[matches.length - 1];
-
-    if (sourceStep) {
-      const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
-      const execution = this.resolveStepExecution(sourceStep, stepExecutions);
-
-      if (
-        execution?.type === 'load-related-record' &&
-        execution.executionResult !== undefined &&
-        'record' in execution.executionResult
-      ) {
-        return execution.executionResult.record;
-      }
-
-      // The source step exists but loaded nothing → clear "no source record" message (PRD-550),
-      // distinct from a config pointing at a non-existent step.
-      throw new SourceRecordMissingError(sourceStep.stepDefinition.title);
-    }
-
-    throw new InvalidPreRecordedArgsError(`No source record found for step "${stepId}"`);
   }
 
   private async buildRelationCandidates(records: RecordRef[]): Promise<RelationCandidate[]> {

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -562,8 +562,6 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       relation: target.name,
       relatedSchema,
       limit,
-      // 1–n only: the build-time filter (PRD-553) narrows the candidate list. xToOne goes through
-      // fetchXToOneCandidate (no list to filter), so it never reaches here.
       filters: this.context.stepDefinition.preRecordedArgs?.filters,
     });
   }

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -24,7 +24,7 @@ import {
   StepStateError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
-import { StepExecutionMode } from '../types/validated/step-definition';
+import { StepExecutionMode, StepType } from '../types/validated/step-definition';
 
 const SELECT_RELATION_SYSTEM_PROMPT = `You are an AI agent loading a related record based on a user request.
 You are given relations to follow, each shown as "<source record> → <relation> (→ <target collection>)".
@@ -145,12 +145,11 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   // store→dvds rather than latching onto a previously-loaded dvd whose collection just matches.
   private async resolveTarget(): Promise<RelationTarget> {
     const { preRecordedArgs } = this.context.stepDefinition;
-    const records = await this.getAvailableRecordRefs();
 
     const sourceRecords =
       preRecordedArgs?.selectedRecordStepIndex !== undefined
-        ? [this.requireRecordAtStepIndex(records, preRecordedArgs.selectedRecordStepIndex)]
-        : records;
+        ? [await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepIndex)]
+        : await this.getAvailableRecordRefs();
 
     const candidates = await this.buildRelationCandidates(sourceRecords);
 
@@ -187,14 +186,36 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     };
   }
 
-  private requireRecordAtStepIndex(records: RecordRef[], stepIndex: number): RecordRef {
-    const match = records.find(r => r.stepIndex === stepIndex);
-
-    if (!match) {
-      throw new InvalidPreRecordedArgsError(`No record found at step index ${stepIndex}`);
+  // Revise-safe source resolution. The editor's selectedRecordStepIndex references a step by its
+  // original graph position; on a revise, indices shift, so match a previous load-related step on
+  // its own stepIndex OR its originalStepIndex (mirrors resolveStepExecution / getAvailableRecordRefs),
+  // and also accept the workflow-start record. A strict own-index match would wrongly report a valid
+  // chained source as "no source record" after a revise.
+  private async resolveSourceRecordRef(stepIndex: number): Promise<RecordRef> {
+    if (this.context.baseRecordRef.stepIndex === stepIndex) {
+      return this.context.baseRecordRef;
     }
 
-    return match;
+    const sourceStep = this.context.previousSteps.find(
+      step =>
+        step.stepDefinition.type === StepType.LoadRelatedRecord &&
+        (step.stepOutcome.stepIndex === stepIndex || step.originalStepIndex === stepIndex),
+    );
+
+    if (sourceStep) {
+      const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
+      const execution = this.resolveStepExecution(sourceStep, stepExecutions);
+
+      if (
+        execution?.type === 'load-related-record' &&
+        execution.executionResult !== undefined &&
+        'record' in execution.executionResult
+      ) {
+        return execution.executionResult.record;
+      }
+    }
+
+    throw new InvalidPreRecordedArgsError(`No record found at step index ${stepIndex}`);
   }
 
   private async buildRelationCandidates(records: RecordRef[]): Promise<RelationCandidate[]> {
@@ -473,29 +494,8 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       return { relatedData, bestIndex: 0, suggestedFields: [], relatedSchema };
     }
 
-    const { preRecordedArgs } = this.context.stepDefinition;
-
-    if (preRecordedArgs?.selectedRecordIndex !== undefined) {
-      if (
-        !Number.isInteger(preRecordedArgs.selectedRecordIndex) ||
-        preRecordedArgs.selectedRecordIndex < 0 ||
-        preRecordedArgs.selectedRecordIndex >= relatedData.length
-      ) {
-        throw new InvalidPreRecordedArgsError(
-          `Record index ${preRecordedArgs.selectedRecordIndex} is out of range (0-${
-            relatedData.length - 1
-          })`,
-        );
-      }
-
-      return {
-        relatedData,
-        bestIndex: preRecordedArgs.selectedRecordIndex,
-        suggestedFields: [],
-        relatedSchema,
-      };
-    }
-
+    // The final record stays AI-suggested + user-confirmed — only the source + relation are
+    // pinned deterministically (PRD-471). Index-based record pinning was removed (not revise-safe).
     const suggestedFields = await this.selectRelevantFields(
       relatedSchema,
       this.context.stepDefinition.prompt,

--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -6,9 +6,14 @@ import type { RecordStepStatus } from '../types/validated/step-outcome';
 import { DynamicStructuredTool, HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
 import { z } from 'zod';
 
-import { InvalidAIResponseError, InvalidPreRecordedArgsError, NoRecordsError } from '../errors';
+import {
+  InvalidAIResponseError,
+  InvalidPreRecordedArgsError,
+  NoRecordsError,
+  SourceRecordMissingError,
+} from '../errors';
 import BaseStepExecutor from './base-step-executor';
-import { StepType } from '../types/validated/step-definition';
+import { StepType, WORKFLOW_START_STEP_ID } from '../types/validated/step-definition';
 
 export default abstract class RecordStepExecutor<
   TStep extends StepDefinition = StepDefinition,
@@ -45,6 +50,44 @@ export default abstract class RecordStepExecutor<
     }
 
     return this.selectRecordRef(records, prompt);
+  }
+
+  // Revise-safe source resolution shared by deterministic steps (load-related "Related to",
+  // trigger-action "On record"). The reference is a stable BPMN step id (or the
+  // WORKFLOW_START_STEP_ID sentinel), not a runtime index — so it survives the index shifts a
+  // revision causes (clones keep their step id) and is knowable by the editor at build time.
+  // previousSteps are already restricted to the live path; in a loop the same id can appear more
+  // than once, so we take the most recent occurrence.
+  protected async resolveSourceRecordRef(stepId: string): Promise<RecordRef> {
+    if (stepId === WORKFLOW_START_STEP_ID) {
+      return this.context.baseRecordRef;
+    }
+
+    const matches = this.context.previousSteps.filter(
+      step =>
+        step.stepDefinition.type === StepType.LoadRelatedRecord &&
+        step.stepOutcome.stepId === stepId,
+    );
+    const sourceStep = matches[matches.length - 1];
+
+    if (sourceStep) {
+      const stepExecutions = await this.context.runStore.getStepExecutions(this.context.runId);
+      const execution = this.resolveStepExecution(sourceStep, stepExecutions);
+
+      if (
+        execution?.type === 'load-related-record' &&
+        execution.executionResult !== undefined &&
+        'record' in execution.executionResult
+      ) {
+        return execution.executionResult.record;
+      }
+
+      // The source step exists but loaded nothing → clear "no source record" message (PRD-550),
+      // distinct from a config pointing at a non-existent step.
+      throw new SourceRecordMissingError(sourceStep.stepDefinition.title);
+    }
+
+    throw new InvalidPreRecordedArgsError(`No source record found for step "${stepId}"`);
   }
 
   // Candidate sources for the AI: the base record plus the record each live prior

--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -82,7 +82,7 @@ export default abstract class RecordStepExecutor<
         return execution.executionResult.record;
       }
 
-      // The source step exists but loaded nothing → clear "no source record" message (PRD-550),
+      // The source step exists but loaded nothing → clear "no source record" message,
       // distinct from a config pointing at a non-existent step.
       throw new SourceRecordMissingError(sourceStep.stepDefinition.title);
     }

--- a/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
+++ b/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
@@ -3,6 +3,7 @@ import type {
   LoadRelatedRecordStepExecutionData,
   McpStepExecutionData,
   StepExecutionData,
+  TriggerRecordActionStepExecutionData,
 } from '../../types/step-execution-data';
 
 export default class StepExecutionFormatters {
@@ -16,9 +17,51 @@ export default class StepExecutionFormatters {
         return StepExecutionFormatters.formatMcp(execution as McpStepExecutionData);
       case 'guidance':
         return StepExecutionFormatters.formatGuidance(execution as GuidanceStepExecutionData);
+      case 'trigger-action':
+        return StepExecutionFormatters.formatTriggerAction(
+          execution as TriggerRecordActionStepExecutionData,
+        );
       default:
         return null;
     }
+  }
+
+  // Audit/context summary for a Trigger Action (PRD-513). Critically distinguishes an executed
+  // action from one merely submitted for approval — downstream AI steps must NOT treat a
+  // pending-approval action as if it ran.
+  private static formatTriggerAction(
+    execution: TriggerRecordActionStepExecutionData,
+  ): string | null {
+    const { executionResult } = execution;
+    if (!executionResult || 'skipped' in executionResult) return null;
+
+    const action = execution.executionParams?.displayName ?? 'the action';
+    const submitter = executionResult.submittedBy === 'ai' ? 'AI' : 'the user';
+
+    if (executionResult.submissionOutcome === 'pending-approval') {
+      return `  Submitted action "${action}" for approval (by ${submitter}). It is AWAITING APPROVAL and has NOT been executed — no result is available yet.`;
+    }
+
+    const lines = [`  Triggered action "${action}" (submitted by ${submitter}).`];
+    const aiFilled = executionResult.aiFilledValues;
+
+    if (aiFilled?.length) {
+      lines.push(`  AI pre-filled: ${aiFilled.map(v => v.field).join(', ')}.`);
+
+      // Human-edited fields = those whose submitted value differs from the AI prefill (AI-assisted).
+      const submitted = executionResult.submittedValues;
+
+      if (submitted) {
+        const aiMap = Object.fromEntries(aiFilled.map(v => [v.field, v.value]));
+        const edited = Object.keys(submitted).filter(
+          field => JSON.stringify(submitted[field]) !== JSON.stringify(aiMap[field]),
+        );
+
+        if (edited.length) lines.push(`  Edited by the user before submitting: ${edited.join(', ')}.`);
+      }
+    }
+
+    return lines.join('\n');
   }
 
   private static formatMcp(execution: McpStepExecutionData): string | null {

--- a/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
+++ b/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
@@ -57,7 +57,9 @@ export default class StepExecutionFormatters {
           field => JSON.stringify(submitted[field]) !== JSON.stringify(aiMap[field]),
         );
 
-        if (edited.length) lines.push(`  Edited by the user before submitting: ${edited.join(', ')}.`);
+        if (edited.length) {
+          lines.push(`  Edited by the user before submitting: ${edited.join(', ')}.`);
+        }
       }
     }
 

--- a/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
+++ b/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
@@ -26,7 +26,7 @@ export default class StepExecutionFormatters {
     }
   }
 
-  // Audit/context summary for a Trigger Action (PRD-513). Critically distinguishes an executed
+  // Audit/context summary for a Trigger Action. Critically distinguishes an executed
   // action from one merely submitted for approval — downstream AI steps must NOT treat a
   // pending-approval action as if it ran.
   private static formatTriggerAction(

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -61,7 +61,6 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   }
 
   protected async doExecute(): Promise<StepExecutionResult> {
-    // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<TriggerRecordActionStepExecutionData>(
       this.context.incomingPendingData,
     );
@@ -99,7 +98,6 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       );
     }
 
-    // Branches B & C -- First call
     return this.handleFirstCall();
   }
 
@@ -134,7 +132,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     });
     const hasForm = form.fields.length > 0;
 
-    // Formless action — unchanged behavior: Full AI runs it directly, otherwise pause for the user.
+    // Formless: Full AI executes directly, else pause for the user.
     if (!hasForm) {
       return step.executionType === StepExecutionMode.FullyAutomated
         ? this.executeOnExecutor(target)
@@ -159,8 +157,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       return this.pauseForConfirmation(target, reviewState);
     }
 
-    // Full AI: submit if the AI filled every required field; otherwise fall back to the
-    // exact AI-assisted review state, carrying what was filled.
+    // Full AI: submit if all required fields are filled, else fallback (pause) with what was filled.
     if (!filledForm.canExecute) {
       return this.pauseForConfirmation(target, reviewState);
     }
@@ -251,8 +248,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     const finalFieldNames = new Set(form.fields.map(f => f.name));
     const aiFilledValues = ordered.filter(v => finalFieldNames.has(v.field));
 
-    // Debug trace for support: the net field values actually retained (after drop-stale) + whether
-    // the form is now complete enough to submit. Off by default (Debug level). Client-side log only.
+    // Debug: net retained values + whether the form can execute.
     this.context.logger('Debug', 'AI form-fill: final values', {
       ...this.logCtx,
       aiFilledValues,
@@ -304,11 +300,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       new HumanMessage(`**Request**: ${step.prompt ?? 'Fill the action form.'}`),
     ];
 
-    // Debug trace for support: the inputs the AI fill works from. Off by default (Debug level); a
-    // client turns it on with LOG_LEVEL=Debug to diagnose an under-/mis-filled form. Logged before
-    // the call so it's available even if the AI invocation fails. Client-side log only.
-    // Only the non-redundant parts: the request (instruction), the fields as structured rows, and
-    // the workflow context (record + previous steps) — the static fill rules aren't logged.
+    // Debug: AI form inputs (request, fields, context); logged before the call to trace mis-fills.
     this.context.logger('Debug', 'AI form-fill: context', {
       ...this.logCtx,
       request: step.prompt ?? null,

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -28,13 +28,15 @@ Important rules:
 - Final answer is definitive, you won't receive any other input from the user.
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
 
-const FILL_FORM_SYSTEM_PROMPT = `You are filling out an action form using the data available in the workflow context.
+const FILL_FORM_SYSTEM_PROMPT = `You are filling out an action form using the user's request and the data available in the workflow context.
 
 Important rules:
-- Only fill a field when the workflow context gives you the value with confidence.
-- If you do not have the necessary context for a field, LEAVE IT OUT — never guess or assume.
+- The request is an explicit instruction. When it states a value for a field (e.g. "set the price to 35"), use that exact value — following an explicit instruction is NOT guessing.
+- Otherwise, fill a field only when the workflow context gives you the value with confidence.
+- A field's "current" value is just its existing default; override it when the request asks you to.
+- If neither the request nor the workflow context gives you a field's value, LEAVE IT OUT — never guess or assume.
 - For Enum fields, use exactly one of the allowed values, otherwise leave the field out.
-- Do not invent identifiers, dates, amounts, or file contents.`;
+- Do not invent identifiers, dates, amounts, or file contents that are absent from both the request and the context.`;
 
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -226,8 +226,17 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
 
     // Drop any value whose field no longer exists after the hooks (state drift) — fail-safe.
     const finalFieldNames = new Set(form.fields.map(f => f.name));
+    const aiFilledValues = ordered.filter(v => finalFieldNames.has(v.field));
 
-    return { aiFilledValues: ordered.filter(v => finalFieldNames.has(v.field)), form };
+    // Debug trace for support: the net field values actually retained (after drop-stale) + whether
+    // the form is now complete enough to submit. Off by default (Debug level). Client-side log only.
+    this.context.logger('Debug', 'AI form-fill: final values', {
+      ...this.logCtx,
+      aiFilledValues,
+      canExecute: form.canExecute,
+    });
+
+    return { aiFilledValues, form };
   }
 
   // One AI fill pass: present the current form fields and ask the AI for values it's confident
@@ -262,18 +271,43 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       func: undefined,
     });
 
+    const contextMessage = this.buildContextMessage();
+    const previousStepsMessages = await this.buildPreviousStepsMessages();
     const messages = [
-      this.buildContextMessage(),
-      ...(await this.buildPreviousStepsMessages()),
+      contextMessage,
+      ...previousStepsMessages,
       new SystemMessage(FILL_FORM_SYSTEM_PROMPT),
       new SystemMessage(`Action form fields:\n${fieldLines}`),
       new HumanMessage(`**Request**: ${step.prompt ?? 'Fill the action form.'}`),
     ];
 
+    // Debug trace for support: the inputs the AI fill works from. Off by default (Debug level); a
+    // client turns it on with LOG_LEVEL=Debug to diagnose an under-/mis-filled form. Logged before
+    // the call so it's available even if the AI invocation fails. Client-side log only.
+    // Only the non-redundant parts: the request (instruction), the fields as structured rows, and
+    // the workflow context (record + previous steps) — the static fill rules aren't logged.
+    this.context.logger('Debug', 'AI form-fill: context', {
+      ...this.logCtx,
+      request: step.prompt ?? null,
+      fields: form.fields.map(field => ({
+        name: field.name,
+        type: field.type,
+        required: field.isRequired,
+        current: field.value,
+        ...(field.enumValues?.length ? { allowed: field.enumValues } : {}),
+      })),
+      workflowContext: [contextMessage, ...previousStepsMessages].map(message => message.content),
+    });
+
     const { values } = await this.invokeWithTool<{ values?: Record<string, unknown> }>(
       messages,
       tool,
     );
+
+    this.context.logger('Debug', 'AI form-fill: values returned by the AI', {
+      ...this.logCtx,
+      values: values ?? {},
+    });
 
     return values ?? {};
   }

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -61,6 +61,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   }
 
   protected async doExecute(): Promise<StepExecutionResult> {
+    // Branch A -- Re-entry after pending execution found in RunStore
     const pending = await this.patchAndReloadPendingData<TriggerRecordActionStepExecutionData>(
       this.context.incomingPendingData,
     );
@@ -98,6 +99,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       );
     }
 
+    // Branches B & C -- First call
     return this.handleFirstCall();
   }
 

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -12,10 +12,11 @@ import { DynamicStructuredTool, HumanMessage, SystemMessage } from '@forestadmin
 import { z } from 'zod';
 
 import {
+  ActionFormValidationError,
   ActionNotFoundError,
+  ActionRequiresApprovalError,
   NoActionsError,
   StepStateError,
-  UnsupportedActionFormError,
 } from '../errors';
 import RecordStepExecutor from './record-step-executor';
 import { StepExecutionMode } from '../types/validated/step-definition';
@@ -145,20 +146,42 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       return this.pauseForConfirmation(target, { fields: form.fields, aiFilledValues: [] });
     }
 
-    // Full AI on a form is implemented in PRD-512 (fill + submit). Until then, unsupported.
-    if (step.executionType === StepExecutionMode.FullyAutomated) {
-      throw new UnsupportedActionFormError(target.displayName);
-    }
-
-    // AI-assisted (PRD-511): AI pre-fills what it can from the workflow context, then pause for
-    // the user to review/edit/submit natively.
+    // AI-assisted + Full AI share the same fill loop; only the exit differs.
     const { aiFilledValues, form: filledForm } = await this.fillFormWithAi(
       selectedRecordRef,
       target.name,
       form,
     );
+    const reviewState = { fields: filledForm.fields, aiFilledValues };
 
-    return this.pauseForConfirmation(target, { fields: filledForm.fields, aiFilledValues });
+    // AI-assisted (PRD-511): pause for the user to review/edit/submit natively.
+    if (step.executionType !== StepExecutionMode.FullyAutomated) {
+      return this.pauseForConfirmation(target, reviewState);
+    }
+
+    // Full AI (PRD-512): submit if the AI filled every required field; otherwise fall back to the
+    // exact AI-assisted review state, carrying what was filled.
+    if (!filledForm.canExecute) {
+      return this.pauseForConfirmation(target, reviewState);
+    }
+
+    const values = Object.fromEntries(aiFilledValues.map(v => [v.field, v.value]));
+
+    try {
+      return await this.executeOnExecutor(target, { values, aiFilledValues });
+    } catch (error) {
+      // Validation rejection or an approval-gated action → not a hard failure: pause as
+      // AI-assisted so a human can finish/submit natively. Plain permission 403, infra errors,
+      // etc. propagate as a real step error (a reviewing human couldn't fix those).
+      if (
+        error instanceof ActionFormValidationError ||
+        error instanceof ActionRequiresApprovalError
+      ) {
+        return this.pauseForConfirmation(target, reviewState);
+      }
+
+      throw error;
+    }
   }
 
   // Pause the step awaiting user confirmation. For form-bearing actions, `form` carries the native
@@ -313,7 +336,12 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   }
 
   /** Branch B — executor runs the action via the audited agent, then persists the result. */
-  private async executeOnExecutor(target: ActionTarget): Promise<StepExecutionResult> {
+  private async executeOnExecutor(
+    target: ActionTarget,
+    // Form submission (Full AI, PRD-512): the AI-filled values to submit + the ordered prefill for
+    // the audit trail. Omitted for a formless action (executor just triggers it).
+    form?: { values: Record<string, unknown>; aiFilledValues: AiFilledFormValue[] },
+  ): Promise<StepExecutionResult> {
     const { selectedRecordRef, displayName, name } = target;
 
     const actionResult = await this.context.agent.executeAction(
@@ -321,6 +349,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         collection: selectedRecordRef.collectionName,
         action: name,
         id: selectedRecordRef.recordId,
+        ...(form && { values: form.values }),
       },
       {
         beforeCall: () =>
@@ -337,7 +366,16 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       type: 'trigger-action',
       stepIndex: this.context.stepIndex,
       executionParams: { displayName, name },
-      executionResult: { success: true, actionResult },
+      executionResult: {
+        success: true,
+        actionResult,
+        // Form-bearing Full AI: record what the executor submitted (PRD-512/513).
+        ...(form && {
+          submissionOutcome: 'executed',
+          submittedValues: form.values,
+          ...(form.aiFilledValues.length && { aiFilledValues: form.aiFilledValues }),
+        }),
+      },
       selectedRecordRef,
       idempotencyPhase: 'done',
     });

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -1,5 +1,10 @@
+import type { ActionForm, ActionFormField } from '../ports/agent-port';
 import type { StepExecutionResult } from '../types/execution-context';
-import type { ActionRef, TriggerRecordActionStepExecutionData } from '../types/step-execution-data';
+import type {
+  ActionRef,
+  AiFilledFormValue,
+  TriggerRecordActionStepExecutionData,
+} from '../types/step-execution-data';
 import type { ActionSchema, CollectionSchema, RecordRef } from '../types/validated/collection';
 import type { TriggerActionStepDefinition } from '../types/validated/step-definition';
 
@@ -22,6 +27,14 @@ Important rules:
 - Be precise: only trigger the action directly relevant to the request.
 - Final answer is definitive, you won't receive any other input from the user.
 - Do not refer to yourself as "I" in the response, use a passive formulation instead.`;
+
+const FILL_FORM_SYSTEM_PROMPT = `You are filling out an action form using the data available in the workflow context.
+
+Important rules:
+- Only fill a field when the workflow context gives you the value with confidence.
+- If you do not have the necessary context for a field, LEAVE IT OUT — never guess or assume.
+- For Enum fields, use exactly one of the allowed values, otherwise leave the field out.
+- Do not invent identifiers, dates, amounts, or file contents.`;
 
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
@@ -56,9 +69,16 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         async exec => {
           const { selectedRecordRef, pendingData, userConfirmation } = exec;
 
-          // The frontend executes the action itself and posts the result back.
-          // A confirmed step without actionResult is a broken frontend contract.
-          if (!pendingData || !userConfirmation || !('actionResult' in userConfirmation)) {
+          // The frontend executes the action natively and posts the result back. A confirmed step
+          // must carry an actionResult — UNLESS the submission only created an approval request
+          // (pending-approval), in which case no result exists yet (PRD-511/520).
+          const isPendingApproval = userConfirmation?.submissionOutcome === 'pending-approval';
+
+          if (
+            !pendingData ||
+            !userConfirmation ||
+            (!('actionResult' in userConfirmation) && !isPendingApproval)
+          ) {
             throw new StepStateError(
               `Frontend confirmed action but did not provide actionResult ` +
                 `(run "${this.context.runId}", step ${this.context.stepIndex})`,
@@ -71,7 +91,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
             name: pendingData.name,
           };
 
-          return this.saveFrontendResult(target, userConfirmation.actionResult, exec);
+          return this.saveFrontendResult(target, exec);
         },
       );
     }
@@ -104,29 +124,156 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       name: action.name,
     };
 
-    // Branch B -- fully automated: executor runs the action itself, so it cannot
-    // handle forms (no UI to fill them). Reject form-bearing actions here. When the
-    // frontend is in the loop (Branch C), it handles the form natively so no check.
-    if (step.executionType === StepExecutionMode.FullyAutomated) {
-      const { hasForm } = await this.context.agent.getActionFormInfo({
-        collection: selectedRecordRef.collectionName,
-        action: target.name,
-        id: selectedRecordRef.recordId,
-      });
-      if (hasForm) throw new UnsupportedActionFormError(target.displayName);
+    const form = await this.context.agent.getActionForm({
+      collection: selectedRecordRef.collectionName,
+      action: target.name,
+      id: selectedRecordRef.recordId,
+    });
+    const hasForm = form.fields.length > 0;
 
-      return this.executeOnExecutor(target);
+    // Formless action — unchanged behavior: Full AI runs it directly, otherwise pause for the user.
+    if (!hasForm) {
+      return step.executionType === StepExecutionMode.FullyAutomated
+        ? this.executeOnExecutor(target)
+        : this.pauseForConfirmation(target);
     }
 
-    // Branch C -- Awaiting confirmation (frontend executes the action, including forms)
+    // Manual (PRD-511): pause with the native form, NO AI pre-fill.
+    if (step.executionType === StepExecutionMode.Manual) {
+      return this.pauseForConfirmation(target, { fields: form.fields, aiFilledValues: [] });
+    }
+
+    // Full AI on a form is implemented in PRD-512 (fill + submit). Until then, unsupported.
+    if (step.executionType === StepExecutionMode.FullyAutomated) {
+      throw new UnsupportedActionFormError(target.displayName);
+    }
+
+    // AI-assisted (PRD-511): AI pre-fills what it can from the workflow context, then pause for
+    // the user to review/edit/submit natively.
+    const { aiFilledValues, form: filledForm } = await this.fillFormWithAi(
+      selectedRecordRef,
+      target.name,
+      form,
+    );
+
+    return this.pauseForConfirmation(target, { fields: filledForm.fields, aiFilledValues });
+  }
+
+  // Pause the step awaiting user confirmation. For form-bearing actions, `form` carries the native
+  // form fields + the ordered AI prefill the front replays sequentially (PRD-511).
+  private async pauseForConfirmation(
+    target: ActionTarget,
+    form?: { fields: ActionFormField[]; aiFilledValues: AiFilledFormValue[] },
+  ): Promise<StepExecutionResult> {
     await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'trigger-action',
       stepIndex: this.context.stepIndex,
-      pendingData: { displayName: target.displayName, name: target.name },
+      pendingData: { displayName: target.displayName, name: target.name, ...(form && { form }) },
       selectedRecordRef: target.selectedRecordRef,
     });
 
     return this.buildOutcomeResult({ status: 'awaiting-input' });
+  }
+
+  // Shared AI form-fill loop (PRD-511, reused by Full AI in PRD-512). Iteratively asks the AI to
+  // fill the fields it has context for (leave-empty-if-unsure), re-applying after each pass so
+  // change hooks reveal dependent fields. Bounded by max iterations + no-progress detection so an
+  // oscillating dynamic form can't loop forever. Returns the values in fill order + the final form.
+  private async fillFormWithAi(
+    recordRef: RecordRef,
+    action: string,
+    initialForm: ActionForm,
+  ): Promise<{ aiFilledValues: AiFilledFormValue[]; form: ActionForm }> {
+    const MAX_ITERATIONS = 3;
+    const accumulator: Record<string, unknown> = {};
+    const ordered: AiFilledFormValue[] = [];
+    let form = initialForm;
+
+    for (let i = 0; i < MAX_ITERATIONS; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const aiValues = await this.askAiToFillForm(form);
+      let progressed = false;
+
+      for (const [field, value] of Object.entries(aiValues)) {
+        const isEmpty = value === undefined || value === null || value === '';
+        const exists = form.fields.some(f => f.name === field);
+        const isNew = accumulator[field] !== value;
+
+        // Keep only non-empty values for fields that still exist and weren't already set.
+        if (!isEmpty && exists && isNew) {
+          accumulator[field] = value;
+          ordered.push({ field, value });
+          progressed = true;
+        }
+      }
+
+      // No-progress guard: the AI added nothing new this pass → it has no more context to offer.
+      if (!progressed) break;
+
+      // Re-apply so change hooks reveal/adjust dependent fields for the next pass.
+      // eslint-disable-next-line no-await-in-loop
+      form = await this.context.agent.getActionForm({
+        collection: recordRef.collectionName,
+        action,
+        id: recordRef.recordId,
+        values: accumulator,
+      });
+
+      if (form.canExecute) break;
+    }
+
+    // Drop any value whose field no longer exists after the hooks (state drift) — fail-safe.
+    const finalFieldNames = new Set(form.fields.map(f => f.name));
+
+    return { aiFilledValues: ordered.filter(v => finalFieldNames.has(v.field)), form };
+  }
+
+  // One AI fill pass: present the current form fields and ask the AI for values it's confident
+  // about. The strict leave-empty rule (never guess) lives in the prompt + tool description.
+  private async askAiToFillForm(form: ActionForm): Promise<Record<string, unknown>> {
+    const { stepDefinition: step } = this.context;
+    const fieldLines = form.fields
+      .map(field => {
+        const parts = [`- ${field.name} (${field.type}${field.isRequired ? ', required' : ''})`];
+        if (field.enumValues?.length) parts.push(`allowed: ${field.enumValues.join(', ')}`);
+
+        if (field.value !== undefined && field.value !== null) {
+          parts.push(`current: ${JSON.stringify(field.value)}`);
+        }
+
+        return parts.join(' — ');
+      })
+      .join('\n');
+
+    const tool = new DynamicStructuredTool({
+      name: 'fill_action_form',
+      description:
+        'Provide values for the action form fields you have enough context to fill. ' +
+        'Return a `values` object keyed by field name. Leave a field OUT entirely if you are ' +
+        'not sure — never guess or assume. For Enum fields use exactly one of the allowed values.',
+      schema: z.object({
+        values: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe('Field name → value, only for fields you are confident about.'),
+      }),
+      func: undefined,
+    });
+
+    const messages = [
+      this.buildContextMessage(),
+      ...(await this.buildPreviousStepsMessages()),
+      new SystemMessage(FILL_FORM_SYSTEM_PROMPT),
+      new SystemMessage(`Action form fields:\n${fieldLines}`),
+      new HumanMessage(`**Request**: ${step.prompt ?? 'Fill the action form.'}`),
+    ];
+
+    const { values } = await this.invokeWithTool<{ values?: Record<string, unknown> }>(
+      messages,
+      tool,
+    );
+
+    return values ?? {};
   }
 
   /** Branch B — executor runs the action via the audited agent, then persists the result. */
@@ -162,20 +309,33 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     return this.buildOutcomeResult({ status: 'success' });
   }
 
-  /** Branch A — the frontend executed the action; executor only persists the result it sent. */
+  /**
+   * Branch A — the frontend executed the action natively; the executor persists what it reported.
+   * Records the submission outcome (executed vs pending-approval), the submitted values, and the
+   * AI prefill (from the stored pending payload) for the audit trail / downstream-AI context.
+   */
   private async saveFrontendResult(
     target: ActionTarget,
-    actionResult: unknown,
     existingExecution: TriggerRecordActionStepExecutionData,
   ): Promise<StepExecutionResult> {
     const { selectedRecordRef, displayName, name } = target;
+    const confirmation = existingExecution.userConfirmation;
+    const submissionOutcome = confirmation?.submissionOutcome ?? 'executed';
+    const aiFilledValues = existingExecution.pendingData?.form?.aiFilledValues;
 
     await this.context.runStore.saveStepExecution(this.context.runId, {
       ...existingExecution,
       type: 'trigger-action',
       stepIndex: this.context.stepIndex,
       executionParams: { displayName, name },
-      executionResult: { success: true, actionResult },
+      executionResult: {
+        success: true,
+        // No action result exists yet when the submission only created an approval request.
+        ...(submissionOutcome === 'executed' && { actionResult: confirmation?.actionResult }),
+        submissionOutcome,
+        ...(confirmation?.submittedValues && { submittedValues: confirmation.submittedValues }),
+        ...(aiFilledValues?.length && { aiFilledValues }),
+      },
       selectedRecordRef,
     });
 

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -83,13 +83,12 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   private async handleFirstCall(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const { preRecordedArgs } = step;
-    const records = await this.getAvailableRecordRefs();
 
-    const selectedRecordRef = await this.resolveRecordRef(
-      records,
-      step.prompt,
-      preRecordedArgs?.selectedRecordStepIndex,
-    );
+    // "On record" pins the source by stable step id (revise-safe); legacy steps without it fall
+    // back to AI record selection among the available source records (PRD-469).
+    const selectedRecordRef = preRecordedArgs?.selectedRecordStepId
+      ? await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepId)
+      : await this.resolveRecordRef(await this.getAvailableRecordRefs(), step.prompt);
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const recordedAction = preRecordedArgs?.actionName;
     const actionName = recordedAction ?? (await this.selectAction(schema, step.prompt)).actionName;

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -74,7 +74,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
 
           // The frontend executes the action natively and posts the result back. A confirmed step
           // must carry an actionResult — UNLESS the submission only created an approval request
-          // (pending-approval), in which case no result exists yet (PRD-511/520).
+          // (pending-approval), in which case no result exists yet.
           const isPendingApproval = userConfirmation?.submissionOutcome === 'pending-approval';
 
           if (
@@ -108,7 +108,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     const { preRecordedArgs } = step;
 
     // "On record" pins the source by stable step id (revise-safe); legacy steps without it fall
-    // back to AI record selection among the available source records (PRD-469).
+    // back to AI record selection among the available source records.
     const selectedRecordRef = preRecordedArgs?.selectedRecordStepId
       ? await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepId)
       : await this.resolveRecordRef(await this.getAvailableRecordRefs(), step.prompt);
@@ -141,7 +141,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         : this.pauseForConfirmation(target);
     }
 
-    // Manual (PRD-511): pause with the native form, NO AI pre-fill.
+    // Manual: pause with the native form, NO AI pre-fill.
     if (step.executionType === StepExecutionMode.Manual) {
       return this.pauseForConfirmation(target, { fields: form.fields, aiFilledValues: [] });
     }
@@ -154,12 +154,12 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     );
     const reviewState = { fields: filledForm.fields, aiFilledValues };
 
-    // AI-assisted (PRD-511): pause for the user to review/edit/submit natively.
+    // AI-assisted: pause for the user to review/edit/submit natively.
     if (step.executionType !== StepExecutionMode.FullyAutomated) {
       return this.pauseForConfirmation(target, reviewState);
     }
 
-    // Full AI (PRD-512): submit if the AI filled every required field; otherwise fall back to the
+    // Full AI: submit if the AI filled every required field; otherwise fall back to the
     // exact AI-assisted review state, carrying what was filled.
     if (!filledForm.canExecute) {
       return this.pauseForConfirmation(target, reviewState);
@@ -185,7 +185,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   }
 
   // Pause the step awaiting user confirmation. For form-bearing actions, `form` carries the native
-  // form fields + the ordered AI prefill the front replays sequentially (PRD-511).
+  // form fields + the ordered AI prefill the front replays sequentially.
   private async pauseForConfirmation(
     target: ActionTarget,
     form?: { fields: ActionFormField[]; aiFilledValues: AiFilledFormValue[] },
@@ -200,7 +200,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     return this.buildOutcomeResult({ status: 'awaiting-input' });
   }
 
-  // Shared AI form-fill loop (PRD-511, reused by Full AI in PRD-512). Iteratively asks the AI to
+  // Shared AI form-fill loop (reused by Full AI). Iteratively asks the AI to
   // fill the fields it has context for (leave-empty-if-unsure), re-applying after each pass so
   // change hooks reveal dependent fields. Bounded by max iterations + no-progress detection so an
   // oscillating dynamic form can't loop forever. Returns the values in fill order + the final form.
@@ -338,7 +338,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   /** Branch B — executor runs the action via the audited agent, then persists the result. */
   private async executeOnExecutor(
     target: ActionTarget,
-    // Form submission (Full AI, PRD-512): the AI-filled values to submit + the ordered prefill for
+    // Form submission (Full AI): the AI-filled values to submit + the ordered prefill for
     // the audit trail. Omitted for a formless action (executor just triggers it).
     form?: { values: Record<string, unknown>; aiFilledValues: AiFilledFormValue[] },
   ): Promise<StepExecutionResult> {
@@ -369,7 +369,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       executionResult: {
         success: true,
         actionResult,
-        // Form-bearing Full AI: record what the executor submitted (PRD-512/513).
+        // Form-bearing Full AI: record what the executor submitted.
         ...(form && {
           submissionOutcome: 'executed',
           submittedBy: 'ai',
@@ -408,7 +408,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         // No action result exists yet when the submission only created an approval request.
         ...(submissionOutcome === 'executed' && { actionResult: confirmation?.actionResult }),
         submissionOutcome,
-        // AI-assisted = the human submitted natively (PRD-513 audit).
+        // AI-assisted = the human submitted natively (audit).
         submittedBy: 'user',
         ...(confirmation?.submittedValues && { submittedValues: confirmation.submittedValues }),
         ...(aiFilledValues?.length && { aiFilledValues }),

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -372,6 +372,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         // Form-bearing Full AI: record what the executor submitted (PRD-512/513).
         ...(form && {
           submissionOutcome: 'executed',
+          submittedBy: 'ai',
           submittedValues: form.values,
           ...(form.aiFilledValues.length && { aiFilledValues: form.aiFilledValues }),
         }),
@@ -407,6 +408,8 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         // No action result exists yet when the submission only created an approval request.
         ...(submissionOutcome === 'executed' && { actionResult: confirmation?.actionResult }),
         submissionOutcome,
+        // AI-assisted = the human submitted natively (PRD-513 audit).
+        submittedBy: 'user',
         ...(confirmation?.submittedValues && { submittedValues: confirmation.submittedValues }),
         ...(aiFilledValues?.length && { aiFilledValues }),
       },

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -20,7 +20,7 @@ const triggerActionPatchSchema = z
     // presence check lives in the step-executor so a descriptive StepStateError can
     // name the runId/stepIndex — not achievable from inside a zod schema.
     actionResult: z.unknown().optional(),
-    // PRD-511/520: the front executes the action natively, so it self-reports the final form
+    // The front executes the action natively, so it self-reports the final form
     // values it submitted (lets the executor diff against the AI prefill for the audit trail).
     submittedValues: z.record(z.string(), z.unknown()).optional(),
     // Whether the native submit actually executed the action, or only created an approval request

--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -20,6 +20,12 @@ const triggerActionPatchSchema = z
     // presence check lives in the step-executor so a descriptive StepStateError can
     // name the runId/stepIndex — not achievable from inside a zod schema.
     actionResult: z.unknown().optional(),
+    // PRD-511/520: the front executes the action natively, so it self-reports the final form
+    // values it submitted (lets the executor diff against the AI prefill for the audit trail).
+    submittedValues: z.record(z.string(), z.unknown()).optional(),
+    // Whether the native submit actually executed the action, or only created an approval request
+    // (non-blocking): downstream AI steps must be told an awaiting-approval action did NOT run.
+    submissionOutcome: z.enum(['executed', 'pending-approval']).optional(),
   })
   .strict();
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -17,8 +17,6 @@ export type GetRelatedDataQuery = {
   // record ID and restore original field names without consulting any cache.
   relatedSchema: CollectionSchema;
   fields?: string[];
-  // Build-time filter (PRD-553) forwarded verbatim to the agent. Port stays agnostic of the
-  // filter shape; the adapter casts it to the agent-client's conditionTree type.
   filters?: unknown;
 } & Limit;
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -17,6 +17,9 @@ export type GetRelatedDataQuery = {
   // record ID and restore original field names without consulting any cache.
   relatedSchema: CollectionSchema;
   fields?: string[];
+  // Build-time filter (PRD-553) forwarded verbatim to the agent. Port stays agnostic of the
+  // filter shape; the adapter casts it to the agent-client's conditionTree type.
+  filters?: unknown;
 } & Limit;
 
 // xToOne relations (BelongsTo / HasOne) — the agent does not serve

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -38,7 +38,44 @@ export type GetSingleRelatedDataQuery = {
   fields?: string[];
 };
 
-export type ExecuteActionQuery = { collection: string; action: string; id?: Id[] };
+export type ExecuteActionQuery = {
+  collection: string;
+  action: string;
+  id?: Id[];
+  // Pre-filled form values (PRD-509). Set on the form before execution, going through the agent's
+  // normal server-side validation — no bypass. Omitted for formless actions.
+  values?: Record<string, unknown>;
+};
+
+export type GetActionFormQuery = {
+  collection: string;
+  action: string;
+  id: Id[];
+  // Optional values to apply before reading the form back (fires the change hooks so dependent
+  // fields appear/update). Soft-applied: unknown fields are reported in `skippedFields`.
+  values?: Record<string, unknown>;
+};
+
+// One field of an action form, flattened for the executor/AI (PRD-509). Mirrors the MCP
+// get-action-form tool's field shape.
+export type ActionFormField = {
+  name: string;
+  type: string;
+  value?: unknown;
+  isRequired: boolean;
+  // Allowed values for an Enum field — the AI must pick one of these or leave the field empty.
+  enumValues?: string[];
+};
+
+export type ActionForm = {
+  fields: ActionFormField[];
+  // True when every required field has a value (the agent-client form state's completeness check).
+  canExecute: boolean;
+  // Required fields still missing a value (empty when canExecute is true).
+  requiredFields: string[];
+  // Fields from `values` that no longer exist in the form (dropped by dynamic-form change hooks).
+  skippedFields: string[];
+};
 
 export type GetActionFormInfoQuery = { collection: string; action: string; id: Id[] };
 
@@ -63,6 +100,9 @@ export interface AgentPort {
   // Old Ruby agents with hooks.load=false return 404; agent-client falls back to the fields
   // passed via ActionEndpointsByCollection (populated from the orchestrator's schema).
   getActionFormInfo(query: GetActionFormInfoQuery, user: StepUser): Promise<{ hasForm: boolean }>;
+  // Full form structure for AI form-filling (PRD-509): field list (types, required, enum options),
+  // completeness (canExecute / requiredFields), and any values dropped by change hooks.
+  getActionForm(query: GetActionFormQuery, user: StepUser): Promise<ActionForm>;
   // Startup healthcheck. Throws AgentProbeError on network error, timeout, or non-2xx.
   // JWT is not verified here — it's validated naturally when the first step runs.
   probe(): Promise<void>;

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -40,7 +40,7 @@ export type ExecuteActionQuery = {
   collection: string;
   action: string;
   id?: Id[];
-  // Pre-filled form values (PRD-509). Set on the form before execution, going through the agent's
+  // Pre-filled form values. Set on the form before execution, going through the agent's
   // normal server-side validation — no bypass. Omitted for formless actions.
   values?: Record<string, unknown>;
 };
@@ -54,7 +54,7 @@ export type GetActionFormQuery = {
   values?: Record<string, unknown>;
 };
 
-// One field of an action form, flattened for the executor/AI (PRD-509). Mirrors the MCP
+// One field of an action form, flattened for the executor/AI. Mirrors the MCP
 // get-action-form tool's field shape.
 export type ActionFormField = {
   name: string;
@@ -98,7 +98,7 @@ export interface AgentPort {
   // Old Ruby agents with hooks.load=false return 404; agent-client falls back to the fields
   // passed via ActionEndpointsByCollection (populated from the orchestrator's schema).
   getActionFormInfo(query: GetActionFormInfoQuery, user: StepUser): Promise<{ hasForm: boolean }>;
-  // Full form structure for AI form-filling (PRD-509): field list (types, required, enum options),
+  // Full form structure for AI form-filling: field list (types, required, enum options),
   // completeness (canExecute / requiredFields), and any values dropped by change hooks.
   getActionForm(query: GetActionFormQuery, user: StepUser): Promise<ActionForm>;
   // Startup healthcheck. Throws AgentProbeError on network error, timeout, or non-2xx.

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -81,14 +81,14 @@ export interface ActionRef {
   displayName: string;
 }
 
-// One AI-prefilled form value (PRD-511). Kept as an ORDERED list (not a map) so the front can
+// One AI-prefilled form value. Kept as an ORDERED list (not a map) so the front can
 // replay it sequentially — setting a field fires its change hook, which may reveal dependent fields.
 export interface AiFilledFormValue {
   field: string;
   value: unknown;
 }
 
-// Pending payload for a form-bearing Trigger Action paused for review (PRD-511). `form` is absent
+// Pending payload for a form-bearing Trigger Action paused for review. `form` is absent
 // for formless actions and for Manual mode (no AI prefill at all).
 export interface TriggerActionPendingData extends ActionRef {
   form?: {
@@ -97,7 +97,7 @@ export interface TriggerActionPendingData extends ActionRef {
   };
 }
 
-// Submission outcome reported by the native front (PRD-511/520): `executed` = the action ran and a
+// Submission outcome reported by the native front: `executed` = the action ran and a
 // result exists; `pending-approval` = the submit only created an approval request (no result yet).
 export type TriggerActionSubmissionOutcome = 'executed' | 'pending-approval';
 
@@ -118,12 +118,12 @@ export interface TriggerRecordActionStepExecutionData
         success: true;
         // Absent when submissionOutcome is 'pending-approval' (no result exists yet).
         actionResult?: unknown;
-        // Defaults to 'executed' semantics when absent (formless / legacy flows). PRD-511/520.
+        // Defaults to 'executed' semantics when absent (formless / legacy flows).
         submissionOutcome?: TriggerActionSubmissionOutcome;
-        // Final values the front submitted + the ordered AI prefill — PRD-513 audit (human-edit diff).
+        // Final values the front submitted + the ordered AI prefill — audit (human-edit diff).
         submittedValues?: Record<string, unknown>;
         aiFilledValues?: AiFilledFormValue[];
-        // Who submitted the action (PRD-513 audit): 'ai' = Full AI (executor), 'user' = AI-assisted
+        // Who submitted the action (audit): 'ai' = Full AI (executor), 'user' = AI-assisted
         // (human via the native front). Absent for formless/legacy flows.
         submittedBy?: 'ai' | 'user';
       }

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -123,6 +123,9 @@ export interface TriggerRecordActionStepExecutionData
         // Final values the front submitted + the ordered AI prefill — PRD-513 audit (human-edit diff).
         submittedValues?: Record<string, unknown>;
         aiFilledValues?: AiFilledFormValue[];
+        // Who submitted the action (PRD-513 audit): 'ai' = Full AI (executor), 'user' = AI-assisted
+        // (human via the native front). Absent for formless/legacy flows.
+        submittedBy?: 'ai' | 'user';
       }
     | { skipped: true };
   pendingData?: TriggerActionPendingData;

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -1,3 +1,4 @@
+import type { ActionFormField } from '../ports/agent-port';
 import type { RecordId, RecordRef } from './validated/collection';
 import type {
   LoadRelatedRecordConfirmation,
@@ -80,6 +81,26 @@ export interface ActionRef {
   displayName: string;
 }
 
+// One AI-prefilled form value (PRD-511). Kept as an ORDERED list (not a map) so the front can
+// replay it sequentially — setting a field fires its change hook, which may reveal dependent fields.
+export interface AiFilledFormValue {
+  field: string;
+  value: unknown;
+}
+
+// Pending payload for a form-bearing Trigger Action paused for review (PRD-511). `form` is absent
+// for formless actions and for Manual mode (no AI prefill at all).
+export interface TriggerActionPendingData extends ActionRef {
+  form?: {
+    fields: ActionFormField[];
+    aiFilledValues: AiFilledFormValue[];
+  };
+}
+
+// Submission outcome reported by the native front (PRD-511/520): `executed` = the action ran and a
+// result exists; `pending-approval` = the submit only created an approval request (no result yet).
+export type TriggerActionSubmissionOutcome = 'executed' | 'pending-approval';
+
 // Intentionally separate from ActionRef/FieldRef: expected to gain relation-specific
 // fields (e.g. relationType) in a future iteration.
 export interface RelationRef {
@@ -92,8 +113,19 @@ export interface TriggerRecordActionStepExecutionData
     WithUserConfirmation<TriggerActionConfirmation> {
   type: 'trigger-action';
   executionParams?: ActionRef;
-  executionResult?: { success: true; actionResult: unknown } | { skipped: true };
-  pendingData?: ActionRef;
+  executionResult?:
+    | {
+        success: true;
+        // Absent when submissionOutcome is 'pending-approval' (no result exists yet).
+        actionResult?: unknown;
+        // Defaults to 'executed' semantics when absent (formless / legacy flows). PRD-511/520.
+        submissionOutcome?: TriggerActionSubmissionOutcome;
+        // Final values the front submitted + the ordered AI prefill — PRD-513 audit (human-edit diff).
+        submittedValues?: Record<string, unknown>;
+        aiFilledValues?: AiFilledFormValue[];
+      }
+    | { skipped: true };
+  pendingData?: TriggerActionPendingData;
   selectedRecordRef: RecordRef;
 }
 

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -74,7 +74,7 @@ export type UpdateRecordStepDefinition = z.infer<typeof UpdateRecordStepDefiniti
 export const TriggerActionStepDefinitionSchema = z.object({
   ...sharedFields,
   type: z.literal(StepType.TriggerAction),
-  // PRD-511: a form-bearing action can be Manual (pause, no AI prefill), AI-assisted
+  // A form-bearing action can be Manual (pause, no AI prefill), AI-assisted
   // (AutomatedWithConfirmation) or Full AI (FullyAutomated). NO `.catch` — coercing a `manual`
   // value to AutomatedWithConfirmation would silently opt the builder back into AI prefill.
   executionType: z
@@ -85,7 +85,7 @@ export const TriggerActionStepDefinitionSchema = z.object({
       /**
        * "On record" — the source record the action is triggered on, referenced by the stable BPMN
        * step id of the previous Load Related Record step that loaded it, or WORKFLOW_START_STEP_ID
-       * for the trigger record. Stable across revisions, unlike the runtime stepIndex (PRD-469).
+       * for the trigger record. Stable across revisions, unlike the runtime stepIndex.
        */
       selectedRecordStepId: z.string().optional(),
       /** Technical name of the action to trigger */

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -106,6 +106,12 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
       selectedRecordStepId: z.string().optional(),
       /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
+      /**
+       * Build-time filter narrowing the candidate records on a 1–n relation (PRD-553). Forest's
+       * plain conditionTree, forwarded verbatim to the agent (which validates it at query time) —
+       * kept loose here since it's trusted build config, not executor-validated input.
+       */
+      filters: z.unknown().optional(),
     })
     .optional(),
 });

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -74,10 +74,12 @@ export type UpdateRecordStepDefinition = z.infer<typeof UpdateRecordStepDefiniti
 export const TriggerActionStepDefinitionSchema = z.object({
   ...sharedFields,
   type: z.literal(StepType.TriggerAction),
+  // PRD-511: a form-bearing action can be Manual (pause, no AI prefill), AI-assisted
+  // (AutomatedWithConfirmation) or Full AI (FullyAutomated). NO `.catch` — coercing a `manual`
+  // value to AutomatedWithConfirmation would silently opt the builder back into AI prefill.
   executionType: z
-    .enum([AutomatedWithConfirmation, FullyAutomated])
-    .default(AutomatedWithConfirmation)
-    .catch(AutomatedWithConfirmation),
+    .enum([Manual, AutomatedWithConfirmation, FullyAutomated])
+    .default(AutomatedWithConfirmation),
   preRecordedArgs: z
     .object({
       /**

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -97,10 +97,10 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
     .catch(AutomatedWithConfirmation),
   preRecordedArgs: z
     .object({
+      /** "Related to" — the source record, by step index */
       selectedRecordStepIndex: z.number().int().optional(),
-      /** Technical name of the relation to follow */
+      /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
-      selectedRecordIndex: z.number().int().optional(),
     })
     .optional(),
 });

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -97,14 +97,22 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
     .catch(AutomatedWithConfirmation),
   preRecordedArgs: z
     .object({
-      /** "Related to" — the source record, by step index */
-      selectedRecordStepIndex: z.number().int().optional(),
+      /**
+       * "Related to" — the source record, referenced by the stable BPMN step id of the previous
+       * Load Related Record step that loaded it, or WORKFLOW_START_STEP_ID for the trigger record.
+       * Stable across revisions (clones keep the id) and known at build time (unlike the runtime
+       * stepIndex), so the editor can write it deterministically.
+       */
+      selectedRecordStepId: z.string().optional(),
       /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
     })
     .optional(),
 });
 export type LoadRelatedRecordStepDefinition = z.infer<typeof LoadRelatedRecordStepDefinitionSchema>;
+
+/** Sentinel "Related to" reference for the record the workflow was triggered on (the base record). */
+export const WORKFLOW_START_STEP_ID = 'workflow-start';
 
 export const McpStepDefinitionSchema = z.object({
   ...sharedFields,

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -80,7 +80,12 @@ export const TriggerActionStepDefinitionSchema = z.object({
     .catch(AutomatedWithConfirmation),
   preRecordedArgs: z
     .object({
-      selectedRecordStepIndex: z.number().int().optional(),
+      /**
+       * "On record" — the source record the action is triggered on, referenced by the stable BPMN
+       * step id of the previous Load Related Record step that loaded it, or WORKFLOW_START_STEP_ID
+       * for the trigger record. Stable across revisions, unlike the runtime stepIndex (PRD-469).
+       */
+      selectedRecordStepId: z.string().optional(),
       /** Technical name of the action to trigger */
       actionName: z.string().optional(),
     })

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -106,11 +106,7 @@ export const LoadRelatedRecordStepDefinitionSchema = z.object({
       selectedRecordStepId: z.string().optional(),
       /** "From collection" — the relation to follow (technical name) */
       relationName: z.string().optional(),
-      /**
-       * Build-time filter narrowing the candidate records on a 1–n relation (PRD-553). Forest's
-       * plain conditionTree, forwarded verbatim to the agent (which validates it at query time) —
-       * kept loose here since it's trusted build config, not executor-validated input.
-       */
+      /** 1–n relation filter (conditionTree), forwarded verbatim; loosely typed as it's trusted config the agent validates. */
       filters: z.unknown().optional(),
     })
     .optional(),

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -4,7 +4,13 @@ import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-clien
 import jsonwebtoken from 'jsonwebtoken';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
-import { AgentPortError, AgentProbeError, RecordNotFoundError } from '../../src/errors';
+import {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  AgentPortError,
+  AgentProbeError,
+  RecordNotFoundError,
+} from '../../src/errors';
 import SchemaCache from '../../src/schema-cache';
 
 jest.mock('@forestadmin/agent-client', () => ({
@@ -20,7 +26,13 @@ const mockedIs404Error = HttpRequester.is404Error as jest.MockedFunction<
 >;
 
 function createMockClient() {
-  const mockAction = { execute: jest.fn(), getFields: jest.fn().mockReturnValue([]) };
+  const mockAction = {
+    execute: jest.fn(),
+    getFields: jest.fn().mockReturnValue([]),
+    setFields: jest.fn().mockResolvedValue(undefined),
+    tryToSetFields: jest.fn().mockResolvedValue([]),
+    getEnumField: jest.fn(),
+  };
   const mockRelation = { list: jest.fn() };
   const mockCollection = {
     list: jest.fn(),
@@ -722,6 +734,136 @@ describe('AgentClientAgentPort', () => {
       await expect(
         port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, user),
       ).rejects.toThrow('Action failed');
+    });
+
+    it('sets pre-filled values (strict) before executing (PRD-509)', async () => {
+      mockAction.execute.mockResolvedValue({ success: 'done' });
+
+      await port.executeAction(
+        { collection: 'users', action: 'refund', id: [1], values: { amount: 50 } },
+        user,
+      );
+
+      expect(mockAction.setFields).toHaveBeenCalledWith({ amount: 50 });
+      expect(mockAction.execute).toHaveBeenCalled();
+    });
+
+    it('maps a setFields failure (unknown field) to ActionFormValidationError', async () => {
+      mockAction.setFields.mockRejectedValue(new Error('Field "x" does not exist in this form'));
+
+      await expect(
+        port.executeAction(
+          { collection: 'users', action: 'refund', id: [1], values: { x: 1 } },
+          user,
+        ),
+      ).rejects.toBeInstanceOf(ActionFormValidationError);
+      expect(mockAction.execute).not.toHaveBeenCalled();
+    });
+
+    it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles (PRD-509)', async () => {
+      mockAction.execute.mockRejectedValue(
+        new Error(
+          JSON.stringify({
+            error: {
+              status: 403,
+              text: JSON.stringify({
+                errors: [
+                  {
+                    name: 'CustomActionRequiresApprovalError',
+                    data: { roleIdsAllowedToApprove: [7, 9] },
+                  },
+                ],
+              }),
+            },
+            body: null,
+          }),
+        ),
+      );
+
+      const error = await port
+        .executeAction({ collection: 'users', action: 'refund', id: [1] }, user)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(ActionRequiresApprovalError);
+      expect((error as ActionRequiresApprovalError).roleIdsAllowedToApprove).toEqual([7, 9]);
+    });
+
+    it('maps a 422 validation rejection to ActionFormValidationError', async () => {
+      mockAction.execute.mockRejectedValue(
+        new Error(JSON.stringify({ error: { status: 422, text: 'invalid' }, body: null })),
+      );
+
+      await expect(
+        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),
+      ).rejects.toBeInstanceOf(ActionFormValidationError);
+    });
+
+    it('leaves a plain permission 403 as a generic AgentPortError (step error, not a fallback)', async () => {
+      mockAction.execute.mockRejectedValue(
+        new Error(JSON.stringify({ error: { status: 403, text: 'Forbidden' }, body: null })),
+      );
+
+      await expect(
+        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),
+      ).rejects.toBeInstanceOf(AgentPortError);
+    });
+  });
+
+  describe('getActionForm', () => {
+    function makeField(over: { name: string; type?: string; value?: unknown; required?: boolean }) {
+      return {
+        getName: () => over.name,
+        getType: () => over.type ?? 'String',
+        getValue: () => over.value,
+        isRequired: () => over.required ?? false,
+      };
+    }
+
+    it('returns the field list, completeness and skipped fields (PRD-509)', async () => {
+      mockAction.tryToSetFields.mockResolvedValue(['ghost']);
+      mockAction.getFields.mockReturnValue([
+        makeField({ name: 'amount', type: 'Number', value: 50, required: true }),
+        makeField({ name: 'reason', type: 'String', required: true }),
+        makeField({ name: 'tier', type: 'Enum', value: 'gold', required: false }),
+      ]);
+      mockAction.getEnumField.mockReturnValue({ getOptions: () => ['gold', 'silver'] });
+
+      const form = await port.getActionForm(
+        { collection: 'users', action: 'refund', id: [1], values: { amount: 50, ghost: 1 } },
+        user,
+      );
+
+      expect(mockAction.tryToSetFields).toHaveBeenCalledWith({ amount: 50, ghost: 1 });
+      expect(form.fields).toEqual([
+        { name: 'amount', type: 'Number', value: 50, isRequired: true },
+        { name: 'reason', type: 'String', value: undefined, isRequired: true },
+        {
+          name: 'tier',
+          type: 'Enum',
+          value: 'gold',
+          isRequired: false,
+          enumValues: ['gold', 'silver'],
+        },
+      ]);
+      // 'reason' is required and empty → not executable yet; 'ghost' was dropped by the form.
+      expect(form.canExecute).toBe(false);
+      expect(form.requiredFields).toEqual(['reason']);
+      expect(form.skippedFields).toEqual(['ghost']);
+    });
+
+    it('reports canExecute true when all required fields have values', async () => {
+      mockAction.getFields.mockReturnValue([
+        makeField({ name: 'amount', type: 'Number', value: 50, required: true }),
+      ]);
+
+      const form = await port.getActionForm(
+        { collection: 'users', action: 'refund', id: [1] },
+        user,
+      );
+
+      expect(form.canExecute).toBe(true);
+      expect(form.requiredFields).toEqual([]);
+      expect(mockAction.tryToSetFields).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1,6 +1,13 @@
+/* eslint-disable max-classes-per-file */
 import type { StepUser } from '../../src/types/execution-context';
 
-import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import {
+  AgentHttpError,
+  ActionRequiresApprovalError as ClientApprovalError,
+  ActionFormValidationError as ClientFormValidationError,
+  HttpRequester,
+  createRemoteAgentClient,
+} from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
@@ -13,10 +20,43 @@ import {
 } from '../../src/errors';
 import SchemaCache from '../../src/schema-cache';
 
-jest.mock('@forestadmin/agent-client', () => ({
-  createRemoteAgentClient: jest.fn(),
-  HttpRequester: { is404Error: jest.fn() },
-}));
+jest.mock('@forestadmin/agent-client', () => {
+  // Real class so `instanceof AgentHttpError` in the adapter matches errors built by these tests.
+  class MockAgentHttpError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly body: unknown,
+      public readonly responseText?: string,
+    ) {
+      super(`Agent responded with HTTP ${status}`);
+      this.name = 'AgentHttpError';
+    }
+  }
+
+  // Semantic action errors agent-client throws from execute(); real classes so the adapter's
+  // `instanceof` checks match errors built by these tests.
+  class MockActionRequiresApprovalError extends Error {
+    constructor(message: string, public readonly roleIdsAllowedToApprove?: number[]) {
+      super(message);
+      this.name = 'ActionRequiresApprovalError';
+    }
+  }
+
+  class MockActionFormValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'ActionFormValidationError';
+    }
+  }
+
+  return {
+    AgentHttpError: MockAgentHttpError,
+    ActionRequiresApprovalError: MockActionRequiresApprovalError,
+    ActionFormValidationError: MockActionFormValidationError,
+    createRemoteAgentClient: jest.fn(),
+    HttpRequester: { is404Error: jest.fn() },
+  };
+});
 
 const mockedCreateRemoteAgentClient = createRemoteAgentClient as jest.MockedFunction<
   typeof createRemoteAgentClient
@@ -760,25 +800,8 @@ describe('AgentClientAgentPort', () => {
       expect(mockAction.execute).not.toHaveBeenCalled();
     });
 
-    it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles', async () => {
-      mockAction.execute.mockRejectedValue(
-        new Error(
-          JSON.stringify({
-            error: {
-              status: 403,
-              text: JSON.stringify({
-                errors: [
-                  {
-                    name: 'CustomActionRequiresApprovalError',
-                    data: { roleIdsAllowedToApprove: [7, 9] },
-                  },
-                ],
-              }),
-            },
-            body: null,
-          }),
-        ),
-      );
+    it('re-wraps agent-client ActionRequiresApprovalError, carrying the allowed roles', async () => {
+      mockAction.execute.mockRejectedValue(new ClientApprovalError('Needs approval', [7, 9]));
 
       const error = await port
         .executeAction({ collection: 'users', action: 'refund', id: [1] }, user)
@@ -788,10 +811,8 @@ describe('AgentClientAgentPort', () => {
       expect((error as ActionRequiresApprovalError).roleIdsAllowedToApprove).toEqual([7, 9]);
     });
 
-    it('maps a 422 validation rejection to ActionFormValidationError', async () => {
-      mockAction.execute.mockRejectedValue(
-        new Error(JSON.stringify({ error: { status: 422, text: 'invalid' }, body: null })),
-      );
+    it('re-wraps agent-client ActionFormValidationError', async () => {
+      mockAction.execute.mockRejectedValue(new ClientFormValidationError('invalid'));
 
       await expect(
         port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),
@@ -800,7 +821,7 @@ describe('AgentClientAgentPort', () => {
 
     it('leaves a plain permission 403 as a generic AgentPortError (step error, not a fallback)', async () => {
       mockAction.execute.mockRejectedValue(
-        new Error(JSON.stringify({ error: { status: 403, text: 'Forbidden' }, body: null })),
+        new AgentHttpError(403, { errors: [{ name: 'ForbiddenError' }] }, 'Forbidden'),
       );
 
       await expect(

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -736,7 +736,7 @@ describe('AgentClientAgentPort', () => {
       ).rejects.toThrow('Action failed');
     });
 
-    it('sets pre-filled values (strict) before executing (PRD-509)', async () => {
+    it('sets pre-filled values (strict) before executing', async () => {
       mockAction.execute.mockResolvedValue({ success: 'done' });
 
       await port.executeAction(
@@ -760,7 +760,7 @@ describe('AgentClientAgentPort', () => {
       expect(mockAction.execute).not.toHaveBeenCalled();
     });
 
-    it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles (PRD-509)', async () => {
+    it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles', async () => {
       mockAction.execute.mockRejectedValue(
         new Error(
           JSON.stringify({
@@ -819,7 +819,7 @@ describe('AgentClientAgentPort', () => {
       };
     }
 
-    it('returns the field list, completeness and skipped fields (PRD-509)', async () => {
+    it('returns the field list, completeness and skipped fields', async () => {
       mockAction.tryToSetFields.mockResolvedValue(['ghost']);
       mockAction.getFields.mockReturnValue([
         makeField({ name: 'amount', type: 'Number', value: 50, required: true }),

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -160,13 +160,13 @@ describe('toStepDefinition', () => {
       });
     });
 
-    it('preserves executionType=manual on a trigger-action task — no silent coercion (PRD-511)', () => {
+    it('preserves executionType=manual on a trigger-action task — no silent coercion', () => {
       const task = makeTask({
         taskType: ServerTaskTypeEnum.TriggerAction,
         executionType: ServerStepExecutionTypeEnum.Manual,
       });
 
-      // Before PRD-511 the trigger schema's `.catch(AutomatedWithConfirmation)` would have coerced
+      // Previously the trigger schema's `.catch(AutomatedWithConfirmation)` would have coerced
       // `manual` into AI-assisted — opting the builder back into AI prefill against their choice.
       expect(toStepDefinition(task)).toMatchObject({
         type: StepType.TriggerAction,

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -160,6 +160,20 @@ describe('toStepDefinition', () => {
       });
     });
 
+    it('preserves executionType=manual on a trigger-action task — no silent coercion (PRD-511)', () => {
+      const task = makeTask({
+        taskType: ServerTaskTypeEnum.TriggerAction,
+        executionType: ServerStepExecutionTypeEnum.Manual,
+      });
+
+      // Before PRD-511 the trigger schema's `.catch(AutomatedWithConfirmation)` would have coerced
+      // `manual` into AI-assisted — opting the builder back into AI prefill against their choice.
+      expect(toStepDefinition(task)).toMatchObject({
+        type: StepType.TriggerAction,
+        executionType: StepExecutionMode.Manual,
+      });
+    });
+
     // Casts through `as` because the orchestrator types forbid this combination — the runtime
     // normalization is a defensive safety net for wire data the server should not emit.
     it('should silently fall back to default when executionType is unsupported for the step type', () => {

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3603,8 +3603,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  // PRD-552: legacy prompt-only steps and new deterministic steps must coexist — the same executor
-  // takes the AI path for one and the deterministic (no-AI) path for the other within one run.
   describe('backward compatibility (PRD-552): legacy and deterministic coexist', () => {
     it('runs the AI path for a legacy step and the deterministic path for a configured step', async () => {
       // Legacy prompt-only step → AI selects the relation.

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -635,6 +635,65 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('also forwards the filter on the AutomatedWithConfirmation path (the user-facing list)', async () => {
+      const hasManySchema = makeCollectionSchema({
+        fields: [
+          {
+            fieldName: 'address',
+            displayName: 'Address',
+            isRelationship: true,
+            relationType: 'HasMany',
+            relatedCollectionName: 'addresses',
+          },
+        ],
+      });
+      const relatedData: RecordData[] = [
+        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
+        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
+      ];
+      const agentPort = makeMockAgentPort(relatedData);
+      const addressSchema = makeCollectionSchema({
+        collectionName: 'addresses',
+        collectionDisplayName: 'Addresses',
+        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
+      });
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record-by-content',
+              args: { recordIndex: 0, reasoning: 'r' },
+              id: 'c3',
+            },
+          ],
+        });
+      const model = {
+        bindTools: jest.fn().mockReturnValue({ invoke }),
+      } as unknown as ExecutionContext['model'];
+
+      const filters = { field: 'city', operator: 'equal', value: 'Lyon' };
+      const context = makeContext({
+        model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({ customers: hasManySchema, addresses: addressSchema }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.AutomatedWithConfirmation,
+          preRecordedArgs: { relationName: 'address', filters },
+        }),
+      });
+
+      await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(agentPort.getRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', relation: 'address', filters }),
+        expect.anything(),
+      );
+    });
+
     it('skips field-selection AI call when related collection has no non-relation fields', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3389,6 +3389,65 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('resolves selectedRecordStepIndex via originalStepIndex after a revise (revise-safe)', async () => {
+      // After a revise, the source step is a clone at a shifted own index (4) whose execution is
+      // persisted at that own index, while the editor reference still points at the original index
+      // (1). A strict own-index match would report "no source record"; the fallback must resolve it.
+      const loadedOrder: RecordRef = { collectionName: 'orders', recordId: [99], stepIndex: 4 };
+      const ordersSchema = makeCollectionSchema({
+        collectionName: 'orders',
+        collectionDisplayName: 'Orders',
+        fields: [
+          {
+            fieldName: 'customer',
+            displayName: 'Customer',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            relatedCollectionName: 'customers',
+          },
+        ],
+      });
+      const { model } = makeMockModel();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 4,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: loadedOrder,
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const agentPort = makeMockAgentPort([
+        makeRelatedRecordData({ collectionName: 'customers', recordId: [7], values: {} }),
+      ]);
+      const context = makeContext({
+        model,
+        runStore,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema(),
+          orders: ordersSchema,
+        }),
+        previousSteps: [makeLoadRelatedPreviousStep(4, 1)],
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepIndex: 1, relationName: 'customer' },
+        }),
+      });
+
+      const result = await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.getSingleRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'orders', id: [99], relation: 'customer' }),
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+
     it('errors with the pre-recorded-args message when selectedRecordStepIndex matches no record', async () => {
       const context = makeContext({
         stepDefinition: makeStep({
@@ -3415,76 +3474,6 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('error');
       expect(result.stepOutcome.error).toBe('The pre-configured step parameters are invalid');
-    });
-
-    it('skips AI record selection when selectedRecordIndex is pre-recorded with HasMany', async () => {
-      const relatedData = [
-        makeRelatedRecordData({
-          collectionName: 'addresses',
-          recordId: [101],
-          values: { city: 'Paris' },
-        }),
-        makeRelatedRecordData({
-          collectionName: 'addresses',
-          recordId: [102],
-          values: { city: 'Lyon' },
-        }),
-      ];
-
-      const { model, bindTools } = makeMockModel();
-      const runStore = makeMockRunStore();
-      const context = makeContext({
-        model,
-        runStore,
-        agentPort: makeMockAgentPort(relatedData),
-        stepDefinition: makeStep({
-          executionType: StepExecutionMode.FullyAutomated,
-          preRecordedArgs: { relationName: 'address', selectedRecordIndex: 1 },
-        }),
-      });
-      const executor = new LoadRelatedRecordStepExecutor(context);
-
-      const result = await executor.execute();
-
-      expect(result.stepOutcome.status).toBe('success');
-      expect(bindTools).not.toHaveBeenCalled();
-      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
-        'run-1',
-        expect.objectContaining({
-          executionResult: expect.objectContaining({
-            record: expect.objectContaining({ recordId: [102] }),
-          }),
-        }),
-      );
-    });
-
-    it('returns error when selectedRecordIndex is out of range', async () => {
-      const relatedData = [
-        makeRelatedRecordData({
-          collectionName: 'addresses',
-          recordId: [1],
-          values: { city: 'Paris' },
-        }),
-        makeRelatedRecordData({
-          collectionName: 'addresses',
-          recordId: [2],
-          values: { city: 'Lyon' },
-        }),
-      ];
-      const { model } = makeMockModel();
-      const context = makeContext({
-        model,
-        agentPort: makeMockAgentPort(relatedData),
-        stepDefinition: makeStep({
-          executionType: StepExecutionMode.FullyAutomated,
-          preRecordedArgs: { relationName: 'address', selectedRecordIndex: 99 },
-        }),
-      });
-      const executor = new LoadRelatedRecordStepExecutor(context);
-
-      const result = await executor.execute();
-
-      expect(result.stepOutcome.status).toBe('error');
     });
 
     it('returns error when a pre-recorded relationName does not resolve', async () => {

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -576,7 +576,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    it('forwards a build-time filter (PRD-553) to getRelatedData on the 1–n list fetch', async () => {
+    it('forwards a build-time filter to getRelatedData on the 1–n list fetch', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [
           {
@@ -1033,7 +1033,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  describe('operation activity log (PRD-442 #1)', () => {
+  describe('operation activity log', () => {
     it('logs listRelatedData against the source record and its collection, not the trigger', async () => {
       const runStore = makeMockRunStore();
       const activityLogPort = {
@@ -3251,7 +3251,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
   // by a prior step, "Load the dvd titanic" must still follow store → dvds (the relation that
   // LEADS TO a dvd), not read a relation off the already-loaded dvd. resolveTarget now offers
   // every relation across all available records and lets the AI choose by target collection.
-  describe('follows the relation leading to the requested collection (PRD-214 repro)', () => {
+  describe('follows the relation leading to the requested collection (repro)', () => {
     it('follows store → dvds rather than a relation on the already-loaded dvd', async () => {
       // Available records: base account #1 (store BelongsTo), loaded store #6 (dvds HasMany),
       // loaded dvd #32 (store BelongsTo).
@@ -3721,7 +3721,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  describe('backward compatibility (PRD-552): legacy and deterministic coexist', () => {
+  describe('backward compatibility: legacy and deterministic coexist', () => {
     it('runs the AI path for a legacy step and the deterministic path for a configured step', async () => {
       // Legacy prompt-only step → AI selects the relation.
       const legacy = makeMockModel({ relationName: 'Orders', reasoning: 'r' });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3635,7 +3635,10 @@ describe('LoadRelatedRecordStepExecutor', () => {
           agentPort: makeMockAgentPort([
             makeRelatedRecordData({ collectionName: 'customers', recordId: [7], values: {} }),
           ]),
-          workflowPort: makeMockWorkflowPort({ customers: makeCollectionSchema(), orders: ordersSchema }),
+          workflowPort: makeMockWorkflowPort({
+            customers: makeCollectionSchema(),
+            orders: ordersSchema,
+          }),
           previousSteps: [makeLoadRelatedPreviousStep(1)],
           stepDefinition: makeStep({
             executionType: StepExecutionMode.FullyAutomated,

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -576,6 +576,65 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    it('forwards a build-time filter (PRD-553) to getRelatedData on the 1–n list fetch', async () => {
+      const hasManySchema = makeCollectionSchema({
+        fields: [
+          {
+            fieldName: 'address',
+            displayName: 'Address',
+            isRelationship: true,
+            relationType: 'HasMany',
+            relatedCollectionName: 'addresses',
+          },
+        ],
+      });
+      const relatedData: RecordData[] = [
+        { collectionName: 'addresses', recordId: [1], values: { city: 'Paris' } },
+        { collectionName: 'addresses', recordId: [2], values: { city: 'Lyon' } },
+      ];
+      const agentPort = makeMockAgentPort(relatedData);
+      const addressSchema = makeCollectionSchema({
+        collectionName: 'addresses',
+        collectionDisplayName: 'Addresses',
+        fields: [{ fieldName: 'city', displayName: 'City', isRelationship: false }],
+      });
+      const invoke = jest
+        .fn()
+        .mockResolvedValueOnce({
+          tool_calls: [{ name: 'select-fields', args: { fieldNames: ['City'] }, id: 'c2' }],
+        })
+        .mockResolvedValueOnce({
+          tool_calls: [
+            {
+              name: 'select-record-by-content',
+              args: { recordIndex: 0, reasoning: 'r' },
+              id: 'c3',
+            },
+          ],
+        });
+      const model = {
+        bindTools: jest.fn().mockReturnValue({ invoke }),
+      } as unknown as ExecutionContext['model'];
+
+      const filters = { field: 'city', operator: 'equal', value: 'Lyon' };
+      const context = makeContext({
+        model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({ customers: hasManySchema, addresses: addressSchema }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { relationName: 'address', filters },
+        }),
+      });
+
+      await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(agentPort.getRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', relation: 'address', filters }),
+        expect.anything(),
+      );
+    });
+
     it('skips field-selection AI call when related collection has no non-relation fields', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -14,7 +14,11 @@ import AgentWithLog from '../../src/executors/agent-with-log';
 import LoadRelatedRecordStepExecutor from '../../src/executors/load-related-record-step-executor';
 import SchemaCache from '../../src/schema-cache';
 import SchemaResolver from '../../src/schema-resolver';
-import { StepExecutionMode, StepType } from '../../src/types/validated/step-definition';
+import {
+  StepExecutionMode,
+  StepType,
+  WORKFLOW_START_STEP_ID,
+} from '../../src/types/validated/step-definition';
 
 function makeStep(
   overrides: Partial<LoadRelatedRecordStepDefinition> = {},
@@ -257,7 +261,11 @@ function makePendingExecution(
   };
 }
 
-function makeLoadRelatedPreviousStep(stepIndex: number, originalStepIndex?: number): Step {
+function makeLoadRelatedPreviousStep(
+  stepIndex: number,
+  originalStepIndex?: number,
+  stepId = `load-${stepIndex}`,
+): Step {
   return {
     stepDefinition: {
       type: StepType.LoadRelatedRecord,
@@ -266,7 +274,7 @@ function makeLoadRelatedPreviousStep(stepIndex: number, originalStepIndex?: numb
     },
     stepOutcome: {
       type: 'record',
-      stepId: `load-${stepIndex}`,
+      stepId,
       stepIndex,
       status: 'success',
     },
@@ -3322,7 +3330,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    it('pins the source record via selectedRecordStepIndex (among several records)', async () => {
+    it('pins the source record via selectedRecordStepId (among several records)', async () => {
       // Base customers #42 (step 0) + a loaded order #99 (step 1) are both available;
       // pinning step 1 must make the relation follow the ORDER, not the base customer.
       const loadedOrder: RecordRef = { collectionName: 'orders', recordId: [99], stepIndex: 1 };
@@ -3367,7 +3375,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
         previousSteps: [makeLoadRelatedPreviousStep(1)],
         stepDefinition: makeStep({
           executionType: StepExecutionMode.FullyAutomated,
-          preRecordedArgs: { selectedRecordStepIndex: 1, relationName: 'customer' },
+          preRecordedArgs: { selectedRecordStepId: 'load-1', relationName: 'customer' },
         }),
       });
 
@@ -3389,10 +3397,32 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    it('resolves selectedRecordStepIndex via originalStepIndex after a revise (revise-safe)', async () => {
-      // After a revise, the source step is a clone at a shifted own index (4) whose execution is
-      // persisted at that own index, while the editor reference still points at the original index
-      // (1). A strict own-index match would report "no source record"; the fallback must resolve it.
+    it('resolves the WORKFLOW_START_STEP_ID sentinel to the base (trigger) record', async () => {
+      const agentPort = makeMockAgentPort();
+      const { model, bindTools } = makeMockModel();
+      const context = makeContext({
+        model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepId: WORKFLOW_START_STEP_ID, relationName: 'order' },
+        }),
+      });
+
+      const result = await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(bindTools).not.toHaveBeenCalled();
+      // Followed the 'order' relation off the base customer record, not a previous step.
+      expect(agentPort.getSingleRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', relation: 'order' }),
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+
+    it('resolves selectedRecordStepId after a revise shifts the index (revise-safe)', async () => {
+      // After a revise, the source step is a clone at a shifted index (4) but keeps its stable
+      // step id ('load-1') — what the editor referenced. Resolving by id ignores the index shift.
       const loadedOrder: RecordRef = { collectionName: 'orders', recordId: [99], stepIndex: 4 };
       const ordersSchema = makeCollectionSchema({
         collectionName: 'orders',
@@ -3432,10 +3462,10 @@ describe('LoadRelatedRecordStepExecutor', () => {
           customers: makeCollectionSchema(),
           orders: ordersSchema,
         }),
-        previousSteps: [makeLoadRelatedPreviousStep(4, 1)],
+        previousSteps: [makeLoadRelatedPreviousStep(4, 1, 'load-1')],
         stepDefinition: makeStep({
           executionType: StepExecutionMode.FullyAutomated,
-          preRecordedArgs: { selectedRecordStepIndex: 1, relationName: 'customer' },
+          preRecordedArgs: { selectedRecordStepId: 'load-1', relationName: 'customer' },
         }),
       });
 
@@ -3448,11 +3478,11 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    it('errors with the pre-recorded-args message when selectedRecordStepIndex matches no record', async () => {
+    it('errors with the pre-recorded-args message when selectedRecordStepId matches no record', async () => {
       const context = makeContext({
         stepDefinition: makeStep({
           executionType: StepExecutionMode.FullyAutomated,
-          preRecordedArgs: { selectedRecordStepIndex: 99 },
+          preRecordedArgs: { selectedRecordStepId: 'load-missing' },
         }),
       });
 

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3585,6 +3585,70 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
+  // PRD-552: legacy prompt-only steps and new deterministic steps must coexist — the same executor
+  // takes the AI path for one and the deterministic (no-AI) path for the other within one run.
+  describe('backward compatibility (PRD-552): legacy and deterministic coexist', () => {
+    it('runs the AI path for a legacy step and the deterministic path for a configured step', async () => {
+      // Legacy prompt-only step → AI selects the relation.
+      const legacy = makeMockModel({ relationName: 'Orders', reasoning: 'r' });
+      await new LoadRelatedRecordStepExecutor(
+        makeContext({
+          model: legacy.model,
+          stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+        }),
+      ).execute();
+
+      expect(legacy.bindTools).toHaveBeenCalled();
+
+      // Deterministic step (source + relation pinned) → no relation AI call.
+      const ordersSchema = makeCollectionSchema({
+        collectionName: 'orders',
+        collectionDisplayName: 'Orders',
+        fields: [
+          {
+            fieldName: 'customer',
+            displayName: 'Customer',
+            isRelationship: true,
+            relationType: 'BelongsTo',
+            relatedCollectionName: 'customers',
+          },
+        ],
+      });
+      const deterministic = makeMockModel();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 1,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: { collectionName: 'orders', recordId: [99], stepIndex: 1 },
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const result = await new LoadRelatedRecordStepExecutor(
+        makeContext({
+          model: deterministic.model,
+          runStore,
+          agentPort: makeMockAgentPort([
+            makeRelatedRecordData({ collectionName: 'customers', recordId: [7], values: {} }),
+          ]),
+          workflowPort: makeMockWorkflowPort({ customers: makeCollectionSchema(), orders: ordersSchema }),
+          previousSteps: [makeLoadRelatedPreviousStep(1)],
+          stepDefinition: makeStep({
+            executionType: StepExecutionMode.FullyAutomated,
+            preRecordedArgs: { selectedRecordStepId: 'load-1', relationName: 'customer' },
+          }),
+        }),
+      ).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(deterministic.bindTools).not.toHaveBeenCalled();
+    });
+  });
+
   describe('record pool after revision', () => {
     it('re-executes a revised load step from the base record, not from the dead branch record', async () => {
       // Given: the run loaded an owner before the user revised the "Load store" step. The

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3492,6 +3492,24 @@ describe('LoadRelatedRecordStepExecutor', () => {
       expect(result.stepOutcome.error).toBe('The pre-configured step parameters are invalid');
     });
 
+    it('surfaces a distinct "no source record" message when the source step loaded nothing', async () => {
+      // The source step exists in the live path but its run-store execution has no record.
+      const runStore = makeMockRunStore({ getStepExecutions: jest.fn().mockResolvedValue([]) });
+      const context = makeContext({
+        runStore,
+        previousSteps: [makeLoadRelatedPreviousStep(1)],
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepId: 'load-1', relationName: 'customer' },
+        }),
+      });
+
+      const result = await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toContain("didn't load any record");
+    });
+
     it('errors with the pre-recorded-args message when the pinned relation matches nothing', async () => {
       const context = makeContext({
         stepDefinition: makeStep({

--- a/packages/workflow-executor/test/executors/step-execution-formatters.test.ts
+++ b/packages/workflow-executor/test/executors/step-execution-formatters.test.ts
@@ -168,5 +168,81 @@ describe('StepExecutionFormatters', () => {
         expect(StepExecutionFormatters.format(execution)).toBeNull();
       });
     });
+
+    describe('trigger-action (PRD-513)', () => {
+      const recordRef = { collectionName: 'customers', recordId: [42], stepIndex: 0 };
+
+      it('marks a pending-approval submission as NOT executed', () => {
+        const execution: StepExecutionData = {
+          type: 'trigger-action',
+          stepIndex: 1,
+          selectedRecordRef: recordRef,
+          executionParams: { name: 'refund', displayName: 'Process refund' },
+          executionResult: {
+            success: true,
+            submissionOutcome: 'pending-approval',
+            submittedBy: 'user',
+          },
+        };
+
+        const summary = StepExecutionFormatters.format(execution);
+        expect(summary).toContain('AWAITING APPROVAL');
+        expect(summary).toContain('has NOT been executed');
+      });
+
+      it('reports a Full AI execution as submitted by AI with the pre-filled fields', () => {
+        const execution: StepExecutionData = {
+          type: 'trigger-action',
+          stepIndex: 1,
+          selectedRecordRef: recordRef,
+          executionParams: { name: 'refund', displayName: 'Process refund' },
+          executionResult: {
+            success: true,
+            actionResult: { ok: true },
+            submissionOutcome: 'executed',
+            submittedBy: 'ai',
+            submittedValues: { amount: 50 },
+            aiFilledValues: [{ field: 'amount', value: 50 }],
+          },
+        };
+
+        const summary = StepExecutionFormatters.format(execution) ?? '';
+        expect(summary).toContain('submitted by AI');
+        expect(summary).toContain('AI pre-filled: amount');
+      });
+
+      it('reports human edits in AI-assisted mode (diff prefill vs submitted)', () => {
+        const execution: StepExecutionData = {
+          type: 'trigger-action',
+          stepIndex: 1,
+          selectedRecordRef: recordRef,
+          executionParams: { name: 'refund', displayName: 'Process refund' },
+          executionResult: {
+            success: true,
+            actionResult: { ok: true },
+            submissionOutcome: 'executed',
+            submittedBy: 'user',
+            // AI proposed amount 50; the human changed it to 80 before submitting.
+            aiFilledValues: [{ field: 'amount', value: 50 }],
+            submittedValues: { amount: 80 },
+          },
+        };
+
+        const summary = StepExecutionFormatters.format(execution) ?? '';
+        expect(summary).toContain('submitted by the user');
+        expect(summary).toContain('Edited by the user before submitting: amount');
+      });
+
+      it('returns null for a skipped action', () => {
+        const execution: StepExecutionData = {
+          type: 'trigger-action',
+          stepIndex: 1,
+          selectedRecordRef: recordRef,
+          executionResult: { skipped: true },
+        };
+
+        expect(StepExecutionFormatters.format(execution)).toBeNull();
+      });
+    });
   });
 });

--- a/packages/workflow-executor/test/executors/step-execution-formatters.test.ts
+++ b/packages/workflow-executor/test/executors/step-execution-formatters.test.ts
@@ -169,7 +169,7 @@ describe('StepExecutionFormatters', () => {
       });
     });
 
-    describe('trigger-action (PRD-513)', () => {
+    describe('trigger-action', () => {
       const recordRef = { collectionName: 'customers', recordId: [42], stepIndex: 0 };
 
       it('marks a pending-approval submission as NOT executed', () => {

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -1351,6 +1351,61 @@ describe('TriggerRecordActionStepExecutor', () => {
 
       expect(mockModel.bindTools).toHaveBeenCalledTimes(1);
     });
+
+    it('pins the source record from selectedRecordStepId=workflow-start without AI (PRD-469)', async () => {
+      const mockModel = makeMockModel();
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+      const executor = new TriggerRecordActionStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // Neither record nor action selection invoked the AI.
+      expect(mockModel.bindTools).not.toHaveBeenCalled();
+      // Action runs on the workflow-start (base) record, recordId [42].
+      expect(agentPort.executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: 'customers',
+          action: 'send-welcome-email',
+          id: [42],
+        }),
+        context.user,
+      );
+    });
+
+    it('errors when the pinned source step (a Load Related Record) loaded no record (PRD-469)', async () => {
+      const agentPort = makeMockAgentPort();
+      // The source Load Related Record step is on the live path but has no execution record stored
+      // (it loaded nothing) → SourceRecordMissingError, no action triggered.
+      const runStore = makeMockRunStore({ getStepExecutions: jest.fn().mockResolvedValue([]) });
+      const context = makeContext({
+        agentPort,
+        runStore,
+        previousSteps: [makeLoadRelatedPreviousStep(2)],
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepId: 'load-2', actionName: 'send-welcome-email' },
+        }),
+      });
+      const executor = new TriggerRecordActionStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toContain("didn't load any record");
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
   });
 
   describe('idempotency', () => {

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -8,7 +8,13 @@ import type { CollectionSchema, RecordRef } from '../../src/types/validated/coll
 import type { Step } from '../../src/types/validated/execution';
 import type { TriggerActionStepDefinition } from '../../src/types/validated/step-definition';
 
-import { AgentPortError, RunStorePortError, StepStateError } from '../../src/errors';
+import {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  AgentPortError,
+  RunStorePortError,
+  StepStateError,
+} from '../../src/errors';
 import ActivityLog from '../../src/executors/activity-log';
 import AgentWithLog from '../../src/executors/agent-with-log';
 import TriggerRecordActionStepExecutor from '../../src/executors/trigger-record-action-step-executor';
@@ -641,73 +647,138 @@ describe('TriggerRecordActionStepExecutor', () => {
     });
   });
 
-  describe('UnsupportedActionFormError (form detection)', () => {
-    it('throws when the action has a form and executionType is FullyAutomated (PRD-512 not yet)', async () => {
-      const agentPort = makeMockAgentPort();
-      (agentPort.getActionForm as jest.Mock).mockResolvedValue({
-        fields: [{ name: 'reason', type: 'String', isRequired: true }],
-        canExecute: false,
-        requiredFields: ['reason'],
-        skippedFields: [],
-      });
-      const mockModel = makeMockModel({
-        actionName: 'Send Welcome Email',
-        reasoning: 'r',
-      });
-      const runStore = makeMockRunStore();
-      const context = makeContext({
-        model: mockModel.model,
+  describe('Full AI on a form (PRD-512)', () => {
+    // initial form (required field empty) then the re-fetch after the AI fills it (canExecute).
+    function mockFillThenComplete(agentPort: AgentPort) {
+      (agentPort.getActionForm as jest.Mock)
+        .mockResolvedValueOnce({
+          fields: [{ name: 'amount', type: 'Number', isRequired: true }],
+          canExecute: false,
+          requiredFields: ['amount'],
+          skippedFields: [],
+        })
+        .mockResolvedValueOnce({
+          fields: [{ name: 'amount', type: 'Number', isRequired: true, value: 50 }],
+          canExecute: true,
+          requiredFields: [],
+          skippedFields: [],
+        });
+    }
+
+    function fullAiContext(agentPort: AgentPort, runStore: ReturnType<typeof makeMockRunStore>) {
+      return makeContext({
+        model: makeMockModel({ values: { amount: 50 } }, 'fill_action_form').model,
         agentPort,
         runStore,
-        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
       });
-      const executor = new TriggerRecordActionStepExecutor(context);
+    }
 
-      const result = await executor.execute();
-
-      expect(result.stepOutcome.status).toBe('error');
-      expect(result.stepOutcome.error).toBe(
-        'This action requires user input via a form, which is not yet supported in workflows.',
-      );
-      // Form detection uses the resolved technical name, not the AI display name —
-      // passing "Send Welcome Email" would 404 against the agent.
-      expect(agentPort.getActionForm).toHaveBeenCalledWith(
-        { collection: 'customers', action: 'send-welcome-email', id: [42] },
-        expect.objectContaining({ id: 1 }),
-      );
-      expect(agentPort.executeAction).not.toHaveBeenCalled();
-      expect(runStore.saveStepExecution).not.toHaveBeenCalled();
-    });
-
-    it('supports form-bearing actions when executionType is not FullyAutomated (frontend handles the form)', async () => {
+    it('fills every required field then submits the action with the AI values', async () => {
       const agentPort = makeMockAgentPort();
-      // hasForm would return true if called — but it should not be called in this branch.
-      (agentPort.getActionFormInfo as jest.Mock).mockResolvedValue({ hasForm: true });
-      const mockModel = makeMockModel({
-        actionName: 'Send Welcome Email',
-        reasoning: 'r',
-      });
+      mockFillThenComplete(agentPort);
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ success: 'ok' });
       const runStore = makeMockRunStore();
-      const context = makeContext({
-        model: mockModel.model,
-        agentPort,
-        runStore,
-      });
-      const executor = new TriggerRecordActionStepExecutor(context);
 
-      const result = await executor.execute();
+      const result = await new TriggerRecordActionStepExecutor(
+        fullAiContext(agentPort, runStore),
+      ).execute();
 
-      expect(result.stepOutcome.status).toBe('awaiting-input');
-      // Form check is skipped when not automatic — the frontend will handle the form.
-      expect(agentPort.getActionFormInfo).not.toHaveBeenCalled();
-      expect(agentPort.executeAction).not.toHaveBeenCalled();
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'send-welcome-email', values: { amount: 50 } }),
+        expect.anything(),
+      );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
         expect.objectContaining({
-          type: 'trigger-action',
-          pendingData: { displayName: 'Send Welcome Email', name: 'send-welcome-email' },
+          executionResult: expect.objectContaining({
+            success: true,
+            submissionOutcome: 'executed',
+            submittedValues: { amount: 50 },
+          }),
         }),
       );
+    });
+
+    it('falls back to the AI-assisted review state when a required field stays empty', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.getActionForm as jest.Mock).mockResolvedValue({
+        fields: [{ name: 'amount', type: 'Number', isRequired: true }],
+        canExecute: false,
+        requiredFields: ['amount'],
+        skippedFields: [],
+      });
+      // AI returns no values → loop makes no progress → required field unfilled.
+      const context = makeContext({
+        model: makeMockModel({ values: {} }, 'fill_action_form').model,
+        agentPort,
+        runStore: makeMockRunStore(),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
+
+    it('falls back to AI-assisted when the action requires an approval', async () => {
+      const agentPort = makeMockAgentPort();
+      mockFillThenComplete(agentPort);
+      (agentPort.executeAction as jest.Mock).mockRejectedValue(
+        new ActionRequiresApprovalError('send-welcome-email', [7]),
+      );
+      const runStore = makeMockRunStore();
+      const result = await new TriggerRecordActionStepExecutor(
+        fullAiContext(agentPort, runStore),
+      ).execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      // The execute attempt wrote an `executing` write-ahead marker; the fallback pause must
+      // overwrite it with a clean awaiting-input record — otherwise a re-dispatch would think the
+      // step is stuck (StepStateError) instead of resumable.
+      const lastSave = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
+      expect(lastSave).toHaveProperty('pendingData');
+      expect(lastSave).not.toHaveProperty('idempotencyPhase');
+    });
+
+    it('falls back to AI-assisted when the submission is rejected by validation', async () => {
+      const agentPort = makeMockAgentPort();
+      mockFillThenComplete(agentPort);
+      (agentPort.executeAction as jest.Mock).mockRejectedValue(
+        new ActionFormValidationError('send-welcome-email'),
+      );
+      const result = await new TriggerRecordActionStepExecutor(
+        fullAiContext(agentPort, makeMockRunStore()),
+      ).execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+    });
+
+    it('surfaces a plain permission/infra error as a step error (no fallback)', async () => {
+      const agentPort = makeMockAgentPort();
+      mockFillThenComplete(agentPort);
+      (agentPort.executeAction as jest.Mock).mockRejectedValue(
+        new AgentPortError('executeAction', new Error('403 Forbidden')),
+      );
+      const result = await new TriggerRecordActionStepExecutor(
+        fullAiContext(agentPort, makeMockRunStore()),
+      ).execute();
+
+      expect(result.stepOutcome.status).toBe('error');
     });
   });
 

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -49,7 +49,7 @@ function makeMockAgentPort(): AgentPort {
     getRelatedData: jest.fn(),
     executeAction: jest.fn().mockResolvedValue(undefined),
     getActionFormInfo: jest.fn().mockResolvedValue({ hasForm: false }),
-    // Default: a formless action (no fields) — matches the pre-PRD-511 behavior of most tests.
+    // Default: a formless action (no fields) — matches the prior behavior of most tests.
     getActionForm: jest
       .fn()
       .mockResolvedValue({ fields: [], canExecute: true, requiredFields: [], skippedFields: [] }),
@@ -247,7 +247,7 @@ describe('TriggerRecordActionStepExecutor', () => {
     });
   });
 
-  describe('operation activity log (PRD-442 #1)', () => {
+  describe('operation activity log', () => {
     it('logs the action against the acted record and its collection, not the trigger', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.executeAction as jest.Mock).mockResolvedValue({ ok: true });
@@ -653,7 +653,7 @@ describe('TriggerRecordActionStepExecutor', () => {
     });
   });
 
-  describe('Full AI on a form (PRD-512)', () => {
+  describe('Full AI on a form', () => {
     // initial form (required field empty) then the re-fetch after the AI fills it (canExecute).
     function mockFillThenComplete(agentPort: AgentPort) {
       (agentPort.getActionForm as jest.Mock)
@@ -1426,7 +1426,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
-    it('Manual mode on a form action pauses WITHOUT any AI pre-fill (PRD-511)', async () => {
+    it('Manual mode on a form action pauses WITHOUT any AI pre-fill', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.getActionForm as jest.Mock).mockResolvedValue({
         fields: [{ name: 'reason', type: 'String', isRequired: true }],
@@ -1467,7 +1467,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
-    it('AI-assisted mode pre-fills the form (ordered) and pauses for review (PRD-511)', async () => {
+    it('AI-assisted mode pre-fills the form (ordered) and pauses for review', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.getActionForm as jest.Mock).mockResolvedValue({
         fields: [
@@ -1509,7 +1509,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
-    it('persists a pending-approval submission without an actionResult (PRD-511/520)', async () => {
+    it('persists a pending-approval submission without an actionResult', async () => {
       const agentPort = makeMockAgentPort();
       const execution: TriggerRecordActionStepExecutionData = {
         type: 'trigger-action',
@@ -1562,7 +1562,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(mockModel.bindTools).toHaveBeenCalledTimes(1);
     });
 
-    it('pins the source record from selectedRecordStepId=workflow-start without AI (PRD-469)', async () => {
+    it('pins the source record from selectedRecordStepId=workflow-start without AI', async () => {
       const mockModel = makeMockModel();
       const agentPort = makeMockAgentPort();
       const context = makeContext({
@@ -1594,7 +1594,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
-    it('errors when the pinned source step (a Load Related Record) loaded no record (PRD-469)', async () => {
+    it('errors when the pinned source step (a Load Related Record) loaded no record', async () => {
       const agentPort = makeMockAgentPort();
       // The source Load Related Record step is on the live path but has no execution record stored
       // (it loaded nothing) → SourceRecordMissingError, no action triggered.

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -43,6 +43,10 @@ function makeMockAgentPort(): AgentPort {
     getRelatedData: jest.fn(),
     executeAction: jest.fn().mockResolvedValue(undefined),
     getActionFormInfo: jest.fn().mockResolvedValue({ hasForm: false }),
+    // Default: a formless action (no fields) — matches the pre-PRD-511 behavior of most tests.
+    getActionForm: jest
+      .fn()
+      .mockResolvedValue({ fields: [], canExecute: true, requiredFields: [], skippedFields: [] }),
   } as unknown as AgentPort;
 }
 
@@ -449,6 +453,7 @@ describe('TriggerRecordActionStepExecutor', () => {
           executionResult: {
             success: true,
             actionResult: { success: 'ok', html: '<p>Email queued</p>' },
+            submissionOutcome: 'executed',
           },
           pendingData: {
             displayName: 'Send Welcome Email',
@@ -486,7 +491,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
         expect.objectContaining({
-          executionResult: { success: true, actionResult: null },
+          executionResult: { success: true, actionResult: null, submissionOutcome: 'executed' },
         }),
       );
     });
@@ -637,9 +642,14 @@ describe('TriggerRecordActionStepExecutor', () => {
   });
 
   describe('UnsupportedActionFormError (form detection)', () => {
-    it('throws when the action has a form and executionType is FullyAutomated', async () => {
+    it('throws when the action has a form and executionType is FullyAutomated (PRD-512 not yet)', async () => {
       const agentPort = makeMockAgentPort();
-      (agentPort.getActionFormInfo as jest.Mock).mockResolvedValue({ hasForm: true });
+      (agentPort.getActionForm as jest.Mock).mockResolvedValue({
+        fields: [{ name: 'reason', type: 'String', isRequired: true }],
+        canExecute: false,
+        requiredFields: ['reason'],
+        skippedFields: [],
+      });
       const mockModel = makeMockModel({
         actionName: 'Send Welcome Email',
         reasoning: 'r',
@@ -661,7 +671,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
       // Form detection uses the resolved technical name, not the AI display name —
       // passing "Send Welcome Email" would 404 against the agent.
-      expect(agentPort.getActionFormInfo).toHaveBeenCalledWith(
+      expect(agentPort.getActionForm).toHaveBeenCalledWith(
         { collection: 'customers', action: 'send-welcome-email', id: [42] },
         expect.objectContaining({ id: 1 }),
       );
@@ -1335,6 +1345,128 @@ describe('TriggerRecordActionStepExecutor', () => {
         'run-1',
         expect.objectContaining({
           executionParams: { displayName: 'Send Welcome Email', name: 'archive' },
+        }),
+      );
+    });
+
+    it('Manual mode on a form action pauses WITHOUT any AI pre-fill (PRD-511)', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.getActionForm as jest.Mock).mockResolvedValue({
+        fields: [{ name: 'reason', type: 'String', isRequired: true }],
+        canExecute: false,
+        requiredFields: ['reason'],
+        skippedFields: [],
+      });
+      const mockModel = makeMockModel();
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.Manual,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      // Manual = no AI involvement at all.
+      expect(mockModel.bindTools).not.toHaveBeenCalled();
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          pendingData: expect.objectContaining({
+            form: {
+              fields: [{ name: 'reason', type: 'String', isRequired: true }],
+              aiFilledValues: [],
+            },
+          }),
+        }),
+      );
+    });
+
+    it('AI-assisted mode pre-fills the form (ordered) and pauses for review (PRD-511)', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.getActionForm as jest.Mock).mockResolvedValue({
+        fields: [
+          { name: 'amount', type: 'Number', isRequired: true },
+          { name: 'reason', type: 'String', isRequired: false },
+        ],
+        canExecute: true,
+        requiredFields: [],
+        skippedFields: [],
+      });
+      // AI fills amount but leaves `reason` out (no context) — must stay empty.
+      const mockModel = makeMockModel({ values: { amount: 50 } }, 'fill_action_form');
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.AutomatedWithConfirmation,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(mockModel.bindTools).toHaveBeenCalled();
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          pendingData: expect.objectContaining({
+            form: expect.objectContaining({ aiFilledValues: [{ field: 'amount', value: 50 }] }),
+          }),
+        }),
+      );
+    });
+
+    it('persists a pending-approval submission without an actionResult (PRD-511/520)', async () => {
+      const agentPort = makeMockAgentPort();
+      const execution: TriggerRecordActionStepExecutionData = {
+        type: 'trigger-action',
+        stepIndex: 0,
+        pendingData: {
+          displayName: 'Process Refund',
+          name: 'process-refund',
+          form: { fields: [], aiFilledValues: [{ field: 'amount', value: 50 }] },
+        },
+        userConfirmation: {
+          userConfirmed: true,
+          submissionOutcome: 'pending-approval',
+          submittedValues: { amount: 50 },
+        },
+        selectedRecordRef: makeRecordRef(),
+      };
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([execution]),
+      });
+      const context = makeContext({ agentPort, runStore });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          executionResult: {
+            success: true,
+            submissionOutcome: 'pending-approval',
+            submittedValues: { amount: 50 },
+            aiFilledValues: [{ field: 'amount', value: 50 }],
+          },
         }),
       );
     });

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -460,6 +460,7 @@ describe('TriggerRecordActionStepExecutor', () => {
             success: true,
             actionResult: { success: 'ok', html: '<p>Email queued</p>' },
             submissionOutcome: 'executed',
+            submittedBy: 'user',
           },
           pendingData: {
             displayName: 'Send Welcome Email',
@@ -497,7 +498,12 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
         expect.objectContaining({
-          executionResult: { success: true, actionResult: null, submissionOutcome: 'executed' },
+          executionResult: {
+            success: true,
+            actionResult: null,
+            submissionOutcome: 'executed',
+            submittedBy: 'user',
+          },
         }),
       );
     });
@@ -1535,6 +1541,7 @@ describe('TriggerRecordActionStepExecutor', () => {
           executionResult: {
             success: true,
             submissionOutcome: 'pending-approval',
+            submittedBy: 'user',
             submittedValues: { amount: 50 },
             aiFilledValues: [{ field: 'amount', value: 50 }],
           },

--- a/packages/workflow-executor/test/integration/workflow-execution.test.ts
+++ b/packages/workflow-executor/test/integration/workflow-execution.test.ts
@@ -168,6 +168,9 @@ function createMockAgentPort(): jest.Mocked<AgentPort> {
     resolvePolymorphicType: jest.fn().mockResolvedValue(null),
     executeAction: jest.fn().mockResolvedValue(undefined),
     getActionFormInfo: jest.fn().mockResolvedValue({ hasForm: false }),
+    getActionForm: jest
+      .fn()
+      .mockResolvedValue({ fields: [], canExecute: true, requiredFields: [], skippedFields: [] }),
     probe: jest.fn().mockResolvedValue(undefined),
   } as jest.Mocked<AgentPort>;
 }


### PR DESCRIPTION
## Integration / tracking PR (draft)

Branche d'intégration qui regroupe 3 epics de workflow steps (moteur orchestrateur) :
- Deterministic **Load Related Record**
- Deterministic **Trigger Action** step
- **Full AI Action Forms** (PRD-57)

### Process
Les PRs de story ciblent cette branche → review ponytail → merge ici. À la toute fin, cette branche merge sur `main` (les 3 repos en même temps).

**Ne pas merger tant que les stories ne sont pas toutes validées.** PR gardée en draft pour suivre l'évolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AI form-fill and deterministic step pinning to workflow action and related-record steps
> - `TriggerRecordActionStepExecutor` now fetches the full action form via `agent.getActionForm`, runs an iterative AI fill loop, and either executes immediately (Full AI, `canExecute`) or pauses with prefilled values for user review; approval-gated and validation errors fall back to pause instead of failing the step.
> - `LoadRelatedRecordStepExecutor` and `TriggerRecordActionStepExecutor` resolve their source record by stable `selectedRecordStepId` (or the `workflow-start` sentinel) via a new `resolveSourceRecordRef` helper, replacing runtime index references that broke after revisions.
> - `AgentClientAgentPort` gains `getActionForm` and extends `executeAction` to accept pre-filled values, translating agent-client HTTP errors (403, 400/422) into typed domain errors (`ActionRequiresApprovalError`, `ActionFormValidationError`).
> - `agent-client` introduces `AgentHttpError`, `ActionRequiresApprovalError`, and `ActionFormValidationError` classes; `HttpRequester` now rejects with a structured `AgentHttpError` instead of embedding JSON in `Error.message`.
> - Step definitions for `trigger-action` and `load-related-record` accept `preRecordedArgs.selectedRecordStepId` and optional `filters`; `executionType` now includes `Manual` without coercion.
> - `StepExecutionFormatters` adds a `trigger-action` formatter that surfaces approval status, AI-prefilled fields, and user edits.
> - Risk: removing `.catch()` coercion from `TriggerActionStepDefinitionSchema` means previously-invalid `executionType` values that were silently converted to `AutomatedWithConfirmation` will now fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a3b867.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->