### PR TITLE
feat(workflow-executor): add migrate command and --skip-migrations

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -87,6 +87,24 @@ are force-killed and the process exits with code `1`.
 | `0` | Graceful shutdown |
 | `1` | Startup error (missing env, invalid config) or forced shutdown |
 
+### Migrations
+
+By default the executor applies its database migrations on boot, then runs. That's
+fine for a single instance (demos, staging). It does **not** coordinate concurrent
+boots — if you run several instances that all migrate at once, they race.
+
+For multi-instance deployments, decouple migrations from boot:
+
+```bash
+# 1. Once, in your release/CI pipeline (applies migrations, then exits):
+forest-workflow-executor migrate
+
+# 2. Then start any number of instances that skip migrating:
+forest-workflow-executor --skip-migrations
+```
+
+`--skip-migrations` assumes the schema is already migrated; queries fail otherwise.
+
 ### In-memory mode (dev only)
 
 ```bash

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -32,6 +32,8 @@ const FORCE_EXIT_DELAY_S = 5;
 export interface WorkflowExecutor {
   start(): Promise<void>;
   stop(): Promise<void>;
+  // Apply migrations then exit (the `migrate` CLI command). Does not start the runner or server.
+  migrate(): Promise<void>;
   readonly state: RunnerState;
 }
 
@@ -54,6 +56,8 @@ export interface ExecutorOptions {
   schemaCacheTtlS?: number;
   // Dev only: makes every AI call fail immediately so error paths can be exercised locally.
   forceAiError?: boolean;
+  // Boot without running migrations (applied out-of-band via the `migrate` command).
+  skipMigrations?: boolean;
 }
 
 export type DatabaseExecutorOptions = ExecutorOptions &
@@ -130,6 +134,7 @@ function buildCommonDependencies(options: ExecutorOptions) {
     stepTimeoutS: positiveOrDefault(options.stepTimeoutS, DEFAULT_STEP_TIMEOUT_S),
     aiInvokeTimeoutS: positiveOrDefault(options.aiInvokeTimeoutS, DEFAULT_AI_INVOKE_TIMEOUT_S),
     maxChainDepth: options.maxChainDepth,
+    skipMigrations: options.skipMigrations,
   };
 }
 
@@ -177,6 +182,10 @@ function createWorkflowExecutor(
   return {
     get state() {
       return runner.state;
+    },
+
+    migrate() {
+      return runner.migrate();
     },
 
     async start() {

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -65,6 +65,10 @@ export interface CliArgs {
   inMemory: boolean;
   pretty: boolean;
   json: boolean;
+  // `migrate` subcommand: apply migrations then exit (for CI/release pipelines).
+  migrate: boolean;
+  // Boot without migrating (migrations applied out-of-band via `migrate`).
+  skipMigrations: boolean;
 }
 
 export interface CliConfig {
@@ -85,10 +89,18 @@ export function parseArgs(argv: string[]): CliArgs {
     inMemory: false,
     pretty: false,
     json: false,
+    migrate: false,
+    skipMigrations: false,
   };
 
   for (const arg of argv) {
     switch (arg) {
+      case 'migrate':
+        result.migrate = true;
+        break;
+      case '--skip-migrations':
+        result.skipMigrations = true;
+        break;
       case '--help':
       case '-h':
         result.help = true;
@@ -184,6 +196,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
     maxChainDepth: parsePositiveIntEnv('MAX_CHAIN_DEPTH', env.MAX_CHAIN_DEPTH),
     schemaCacheTtlS: parsePositiveIntEnv('SCHEMA_CACHE_TTL_S', env.SCHEMA_CACHE_TTL_S),
     loggerLevel: parseLoggerLevelEnv(env.LOG_LEVEL) ?? DEFAULT_LOGGER_LEVEL,
+    skipMigrations: args.skipMigrations,
     ...(aiConfigurations && { aiConfigurations }),
     ...(env.FORCE_AI_ERROR === 'true' && { forceAiError: true }),
   };
@@ -196,11 +209,16 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
 }
 
 export function printHelp(): void {
-  console.log(`Usage: ${BINARY_NAME} [options]
+  console.log(`Usage: ${BINARY_NAME} [command] [options]
 
 Run the Forest Admin workflow executor.
 
+Commands:
+  (default)         Apply migrations, then run the executor (HTTP server + polling)
+  migrate           Apply migrations, then exit (run once in CI/release; pair with --skip-migrations)
+
 Options:
+  --skip-migrations Boot without migrating (migrations applied out-of-band via \`migrate\`)
   --in-memory       Use an in-memory run store (no DB needed, not for prod)
   --pretty          Force colorized human-readable logs (default when stdout is a TTY)
   --json            Force structured JSON logs (default when stdout is not a TTY)
@@ -298,6 +316,13 @@ export async function runCli(
         database: { uri: config.databaseUrl as string },
       };
       executor = factories.buildDatabase(databaseOptions);
+    }
+
+    if (args.migrate) {
+      await executor.migrate();
+      logger('Info', 'Migrations applied');
+
+      return executor;
     }
 
     await executor.start();

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -50,6 +50,9 @@ export interface RunnerConfig {
   // Max number of ADDITIONAL steps auto-chained via /update-step response before yielding to the
   // next poll cycle (counted after the initial step). 0 disables chaining entirely. Default 50.
   maxChainDepth?: number;
+  // Skip running migrations on start (applied out-of-band, e.g. via the `migrate` command). The
+  // store must already be migrated or queries will fail.
+  skipMigrations?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
@@ -89,12 +92,20 @@ export default class Runner {
     // Probe the agent first so we fail fast without opening DB connections when unreachable.
     await this.config.agentPort.probe();
     this.logger('Info', 'Agent probe passed', {});
-    await this.config.runStore.init(this.logger);
+
+    if (!this.config.skipMigrations) await this.config.runStore.init(this.logger);
 
     this._state = 'running';
 
     this.pushMetadataToOrchestrator();
     this.schedulePoll();
+  }
+
+  // One-shot migration entry point for the `migrate` CLI command: applies migrations and closes the
+  // connection so the process can exit. No agent probe, no polling, no HTTP server.
+  async migrate(): Promise<void> {
+    await this.config.runStore.init(this.logger);
+    await this.config.runStore.close(this.logger);
   }
 
   async stop(): Promise<void> {

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -42,6 +42,7 @@ function makeFakeExecutor(): WorkflowExecutor {
   return {
     start: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn().mockResolvedValue(undefined),
+    migrate: jest.fn().mockResolvedValue(undefined),
     state: 'running',
   } as unknown as WorkflowExecutor;
 }
@@ -66,7 +67,17 @@ describe('parseArgs', () => {
       inMemory: false,
       pretty: false,
       json: false,
+      migrate: false,
+      skipMigrations: false,
     });
+  });
+
+  it('parses the migrate command', () => {
+    expect(parseArgs(['migrate']).migrate).toBe(true);
+  });
+
+  it('parses --skip-migrations', () => {
+    expect(parseArgs(['--skip-migrations']).skipMigrations).toBe(true);
   });
 
   it('parses --help and -h', () => {
@@ -97,7 +108,15 @@ describe('parseArgs', () => {
 });
 
 describe('pickLogger', () => {
-  const baseArgs = { help: false, version: false, inMemory: false, pretty: false, json: false };
+  const baseArgs = {
+    help: false,
+    version: false,
+    inMemory: false,
+    pretty: false,
+    json: false,
+    migrate: false,
+    skipMigrations: false,
+  };
   let infoSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -147,7 +166,15 @@ describe('pickLogger', () => {
 });
 
 describe('readEnvConfig', () => {
-  const args = { help: false, version: false, inMemory: false, pretty: false, json: false };
+  const args = {
+    help: false,
+    version: false,
+    inMemory: false,
+    pretty: false,
+    json: false,
+    migrate: false,
+    skipMigrations: false,
+  };
 
   it('returns a full config when all required vars are present', () => {
     const config = readEnvConfig(baseEnv, args);
@@ -510,6 +537,27 @@ describe('runCli', () => {
     );
     expect(factories.buildDatabase).not.toHaveBeenCalled();
     expect(executor.start).toHaveBeenCalled();
+  });
+
+  it('runs migrations and exits without starting on the migrate command', async () => {
+    const { factories, executor } = makeFactories();
+
+    await runCli(['migrate'], baseEnv, factories);
+
+    expect(executor.migrate).toHaveBeenCalled();
+    expect(executor.start).not.toHaveBeenCalled();
+  });
+
+  it('threads skipMigrations into the build options and still starts', async () => {
+    const { factories, executor } = makeFactories();
+
+    await runCli(['--skip-migrations'], baseEnv, factories);
+
+    expect(factories.buildDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({ skipMigrations: true }),
+    );
+    expect(executor.start).toHaveBeenCalled();
+    expect(executor.migrate).not.toHaveBeenCalled();
   });
 
   it('does not log any secret during startup', async () => {

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -95,6 +95,7 @@ function createRunnerConfig(
     schemaCache: SchemaCache;
     stopTimeoutS: number;
     maxChainDepth: number;
+    skipMigrations: boolean;
   }> = {},
 ) {
   return {
@@ -242,6 +243,26 @@ describe('start', () => {
     await runner.start();
 
     expect(config.runStore.init).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call runStore.init() on start when skipMigrations is set', async () => {
+    const config = createRunnerConfig({ skipMigrations: true });
+    runner = new Runner(config);
+
+    await runner.start();
+
+    expect(config.runStore.init).not.toHaveBeenCalled();
+  });
+
+  it('migrate() initialises then closes the run store and does not probe the agent', async () => {
+    const config = createRunnerConfig();
+    runner = new Runner(config);
+
+    await runner.migrate();
+
+    expect(config.runStore.init).toHaveBeenCalledTimes(1);
+    expect(config.runStore.close).toHaveBeenCalledTimes(1);
+    expect(config.agentPort.probe).not.toHaveBeenCalled();
   });
 
   it('should throw ConfigurationError when envSecret is invalid', async () => {


### PR DESCRIPTION
## What

Three boot modes for the executor — progressive disclosure, no boot-time lock:

```bash
npx @forestadmin/workflow-executor                    # default: auto-migrate at boot, then run (unchanged)
npx @forestadmin/workflow-executor migrate            # apply migrations, then exit (one-shot for CI/release)
npx @forestadmin/workflow-executor --skip-migrations  # boot without migrating (DDL-readonly instance)
```

## Why

Migrations run inside every booting instance (`Runner.start()` → `runStore.init()`). For a single instance (demos/staging) that's fine; for **N concurrent boots** they race on `SequelizeMeta`. Rather than add boot-time locking plumbing, let serious deployments **decouple**: run `migrate` once in CI, then start N instances with `--skip-migrations` → zero race, no lock.

The default is deliberately left with **no concurrency handling** — simple by default, controllable when needed.

## How

- **`Runner`**: `skipMigrations?` config — `start()` skips `runStore.init()` when set. New `migrate()` applies migrations then closes the connection (no agent probe, no server, no polling) so the one-shot process exits.
- **`build-workflow-executor`**: `skipMigrations?` on `ExecutorOptions` threaded to the runner; `migrate()` exposed on `WorkflowExecutor`.
- **`cli-core`**: `migrate` positional command + `--skip-migrations` flag; `runCli` routes `migrate` to `executor.migrate()` (does not start the server). Help + README updated.

One migration code path (`runStore.init()`), two entry points. No new dependency, no advisory lock, no transaction gymnastics.

## Tests

- `parseArgs`: `migrate` and `--skip-migrations`; unknown args still throw.
- `runCli`: `migrate` calls `executor.migrate()` and not `start()`; `--skip-migrations` threads `skipMigrations: true` into the build options and still starts.
- `Runner`: `start()` with `skipMigrations` does not call `runStore.init`; `migrate()` calls `init` then `close` and does not probe the agent.
- All touched suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `migrate` subcommand and `--skip-migrations` flag to workflow-executor CLI
> - Adds a `migrate` subcommand to the CLI that runs database migrations and exits without starting the HTTP server or polling, useful for running migrations separately in concurrent deployments.
> - Adds a `--skip-migrations` flag that boots the executor without running migrations, intended for use when migrations are applied out-of-band via the `migrate` subcommand.
> - Adds a `migrate()` method to the `Runner` and `WorkflowExecutor` interfaces that initializes the run store and closes it without probing the agent or starting normal activities.
> - Risk: when `--skip-migrations` is set, queries will fail if the schema has not been migrated separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d77bb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->