### PR TITLE
fix(workflow-executor): expose executor version on every HTTP response

### DIFF
--- a/packages/workflow-executor/src/http/executor-http-server.ts
+++ b/packages/workflow-executor/src/http/executor-http-server.ts
@@ -20,6 +20,9 @@ import serializeStepForWire from './step-serializer';
 import createConsoleLogger from '../adapters/console-logger';
 import { extractErrorMessage } from '../errors';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+const { version } = require('../../package.json') as { version: string };
+
 export interface ExecutorHttpServerOptions {
   port: number;
   runner: Runner;
@@ -38,6 +41,11 @@ export default class ExecutorHttpServer {
     this.options = options;
     this.logger = options.logger ?? createConsoleLogger();
     this.app = new Koa();
+
+    this.app.use(async (ctx, next) => {
+      ctx.set('X-Executor-Version', version);
+      await next();
+    });
 
     // Error-translation middleware — the single place converting thrown errors (typed HTTP
     // errors, domain errors via toHttpError, JWT 401) into HTTP responses. Handlers just throw.

--- a/packages/workflow-executor/test/http/executor-http-server.test.ts
+++ b/packages/workflow-executor/test/http/executor-http-server.test.ts
@@ -207,6 +207,34 @@ describe('ExecutorHttpServer', () => {
     });
   });
 
+  describe('X-Executor-Version header', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+    const { version } = require('../../package.json') as { version: string };
+
+    it('is present on the public /health response', async () => {
+      const response = await request(createServer().callback).get('/health');
+
+      expect(response.headers['x-executor-version']).toBe(version);
+    });
+
+    it('is present on an authenticated route response', async () => {
+      const token = signToken({ id: 1 });
+
+      const response = await request(createServer().callback)
+        .get('/runs/run-1')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.headers['x-executor-version']).toBe(version);
+    });
+
+    it('is present on an error response (401, no token)', async () => {
+      const response = await request(createServer().callback).get('/runs/run-1');
+
+      expect(response.status).toBe(401);
+      expect(response.headers['x-executor-version']).toBe(version);
+    });
+  });
+
   describe('run access authorization', () => {
     it('returns 401 on GET /runs/:runId when the token has invalid claims, before the access check', async () => {
       const workflowPort = createMockWorkflowPort();


### PR DESCRIPTION
## :evergreen_tree: Description

[Fixes PRD-574](https://linear.app/forestadmin/issue/PRD-574/executor-include-the-executor-version-in-every-http-route-response)

The workflow executor runs on customer infrastructure with versions varying per install, and nothing in an HTTP response identified which version answered.

This adds an `X-Executor-Version` response header via a single global Koa middleware, registered first so it lands on **every** response — the public `/health` probe, authenticated routes, and error responses (401/404/500) alike. The version is read from `package.json`, reusing the existing `cli-core` / `check-node-version` pattern. No body shapes change, and the agent proxy (#1666) already forwards `X-` headers verbatim to the client.

## Changes

- `executor-http-server.ts`: read `version` from `package.json` + version-header middleware (set first).
- `executor-http-server.test.ts`: 3 tests — header present on public `/health`, on an authenticated route, and on a 401 error response.

## Verification

- `yarn jest test/http/executor-http-server.test.ts` → 41/41 pass (incl. 3 new).
- `eslint` on both files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose executor version via `X-Executor-Version` header on every HTTP response
> Adds a Koa middleware in [`ExecutorHttpServer`](https://github.com/ForestAdmin/agent-nodejs/pull/1699/files#diff-f24eaa83e4d72cc710e9cb4cea88a2047543ee3c17a0b68627f6af587546b614) that reads the version from `package.json` and sets the `X-Executor-Version` header on all responses, including errors and unauthenticated requests. Tests cover the `/health` endpoint, authenticated run responses, and 401 error responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8d3490.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->