### PR TITLE
refactor(agent-client): typed AgentHttpError instead of a stringified message

### DIFF
--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -25,10 +25,8 @@ type ActionErrorBody = {
   data?: { roleIdsAllowedToApprove?: number[] };
 };
 
-// Translate a transport-level AgentHttpError from an action execution into a semantic action error,
-// so callers route on meaning instead of HTTP status/body. The agent rejects an approval-gated
-// action with 403 CustomActionRequiresApprovalError (carrying roleIdsAllowedToApprove) and a
-// form-validation failure with 400/422. Anything else propagates unchanged.
+// Translate the transport AgentHttpError into a semantic action error so callers route on meaning.
+// Approval gate = 403 CustomActionRequiresApprovalError; form validation = 400/422; else unchanged.
 function toActionError(error: unknown): unknown {
   if (!(error instanceof AgentHttpError)) return error;
 

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -17,6 +17,40 @@ import ActionFieldRadioGroup from '../action-fields/action-field-radio-group';
 import ActionFieldString from '../action-fields/action-field-string';
 import ActionFieldStringList from '../action-fields/action-field-string-list';
 import ActionLayoutRoot from '../action-layout/action-layout-root';
+import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from '../errors';
+
+// JSON:API error body the agent returns on a rejected action.
+type ActionErrorBody = {
+  errors?: { name?: string; detail?: string; data?: { roleIdsAllowedToApprove?: number[] } }[];
+  data?: { roleIdsAllowedToApprove?: number[] };
+};
+
+// Translate a transport-level AgentHttpError from an action execution into a semantic action error,
+// so callers route on meaning instead of HTTP status/body. The agent rejects an approval-gated
+// action with 403 CustomActionRequiresApprovalError (carrying roleIdsAllowedToApprove) and a
+// form-validation failure with 400/422. Anything else propagates unchanged.
+function toActionError(error: unknown): unknown {
+  if (!(error instanceof AgentHttpError)) return error;
+
+  const body = (error.body ?? {}) as ActionErrorBody;
+  const detail = body.errors?.[0]?.detail;
+  const isApproval =
+    body.errors?.[0]?.name === 'CustomActionRequiresApprovalError' ||
+    !!error.responseText?.includes('CustomActionRequiresApprovalError');
+
+  if (error.status === 403 && isApproval) {
+    return new ActionRequiresApprovalError(
+      detail ?? 'This action requires an approval before it can run.',
+      body.errors?.[0]?.data?.roleIdsAllowedToApprove ?? body.data?.roleIdsAllowedToApprove,
+    );
+  }
+
+  if (error.status === 400 || error.status === 422) {
+    return new ActionFormValidationError(detail ?? 'The action form values were rejected.');
+  }
+
+  return error;
+}
 
 export type BaseActionContext = {
   recordId?: RecordId;
@@ -69,11 +103,15 @@ export default class Action {
       },
     };
 
-    return this.httpRequester.query<{ success: string }>({
-      method: 'post',
-      path: this.actionPath,
-      body: requestBody,
-    });
+    try {
+      return await this.httpRequester.query<{ success: string }>({
+        method: 'post',
+        path: this.actionPath,
+        body: requestBody,
+      });
+    } catch (error) {
+      throw toActionError(error);
+    }
   }
 
   async setFields(fields: Record<string, unknown>): Promise<void> {

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
-// Typed HTTP error from the agent. Carries the status and the parsed response body so callers route
-// on structured data instead of string-parsing a message. `body` is the parsed JSON:API error
-// ({ errors: [...] }) when available, else the raw text; `responseText` keeps the raw body.
+// Typed transport error: status + parsed body (JSON:API `{ errors: [...] }` when available, else
+// raw text). Callers read fields directly instead of parsing a stringified message.
 export default class AgentHttpError extends Error {
   constructor(readonly status: number, readonly body: unknown, readonly responseText?: string) {
     super(`Agent responded with HTTP ${status}`);
@@ -10,9 +9,8 @@ export default class AgentHttpError extends Error {
   }
 }
 
-// Semantic errors for action execution: agent-client interprets the HTTP failure once (status +
-// JSON:API body) and exposes the meaning, so callers never inspect transport details. `message`
-// carries the agent's own detail when available.
+// Semantic action errors: agent-client interprets the failure once so callers route on meaning, not
+// status/body. `message` carries the agent's detail when available.
 export class ActionRequiresApprovalError extends Error {
   constructor(message: string, readonly roleIdsAllowedToApprove?: number[]) {
     super(message);

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -1,12 +1,8 @@
 // Typed HTTP error from the agent. Carries the status and the parsed response body so callers route
 // on structured data instead of string-parsing a message. `body` is the parsed JSON:API error
 // ({ errors: [...] }) when available, else the raw text; `responseText` keeps the raw body.
-export class AgentHttpError extends Error {
-  constructor(
-    readonly status: number,
-    readonly body: unknown,
-    readonly responseText?: string,
-  ) {
+export default class AgentHttpError extends Error {
+  constructor(readonly status: number, readonly body: unknown, readonly responseText?: string) {
     super(`Agent responded with HTTP ${status}`);
     this.name = 'AgentHttpError';
   }

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-classes-per-file */
+
 // Typed HTTP error from the agent. Carries the status and the parsed response body so callers route
 // on structured data instead of string-parsing a message. `body` is the parsed JSON:API error
 // ({ errors: [...] }) when available, else the raw text; `responseText` keeps the raw body.
@@ -5,5 +7,22 @@ export default class AgentHttpError extends Error {
   constructor(readonly status: number, readonly body: unknown, readonly responseText?: string) {
     super(`Agent responded with HTTP ${status}`);
     this.name = 'AgentHttpError';
+  }
+}
+
+// Semantic errors for action execution: agent-client interprets the HTTP failure once (status +
+// JSON:API body) and exposes the meaning, so callers never inspect transport details. `message`
+// carries the agent's own detail when available.
+export class ActionRequiresApprovalError extends Error {
+  constructor(message: string, readonly roleIdsAllowedToApprove?: number[]) {
+    super(message);
+    this.name = 'ActionRequiresApprovalError';
+  }
+}
+
+export class ActionFormValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ActionFormValidationError';
   }
 }

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -1,0 +1,13 @@
+// Typed HTTP error from the agent. Carries the status and the parsed response body so callers route
+// on structured data instead of string-parsing a message. `body` is the parsed JSON:API error
+// ({ errors: [...] }) when available, else the raw text; `responseText` keeps the raw body.
+export class AgentHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: unknown,
+    readonly responseText?: string,
+  ) {
+    super(`Agent responded with HTTP ${status}`);
+    this.name = 'AgentHttpError';
+  }
+}

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -3,10 +3,11 @@ import type { WriteStream } from 'fs';
 import { Deserializer } from 'jsonapi-serializer';
 import superagent from 'superagent';
 
-import { AgentHttpError } from './errors';
+import AgentHttpError from './errors';
 
 function parseJson(text: string | undefined): unknown {
   if (text === undefined) return undefined;
+
   try {
     return JSON.parse(text);
   } catch {

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -3,6 +3,17 @@ import type { WriteStream } from 'fs';
 import { Deserializer } from 'jsonapi-serializer';
 import superagent from 'superagent';
 
+import { AgentHttpError } from './errors';
+
+function parseJson(text: string | undefined): unknown {
+  if (text === undefined) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 export default class HttpRequester {
   private readonly deserializer: Deserializer;
 
@@ -60,9 +71,15 @@ export default class HttpRequester {
         return (response.body ?? response.text) as Data;
       }
     } catch (error) {
-      const superagentError = error as { response?: { error?: Record<string, string> } };
-      if (!superagentError.response) throw error;
-      throw new Error(JSON.stringify({ error: superagentError.response.error, body }, null, 4));
+      const res = (error as { response?: { status?: number; body?: unknown; text?: string } })
+        .response;
+      if (!res) throw error; // network/timeout/abort → no HTTP response, propagate raw
+
+      const text = typeof res.text === 'string' ? res.text : undefined;
+      const hasBody =
+        !!res.body && typeof res.body === 'object' && Object.keys(res.body).length > 0;
+
+      throw new AgentHttpError(res.status ?? 0, hasBody ? res.body : parseJson(text), text);
     }
   }
 
@@ -105,13 +122,7 @@ export default class HttpRequester {
   }
 
   static is404Error(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-
-    try {
-      return JSON.parse(error.message)?.error?.status === 404;
-    } catch {
-      return false;
-    }
+    return error instanceof AgentHttpError && error.status === 404;
   }
 
   private buildUrl(path: string): string {

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -8,7 +8,7 @@ import type {
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
 import RemoteAgentClient from './domains/remote-agent-client';
-import { AgentHttpError } from './errors';
+import AgentHttpError from './errors';
 import HttpRequester from './http-requester';
 
 export { ActionFieldJson, ActionFieldStringList, RemoteAgentClient, HttpRequester, AgentHttpError };

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -8,10 +8,18 @@ import type {
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
 import RemoteAgentClient from './domains/remote-agent-client';
-import AgentHttpError from './errors';
+import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from './errors';
 import HttpRequester from './http-requester';
 
-export { ActionFieldJson, ActionFieldStringList, RemoteAgentClient, HttpRequester, AgentHttpError };
+export {
+  ActionFieldJson,
+  ActionFieldStringList,
+  RemoteAgentClient,
+  HttpRequester,
+  AgentHttpError,
+  ActionRequiresApprovalError,
+  ActionFormValidationError,
+};
 export type {
   ActionEndpointsByCollection,
   CollectionPermissionsOverride,

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -8,9 +8,10 @@ import type {
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
 import RemoteAgentClient from './domains/remote-agent-client';
+import { AgentHttpError } from './errors';
 import HttpRequester from './http-requester';
 
-export { ActionFieldJson, ActionFieldStringList, RemoteAgentClient, HttpRequester };
+export { ActionFieldJson, ActionFieldStringList, RemoteAgentClient, HttpRequester, AgentHttpError };
 export type {
   ActionEndpointsByCollection,
   CollectionPermissionsOverride,

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -1,7 +1,7 @@
 import type HttpRequester from '../../src/http-requester';
 
 import FieldFormStates from '../../src/action-fields/field-form-states';
-import { AgentHttpError } from '../../src/errors';
+import AgentHttpError from '../../src/errors';
 
 jest.mock('../../src/http-requester', () => {
   const actual = jest.requireActual('../../src/http-requester');

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -1,6 +1,7 @@
 import type HttpRequester from '../../src/http-requester';
 
 import FieldFormStates from '../../src/action-fields/field-form-states';
+import { AgentHttpError } from '../../src/errors';
 
 jest.mock('../../src/http-requester', () => {
   const actual = jest.requireActual('../../src/http-requester');
@@ -278,9 +279,7 @@ describe('FieldFormStates', () => {
         { load: false, change: [] },
       );
 
-      const error404 = new Error(
-        JSON.stringify({ error: { status: 404, text: 'Not Found' }, body: null }),
-      );
+      const error404 = new AgentHttpError(404, null, 'Not Found');
       httpRequester.query.mockRejectedValue(error404);
 
       await formStates.loadInitialState();
@@ -307,9 +306,7 @@ describe('FieldFormStates', () => {
         fallbackFields,
       );
 
-      const error404 = new Error(
-        JSON.stringify({ error: { status: 404, text: 'Not Found' }, body: null }),
-      );
+      const error404 = new AgentHttpError(404, null, 'Not Found');
       httpRequester.query.mockRejectedValue(error404);
 
       await formStates.loadInitialState();
@@ -331,9 +328,7 @@ describe('FieldFormStates', () => {
         { load: false, change: [] },
       );
 
-      const error500 = new Error(
-        JSON.stringify({ error: { status: 500, text: 'Internal Server Error' }, body: null }),
-      );
+      const error500 = new AgentHttpError(500, null, 'Internal Server Error');
       httpRequester.query.mockRejectedValue(error500);
 
       await expect(formStates.loadInitialState()).rejects.toThrow();

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -2,6 +2,7 @@ import type FieldFormStates from '../../src/action-fields/field-form-states';
 import type HttpRequester from '../../src/http-requester';
 
 import Action from '../../src/domains/action';
+import AgentHttpError from '../../src/errors';
 
 jest.mock('../../src/http-requester');
 jest.mock('../../src/action-fields/field-form-states');
@@ -114,6 +115,44 @@ describe('Action', () => {
           },
         },
       });
+    });
+
+    it('should translate a 403 approval rejection into ActionRequiresApprovalError', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [
+            {
+              name: 'CustomActionRequiresApprovalError',
+              detail: 'Needs approval',
+              data: { roleIdsAllowedToApprove: [7, 9] },
+            },
+          ],
+        }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionRequiresApprovalError',
+        message: 'Needs approval',
+        roleIdsAllowedToApprove: [7, 9],
+      });
+    });
+
+    it('should translate a 422 rejection into ActionFormValidationError', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(422, { errors: [{ detail: 'Invalid value' }] }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'Invalid value',
+      });
+    });
+
+    it('should propagate other HTTP errors unchanged', async () => {
+      const error = new AgentHttpError(500, null);
+      httpRequester.query.mockRejectedValue(error);
+
+      await expect(action.execute()).rejects.toBe(error);
     });
   });
 

--- a/packages/agent-client/test/http-requester.test.ts
+++ b/packages/agent-client/test/http-requester.test.ts
@@ -1,5 +1,6 @@
 import superagent from 'superagent';
 
+import { AgentHttpError } from '../src/errors';
 import HttpRequester from '../src/http-requester';
 
 jest.mock('superagent');
@@ -43,23 +44,20 @@ describe('HttpRequester', () => {
   });
 
   describe('is404Error', () => {
-    it('should return true for a 404 error', () => {
-      const error = new Error(JSON.stringify({ error: { status: 404 }, body: null }));
-      expect(HttpRequester.is404Error(error)).toBe(true);
+    it('should return true for a 404 AgentHttpError', () => {
+      expect(HttpRequester.is404Error(new AgentHttpError(404, null))).toBe(true);
     });
 
-    it('should return false for a 500 error', () => {
-      const error = new Error(JSON.stringify({ error: { status: 500 }, body: null }));
-      expect(HttpRequester.is404Error(error)).toBe(false);
+    it('should return false for a non-404 AgentHttpError', () => {
+      expect(HttpRequester.is404Error(new AgentHttpError(500, null))).toBe(false);
     });
 
     it('should return false for a non-Error', () => {
       expect(HttpRequester.is404Error('not an error')).toBe(false);
     });
 
-    it('should return false for non-JSON error message', () => {
-      const error = new Error('plain text error');
-      expect(HttpRequester.is404Error(error)).toBe(false);
+    it('should return false for a plain Error', () => {
+      expect(HttpRequester.is404Error(new Error('plain text error'))).toBe(false);
     });
   });
 

--- a/packages/agent-client/test/http-requester.test.ts
+++ b/packages/agent-client/test/http-requester.test.ts
@@ -1,6 +1,6 @@
 import superagent from 'superagent';
 
-import { AgentHttpError } from '../src/errors';
+import AgentHttpError from '../src/errors';
 import HttpRequester from '../src/http-requester';
 
 jest.mock('superagent');

--- a/packages/agent-client/test/http-requester.test.ts
+++ b/packages/agent-client/test/http-requester.test.ts
@@ -240,6 +240,28 @@ describe('HttpRequester', () => {
       );
     });
 
+    it('should parse the JSON body from the response text when body is empty', async () => {
+      const error = { response: { status: 422, text: '{"errors":[{"detail":"bad"}]}' } };
+      mockRequest.then = jest.fn((_onFulfilled: any, onRejected: any) =>
+        Promise.resolve(onRejected(error)),
+      );
+
+      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
+        { status: 422, body: { errors: [{ detail: 'bad' }] }, responseText: error.response.text },
+      );
+    });
+
+    it('should fall back to the raw text when it is not valid JSON', async () => {
+      const error = { response: { status: 500, text: 'Internal Server Error' } };
+      mockRequest.then = jest.fn((_onFulfilled: any, onRejected: any) =>
+        Promise.resolve(onRejected(error)),
+      );
+
+      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
+        { status: 500, body: 'Internal Server Error' },
+      );
+    });
+
     it('should deserialize JSON API response', async () => {
       const responseBody = {
         data: {

--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -17,8 +17,7 @@ function jsonApiDetail(body: unknown, text?: string): string | null {
   return null;
 }
 
-// Turn an agent RPC error into a human-readable message. HTTP failures arrive as AgentHttpError
-// (status + parsed body); everything else falls back to the raw message.
+// Turn an agent RPC error into a human-readable message (AgentHttpError detail, else raw message).
 export default function parseAgentError(error: unknown): string | null {
   if (error instanceof AgentHttpError) {
     return jsonApiDetail(error.body, error.responseText) ?? error.message;

--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -1,64 +1,32 @@
-/**
- * Parse JSON:API error text to extract the detail message.
- */
-function parseJsonApiErrorText(text: string): string | null {
-  try {
-    const parsed = JSON.parse(text) as {
-      errors?: Array<{ detail?: string; name?: string }>;
-    };
+import { AgentHttpError } from '@forestadmin/agent-client';
 
-    if (parsed.errors?.[0]?.detail) {
-      return parsed.errors[0].detail;
+// Extract the JSON:API detail message from a parsed body or its raw text.
+function jsonApiDetail(body: unknown, text?: string): string | null {
+  const fromBody = (body as { errors?: Array<{ detail?: string }> })?.errors?.[0]?.detail;
+  if (fromBody) return fromBody;
+
+  if (typeof text === 'string') {
+    try {
+      const parsed = JSON.parse(text) as { errors?: Array<{ detail?: string }> };
+      if (parsed.errors?.[0]?.detail) return parsed.errors[0].detail;
+    } catch {
+      // not JSON:API → fall through
     }
-  } catch {
-    // Ignore parsing failures
   }
 
   return null;
 }
 
-/**
- * Parse error from the agent RPC client.
- * The error structure can vary:
- * - Error with message containing JSON: { error: { text: '{"errors":[{"detail":"..."}]}' } }
- * - Error with message containing JSON: { text: '{"errors":[{"detail":"..."}]}' }
- * - Error with message containing JSON: { message: '...' }
- * - Error with plain string message
- */
+// Turn an agent RPC error into a human-readable message. HTTP failures arrive as AgentHttpError
+// (status + parsed body); everything else falls back to the raw message.
 export default function parseAgentError(error: unknown): string | null {
-  try {
-    const err = JSON.parse((error as Error).message) as {
-      error?: { text?: string };
-      text?: string;
-      message?: string;
-    };
-
-    // Try nested error.text first (e.g., { error: { text: '...' } })
-    if (err.error?.text) {
-      const detail = parseJsonApiErrorText(err.error.text);
-
-      if (detail) return detail;
-    }
-
-    // Try direct text property (e.g., { text: '...' })
-    if (err.text) {
-      const detail = parseJsonApiErrorText(err.text);
-
-      if (detail) return detail;
-    }
-
-    // Fallback to message property
-    if (err.message) {
-      return err.message;
-    }
-
-    return null;
-  } catch {
-    // If parsing fails, try to get message directly
-    if (error && typeof error === 'object' && 'message' in error) {
-      return (error as { message: string }).message || null;
-    }
-
-    return null;
+  if (error instanceof AgentHttpError) {
+    return jsonApiDetail(error.body, error.responseText) ?? error.message;
   }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    return (error as { message: string }).message || null;
+  }
+
+  return null;
 }

--- a/packages/mcp-server/test/utils/error-parser.test.ts
+++ b/packages/mcp-server/test/utils/error-parser.test.ts
@@ -1,142 +1,48 @@
+import { AgentHttpError } from '@forestadmin/agent-client';
+
 import parseAgentError from '../../src/utils/error-parser';
 
 describe('parseAgentError', () => {
-  describe('nested error.text structure', () => {
-    it('should parse error with nested error.text containing JSON:API errors', () => {
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError', detail: 'Invalid filters provided' }],
-          }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('Invalid filters provided');
+  it('extracts the JSON:API detail from the parsed body', () => {
+    const error = new AgentHttpError(400, {
+      errors: [{ name: 'ValidationError', detail: 'Invalid filters provided' }],
     });
 
-    it('should return null when error.text has no errors array', () => {
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({ success: false }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+    expect(parseAgentError(error)).toBe('Invalid filters provided');
   });
 
-  describe('direct text property', () => {
-    it('should parse error with direct text property containing JSON:API errors', () => {
-      const errorPayload = {
-        text: JSON.stringify({
-          errors: [{ name: 'ValidationError', detail: 'Direct text error' }],
-        }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
+  it('falls back to parsing responseText when the body is not a parsed object', () => {
+    const error = new AgentHttpError(
+      400,
+      undefined,
+      JSON.stringify({ errors: [{ detail: 'From raw text' }] }),
+    );
 
-      expect(parseAgentError(error)).toBe('Direct text error');
-    });
-
-    it('should return null when text has no errors array', () => {
-      const errorPayload = {
-        text: JSON.stringify({ success: false }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+    expect(parseAgentError(error)).toBe('From raw text');
   });
 
-  describe('message property fallback', () => {
-    it('should use message property from parsed JSON when no text field', () => {
-      const errorPayload = {
-        message: 'Error message from JSON payload',
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('Error message from JSON payload');
-    });
+  it('returns the generic HTTP message when the body has no JSON:API detail', () => {
+    expect(parseAgentError(new AgentHttpError(400, { success: false }))).toBe(
+      'Agent responded with HTTP 400',
+    );
   });
 
-  describe('plain error message fallback', () => {
-    it('should fall back to error.message when message is not valid JSON', () => {
-      const error = new Error('Plain error message');
-
-      expect(parseAgentError(error)).toBe('Plain error message');
-    });
+  it('returns the generic HTTP message for an empty errors array', () => {
+    expect(parseAgentError(new AgentHttpError(422, { errors: [] }))).toBe(
+      'Agent responded with HTTP 422',
+    );
   });
 
-  describe('error priority', () => {
-    it('should prioritize error.text over direct text', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({
-            errors: [{ detail: 'From error.text' }],
-          }),
-        },
-        text: JSON.stringify({
-          errors: [{ detail: 'From direct text' }],
-        }),
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('From error.text');
-    });
-
-    it('should prioritize text over message', () => {
-      const errorPayload = {
-        text: JSON.stringify({
-          errors: [{ detail: 'From text' }],
-        }),
-        message: 'From message',
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBe('From text');
-    });
+  it('returns the message of a plain Error', () => {
+    expect(parseAgentError(new Error('Plain error message'))).toBe('Plain error message');
   });
 
-  describe('edge cases', () => {
-    it('should return null for object without message property', () => {
-      const error = { unknownProperty: 'some value' };
+  it('returns null for an object without a message', () => {
+    expect(parseAgentError({ unknownProperty: 'some value' })).toBeNull();
+  });
 
-      expect(parseAgentError(error)).toBeNull();
-    });
-
-    it('should return null for null error', () => {
-      expect(parseAgentError(null)).toBeNull();
-    });
-
-    it('should return null for undefined error', () => {
-      expect(parseAgentError(undefined)).toBeNull();
-    });
-
-    it('should handle empty errors array', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({ errors: [] }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
-
-    it('should handle error without detail property', () => {
-      const errorPayload = {
-        error: {
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError' }],
-          }),
-        },
-      };
-      const error = new Error(JSON.stringify(errorPayload));
-
-      expect(parseAgentError(error)).toBeNull();
-    });
+  it('returns null for null/undefined', () => {
+    expect(parseAgentError(null)).toBeNull();
+    expect(parseAgentError(undefined)).toBeNull();
   });
 });

--- a/packages/mcp-server/test/utils/with-activity-log.test.ts
+++ b/packages/mcp-server/test/utils/with-activity-log.test.ts
@@ -3,6 +3,8 @@ import type { Logger } from '../../src/server';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
 
+import { AgentHttpError } from '@forestadmin/agent-client';
+
 import createPendingActivityLog, {
   markActivityLogAsFailed,
   markActivityLogAsSucceeded,
@@ -137,15 +139,11 @@ describe('withActivityLog', () => {
   });
 
   it('should parse agent error and use detail as error message', async () => {
-    const errorPayload = {
-      error: {
-        status: 400,
-        text: JSON.stringify({
-          errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
-        }),
-      },
-    };
-    const operation = jest.fn().mockRejectedValue(new Error(JSON.stringify(errorPayload)));
+    const operation = jest.fn().mockRejectedValue(
+      new AgentHttpError(400, {
+        errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
+      }),
+    );
 
     await expect(
       withActivityLog({
@@ -283,16 +281,9 @@ describe('withActivityLog', () => {
     });
 
     it('should pass parsed agent error detail to errorEnhancer', async () => {
-      // parseAgentError expects an Error with a JSON message containing error details
-      const errorPayload = {
-        error: {
-          status: 400,
-          text: JSON.stringify({
-            errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
-          }),
-        },
-      };
-      const agentError = new Error(JSON.stringify(errorPayload));
+      const agentError = new AgentHttpError(400, {
+        errors: [{ name: 'ValidationError', detail: 'Invalid field value' }],
+      });
       const operation = jest.fn().mockRejectedValue(agentError);
       const errorEnhancer = jest.fn().mockImplementation(msg => Promise.resolve(`Context: ${msg}`));
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -16,7 +16,7 @@ import type { StepUser } from '../types/execution-context';
 import type { RecordData } from '../types/validated/collection';
 import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/agent-client';
 
-import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import { AgentHttpError, HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import {
@@ -29,50 +29,36 @@ import {
   extractErrorMessage,
 } from '../errors';
 
-// The agent-client throws `new Error(JSON.stringify({ error: { status, text }, body }))` on a non-2xx
-// (superagent's toError sets status + text = raw response body). Parse it back to (status, body).
-function parseAgentHttpError(error: unknown): { status?: number; text?: string } {
-  if (!(error instanceof Error)) return {};
-
-  try {
-    const parsed = JSON.parse(error.message) as { error?: { status?: number; text?: string } };
-
-    return { status: parsed.error?.status, text: parsed.error?.text };
-  } catch {
-    return {};
-  }
-}
+// JSON:API error body the agent returns on a rejected action.
+type ActionErrorBody = {
+  errors?: { name?: string; data?: { roleIdsAllowedToApprove?: number[] } }[];
+  data?: { roleIdsAllowedToApprove?: number[] };
+};
 
 // The agent rejects an approval-gated action with HTTP 403 CustomActionRequiresApprovalError,
-// carrying roleIdsAllowedToApprove. Pull the roles out of the response body when present.
-function extractRoleIdsAllowedToApprove(text: string): number[] | undefined {
-  try {
-    const body = JSON.parse(text) as {
-      errors?: { data?: { roleIdsAllowedToApprove?: number[] } }[];
-      data?: { roleIdsAllowedToApprove?: number[] };
-    };
-
-    return (
-      body.errors?.[0]?.data?.roleIdsAllowedToApprove ??
-      body.data?.roleIdsAllowedToApprove ??
-      undefined
-    );
-  } catch {
-    return undefined;
-  }
+// carrying roleIdsAllowedToApprove. Pull the roles out of the parsed response body when present.
+function extractRoleIdsAllowedToApprove(body: ActionErrorBody): number[] | undefined {
+  return (
+    body.errors?.[0]?.data?.roleIdsAllowedToApprove ?? body.data?.roleIdsAllowedToApprove ?? undefined
+  );
 }
 
 // Map an action `execute()` failure to a typed error so the step executor can route it:
 // approval-403 and validation rejections become distinct fallback-worthy errors; everything else
 // (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
 function mapActionExecutionError(action: string, cause: unknown): unknown {
-  const { status, text } = parseAgentHttpError(cause);
+  if (!(cause instanceof AgentHttpError)) return cause;
 
-  if (status === 403 && text && text.includes('CustomActionRequiresApprovalError')) {
-    return new ActionRequiresApprovalError(action, extractRoleIdsAllowedToApprove(text));
+  const body = (cause.body ?? {}) as ActionErrorBody;
+  const isApproval =
+    body.errors?.[0]?.name === 'CustomActionRequiresApprovalError' ||
+    cause.responseText?.includes('CustomActionRequiresApprovalError');
+
+  if (cause.status === 403 && isApproval) {
+    return new ActionRequiresApprovalError(action, extractRoleIdsAllowedToApprove(body));
   }
 
-  if (status === 400 || status === 422) {
+  if (cause.status === 400 || cause.status === 422) {
     return new ActionFormValidationError(action, cause);
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -16,7 +16,12 @@ import type { StepUser } from '../types/execution-context';
 import type { RecordData } from '../types/validated/collection';
 import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/agent-client';
 
-import { AgentHttpError, HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import {
+  ActionFormValidationError as ClientActionFormValidationError,
+  ActionRequiresApprovalError as ClientActionRequiresApprovalError,
+  HttpRequester,
+  createRemoteAgentClient,
+} from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import {
@@ -29,38 +34,15 @@ import {
   extractErrorMessage,
 } from '../errors';
 
-// JSON:API error body the agent returns on a rejected action.
-type ActionErrorBody = {
-  errors?: { name?: string; data?: { roleIdsAllowedToApprove?: number[] } }[];
-  data?: { roleIdsAllowedToApprove?: number[] };
-};
-
-// The agent rejects an approval-gated action with HTTP 403 CustomActionRequiresApprovalError,
-// carrying roleIdsAllowedToApprove. Pull the roles out of the parsed response body when present.
-function extractRoleIdsAllowedToApprove(body: ActionErrorBody): number[] | undefined {
-  return (
-    body.errors?.[0]?.data?.roleIdsAllowedToApprove ??
-    body.data?.roleIdsAllowedToApprove ??
-    undefined
-  );
-}
-
-// Map an action `execute()` failure to a typed error so the step executor can route it:
-// approval-403 and validation rejections become distinct fallback-worthy errors; everything else
-// (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
+// agent-client already interpreted the HTTP failure into a semantic action error; re-wrap it into
+// the executor's domain error (carrying userMessage + driving the step fallback flow). Anything
+// else (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
 function mapActionExecutionError(action: string, cause: unknown): unknown {
-  if (!(cause instanceof AgentHttpError)) return cause;
-
-  const body = (cause.body ?? {}) as ActionErrorBody;
-  const isApproval =
-    body.errors?.[0]?.name === 'CustomActionRequiresApprovalError' ||
-    cause.responseText?.includes('CustomActionRequiresApprovalError');
-
-  if (cause.status === 403 && isApproval) {
-    return new ActionRequiresApprovalError(action, extractRoleIdsAllowedToApprove(body));
+  if (cause instanceof ClientActionRequiresApprovalError) {
+    return new ActionRequiresApprovalError(action, cause.roleIdsAllowedToApprove);
   }
 
-  if (cause.status === 400 || cause.status === 422) {
+  if (cause instanceof ClientActionFormValidationError) {
     return new ActionFormValidationError(action, cause);
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -39,7 +39,9 @@ type ActionErrorBody = {
 // carrying roleIdsAllowedToApprove. Pull the roles out of the parsed response body when present.
 function extractRoleIdsAllowedToApprove(body: ActionErrorBody): number[] | undefined {
   return (
-    body.errors?.[0]?.data?.roleIdsAllowedToApprove ?? body.data?.roleIdsAllowedToApprove ?? undefined
+    body.errors?.[0]?.data?.roleIdsAllowedToApprove ??
+    body.data?.roleIdsAllowedToApprove ??
+    undefined
   );
 }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -34,9 +34,8 @@ import {
   extractErrorMessage,
 } from '../errors';
 
-// agent-client already interpreted the HTTP failure into a semantic action error; re-wrap it into
-// the executor's domain error (carrying userMessage + driving the step fallback flow). Anything
-// else (plain permission 403, infra 5xx, network) stays raw → wrapped as AgentPortError = step error.
+// Re-wrap agent-client's semantic action error into the executor's domain error (carries userMessage
+// + drives the step fallback). Anything else stays raw → AgentPortError = step error.
 function mapActionExecutionError(action: string, cause: unknown): unknown {
   if (cause instanceof ClientActionRequiresApprovalError) {
     return new ActionRequiresApprovalError(action, cause.roleIdsAllowedToApprove);

--- a/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
+++ b/packages/workflow-executor/src/executors/summary/step-execution-formatters.ts
@@ -57,7 +57,9 @@ export default class StepExecutionFormatters {
           field => JSON.stringify(submitted[field]) !== JSON.stringify(aiMap[field]),
         );
 
-        if (edited.length) lines.push(`  Edited by the user before submitting: ${edited.join(', ')}.`);
+        if (edited.length) {
+          lines.push(`  Edited by the user before submitting: ${edited.join(', ')}.`);
+        }
       }
     }
 

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1,9 +1,10 @@
+/* eslint-disable max-classes-per-file */
 import type { StepUser } from '../../src/types/execution-context';
 
 import {
-  ActionFormValidationError as ClientFormValidationError,
-  ActionRequiresApprovalError as ClientApprovalError,
   AgentHttpError,
+  ActionRequiresApprovalError as ClientApprovalError,
+  ActionFormValidationError as ClientFormValidationError,
   HttpRequester,
   createRemoteAgentClient,
 } from '@forestadmin/agent-client';

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -15,7 +15,7 @@ import SchemaCache from '../../src/schema-cache';
 
 jest.mock('@forestadmin/agent-client', () => {
   // Real class so `instanceof AgentHttpError` in the adapter matches errors built by these tests.
-  class AgentHttpError extends Error {
+  class MockAgentHttpError extends Error {
     constructor(
       public readonly status: number,
       public readonly body: unknown,
@@ -27,7 +27,7 @@ jest.mock('@forestadmin/agent-client', () => {
   }
 
   return {
-    AgentHttpError,
+    AgentHttpError: MockAgentHttpError,
     createRemoteAgentClient: jest.fn(),
     HttpRequester: { is404Error: jest.fn() },
   };
@@ -779,7 +779,10 @@ describe('AgentClientAgentPort', () => {
       mockAction.execute.mockRejectedValue(
         new AgentHttpError(403, {
           errors: [
-            { name: 'CustomActionRequiresApprovalError', data: { roleIdsAllowedToApprove: [7, 9] } },
+            {
+              name: 'CustomActionRequiresApprovalError',
+              data: { roleIdsAllowedToApprove: [7, 9] },
+            },
           ],
         }),
       );

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1,6 +1,12 @@
 import type { StepUser } from '../../src/types/execution-context';
 
-import { AgentHttpError, HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import {
+  ActionFormValidationError as ClientFormValidationError,
+  ActionRequiresApprovalError as ClientApprovalError,
+  AgentHttpError,
+  HttpRequester,
+  createRemoteAgentClient,
+} from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
@@ -26,8 +32,26 @@ jest.mock('@forestadmin/agent-client', () => {
     }
   }
 
+  // Semantic action errors agent-client throws from execute(); real classes so the adapter's
+  // `instanceof` checks match errors built by these tests.
+  class MockActionRequiresApprovalError extends Error {
+    constructor(message: string, public readonly roleIdsAllowedToApprove?: number[]) {
+      super(message);
+      this.name = 'ActionRequiresApprovalError';
+    }
+  }
+
+  class MockActionFormValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'ActionFormValidationError';
+    }
+  }
+
   return {
     AgentHttpError: MockAgentHttpError,
+    ActionRequiresApprovalError: MockActionRequiresApprovalError,
+    ActionFormValidationError: MockActionFormValidationError,
     createRemoteAgentClient: jest.fn(),
     HttpRequester: { is404Error: jest.fn() },
   };
@@ -775,17 +799,8 @@ describe('AgentClientAgentPort', () => {
       expect(mockAction.execute).not.toHaveBeenCalled();
     });
 
-    it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles', async () => {
-      mockAction.execute.mockRejectedValue(
-        new AgentHttpError(403, {
-          errors: [
-            {
-              name: 'CustomActionRequiresApprovalError',
-              data: { roleIdsAllowedToApprove: [7, 9] },
-            },
-          ],
-        }),
-      );
+    it('re-wraps agent-client ActionRequiresApprovalError, carrying the allowed roles', async () => {
+      mockAction.execute.mockRejectedValue(new ClientApprovalError('Needs approval', [7, 9]));
 
       const error = await port
         .executeAction({ collection: 'users', action: 'refund', id: [1] }, user)
@@ -795,10 +810,8 @@ describe('AgentClientAgentPort', () => {
       expect((error as ActionRequiresApprovalError).roleIdsAllowedToApprove).toEqual([7, 9]);
     });
 
-    it('maps a 422 validation rejection to ActionFormValidationError', async () => {
-      mockAction.execute.mockRejectedValue(
-        new AgentHttpError(422, { errors: [{ detail: 'invalid' }] }, 'invalid'),
-      );
+    it('re-wraps agent-client ActionFormValidationError', async () => {
+      mockAction.execute.mockRejectedValue(new ClientFormValidationError('invalid'));
 
       await expect(
         port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1,6 +1,6 @@
 import type { StepUser } from '../../src/types/execution-context';
 
-import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
+import { AgentHttpError, HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 import jsonwebtoken from 'jsonwebtoken';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
@@ -13,10 +13,25 @@ import {
 } from '../../src/errors';
 import SchemaCache from '../../src/schema-cache';
 
-jest.mock('@forestadmin/agent-client', () => ({
-  createRemoteAgentClient: jest.fn(),
-  HttpRequester: { is404Error: jest.fn() },
-}));
+jest.mock('@forestadmin/agent-client', () => {
+  // Real class so `instanceof AgentHttpError` in the adapter matches errors built by these tests.
+  class AgentHttpError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly body: unknown,
+      public readonly responseText?: string,
+    ) {
+      super(`Agent responded with HTTP ${status}`);
+      this.name = 'AgentHttpError';
+    }
+  }
+
+  return {
+    AgentHttpError,
+    createRemoteAgentClient: jest.fn(),
+    HttpRequester: { is404Error: jest.fn() },
+  };
+});
 
 const mockedCreateRemoteAgentClient = createRemoteAgentClient as jest.MockedFunction<
   typeof createRemoteAgentClient
@@ -762,22 +777,11 @@ describe('AgentClientAgentPort', () => {
 
     it('maps an approval-403 to ActionRequiresApprovalError with the allowed roles', async () => {
       mockAction.execute.mockRejectedValue(
-        new Error(
-          JSON.stringify({
-            error: {
-              status: 403,
-              text: JSON.stringify({
-                errors: [
-                  {
-                    name: 'CustomActionRequiresApprovalError',
-                    data: { roleIdsAllowedToApprove: [7, 9] },
-                  },
-                ],
-              }),
-            },
-            body: null,
-          }),
-        ),
+        new AgentHttpError(403, {
+          errors: [
+            { name: 'CustomActionRequiresApprovalError', data: { roleIdsAllowedToApprove: [7, 9] } },
+          ],
+        }),
       );
 
       const error = await port
@@ -790,7 +794,7 @@ describe('AgentClientAgentPort', () => {
 
     it('maps a 422 validation rejection to ActionFormValidationError', async () => {
       mockAction.execute.mockRejectedValue(
-        new Error(JSON.stringify({ error: { status: 422, text: 'invalid' }, body: null })),
+        new AgentHttpError(422, { errors: [{ detail: 'invalid' }] }, 'invalid'),
       );
 
       await expect(
@@ -800,7 +804,7 @@ describe('AgentClientAgentPort', () => {
 
     it('leaves a plain permission 403 as a generic AgentPortError (step error, not a fallback)', async () => {
       mockAction.execute.mockRejectedValue(
-        new Error(JSON.stringify({ error: { status: 403, text: 'Forbidden' }, body: null })),
+        new AgentHttpError(403, { errors: [{ name: 'ForbiddenError' }] }, 'Forbidden'),
       );
 
       await expect(


### PR DESCRIPTION
## Why
`agent-client`'s HTTP requester threw `new Error(JSON.stringify({ error:{status,text}, body }))` — burying status/body in `Error.message`. Every consumer had to `JSON.parse(error.message)` to recover them (workflow-executor adapter, mcp-server error parser, and agent-client's own 404 check). Transport details leaking into domain layers.

## What
- **agent-client**: new `AgentHttpError { status, body, responseText }` (body parsed once, at the boundary); requester throws it; `is404Error` → `instanceof AgentHttpError && status === 404`; exported from the package.
- **workflow-executor**: `parseAgentHttpError` deleted; `mapActionExecutionError` reads `error.status` / `error.body` directly (approval-403 / 4xx routing unchanged, now on structured data).
- **mcp-server**: `parseAgentError` reads the typed error's `body`/`responseText` instead of parsing the message.

Domain interpretation stays in the executor adapter (where it belongs); agent-client stays generic (status + body).

## Tests
agent-client 324/324 · workflow-executor adapter 57/57 · mcp-server 544/544. No `JSON.parse(error.message)` left in any `src`.

Based on `feature/workflow-deterministic-ai-steps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace stringified HTTP errors with typed `AgentHttpError` and semantic action error classes in agent-client
> - Introduces `AgentHttpError` in [errors.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1697/files#diff-60f4e7a32b44076f9b6922ba0dc2ffafcfaca70f20166b2c1389d914b6148875) carrying `status`, `body`, and `responseText`, replacing the previous pattern of throwing a stringified JSON message from `HttpRequester`.
> - Adds `ActionRequiresApprovalError` and `ActionFormValidationError` as semantic error classes; `Action.execute` now catches `AgentHttpError` and maps 403 approval errors and 400/422 validation errors to these typed classes.
> - `parseAgentError` in [error-parser.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1697/files#diff-bdf07c04d227d6a9b8d3effff0b56f64207f15a160d4ff0cb39d8de3a3c7eb42) and `mapActionExecutionError` in [agent-client-agent-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1697/files#diff-1e123e0cbe27612cfd4c2f0c74aa6529888468059a8106cdc6bab8375b9b141a) are refactored to use `instanceof` checks on the new classes instead of parsing stringified payloads.
> - All three new error classes are exported from the package entrypoint.
> - Behavioral Change: `HttpRequester.is404Error` and all downstream error-routing code now relies on `instanceof AgentHttpError` rather than JSON message parsing; any caller that previously matched on raw error message strings will no longer match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8158b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->