### PR TITLE
feat(agent): detect action slug collisions when unsafe endpoint is on

### DIFF
--- a/packages/agent/src/utils/forest-schema/generator-collection.ts
+++ b/packages/agent/src/utils/forest-schema/generator-collection.ts
@@ -15,9 +15,11 @@ import SchemaGeneratorSegments from './generator-segments';
 
 export default class SchemaGeneratorCollection {
   private readonly schemaGeneratorActions: SchemaGeneratorActions;
+  private readonly useUnsafeActionEndpoint: boolean;
 
   constructor(options: AgentOptionsWithDefaults) {
     this.schemaGeneratorActions = new SchemaGeneratorActions(options);
+    this.useUnsafeActionEndpoint = options.useUnsafeActionEndpoint;
   }
 
   /** Build forest-server schema for a collection */
@@ -40,11 +42,33 @@ export default class SchemaGeneratorCollection {
   }
 
   private buildActions(collection: Collection): Promise<ForestServerAction[]> {
+    const names = Object.keys(collection.schema.actions).sort();
+
+    if (this.useUnsafeActionEndpoint) {
+      SchemaGeneratorCollection.assertNoActionSlugCollision(collection.name, names);
+    }
+
     return Promise.all(
-      Object.keys(collection.schema.actions)
-        .sort()
-        .map(name => this.schemaGeneratorActions.buildSchema(collection, name)),
+      names.map(name => this.schemaGeneratorActions.buildSchema(collection, name)),
     );
+  }
+
+  private static assertNoActionSlugCollision(collectionName: string, names: string[]): void {
+    const nameBySlug = new Map<string, string>();
+
+    names.forEach(name => {
+      const slug = SchemaGeneratorActions.getActionSlug(name);
+      const existing = nameBySlug.get(slug);
+
+      if (existing) {
+        throw new Error(
+          `Actions "${existing}" and "${name}" on collection "${collectionName}" resolve to the ` +
+            `same endpoint slug "${slug}". Rename one of them or disable useUnsafeActionEndpoint.`,
+        );
+      }
+
+      nameBySlug.set(slug, name);
+    });
   }
 
   private static buildFields(collection: Collection): ForestServerField[] {

--- a/packages/agent/test/utils/forest-schema/generator-collection.test.ts
+++ b/packages/agent/test/utils/forest-schema/generator-collection.test.ts
@@ -101,4 +101,94 @@ describe('SchemaGeneratorCollection', () => {
       relationship: 'HasOne',
     });
   });
