### PR TITLE
feat(workflow-executor): attribute AI usage to the triggering user [PRD-619]

### DIFF
--- a/packages/workflow-executor/src/adapters/ai-client-adapter.ts
+++ b/packages/workflow-executor/src/adapters/ai-client-adapter.ts
@@ -1,4 +1,4 @@
-import type { AiModelPort } from '../ports/ai-model-port';
+import type { AiModelPort, GetModelOptions } from '../ports/ai-model-port';
 import type { AiConfiguration, BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
 import { AiClient } from '@forestadmin/ai-proxy';
@@ -13,7 +13,7 @@ export default class AiClientAdapter implements AiModelPort {
     this.aiClient = new AiClient({ aiConfigurations: withRetries as AiConfiguration[] });
   }
 
-  getModel(aiConfigName?: string): BaseChatModel {
+  getModel({ aiConfigName }: GetModelOptions = {}): BaseChatModel {
     try {
       return this.aiClient.getModel(aiConfigName);
     } catch (cause) {

--- a/packages/workflow-executor/src/adapters/server-ai-adapter.ts
+++ b/packages/workflow-executor/src/adapters/server-ai-adapter.ts
@@ -1,4 +1,4 @@
-import type { AiModelPort } from '../ports/ai-model-port';
+import type { AiModelPort, GetModelOptions } from '../ports/ai-model-port';
 import type { AiConfiguration, BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
 import { AiClient } from '@forestadmin/ai-proxy';
@@ -11,17 +11,23 @@ export interface ServerAiAdapterOptions {
 }
 
 export default class ServerAiAdapter implements AiModelPort {
+  private readonly options: ServerAiAdapterOptions;
   private readonly aiClient: AiClient;
 
   constructor(options: ServerAiAdapterOptions) {
+    this.options = options;
     this.aiClient = new AiClient({
       aiConfigurations: [ServerAiAdapter.buildProxyConfiguration(options)],
     });
   }
 
-  getModel(): BaseChatModel {
+  getModel({ userId }: GetModelOptions = {}): BaseChatModel {
     try {
-      return this.aiClient.getModel();
+      const client = new AiClient({
+        aiConfigurations: [ServerAiAdapter.buildProxyConfiguration(this.options, userId)],
+      });
+
+      return client.getModel();
     } catch (cause) {
       if (cause instanceof WorkflowExecutorError) throw cause;
       throw new AiModelPortError('getModel', cause);
@@ -39,10 +45,10 @@ export default class ServerAiAdapter implements AiModelPort {
   // Every call is routed to the Forest server's AI proxy, which picks the real provider/model.
   // The model name is therefore a placeholder, and fetch is rewritten to hit the proxy with the
   // env secret instead of an OpenAI Authorization header.
-  private static buildProxyConfiguration({
-    forestServerUrl,
-    envSecret,
-  }: ServerAiAdapterOptions): AiConfiguration {
+  private static buildProxyConfiguration(
+    { forestServerUrl, envSecret }: ServerAiAdapterOptions,
+    userId?: number,
+  ): AiConfiguration {
     const aiProxyUrl = `${forestServerUrl}/liana/v1/ai-proxy`;
 
     return {
@@ -56,6 +62,8 @@ export default class ServerAiAdapter implements AiModelPort {
           const headers = new Headers(init?.headers);
           headers.delete('authorization');
           headers.set('forest-secret-key', envSecret);
+          // Attributes AI usage to the triggering user (proxy route has no user context).
+          if (userId !== undefined) headers.set('user-id', String(userId));
 
           return fetch(aiProxyUrl, { ...init, headers });
         },

--- a/packages/workflow-executor/src/executors/step-executor-factory.ts
+++ b/packages/workflow-executor/src/executors/step-executor-factory.ts
@@ -152,7 +152,10 @@ export default class StepExecutorFactory {
       stepDefinition: step.stepDefinition,
       previousSteps: step.previousSteps,
       user: step.user,
-      model: cfg.aiModelPort.getModel(step.stepDefinition.aiConfigName),
+      model: cfg.aiModelPort.getModel({
+        aiConfigName: step.stepDefinition.aiConfigName,
+        userId: step.user.id,
+      }),
       agent: new AgentWithLog({
         agentPort: cfg.agentPort,
         schemaResolver,

--- a/packages/workflow-executor/src/ports/ai-model-port.ts
+++ b/packages/workflow-executor/src/ports/ai-model-port.ts
@@ -1,7 +1,12 @@
 import type { BaseChatModel, RemoteTool, ToolConfig } from '@forestadmin/ai-proxy';
 
+export interface GetModelOptions {
+  aiConfigName?: string;
+  userId?: number;
+}
+
 export interface AiModelPort {
-  getModel(aiConfigName?: string): BaseChatModel;
+  getModel(options?: GetModelOptions): BaseChatModel;
   loadRemoteTools(configs: Record<string, ToolConfig>): Promise<RemoteTool[]>;
   closeConnections(): Promise<void>;
 }

--- a/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/ai-client-adapter.test.ts
@@ -20,7 +20,7 @@ describe('AiClientAdapter', () => {
       { name: 'my-config', provider: 'openai' as const, model: 'gpt-4o', apiKey: 'sk-test' },
     ]);
 
-    adapter.getModel('my-config');
+    adapter.getModel({ aiConfigName: 'my-config' });
 
     expect(mockGetModel).toHaveBeenCalledWith('my-config');
   });

--- a/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
+++ b/packages/workflow-executor/test/adapters/server-ai-adapter.test.ts
@@ -34,6 +34,31 @@ describe('ServerAiAdapter', () => {
     (mockAiClientConstructor.mock.calls[0][0] as { aiConfigurations: Record<string, unknown>[] })
       .aiConfigurations[0];
 
+  // getModel builds its own AiClient per call; grab the most recent one's config.
+  const latestProxyConfig = () => {
+    const { calls } = mockAiClientConstructor.mock;
+
+    return (calls[calls.length - 1][0] as { aiConfigurations: Record<string, unknown>[] })
+      .aiConfigurations[0];
+  };
+
+  const captureFetchHeaders = (config: Record<string, unknown>): Headers => {
+    const { fetch: customFetch } = config.configuration as {
+      fetch: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+    };
+
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+    try {
+      customFetch('https://ignored.com/chat/completions', { method: 'POST', body: '{}' });
+
+      return new Headers((global.fetch as jest.Mock).mock.calls[0][1].headers);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  };
+
   describe('constructor', () => {
     it('configures AiClient with a single openai config targeting the FA server', () => {
       expect(proxyConfig()).toEqual(
@@ -81,6 +106,18 @@ describe('ServerAiAdapter', () => {
       } finally {
         global.fetch = originalFetch;
       }
+    });
+
+    it('forwards the given userId as a user-id header for usage attribution', () => {
+      adapter.getModel({ userId: 42 });
+
+      expect(captureFetchHeaders(latestProxyConfig()).get('user-id')).toBe('42');
+    });
+
+    it('omits the user-id header when no userId is given', () => {
+      adapter.getModel();
+
+      expect(captureFetchHeaders(latestProxyConfig()).get('user-id')).toBeNull();
     });
   });
 

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1831,6 +1831,18 @@ describe('StepExecutorFactory.create — factory', () => {
       expect.objectContaining({ cause: undefined }),
     );
   });
+
+  it('calls getModel with step.user.id for AI usage attribution', async () => {
+    const cfg = makeContextConfig();
+    const step = makePendingStep({ stepType: StepType.ReadRecord }); // user.id = 1
+
+    await StepExecutorFactory.create(step, cfg, makeRunLogger(), jest.fn());
+
+    expect(cfg.aiModelPort.getModel).toHaveBeenCalledWith({
+      aiConfigName: step.stepDefinition.aiConfigName,
+      userId: step.user.id,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Executor-run workflow AI calls hit `POST /liana/v1/ai-proxy`, which is authenticated by **env secret only** — no user context. So AI usage from orchestrator-engine runs couldn't be attributed to the user who triggered the run.

The server-side fix (PRD-619, `forestadmin-server`) tried to resolve the user via a `workflow-run-id` header lookup — but **the executor never sent any identifying header** (the proxy `fetch` set only `forest-secret-key`), so attribution was always empty.

## Fix

The executor already has `step.user.id` (it comes from the orchestrator's run). Forward it directly as a `user-id` header on the ai-proxy call — no DB lookup, no `runId` string→number mismatch.

- `getModel(aiConfigName?, userId?)` — userId threaded from `step.user.id` at the factory call site.
- The model is built **per call** so the userId is captured in that model's own `fetch` closure. The adapter is shared across concurrent runs, so a mutable field would race; a fresh `AiClient` per call is cheap and race-free.

## Trust

The route is already env-secret authed (client infra = existing trust boundary). `user-id` is used only for usage tracking (billing/analytics), not authorization.

## Tests

`server-ai-adapter.test.ts`: `user-id` header set when userId given, omitted otherwise.

## Pairs with

`forestadmin-server` PR (reads the `user-id` header, drops the dead runId lookup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attribute AI usage to the triggering user in workflow executor
> - Introduces a `GetModelOptions` interface in [`ai-model-port.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1701/files#diff-3b48820bd99c28dccf8be78e8d352be9fa22b68de22521bcbb666e0d2dcdaad6) with optional `aiConfigName` and `userId` fields, replacing the previous string parameter on `AiModelPort.getModel`.
> - Updates [`ServerAiAdapter.getModel`](https://github.com/ForestAdmin/agent-nodejs/pull/1701/files#diff-c956f4e501a2d4f6236f5e7ed03a9ad79a955818f220f62955023fd87bb9b045) to construct a per-call `AiClient` using the provided `userId`, injecting a `user-id` header into downstream proxy requests when present.
> - Updates [`StepExecutorFactory.buildContext`](https://github.com/ForestAdmin/agent-nodejs/pull/1701/files#diff-8bd043179aba0b7fb86303fd2d3cd99f76e8f762d374c0e24be5389107c50b4d) to pass `step.user.id` as `userId` when calling `getModel`, so each workflow step attributes AI usage to the triggering user.
> - Behavioral Change: `AiModelPort.getModel` now expects an options object instead of a plain string; all implementations and callers must be updated.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1701 opened
>
> - Added test case verifying AI usage attribution to triggering user [1734bdb]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cbee6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->