### PR TITLE
feat(agent): forward any executor route generically [PRD-567]

### DIFF
--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -11,8 +11,9 @@ import { request as httpsRequest } from 'https';
 import { HttpCode, RouteType } from '../../types';
 import BaseRoute from '../base-route';
 
-const AGENT_PREFIX = '/_internal/workflow-executions';
-const EXECUTOR_PREFIX = '/runs';
+// Any sub-path under this prefix is forwarded verbatim to the executor root, so a new executor
+// route needs no agent change.
+const AGENT_PREFIX = '/_internal/executor';
 // Never forwarded: hop-by-hop headers, Host (Node derives the executor's from the target URL),
 // and length/encoding the HTTP client recomputes.
 const SKIPPED_HEADERS = new Set([
@@ -27,8 +28,8 @@ const SKIPPED_HEADERS = new Set([
   'host',
   'content-length',
 ]);
-// Substrings that could let the wildcard escape EXECUTOR_PREFIX (traversal, encoded dots,
-// backslash, null byte).
+// Substrings that could let the wildcard escape the executor origin (traversal, encoded dots,
+// backslash, null byte). SSRF hygiene — not a namespace allowlist.
 const UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', '\0'];
 const REQUEST_TIMEOUT_MS = 120_000;
 
@@ -40,12 +41,9 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
 
   constructor(services: ForestAdminHttpDriverServices, options: AgentOptionsWithDefaults) {
     super(services, options);
-    // Remove trailing slash for clean URL joining
     this.executorUrl = new URL(options.workflowExecutorUrl.replace(/\/+$/, ''));
   }
 
-  // Single catch-all: any sub-path/verb under AGENT_PREFIX is forwarded to EXECUTOR_PREFIX, so a
-  // new executor route needs no change here (PRD-567).
   setupRoutes(router: KoaRouter): void {
     router.all(`${AGENT_PREFIX}/:path(.*)`, this.handleProxy.bind(this));
   }
@@ -64,7 +62,7 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     context.response.status = response.status;
 
     // Forward every executor response header (minus hop-by-hop) so new executor headers never
-    // require an agent change (PRD-567: zero breaking, the agent stays a transparent proxy).
+    // require an agent change — the agent stays a transparent proxy.
     for (const [name, value] of Object.entries(response.headers)) {
       if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
         context.response.set(name, value);
@@ -77,12 +75,18 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
   private buildTargetUrl(context: Context): URL {
     const path = this.executorPath(String(context.params.path ?? ''));
     const qs = context.querystring ? `?${context.querystring}` : '';
+    const targetUrl = new URL(`${path}${qs}`, this.executorUrl);
 
-    return new URL(`${path}${qs}`, this.executorUrl);
+    // Authoritative SSRF check: URL parsing strips control chars the string guard can't see
+    // (e.g. a decoded `\t//host` collapses to `//host`), so confirm we never left the executor.
+    if (targetUrl.origin !== this.executorUrl.origin) {
+      throw new NotFoundError('Invalid workflow executor path');
+    }
+
+    return targetUrl;
   }
 
-  // Security boundary: the wildcard can only ever map into EXECUTOR_PREFIX. Reject anything that
-  // could escape it so executor routes outside EXECUTOR_PREFIX stay unreachable through the proxy.
+  // First-pass rejection of escape attempts; the authoritative origin check is in buildTargetUrl.
   private executorPath(wildcard: string): string {
     const unsafe =
       wildcard === '' ||
@@ -91,10 +95,9 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
 
     if (unsafe) throw new NotFoundError('Invalid workflow executor path');
 
-    return `${EXECUTOR_PREFIX}/${wildcard}`;
+    return `/${wildcard}`;
   }
 
-  // Forwards every client header except the ones in SKIPPED_HEADERS.
   private forwardedHeaders(context: Context): OutgoingHttpHeaders {
     const headers: OutgoingHttpHeaders = {};
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -47,8 +47,8 @@ export type AgentOptions = {
   useUnsafeActionEndpoint?: boolean;
   /**
    * Base URL of the workflow executor to proxy requests to.
-   * When set, the agent exposes routes at `/_internal/workflow-executions/`
-   * that forward to the executor, benefiting from the agent's authentication layer.
+   * When set, the agent forwards `/_internal/executor/*` to the executor verbatim,
+   * benefiting from the agent's authentication layer.
    * @example 'http://localhost:4001'
    */
   workflowExecutorUrl?: string | null;

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@forestadmin/datasource-toolkit';
 import { createMockContext } from '@shopify/jest-koa-mocks';
 import http from 'http';
 
@@ -102,7 +103,8 @@ describe('WorkflowExecutorProxyRoute', () => {
   const callHandleProxy = (route: WorkflowExecutorProxyRoute, context: unknown) =>
     (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context);
 
-  // Build a mock context for the catch-all route: `path` is the wildcard segment.
+  // Build a mock context for the catch-all route: `path` is the wildcard segment, forwarded
+  // verbatim to the executor root (so callers address runs as `runs/<id>`).
   const buildContext = (
     path: string,
     extra: Parameters<typeof createMockContext>[0] = {},
@@ -119,11 +121,12 @@ describe('WorkflowExecutorProxyRoute', () => {
   });
 
   describe('setupRoutes', () => {
-    test('registers a single catch-all route for every verb', () => {
+    test('registers a single catch-all mount for every verb', () => {
       buildRoute('http://localhost:4001').setupRoutes(router);
 
+      expect(router.all).toHaveBeenCalledTimes(1);
       expect(router.all).toHaveBeenCalledWith(
-        '/_internal/workflow-executions/:path(.*)',
+        '/_internal/executor/:path(.*)',
         expect.any(Function),
       );
       expect(router.get).not.toHaveBeenCalled();
@@ -133,10 +136,33 @@ describe('WorkflowExecutorProxyRoute', () => {
   });
 
   describe('handleProxy — generic forwarding', () => {
-    test('forwards a GET under /runs and returns the executor response', async () => {
+    test('forwards the sub-path verbatim to the executor root (no namespace prefix added)', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123');
+      const context = buildContext('mcp-oauth-credentials', { method: 'POST' });
+      await callHandleProxy(route, context);
+
+      expect(receivedMethod).toBe('POST');
+      expect(receivedUrl).toBe('/mcp-oauth-credentials');
+      // The agent must NOT inject a /runs (or any) namespace prefix.
+      expect(receivedUrl).not.toBe('/runs/mcp-oauth-credentials');
+      expect(context.response.status).toBe(200);
+    });
+
+    test('forwards a dotted path segment (a single dot is not treated as traversal)', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('mcp.tools/v1');
+      await callHandleProxy(route, context);
+
+      expect(receivedUrl).toBe('/mcp.tools/v1');
+      expect(context.response.status).toBe(200);
+    });
+
+    test('forwards a run GET (caller includes runs/) and returns the executor response', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('runs/run-123');
       await callHandleProxy(route, context);
 
       expect(receivedMethod).toBe('GET');
@@ -149,7 +175,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
       const rawBody = '{"pendingData":{"answer":"yes"}}';
-      const context = buildContext('run-456/trigger', { method: 'POST' });
+      const context = buildContext('runs/run-456/trigger', { method: 'POST' });
       (context.request as unknown as { rawBody: string }).rawBody = rawBody;
 
       await callHandleProxy(route, context);
@@ -166,29 +192,29 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('forwards any verb and any future sub-path without a dedicated route', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123/cancel', { method: 'DELETE' });
+      const context = buildContext('mcp-tools/list/refresh', { method: 'DELETE' });
       await callHandleProxy(route, context);
 
       expect(receivedMethod).toBe('DELETE');
-      expect(receivedUrl).toBe('/runs/run-123/cancel');
+      expect(receivedUrl).toBe('/mcp-tools/list/refresh');
       expect(context.response.status).toBe(200);
     });
 
     test('forwards query params to the executor', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123');
-      Object.defineProperty(context, 'querystring', { value: 'foo=bar&page=2' });
+      const context = buildContext('mcp-tools/list');
+      Object.defineProperty(context, 'querystring', { value: 'server=github&page=2' });
 
       await callHandleProxy(route, context);
 
-      expect(receivedUrl).toBe('/runs/run-123?foo=bar&page=2');
+      expect(receivedUrl).toBe('/mcp-tools/list?server=github&page=2');
     });
 
     test('forwards the executor error status and body verbatim', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('not-found');
+      const context = buildContext('runs/not-found');
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(404);
@@ -199,11 +225,11 @@ describe('WorkflowExecutorProxyRoute', () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
       // No rawBody set → body is undefined; the request must still complete.
-      const context = buildContext('run-123/archive', { method: 'POST' });
+      const context = buildContext('mcp-oauth-credentials', { method: 'DELETE' });
       await callHandleProxy(route, context);
 
-      expect(receivedMethod).toBe('POST');
-      expect(receivedUrl).toBe('/runs/run-123/archive');
+      expect(receivedMethod).toBe('DELETE');
+      expect(receivedUrl).toBe('/mcp-oauth-credentials');
       expect(receivedBody).toBe('');
       expect(context.response.status).toBe(200);
     });
@@ -211,7 +237,7 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('passes a non-JSON executor body through untouched', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123/plain-text');
+      const context = buildContext('plain-text');
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(200);
@@ -221,7 +247,7 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('passes a 204 empty executor response through without throwing', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123/no-content', { method: 'DELETE' });
+      const context = buildContext('no-content', { method: 'DELETE' });
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(204);
@@ -233,7 +259,7 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('forwards all client headers except hop-by-hop / host / content-length', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123', {
+      const context = buildContext('runs/run-123', {
         headers: {
           authorization: 'Bearer jwt-token-value',
           cookie: 'forest_session_token=cookie-token',
@@ -257,7 +283,7 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('forwards executor response headers except hop-by-hop', async () => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      const context = buildContext('run-123');
+      const context = buildContext('runs/run-123');
       await callHandleProxy(route, context);
 
       expect(context.response.get('X-Executor-Custom')).toBe('passthrough-value');
@@ -266,17 +292,25 @@ describe('WorkflowExecutorProxyRoute', () => {
     });
   });
 
-  describe('handleProxy — path traversal protection (security boundary)', () => {
+  // SSRF guard: the wildcard is forwarded verbatim, so it must never resolve off the executor
+  // origin. A leading control char passes the string checks but the URL parser strips it,
+  // collapsing e.g. `\t//evil.com` into `//evil.com` → another host; the final-origin check
+  // rejects these.
+  describe('handleProxy — SSRF guard (cannot escape the executor origin)', () => {
     it.each([
       '..',
       '../mcp-oauth-credentials',
       'run-123/../../mcp-oauth-credentials',
       '%2e%2e/mcp-oauth-credentials',
-      '/runs/run-123',
-    ])('rejects %p and never forwards to the executor', async evilPath => {
+      '/absolute-escape',
+      '\t//evil.com',
+      '\n//evil.com',
+      '\r//evil.com',
+    ])('rejects %j with NotFoundError and never forwards to the executor', async evilPath => {
       const route = buildRoute(`http://localhost:${executorPort}`);
 
-      await expect(callHandleProxy(route, buildContext(evilPath))).rejects.toThrow();
+      // NotFoundError → 404, so an SSRF attempt never surfaces as a 500.
+      await expect(callHandleProxy(route, buildContext(evilPath))).rejects.toThrow(NotFoundError);
       expect(receivedUrl).toBeUndefined();
     });
   });
@@ -285,7 +319,7 @@ describe('WorkflowExecutorProxyRoute', () => {
     test('rejects when the executor cannot be reached', async () => {
       const route = buildRoute('http://localhost:1');
 
-      await expect(callHandleProxy(route, buildContext('run-789'))).rejects.toThrow();
+      await expect(callHandleProxy(route, buildContext('runs/run-789'))).rejects.toThrow();
     });
 
     test('rejects when the executor does not respond before the timeout', async () => {
@@ -293,9 +327,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       // Shrink the timeout so the never-responding 'hang' endpoint trips it quickly.
       (route as unknown as { requestTimeoutMs: number }).requestTimeoutMs = 50;
 
-      await expect(callHandleProxy(route, buildContext('run-123/hang'))).rejects.toThrow(
-        /timed out/,
-      );
+      await expect(callHandleProxy(route, buildContext('hang'))).rejects.toThrow(/timed out/);
     });
   });
 });


### PR DESCRIPTION
## What

Follow-up to PRD-567: make the workflow-executor passthrough **truly generic** — the agent becomes a transparent pipe to the executor, so a new executor route (`mcp-oauth-credentials`, `list-mcp-tools`, future ones) needs **no agent change**.

- **Single catch-all mount** `/_internal/executor/:path(.*)` → executor `/:path` **verbatim** (all verbs). No namespace prefix is injected.
- Replaces the previous `/_internal/workflow-executions → /runs` mapping. Not deployed to customers, so the agent and front move together — the front simply addresses runs as `/_internal/executor/runs/<id>` (one-line `BASE_PATH` change).

## Security — origin check (the load-bearing control)

The verbatim mount needs more than a traversal guard. A decoded control char passes the string checks but the URL parser strips it, collapsing the path into another authority → origin hijack:

```
/_internal/executor/%09//evil.com  →  "\t//evil.com"  →  string guard passes
                                    →  new URL("/\t//evil.com", executor)  →  http://evil.com   ❌
```

Verified (`%09`/`%0a`/`%0d` → `http://evil.com`). The proxy now **verifies the resolved URL never leaves the executor origin**, in addition to rejecting traversal / absolute / encoded-dot / backslash / NUL.

## Tests

**24/24**. Verbatim forwarding (with an explicit "no `/runs` prefix injected" assertion), dotted-path allowed, raw body, req/resp header filtering, query, error/204/non-JSON passthrough, SSRF (traversal + absolute + control-char origin-escape, each asserting `NotFoundError` + nothing reached the executor), timeout, unreachable.

## Notes

- No capability flag — dropped by team decision; front/orchestrator compatibility is handled separately.
- Same change to propagate to the other agents (scoping TBD with the team).

fixes PRD-567

🤖 Generated with [Claude Code](https://claude.com/claude-code)