+
+  const buildCollection = (name: string, actions: Record<string, { scope: 'Single' }>) =>
+    factories.collection.build({
+      name,
+      schema: factories.collectionSchema.build({
+        actions,
+        fields: { id: factories.columnSchema.uuidPrimaryKey().build() },
+      }),
+      getForm: jest.fn().mockResolvedValue(null),
+    });
+
+  describe('when useUnsafeActionEndpoint is true', () => {
+    const generator = new SchemaGeneratorCollection(
+      factories.forestAdminHttpDriverOptions.build({ useUnsafeActionEndpoint: true }),
+    );
+
+    const buildSchemaFor = (actions: Record<string, { scope: 'Single' }>) =>
+      generator.buildSchema(
+        factories.dataSource
+          .buildWithCollections([buildCollection('cards', actions)])
+          .getCollection('cards'),
+      );
+
+    test('throws when two actions resolve to the same route slug', async () => {
+      await expect(
+        buildSchemaFor({ 'Send email': { scope: 'Single' }, 'SEND EMAIL': { scope: 'Single' } }),
+      ).rejects.toThrow(
+        'Actions "SEND EMAIL" and "Send email" on collection "cards" resolve to the same ' +
+          'endpoint slug "send-email". Rename one of them or disable useUnsafeActionEndpoint.',
+      );
+    });
+
+    test('throws naming the first two colliding actions when three collide', async () => {
+      await expect(
+        buildSchemaFor({
+          'Send email': { scope: 'Single' },
+          'SEND EMAIL': { scope: 'Single' },
+          'send-email': { scope: 'Single' },
+        }),
+      ).rejects.toThrow(
+        'Actions "SEND EMAIL" and "Send email" on collection "cards" resolve to the same ' +
+          'endpoint slug "send-email". Rename one of them or disable useUnsafeActionEndpoint.',
+      );
+    });
+
+    test('builds index-free endpoints when slugs are distinct', async () => {
+      const schema = await buildSchemaFor({
+        'Send email': { scope: 'Single' },
+        'Archive card': { scope: 'Single' },
+      });
+
+      expect(schema.actions.map(action => action.endpoint)).toEqual([
+        '/forest/_actions/cards/archive-card',
+        '/forest/_actions/cards/send-email',
+      ]);
+    });
+
+    test('does not throw when the same slug is used across different collections', async () => {
+      const twoCollections = factories.dataSource.buildWithCollections([
+        buildCollection('cards', { 'Send email': { scope: 'Single' } }),
+        buildCollection('users', { 'SEND EMAIL': { scope: 'Single' } }),
+      ]);
+
+      await expect(
+        generator.buildSchema(twoCollections.getCollection('cards')),
+      ).resolves.toBeDefined();
+      await expect(
+        generator.buildSchema(twoCollections.getCollection('users')),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  test('keeps colliding slugs disambiguated by index when useUnsafeActionEndpoint is false', async () => {
+    const collection = factories.dataSource
+      .buildWithCollections([
+        buildCollection('cards', {
+          'Send email': { scope: 'Single' },
+          'SEND EMAIL': { scope: 'Single' },
+        }),
+      ])
+      .getCollection('cards');
+    const generator = new SchemaGeneratorCollection(factories.forestAdminHttpDriverOptions.build());
+
+    const schema = await generator.buildSchema(collection);
+
+    expect(schema.actions.map(action => action.endpoint)).toEqual([
+      '/forest/_actions/cards/1/send-email',
+      '/forest/_actions/cards/0/send-email',
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

Turn on `useUnsafeActionEndpoint` and Smart Action routes drop the positional index:`/_actions/{collection}/{slug}` instead of `/_actions/{collection}/{index}/{slug}`.

Problem: two action names can slugify to the same thing. `"Send email"` and `"SEND EMAIL"` both become `send-email`. 

Same route. Koa keeps one, throws nothing, and triggering one action runs the other. Silent, wrong action.

In the default index-based mode this never bites — the index keeps the two routes distinct. It only shows up once you drop the index.

## Root cause

`SchemaGeneratorActions.getActionSlug(name)` lowercases and strips everything that isn't `[a-z0-9-]`, so different names collapse to the same slug. 
Nothing ever checked slug uniqueness. The index was the only thing keeping the collision invisible, and `useUnsafeActionEndpoint` removes it.

## Fix

A fail check at schema generation (runs on agent `start()`), **only when `useUnsafeActionEndpoint` is true**. 
Per collection: if two actions resolve to the same route slug, the agent refuses to start and tells you exactly what collides:

```
Actions "SEND EMAIL" and "Send email" on collection "User" resolve to the same endpoint slug "send-email". Rename one of them or disable useUnsafeActionEndpoint.
```

It lives in `SchemaGeneratorCollection.buildActions` — the only place that sees all of a collection's actions at once and reuses the exact same `getActionSlug` route registration uses. So the check can't drift from the real routes.

## Scope / safety

- Default mode is untouched. Flag off (the default) → check doesn't run, the index already prevents the collision.
- Scoped per collection. Same slug across two different collections is fine (distinct routes), doesn't throw.
- No change to route registration, endpoint format, or the index path. One private method + its call site.
- Security: turns a silent wrong-action execution into a startup failure. Strictly safer, fail-closed. No new surface, no new input handling.

## How to test

Manual (on your local agent):

**Before:** with `useUnsafeActionEndpoint: true` and two actions slugifying alike (`"Send an email"` + `"SEND AN EMAIL"`) on `User`, both produced `/forest/_actions/User/send-an-email` — one shadowed the other, no error.

**After:** the agent refuses to start with the message above. Rename one action, or set `useUnsafeActionEndpoint: false`, and it starts fine.

Automated:

```
yarn workspace @forestadmin/agent jest test/utils/forest-schema/generator-collection.test.ts
```

Covers 2-way and 3-way collision (throws), distinct slugs and cross-collection reuse (no throw), and asserts the real endpoints in both modes — index-free when unsafe, index-disambiguated when safe.

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made

### Documentation

- [ ] Add documentation for `useUnsafeActionEndpoint` in https://docs.forest.app/
