### PR TITLE
feat(mcp-server): create approval request on action trigger when required by role

### DIFF
--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -29,6 +29,7 @@ export default function makeCreateApprovalRequest(options: {
         data: {
           type: 'action-approvals',
           attributes: {
+            // Required null on create: the Forest server assigns the pending status itself.
             status: null,
             action_name: payload.actionName,
             collection_name: payload.collectionName,

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -32,7 +32,8 @@ export default function makeCreateApprovalRequest(options: {
             action_name: payload.actionName,
             collection_name: payload.collectionName,
             record_ids: payload.recordIds,
-            inputs: payload.values,
+            // The Forest server stores inputs as a list of { name, value } (not a values map).
+            inputs: Object.entries(payload.values).map(([name, value]) => ({ name, value })),
           },
         },
       },

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -1,6 +1,6 @@
 import { ServerUtils } from '@forestadmin/forestadmin-client';
 
-export type ApprovalRequestInput = { name: string; type: string; value: unknown };
+export type ApprovalRequestInput = { name: string; type: string | string[]; value: unknown };
 
 export type ApprovalRequestPayload = {
   collectionName: string;

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -1,10 +1,12 @@
 import { ServerUtils } from '@forestadmin/forestadmin-client';
 
+export type ApprovalRequestInput = { name: string; type: string; value: unknown };
+
 export type ApprovalRequestPayload = {
   collectionName: string;
   actionName: string;
   recordIds: (string | number)[];
-  values: Record<string, unknown>;
+  inputs: ApprovalRequestInput[];
 };
 
 export type CreateApprovalRequest = (payload: ApprovalRequestPayload) => Promise<void>;
@@ -32,8 +34,7 @@ export default function makeCreateApprovalRequest(options: {
             action_name: payload.actionName,
             collection_name: payload.collectionName,
             record_ids: payload.recordIds,
-            // The Forest server stores inputs as a list of { name, value } (not a values map).
-            inputs: Object.entries(payload.values).map(([name, value]) => ({ name, value })),
+            inputs: payload.inputs,
           },
         },
       },

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -11,7 +11,6 @@ export type ApprovalRequestPayload = {
 
 export type CreateApprovalRequest = (payload: ApprovalRequestPayload) => Promise<void>;
 
-// forestadmin-server private-api: POST /api/action-approvals (status null = creation).
 const APPROVAL_REQUEST_PATH = '/api/action-approvals';
 
 export default function makeCreateApprovalRequest(options: {

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -7,25 +7,23 @@ export type ApprovalRequestPayload = {
   values: Record<string, unknown>;
 };
 
+export type CreateApprovalRequest = (payload: ApprovalRequestPayload) => Promise<void>;
+
 // forestadmin-server private-api: POST /api/action-approvals (status null = creation).
 const APPROVAL_REQUEST_PATH = '/api/action-approvals';
 
-export default class ApprovalRequestCreator {
-  constructor(
-    private readonly options: {
-      forestServerUrl: string;
-      forestServerToken: string;
-      renderingId: number | string;
-    },
-  ) {}
-
-  async create(payload: ApprovalRequestPayload): Promise<void> {
+export default function makeCreateApprovalRequest(options: {
+  forestServerUrl: string;
+  forestServerToken: string;
+  renderingId: number | string;
+}): CreateApprovalRequest {
+  return async payload => {
     await ServerUtils.queryWithBearerToken({
-      forestServerUrl: this.options.forestServerUrl,
-      bearerToken: this.options.forestServerToken,
+      forestServerUrl: options.forestServerUrl,
+      bearerToken: options.forestServerToken,
       method: 'post',
       path: APPROVAL_REQUEST_PATH,
-      headers: { 'forest-rendering-id': String(this.options.renderingId) },
+      headers: { 'forest-rendering-id': String(options.renderingId) },
       body: {
         data: {
           type: 'action-approvals',
@@ -39,5 +37,5 @@ export default class ApprovalRequestCreator {
         },
       },
     });
-  }
+  };
 }

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -5,31 +5,36 @@ export type ApprovalRequestPayload = {
   actionName: string;
   recordIds: (string | number)[];
   values: Record<string, unknown>;
-  roleIdsAllowedToApprove?: number[];
 };
 
-// TODO(PRD-288 / Brice): confirm the SaaS endpoint + payload used by the front to create an
-// approval request after a 403. The front already calls it; once known, replace this placeholder.
-const APPROVAL_REQUEST_PATH = '/liana/action-approval-requests';
+// forestadmin-server private-api: POST /api/action-approvals (status null = creation).
+const APPROVAL_REQUEST_PATH = '/api/action-approvals';
 
 export default class ApprovalRequestCreator {
-  constructor(private readonly options: { forestServerUrl: string; bearerToken: string }) {}
+  constructor(
+    private readonly options: {
+      forestServerUrl: string;
+      forestServerToken: string;
+      renderingId: number | string;
+    },
+  ) {}
 
   async create(payload: ApprovalRequestPayload): Promise<void> {
     await ServerUtils.queryWithBearerToken({
       forestServerUrl: this.options.forestServerUrl,
-      bearerToken: this.options.bearerToken,
+      bearerToken: this.options.forestServerToken,
       method: 'post',
       path: APPROVAL_REQUEST_PATH,
+      headers: { 'forest-rendering-id': String(this.options.renderingId) },
       body: {
         data: {
-          type: 'action-approval-requests',
+          type: 'action-approvals',
           attributes: {
-            collection_name: payload.collectionName,
+            status: null,
             action_name: payload.actionName,
-            ids: payload.recordIds,
-            values: payload.values,
-            role_ids_allowed_to_approve: payload.roleIdsAllowedToApprove,
+            collection_name: payload.collectionName,
+            record_ids: payload.recordIds,
+            inputs: payload.values,
           },
         },
       },

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -1,0 +1,38 @@
+import { ServerUtils } from '@forestadmin/forestadmin-client';
+
+export type ApprovalRequestPayload = {
+  collectionName: string;
+  actionName: string;
+  recordIds: (string | number)[];
+  values: Record<string, unknown>;
+  roleIdsAllowedToApprove?: number[];
+};
+
+// TODO(PRD-288 / Brice): confirm the SaaS endpoint + payload used by the front to create an
+// approval request after a 403. The front already calls it; once known, replace this placeholder.
+const APPROVAL_REQUEST_PATH = '/liana/action-approval-requests';
+
+export default class ApprovalRequestCreator {
+  constructor(private readonly options: { forestServerUrl: string; bearerToken: string }) {}
+
+  async create(payload: ApprovalRequestPayload): Promise<void> {
+    await ServerUtils.queryWithBearerToken({
+      forestServerUrl: this.options.forestServerUrl,
+      bearerToken: this.options.bearerToken,
+      method: 'post',
+      path: APPROVAL_REQUEST_PATH,
+      body: {
+        data: {
+          type: 'action-approval-requests',
+          attributes: {
+            collection_name: payload.collectionName,
+            action_name: payload.actionName,
+            ids: payload.recordIds,
+            values: payload.values,
+            role_ids_allowed_to_approve: payload.roleIdsAllowedToApprove,
+          },
+        },
+      },
+    });
+  }
+}

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -118,8 +118,6 @@ export default class Action {
       const mapped = toActionError(error);
 
       if (mapped instanceof ActionRequiresApprovalError && this.createApprovalRequest) {
-        // Pass the field type as-is: scalar ('String', 'Number'…) or list (['String'], ['Number']),
-        // matching the Forest server's ActionInput shape. Do not stringify list types.
         const inputs = this.fieldsFormStates.getFields().map(field => ({
           name: field.getName(),
           type: field.getType(),

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -118,12 +118,13 @@ export default class Action {
       const mapped = toActionError(error);
 
       if (mapped instanceof ActionRequiresApprovalError && this.createApprovalRequest) {
-        const values = this.fieldsFormStates.getFieldValues();
-        const inputs = Object.entries(values).map(([name, value]) => {
-          const type = this.fieldsFormStates.getField(name)?.getType();
-
-          return { name, type: typeof type === 'string' ? type : JSON.stringify(type), value };
-        });
+        // Pass the field type as-is: scalar ('String', 'Number'…) or list (['String'], ['Number']),
+        // matching the Forest server's ActionInput shape. Do not stringify list types.
+        const inputs = this.fieldsFormStates.getFields().map(field => ({
+          name: field.getName(),
+          type: field.getType(),
+          value: field.getValue(),
+        }));
 
         await this.createApprovalRequest({
           collectionName: this.collectionName,

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -56,6 +56,10 @@ export type BaseActionContext = {
   recordIds?: RecordId[];
 };
 
+// Exactly one branch is set: a normal execution result, or an approval request was created instead
+// of executing (only possible when the client is wired with a createApprovalRequest).
+export type ActionExecuteResult = { success: string; html?: string } | { approvalRequested: true };
+
 export type ActionEndpointsByCollection = {
   [collectionName: string]: {
     [actionName: string]: Pick<ForestSchemaAction, 'id' | 'name' | 'endpoint' | 'hooks' | 'fields'>;
@@ -92,9 +96,7 @@ export default class Action {
     this.createApprovalRequest = createApprovalRequest;
   }
 
-  async execute(
-    signedApprovalRequest?: Record<string, unknown>,
-  ): Promise<{ success?: string; html?: string; approvalRequested?: boolean }> {
+  async execute(signedApprovalRequest?: Record<string, unknown>): Promise<ActionExecuteResult> {
     const requestBody = {
       data: {
         attributes: {

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -118,11 +118,18 @@ export default class Action {
       const mapped = toActionError(error);
 
       if (mapped instanceof ActionRequiresApprovalError && this.createApprovalRequest) {
+        const values = this.fieldsFormStates.getFieldValues();
+        const inputs = Object.entries(values).map(([name, value]) => {
+          const type = this.fieldsFormStates.getField(name)?.getType();
+
+          return { name, type: typeof type === 'string' ? type : JSON.stringify(type), value };
+        });
+
         await this.createApprovalRequest({
           collectionName: this.collectionName,
           actionName: this.actionName,
           recordIds: this.ids ?? [],
-          values: this.fieldsFormStates.getFieldValues(),
+          inputs,
         });
 
         return { approvalRequested: true };

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -1,6 +1,6 @@
 import type ActionField from '../action-fields/action-field';
 import type FieldFormStates from '../action-fields/field-form-states';
-import type ApprovalRequestCreator from '../approval-request-creator';
+import type { CreateApprovalRequest } from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { RecordId } from '../types';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
@@ -70,7 +70,7 @@ export default class Action {
   private readonly ids: (string | number)[];
   private readonly actionId: string | undefined;
   private actionPath: string;
-  private readonly approvalRequestCreator?: ApprovalRequestCreator;
+  private readonly createApprovalRequest?: CreateApprovalRequest;
 
   constructor(
     collectionName: string,
@@ -80,7 +80,7 @@ export default class Action {
     fieldsFormStates: FieldFormStates,
     ids?: (string | number)[],
     actionId?: string,
-    approvalRequestCreator?: ApprovalRequestCreator,
+    createApprovalRequest?: CreateApprovalRequest,
   ) {
     this.collectionName = collectionName;
     this.actionName = actionName;
@@ -89,7 +89,7 @@ export default class Action {
     this.actionPath = actionPath;
     this.fieldsFormStates = fieldsFormStates;
     this.actionId = actionId;
-    this.approvalRequestCreator = approvalRequestCreator;
+    this.createApprovalRequest = createApprovalRequest;
   }
 
   async execute(
@@ -117,11 +117,11 @@ export default class Action {
     } catch (error) {
       const mapped = toActionError(error);
 
-      if (mapped instanceof ActionRequiresApprovalError && this.approvalRequestCreator) {
-        await this.approvalRequestCreator.create({
+      if (mapped instanceof ActionRequiresApprovalError && this.createApprovalRequest) {
+        await this.createApprovalRequest({
           collectionName: this.collectionName,
           actionName: this.actionName,
-          recordIds: this.ids,
+          recordIds: this.ids ?? [],
           values: this.fieldsFormStates.getFieldValues(),
         });
 

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -18,7 +18,11 @@ import ActionFieldRadioGroup from '../action-fields/action-field-radio-group';
 import ActionFieldString from '../action-fields/action-field-string';
 import ActionFieldStringList from '../action-fields/action-field-string-list';
 import ActionLayoutRoot from '../action-layout/action-layout-root';
-import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from '../errors';
+import AgentHttpError, {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  ApprovalRequestCreationError,
+} from '../errors';
 
 // JSON:API error body the agent returns on a rejected action.
 type ActionErrorBody = {
@@ -124,12 +128,16 @@ export default class Action {
           value: field.getValue(),
         }));
 
-        await this.createApprovalRequest({
-          collectionName: this.collectionName,
-          actionName: this.actionName,
-          recordIds: this.ids ?? [],
-          inputs,
-        });
+        try {
+          await this.createApprovalRequest({
+            collectionName: this.collectionName,
+            actionName: this.actionName,
+            recordIds: this.ids ?? [],
+            inputs,
+          });
+        } catch (cause) {
+          throw new ApprovalRequestCreationError(cause);
+        }
 
         return { approvalRequested: true };
       }

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -123,7 +123,6 @@ export default class Action {
           actionName: this.actionName,
           recordIds: this.ids,
           values: this.fieldsFormStates.getFieldValues(),
-          roleIdsAllowedToApprove: mapped.roleIdsAllowedToApprove,
         });
 
         return { approvalRequested: true };

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -56,8 +56,6 @@ export type BaseActionContext = {
   recordIds?: RecordId[];
 };
 
-// Exactly one branch is set: a normal execution result, or an approval request was created instead
-// of executing (only possible when the client is wired with a createApprovalRequest).
 export type ActionExecuteResult = { success: string; html?: string } | { approvalRequested: true };
 
 export type ActionEndpointsByCollection = {

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -1,5 +1,6 @@
 import type ActionField from '../action-fields/action-field';
 import type FieldFormStates from '../action-fields/field-form-states';
+import type ApprovalRequestCreator from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { RecordId } from '../types';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
@@ -62,32 +63,38 @@ export type ActionEndpointsByCollection = {
 };
 export default class Action {
   private readonly collectionName: string;
+  private readonly actionName: string;
 
   private readonly httpRequester: HttpRequester;
   protected readonly fieldsFormStates: FieldFormStates;
   private readonly ids: (string | number)[];
   private readonly actionId: string | undefined;
   private actionPath: string;
+  private readonly approvalRequestCreator?: ApprovalRequestCreator;
 
   constructor(
     collectionName: string,
+    actionName: string,
     httpRequester: HttpRequester,
     actionPath: string,
     fieldsFormStates: FieldFormStates,
     ids?: (string | number)[],
     actionId?: string,
+    approvalRequestCreator?: ApprovalRequestCreator,
   ) {
     this.collectionName = collectionName;
+    this.actionName = actionName;
     this.httpRequester = httpRequester;
     this.ids = ids ?? undefined;
     this.actionPath = actionPath;
     this.fieldsFormStates = fieldsFormStates;
     this.actionId = actionId;
+    this.approvalRequestCreator = approvalRequestCreator;
   }
 
   async execute(
     signedApprovalRequest?: Record<string, unknown>,
-  ): Promise<{ success: string; html?: string }> {
+  ): Promise<{ success?: string; html?: string; approvalRequested?: boolean }> {
     const requestBody = {
       data: {
         attributes: {
@@ -108,7 +115,21 @@ export default class Action {
         body: requestBody,
       });
     } catch (error) {
-      throw toActionError(error);
+      const mapped = toActionError(error);
+
+      if (mapped instanceof ActionRequiresApprovalError && this.approvalRequestCreator) {
+        await this.approvalRequestCreator.create({
+          collectionName: this.collectionName,
+          actionName: this.actionName,
+          recordIds: this.ids,
+          values: this.fieldsFormStates.getFieldValues(),
+          roleIdsAllowedToApprove: mapped.roleIdsAllowedToApprove,
+        });
+
+        return { approvalRequested: true };
+      }
+
+      throw mapped;
     }
   }
 

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -1,6 +1,6 @@
 import type { ExportOptions, LiveQueryOptions, RecordId, SelectOptions } from '../types';
 import type { ActionEndpointsByCollection, BaseActionContext } from './action';
-import type ApprovalRequestCreator from '../approval-request-creator';
+import type { CreateApprovalRequest } from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
 import type { WriteStream } from 'fs';
@@ -16,19 +16,19 @@ import serializeRecordId from '../record-id';
 export default class Collection extends CollectionChart {
   protected readonly name: string;
   protected readonly actionEndpoints?: ActionEndpointsByCollection;
-  protected readonly approvalRequestCreator?: ApprovalRequestCreator;
+  protected readonly createApprovalRequest?: CreateApprovalRequest;
 
   constructor(
     name: string,
     httpRequester: HttpRequester,
     actionEndpoints: ActionEndpointsByCollection,
-    approvalRequestCreator?: ApprovalRequestCreator,
+    createApprovalRequest?: CreateApprovalRequest,
   ) {
     super(name, httpRequester);
 
     this.name = name;
     this.actionEndpoints = actionEndpoints;
-    this.approvalRequestCreator = approvalRequestCreator;
+    this.createApprovalRequest = createApprovalRequest;
   }
 
   async action(actionName: string, actionContext?: BaseActionContext): Promise<Action> {
@@ -55,7 +55,7 @@ export default class Collection extends CollectionChart {
       fieldsFormStates,
       ids,
       actionInfo.id,
-      this.approvalRequestCreator,
+      this.createApprovalRequest,
     );
 
     await fieldsFormStates.loadInitialState();

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -1,5 +1,6 @@
 import type { ExportOptions, LiveQueryOptions, RecordId, SelectOptions } from '../types';
 import type { ActionEndpointsByCollection, BaseActionContext } from './action';
+import type ApprovalRequestCreator from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { ForestSchemaAction } from '@forestadmin/forestadmin-client';
 import type { WriteStream } from 'fs';
@@ -15,16 +16,19 @@ import serializeRecordId from '../record-id';
 export default class Collection extends CollectionChart {
   protected readonly name: string;
   protected readonly actionEndpoints?: ActionEndpointsByCollection;
+  protected readonly approvalRequestCreator?: ApprovalRequestCreator;
 
   constructor(
     name: string,
     httpRequester: HttpRequester,
     actionEndpoints: ActionEndpointsByCollection,
+    approvalRequestCreator?: ApprovalRequestCreator,
   ) {
     super(name, httpRequester);
 
     this.name = name;
     this.actionEndpoints = actionEndpoints;
+    this.approvalRequestCreator = approvalRequestCreator;
   }
 
   async action(actionName: string, actionContext?: BaseActionContext): Promise<Action> {
@@ -45,11 +49,13 @@ export default class Collection extends CollectionChart {
 
     const action = new Action(
       this.name,
+      actionName,
       this.httpRequester,
       actionInfo.endpoint,
       fieldsFormStates,
       ids,
       actionInfo.id,
+      this.approvalRequestCreator,
     );
 
     await fieldsFormStates.loadInitialState();

--- a/packages/agent-client/src/domains/remote-agent-client.ts
+++ b/packages/agent-client/src/domains/remote-agent-client.ts
@@ -1,4 +1,5 @@
 import type { ActionEndpointsByCollection } from './action';
+import type ApprovalRequestCreator from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { RawTreeWithSources } from '@forestadmin/forestadmin-client';
 
@@ -38,6 +39,7 @@ export default class RemoteAgentClient<
   TypingsSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends Chart {
   protected actionEndpoints?: ActionEndpointsByCollection;
+  protected approvalRequestCreator?: ApprovalRequestCreator;
 
   private overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
 
@@ -45,12 +47,14 @@ export default class RemoteAgentClient<
     actionEndpoints?: ActionEndpointsByCollection;
     httpRequester: HttpRequester;
     overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
+    approvalRequestCreator?: ApprovalRequestCreator;
   }) {
     super();
     if (!params) return;
     this.httpRequester = params.httpRequester;
     this.actionEndpoints = params.actionEndpoints;
     this.overridePermissions = params.overridePermissions;
+    this.approvalRequestCreator = params.approvalRequestCreator;
   }
 
   async overrideCollectionPermission(
@@ -85,6 +89,11 @@ export default class RemoteAgentClient<
   }
 
   collection(name: CollectionName<TypingsSchema>): Collection {
-    return new Collection(name, this.httpRequester, this.actionEndpoints);
+    return new Collection(
+      name,
+      this.httpRequester,
+      this.actionEndpoints,
+      this.approvalRequestCreator,
+    );
   }
 }

--- a/packages/agent-client/src/domains/remote-agent-client.ts
+++ b/packages/agent-client/src/domains/remote-agent-client.ts
@@ -1,5 +1,5 @@
 import type { ActionEndpointsByCollection } from './action';
-import type ApprovalRequestCreator from '../approval-request-creator';
+import type { CreateApprovalRequest } from '../approval-request-creator';
 import type HttpRequester from '../http-requester';
 import type { RawTreeWithSources } from '@forestadmin/forestadmin-client';
 
@@ -39,7 +39,7 @@ export default class RemoteAgentClient<
   TypingsSchema extends Record<string, unknown> = Record<string, unknown>,
 > extends Chart {
   protected actionEndpoints?: ActionEndpointsByCollection;
-  protected approvalRequestCreator?: ApprovalRequestCreator;
+  protected createApprovalRequest?: CreateApprovalRequest;
 
   private overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
 
@@ -47,14 +47,14 @@ export default class RemoteAgentClient<
     actionEndpoints?: ActionEndpointsByCollection;
     httpRequester: HttpRequester;
     overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
-    approvalRequestCreator?: ApprovalRequestCreator;
+    createApprovalRequest?: CreateApprovalRequest;
   }) {
     super();
     if (!params) return;
     this.httpRequester = params.httpRequester;
     this.actionEndpoints = params.actionEndpoints;
     this.overridePermissions = params.overridePermissions;
-    this.approvalRequestCreator = params.approvalRequestCreator;
+    this.createApprovalRequest = params.createApprovalRequest;
   }
 
   async overrideCollectionPermission(
@@ -93,7 +93,7 @@ export default class RemoteAgentClient<
       name,
       this.httpRequester,
       this.actionEndpoints,
-      this.approvalRequestCreator,
+      this.createApprovalRequest,
     );
   }
 }

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -24,3 +24,12 @@ export class ActionFormValidationError extends Error {
     this.name = 'ActionFormValidationError';
   }
 }
+
+// The action is approval-gated, but filing the approval request failed — distinct from the action
+// itself failing, so the caller can tell the two apart.
+export class ApprovalRequestCreationError extends Error {
+  constructor(readonly cause: unknown) {
+    super('The action requires an approval, but the approval request could not be created.');
+    this.name = 'ApprovalRequestCreationError';
+  }
+}

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -36,10 +36,9 @@ export function createRemoteAgentClient(params: {
   token?: string;
   url: string;
   /**
-   * Connection to the Forest Admin server, shared by server-side features. When provided, an action
-   * that requires approval creates an approval request (returning `{ approvalRequested: true }`)
-   * instead of throwing; omit it to keep the plain behaviour (the 403 is rethrown). `serverUrl` is
-   * the Forest server, distinct from the agent `url` above.
+   * Connection to the Forest Admin server. Provide it to enable server-side features that call the
+   * Forest server (e.g. creating approval requests); omit it for a client that only talks to the
+   * agent (e.g. tests). `serverUrl` is the Forest server, distinct from the agent `url` above.
    */
   forestServer?: { serverUrl: string; serverToken: string; renderingId: number | string };
 }) {

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -35,7 +35,13 @@ export function createRemoteAgentClient(params: {
   actionEndpoints?: ActionEndpointsByCollection;
   token?: string;
   url: string;
-  forestServer?: { url: string; forestServerToken: string; renderingId: number | string };
+  /**
+   * Connection to the Forest Admin server, shared by server-side features. When provided, an action
+   * that requires approval creates an approval request (returning `{ approvalRequested: true }`)
+   * instead of throwing; omit it to keep the plain behaviour (the 403 is rethrown). `serverUrl` is
+   * the Forest server, distinct from the agent `url` above.
+   */
+  forestServer?: { serverUrl: string; serverToken: string; renderingId: number | string };
 }) {
   const httpRequester = new HttpRequester(params.token, { url: params.url });
 
@@ -45,8 +51,8 @@ export function createRemoteAgentClient(params: {
     overridePermissions: params.overridePermissions,
     createApprovalRequest: params.forestServer
       ? makeCreateApprovalRequest({
-          forestServerUrl: params.forestServer.url,
-          forestServerToken: params.forestServer.forestServerToken,
+          forestServerUrl: params.forestServer.serverUrl,
+          forestServerToken: params.forestServer.serverToken,
           renderingId: params.forestServer.renderingId,
         })
       : undefined,

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -7,7 +7,7 @@ import type {
 
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
-import ApprovalRequestCreator from './approval-request-creator';
+import makeCreateApprovalRequest from './approval-request-creator';
 import RemoteAgentClient from './domains/remote-agent-client';
 import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from './errors';
 import HttpRequester from './http-requester';
@@ -15,7 +15,7 @@ import HttpRequester from './http-requester';
 export {
   ActionFieldJson,
   ActionFieldStringList,
-  ApprovalRequestCreator,
+  makeCreateApprovalRequest,
   RemoteAgentClient,
   HttpRequester,
   AgentHttpError,
@@ -28,7 +28,7 @@ export type {
   PermissionsOverride,
   SmartActionPermissionsOverride,
 };
-export type { ApprovalRequestPayload } from './approval-request-creator';
+export type { ApprovalRequestPayload, CreateApprovalRequest } from './approval-request-creator';
 
 export function createRemoteAgentClient(params: {
   overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
@@ -43,8 +43,8 @@ export function createRemoteAgentClient(params: {
     actionEndpoints: params.actionEndpoints,
     httpRequester,
     overridePermissions: params.overridePermissions,
-    approvalRequestCreator: params.forestServer
-      ? new ApprovalRequestCreator({
+    createApprovalRequest: params.forestServer
+      ? makeCreateApprovalRequest({
           forestServerUrl: params.forestServer.url,
           forestServerToken: params.forestServer.forestServerToken,
           renderingId: params.forestServer.renderingId,

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -35,7 +35,7 @@ export function createRemoteAgentClient(params: {
   actionEndpoints?: ActionEndpointsByCollection;
   token?: string;
   url: string;
-  forestServer?: { url: string; bearerToken: string };
+  forestServer?: { url: string; forestServerToken: string; renderingId: number | string };
 }) {
   const httpRequester = new HttpRequester(params.token, { url: params.url });
 
@@ -46,7 +46,8 @@ export function createRemoteAgentClient(params: {
     approvalRequestCreator: params.forestServer
       ? new ApprovalRequestCreator({
           forestServerUrl: params.forestServer.url,
-          bearerToken: params.forestServer.bearerToken,
+          forestServerToken: params.forestServer.forestServerToken,
+          renderingId: params.forestServer.renderingId,
         })
       : undefined,
   });

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -7,6 +7,7 @@ import type {
 
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
+import ApprovalRequestCreator from './approval-request-creator';
 import RemoteAgentClient from './domains/remote-agent-client';
 import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from './errors';
 import HttpRequester from './http-requester';
@@ -14,6 +15,7 @@ import HttpRequester from './http-requester';
 export {
   ActionFieldJson,
   ActionFieldStringList,
+  ApprovalRequestCreator,
   RemoteAgentClient,
   HttpRequester,
   AgentHttpError,
@@ -26,12 +28,14 @@ export type {
   PermissionsOverride,
   SmartActionPermissionsOverride,
 };
+export type { ApprovalRequestPayload } from './approval-request-creator';
 
 export function createRemoteAgentClient(params: {
   overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
   actionEndpoints?: ActionEndpointsByCollection;
   token?: string;
   url: string;
+  forestServer?: { url: string; bearerToken: string };
 }) {
   const httpRequester = new HttpRequester(params.token, { url: params.url });
 
@@ -39,6 +43,12 @@ export function createRemoteAgentClient(params: {
     actionEndpoints: params.actionEndpoints,
     httpRequester,
     overridePermissions: params.overridePermissions,
+    approvalRequestCreator: params.forestServer
+      ? new ApprovalRequestCreator({
+          forestServerUrl: params.forestServer.url,
+          bearerToken: params.forestServer.bearerToken,
+        })
+      : undefined,
   });
 }
 

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -9,7 +9,11 @@ import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
 import makeCreateApprovalRequest from './approval-request-creator';
 import RemoteAgentClient from './domains/remote-agent-client';
-import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError } from './errors';
+import AgentHttpError, {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  ApprovalRequestCreationError,
+} from './errors';
 import HttpRequester from './http-requester';
 
 export {
@@ -21,6 +25,7 @@ export {
   AgentHttpError,
   ActionRequiresApprovalError,
   ActionFormValidationError,
+  ApprovalRequestCreationError,
 };
 export type {
   ActionEndpointsByCollection,

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -22,7 +22,7 @@ describe('makeCreateApprovalRequest', () => {
       collectionName: 'users',
       actionName: 'refund',
       recordIds: ['1', '2'],
-      values: { reason: 'fraud' },
+      inputs: [{ name: 'reason', type: 'String', value: 'fraud' }],
     });
 
     expect(queryWithBearerToken).toHaveBeenCalledWith({
@@ -39,7 +39,7 @@ describe('makeCreateApprovalRequest', () => {
             action_name: 'refund',
             collection_name: 'users',
             record_ids: ['1', '2'],
-            inputs: [{ name: 'reason', value: 'fraud' }],
+            inputs: [{ name: 'reason', type: 'String', value: 'fraud' }],
           },
         },
       },

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -1,0 +1,48 @@
+import { ServerUtils } from '@forestadmin/forestadmin-client';
+
+import makeCreateApprovalRequest from '../src/approval-request-creator';
+
+jest.mock('@forestadmin/forestadmin-client', () => ({
+  ServerUtils: { queryWithBearerToken: jest.fn() },
+}));
+
+describe('makeCreateApprovalRequest', () => {
+  const queryWithBearerToken = ServerUtils.queryWithBearerToken as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('POSTs /api/action-approvals with the server token, rendering id header and payload', async () => {
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    await create({
+      collectionName: 'users',
+      actionName: 'refund',
+      recordIds: ['1', '2'],
+      values: { reason: 'fraud' },
+    });
+
+    expect(queryWithBearerToken).toHaveBeenCalledWith({
+      forestServerUrl: 'https://api.forestadmin.com',
+      bearerToken: 'server-token',
+      method: 'post',
+      path: '/api/action-approvals',
+      headers: { 'forest-rendering-id': '42' },
+      body: {
+        data: {
+          type: 'action-approvals',
+          attributes: {
+            status: null,
+            action_name: 'refund',
+            collection_name: 'users',
+            record_ids: ['1', '2'],
+            inputs: { reason: 'fraud' },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -39,7 +39,7 @@ describe('makeCreateApprovalRequest', () => {
             action_name: 'refund',
             collection_name: 'users',
             record_ids: ['1', '2'],
-            inputs: { reason: 'fraud' },
+            inputs: [{ name: 'reason', value: 'fraud' }],
           },
         },
       },

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -143,6 +143,13 @@ describe('Action', () => {
     });
 
     it('creates an approval request and returns approvalRequested when a creator is wired', async () => {
+      fieldsFormStates.getFields.mockReturnValue([
+        {
+          getName: () => 'email',
+          getType: () => 'String',
+          getValue: () => 'test@example.com',
+        },
+      ] as any);
       const createApprovalRequest = jest.fn().mockResolvedValue(undefined);
       const approvalAction = new Action(
         'users',

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -143,7 +143,7 @@ describe('Action', () => {
     });
 
     it('creates an approval request and returns approvalRequested when a creator is wired', async () => {
-      const approvalRequestCreator = { create: jest.fn().mockResolvedValue(undefined) } as any;
+      const createApprovalRequest = jest.fn().mockResolvedValue(undefined);
       const approvalAction = new Action(
         'users',
         'send-email',
@@ -152,7 +152,7 @@ describe('Action', () => {
         fieldsFormStates,
         ['1', '2'],
         undefined,
-        approvalRequestCreator,
+        createApprovalRequest,
       );
       httpRequester.query.mockRejectedValue(
         new AgentHttpError(403, {
@@ -168,7 +168,7 @@ describe('Action', () => {
 
       const result = await approvalAction.execute();
 
-      expect(approvalRequestCreator.create).toHaveBeenCalledWith({
+      expect(createApprovalRequest).toHaveBeenCalledWith({
         collectionName: 'users',
         actionName: 'send-email',
         recordIds: ['1', '2'],

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -173,7 +173,6 @@ describe('Action', () => {
         actionName: 'send-email',
         recordIds: ['1', '2'],
         values: { email: 'test@example.com' },
-        roleIdsAllowedToApprove: [7, 9],
       });
       expect(result).toEqual({ approvalRequested: true });
     });

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -172,7 +172,7 @@ describe('Action', () => {
         collectionName: 'users',
         actionName: 'send-email',
         recordIds: ['1', '2'],
-        values: { email: 'test@example.com' },
+        inputs: [{ name: 'email', type: 'String', value: 'test@example.com' }],
       });
       expect(result).toEqual({ approvalRequested: true });
     });

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -30,10 +30,14 @@ describe('Action', () => {
       getLayout: jest.fn().mockReturnValue([]),
     } as any;
 
-    action = new Action('users', httpRequester, '/forest/actions/send-email', fieldsFormStates, [
-      '1',
-      '2',
-    ]);
+    action = new Action(
+      'users',
+      'send-email',
+      httpRequester,
+      '/forest/actions/send-email',
+      fieldsFormStates,
+      ['1', '2'],
+    );
   });
 
   describe('execute', () => {
@@ -63,6 +67,7 @@ describe('Action', () => {
     it('should include smart_action_id when actionId is provided', async () => {
       const actionWithId = new Action(
         'users',
+        'send-email',
         httpRequester,
         '/forest/actions/send-email',
         fieldsFormStates,
@@ -135,6 +140,42 @@ describe('Action', () => {
         message: 'Needs approval',
         roleIdsAllowedToApprove: [7, 9],
       });
+    });
+
+    it('creates an approval request and returns approvalRequested when a creator is wired', async () => {
+      const approvalRequestCreator = { create: jest.fn().mockResolvedValue(undefined) } as any;
+      const approvalAction = new Action(
+        'users',
+        'send-email',
+        httpRequester,
+        '/forest/actions/send-email',
+        fieldsFormStates,
+        ['1', '2'],
+        undefined,
+        approvalRequestCreator,
+      );
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [
+            {
+              name: 'CustomActionRequiresApprovalError',
+              detail: 'Needs approval',
+              data: { roleIdsAllowedToApprove: [7, 9] },
+            },
+          ],
+        }),
+      );
+
+      const result = await approvalAction.execute();
+
+      expect(approvalRequestCreator.create).toHaveBeenCalledWith({
+        collectionName: 'users',
+        actionName: 'send-email',
+        recordIds: ['1', '2'],
+        values: { email: 'test@example.com' },
+        roleIdsAllowedToApprove: [7, 9],
+      });
+      expect(result).toEqual({ approvalRequested: true });
     });
 
     it('should translate a 422 rejection into ActionFormValidationError', async () => {

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -184,6 +184,31 @@ describe('Action', () => {
       expect(result).toEqual({ approvalRequested: true });
     });
 
+    it('throws ApprovalRequestCreationError when filing the approval request fails', async () => {
+      fieldsFormStates.getFields.mockReturnValue([] as any);
+      const createApprovalRequest = jest.fn().mockRejectedValue(new Error('forest server down'));
+      const approvalAction = new Action(
+        'users',
+        'send-email',
+        httpRequester,
+        '/forest/actions/send-email',
+        fieldsFormStates,
+        ['1'],
+        undefined,
+        createApprovalRequest,
+      );
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [{ name: 'CustomActionRequiresApprovalError', detail: 'Needs approval' }],
+        }),
+      );
+
+      await expect(approvalAction.execute()).rejects.toMatchObject({
+        name: 'ApprovalRequestCreationError',
+        cause: expect.objectContaining({ message: 'forest server down' }),
+      });
+    });
+
     it('should translate a 422 rejection into ActionFormValidationError', async () => {
       httpRequester.query.mockRejectedValue(
         new AgentHttpError(422, { errors: [{ detail: 'Invalid value' }] }),

--- a/packages/agent-client/test/index.test.ts
+++ b/packages/agent-client/test/index.test.ts
@@ -61,7 +61,7 @@ describe('createRemoteAgentClient', () => {
     });
   });
 
-  it('should wire approval-request creation when forestServer is provided', () => {
+  it('should build a client when forestServer is provided', () => {
     const client = createRemoteAgentClient({
       url: 'https://api.example.com',
       token: 'test-token',

--- a/packages/agent-client/test/index.test.ts
+++ b/packages/agent-client/test/index.test.ts
@@ -1,7 +1,16 @@
+import makeCreateApprovalRequest from '../src/approval-request-creator';
 import RemoteAgentClient from '../src/domains/remote-agent-client';
 import { type ActionEndpointsByCollection, createRemoteAgentClient } from '../src/index';
 
+jest.mock('../src/approval-request-creator');
+
+const mockMakeCreateApprovalRequest = makeCreateApprovalRequest as jest.MockedFunction<
+  typeof makeCreateApprovalRequest
+>;
+
 describe('createRemoteAgentClient', () => {
+  beforeEach(() => jest.clearAllMocks());
+
   it('should create a RemoteAgentClient instance', () => {
     const client = createRemoteAgentClient({
       url: 'https://api.example.com',
@@ -61,8 +70,8 @@ describe('createRemoteAgentClient', () => {
     });
   });
 
-  it('should build a client when forestServer is provided', () => {
-    const client = createRemoteAgentClient({
+  it('wires createApprovalRequest from the forestServer fields when provided', () => {
+    createRemoteAgentClient({
       url: 'https://api.example.com',
       token: 'test-token',
       forestServer: {
@@ -72,7 +81,17 @@ describe('createRemoteAgentClient', () => {
       },
     });
 
-    expect(client).toBeInstanceOf(RemoteAgentClient);
+    expect(mockMakeCreateApprovalRequest).toHaveBeenCalledWith({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+  });
+
+  it('does not wire createApprovalRequest when forestServer is omitted', () => {
+    createRemoteAgentClient({ url: 'https://api.example.com', token: 'test-token' });
+
+    expect(mockMakeCreateApprovalRequest).not.toHaveBeenCalled();
   });
 
   it('should provide a working client that can access collections', () => {

--- a/packages/agent-client/test/index.test.ts
+++ b/packages/agent-client/test/index.test.ts
@@ -61,6 +61,20 @@ describe('createRemoteAgentClient', () => {
     });
   });
 
+  it('should wire approval-request creation when forestServer is provided', () => {
+    const client = createRemoteAgentClient({
+      url: 'https://api.example.com',
+      token: 'test-token',
+      forestServer: {
+        serverUrl: 'https://api.forestadmin.com',
+        serverToken: 'server-token',
+        renderingId: 42,
+      },
+    });
+
+    expect(client).toBeInstanceOf(RemoteAgentClient);
+  });
+
   it('should provide a working client that can access collections', () => {
     const client = createRemoteAgentClient({
       url: 'https://api.example.com',

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -344,6 +344,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
       const forestServerClient = new ForestServerClientImpl(
         this.options.forestAdminClient.schemaService,
         this.options.forestAdminClient.activityLogsService,
+        this.options.forestServerUrl,
       );
 
       const mcpServer = new ForestMCPServer({

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -28,7 +28,7 @@ export function createForestServerClient(
     headers: { 'Forest-Application-Source': 'MCP' },
   });
 
-  return new ForestServerClientImpl(schemaService, activityLogsService);
+  return new ForestServerClientImpl(schemaService, activityLogsService, options.forestServerUrl);
 }
 
 export { ForestServerClientImpl };

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -16,6 +16,7 @@ export default class ForestServerClientImpl implements ForestServerClient {
   constructor(
     private readonly schemaService: SchemaServiceInterface,
     private readonly activityLogsService: ActivityLogsServiceInterface,
+    public readonly forestServerUrl: string,
   ) {}
 
   async fetchSchema(): Promise<ForestSchemaCollection[]> {

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -31,6 +31,11 @@ export type {
  */
 export interface ForestServerClient {
   /**
+   * Base URL of the Forest Admin server this client talks to.
+   */
+  readonly forestServerUrl: string;
+
+  /**
    * Fetches the Forest Admin schema from the server.
    */
   fetchSchema(): Promise<ForestSchemaCollection[]>;

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -64,6 +64,17 @@ If you call executeAction with missing required fields, it will return an error 
 
           const result = await action.execute();
 
+          if (result.approvalRequested) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'Approval requested: this action requires approval by another user before it runs. A request has been created and is pending review.',
+                },
+              ],
+            };
+          }
+
           return { content: [{ type: 'text', text: JSON.stringify(result) }] };
         },
       });

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -64,7 +64,7 @@ If you call executeAction with missing required fields, it will return an error 
 
           const result = await action.execute();
 
-          if (result.approvalRequested) {
+          if ('approvalRequested' in result) {
             return {
               content: [
                 {

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -10,6 +10,7 @@ import { fetchForestSchema, getActionEndpoints } from './schema-fetcher';
 interface BuildClientOptions {
   request: RequestHandlerExtra<ServerRequest, ServerNotification>;
   actionEndpoints?: ActionEndpoints;
+  forestServerUrl?: string;
 }
 
 export type AuthData = {
@@ -22,7 +23,7 @@ export type AuthData = {
 };
 
 function createClient(options: BuildClientOptions) {
-  const { request, actionEndpoints = {} } = options;
+  const { request, actionEndpoints = {}, forestServerUrl } = options;
   const token = request.authInfo?.token;
   const url = request.authInfo?.extra?.environmentApiEndpoint;
   const { forestServerToken, renderingId } = (request.authInfo?.extra ?? {}) as AuthData;
@@ -36,12 +37,8 @@ function createClient(options: BuildClientOptions) {
   }
 
   const forestServer =
-    forestServerToken && renderingId != null
-      ? {
-          url: process.env.FOREST_SERVER_URL || 'https://api.forestadmin.com',
-          forestServerToken,
-          renderingId,
-        }
+    forestServerUrl && forestServerToken && renderingId != null
+      ? { url: forestServerUrl, forestServerToken, renderingId }
       : undefined;
 
   const rpcClient = createRemoteAgentClient({
@@ -74,5 +71,9 @@ export async function buildClientWithActions(
   const schema = await fetchForestSchema(forestServerClient);
   const actionEndpoints = getActionEndpoints(schema);
 
-  return createClient({ request, actionEndpoints });
+  return createClient({
+    request,
+    actionEndpoints,
+    forestServerUrl: forestServerClient.forestServerUrl,
+  });
 }

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -37,6 +37,7 @@ function createClient(options: BuildClientOptions) {
     token,
     url,
     actionEndpoints,
+    forestServer: { url, bearerToken: token },
   });
 
   return {

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -18,12 +18,14 @@ export type AuthData = {
   environmentId?: number;
   projectId?: number;
   environmentApiEndpoint: string;
+  forestServerToken?: string;
 };
 
 function createClient(options: BuildClientOptions) {
   const { request, actionEndpoints = {} } = options;
   const token = request.authInfo?.token;
   const url = request.authInfo?.extra?.environmentApiEndpoint;
+  const { forestServerToken, renderingId } = (request.authInfo?.extra ?? {}) as AuthData;
 
   if (!token) {
     throw new Error('Authentication token is missing');
@@ -33,11 +35,20 @@ function createClient(options: BuildClientOptions) {
     throw new Error('Environment API endpoint is missing or invalid');
   }
 
+  const forestServer =
+    forestServerToken && renderingId != null
+      ? {
+          url: process.env.FOREST_SERVER_URL || 'https://api.forestadmin.com',
+          forestServerToken,
+          renderingId,
+        }
+      : undefined;
+
   const rpcClient = createRemoteAgentClient({
     token,
     url,
     actionEndpoints,
-    forestServer: { url, bearerToken: token },
+    forestServer,
   });
 
   return {

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -38,7 +38,7 @@ function createClient(options: BuildClientOptions) {
 
   const forestServer =
     forestServerUrl && forestServerToken && renderingId != null
-      ? { url: forestServerUrl, forestServerToken, renderingId }
+      ? { serverUrl: forestServerUrl, serverToken: forestServerToken, renderingId }
       : undefined;
 
   const rpcClient = createRemoteAgentClient({

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -21,7 +21,11 @@ describe('ForestServerClientImpl', () => {
       createMcpActivityLog: jest.fn(),
       updateActivityLogStatus: jest.fn(),
     };
-    client = new ForestServerClientImpl(mockSchemaService, mockActivityLogsService);
+    client = new ForestServerClientImpl(
+      mockSchemaService,
+      mockActivityLogsService,
+      'https://api.forestadmin.com',
+    );
   });
 
   describe('fetchSchema', () => {

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../src/utils/with-activity-log');
 
 const mockLogger: Logger = jest.fn();
 const mockForestServerClient: ForestServerClient = {
+  forestServerUrl: 'https://api.forestadmin.com',
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
   createMcpActivityLog: jest.fn(),

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -330,8 +330,6 @@ describe('declareExecuteActionTool', () => {
       expect(result).toEqual({
         content: [{ type: 'text', text: expect.stringContaining('Approval requested') }],
       });
-      // It is not an error → the activity log is not marked failed.
-      expect((result as { isError?: boolean }).isError).toBeUndefined();
     });
 
     describe('activity logging', () => {

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -308,6 +308,31 @@ describe('declareExecuteActionTool', () => {
       });
     });
 
+    it('should return an "approval requested" message when the action requires approval', async () => {
+      const mockExecute = jest.fn().mockResolvedValue({ approvalRequested: true });
+      const mockSetFields = jest.fn().mockResolvedValue(undefined);
+      const mockAction = jest.fn().mockResolvedValue({
+        execute: mockExecute,
+        setFields: mockSetFields,
+      });
+      const mockCollection = jest.fn().mockReturnValue({ action: mockAction });
+      mockBuildClientWithActions.mockResolvedValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClientWithActions>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', actionName: 'refund', recordIds: [1] },
+        mockExtra,
+      );
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: expect.stringContaining('Approval requested') }],
+      });
+      // It is not an error → the activity log is not marked failed.
+      expect((result as { isError?: boolean }).isError).toBeUndefined();
+    });
+
     describe('activity logging', () => {
       beforeEach(() => {
         const mockExecute = jest.fn().mockResolvedValue({ success: 'Action executed' });

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../src/utils/agent-caller');
 
 const mockLogger: Logger = jest.fn();
 const mockForestServerClient: ForestServerClient = {
+  forestServerUrl: 'https://api.forestadmin.com',
   fetchSchema: jest.fn(),
   createActivityLog: jest.fn(),
   createMcpActivityLog: jest.fn(),

--- a/packages/mcp-server/test/utils/agent-caller.test.ts
+++ b/packages/mcp-server/test/utils/agent-caller.test.ts
@@ -264,4 +264,28 @@ describe('buildClientWithActions', () => {
       'Authentication token is missing',
     );
   });
+
+  it('should build the client when the forest server connection is complete', async () => {
+    mockFetchForestSchema.mockResolvedValue({ collections: [] } as never);
+    mockGetActionEndpoints.mockReturnValue({});
+    mockForestServerClient = createMockForestServerClient({
+      forestServerUrl: 'https://api.forestadmin.com',
+    });
+
+    const request = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          renderingId: 456,
+          environmentApiEndpoint: 'http://localhost:3310',
+          forestServerToken: 'server-token',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    const result = await buildClientWithActions(request, mockForestServerClient);
+
+    expect(result.rpcClient).toBeDefined();
+    expect(typeof result.rpcClient.collection).toBe('function');
+  });
 });

--- a/packages/mcp-server/test/utils/agent-caller.test.ts
+++ b/packages/mcp-server/test/utils/agent-caller.test.ts
@@ -2,11 +2,22 @@ import type { ForestServerClient } from '../../src/http-client';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
 
+import { createRemoteAgentClient } from '@forestadmin/agent-client';
+
 import buildClient, { buildClientWithActions } from '../../src/utils/agent-caller';
 import { fetchForestSchema, getActionEndpoints } from '../../src/utils/schema-fetcher';
 import createMockForestServerClient from '../helpers/forest-server-client';
 
 jest.mock('../../src/utils/schema-fetcher');
+jest.mock('@forestadmin/agent-client', () => {
+  const actual = jest.requireActual('@forestadmin/agent-client');
+
+  return { ...actual, createRemoteAgentClient: jest.fn(actual.createRemoteAgentClient) };
+});
+
+const mockCreateRemoteAgentClient = createRemoteAgentClient as jest.MockedFunction<
+  typeof createRemoteAgentClient
+>;
 
 describe('buildClient', () => {
   it('should create a remote agent client with the token from authInfo', () => {
@@ -265,7 +276,7 @@ describe('buildClientWithActions', () => {
     );
   });
 
-  it('should build the client when the forest server connection is complete', async () => {
+  it('passes the forestServer connection when url, token and renderingId are all present', async () => {
     mockFetchForestSchema.mockResolvedValue({ collections: [] } as never);
     mockGetActionEndpoints.mockReturnValue({});
     mockForestServerClient = createMockForestServerClient({
@@ -283,9 +294,40 @@ describe('buildClientWithActions', () => {
       },
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
-    const result = await buildClientWithActions(request, mockForestServerClient);
+    await buildClientWithActions(request, mockForestServerClient);
 
-    expect(result.rpcClient).toBeDefined();
-    expect(typeof result.rpcClient.collection).toBe('function');
+    expect(mockCreateRemoteAgentClient).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        forestServer: {
+          serverUrl: 'https://api.forestadmin.com',
+          serverToken: 'server-token',
+          renderingId: 456,
+        },
+      }),
+    );
+  });
+
+  it('omits the forestServer connection when forestServerToken is missing', async () => {
+    mockFetchForestSchema.mockResolvedValue({ collections: [] } as never);
+    mockGetActionEndpoints.mockReturnValue({});
+    mockForestServerClient = createMockForestServerClient({
+      forestServerUrl: 'https://api.forestadmin.com',
+    });
+
+    const request = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          renderingId: 456,
+          environmentApiEndpoint: 'http://localhost:3310',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    await buildClientWithActions(request, mockForestServerClient);
+
+    expect(mockCreateRemoteAgentClient).toHaveBeenLastCalledWith(
+      expect.objectContaining({ forestServer: undefined }),
+    );
   });
 });


### PR DESCRIPTION
## Context

Some custom actions are gated behind **approval-by-role**: a user whose role can't execute the action triggers it → an approval request is created → another user (with an approving role) reviews it on the front. Until now this guard existed **only via the frontend** — triggering the same action through the **Forest MCP** executed it directly, bypassing approval (compliance hole for refunds, exports, deletions…).

This PR makes an action triggered via MCP **create an approval request** instead of executing, and reports *"approval requested"* to the LLM.

fixes PRD-288

## Approach — approval logic mutualized in `agent-client`

The approval handling lives in `agent-client` `Action.execute()` so every prod consumer (mcp-server, and later the workflow executor) gets it for free, with **no duplicated catch+create** per consumer:

- On a 403 `CustomActionRequiresApprovalError` (mapped to `ActionRequiresApprovalError` by the deterministic-action-steps base work), `execute()` calls an injected `ApprovalRequestCreator` and returns `{ approvalRequested: true }`.
- The creator is **data-injected** via `createRemoteAgentClient({ forestServer: { url, bearerToken } })` — no callback. Prod clients wire it; **`agent-testing` omits it**, so triggering an action in tests never creates an approval request (`execute()` rethrows as before). `agent-testing` is untouched.

### Changes
- **agent-client**: new `ApprovalRequestCreator` (SaaS call); `execute()` approval branch; creator threaded `RemoteAgentClient → Collection → Action`; `createRemoteAgentClient` accepts `forestServer`.
- **mcp-server**: `agent-caller` wires `forestServer`; `execute-action` returns the "approval requested" message (caught **inside** the activity-log operation → log stays `completed`, never `failed`).

## ⚠️ Pending before merge
1. **SaaS endpoint spec** (path / payload / auth) for creating an approval request — used by the front today. `ApprovalRequestCreator.create()` carries a `TODO(PRD-288)` placeholder until confirmed.
2. Based on `feature/workflow-deterministic-ai-steps` (retarget to `main` once that merges).

## Tests
- agent-client: creator wired → `create()` called with correct args + `{ approvalRequested: true }`; no creator → rethrows, nothing created.
- mcp-server: approval path → LLM "approval requested" message, not an error.
- `agent-client` 330 ✓ · `mcp-server` 545 ✓ · lint 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create approval requests on action trigger when required by role in workflow executor
> - `TriggerRecordActionStepExecutor` now supports dynamic action forms: Manual mode pauses for user input with no AI prefill; AI-assisted mode pre-fills and pauses for review; Full AI mode iteratively fills required fields and executes, falling back to review if fields remain empty.
> - When the agent rejects execution with `CustomActionRequiresApprovalError`, the executor calls `makeCreateApprovalRequest` to POST to `/api/action-approvals` on the Forest server, returning `{ approvalRequested: true }` instead of throwing.
> - `AgentHttpError` replaces generic stringified errors throughout `agent-client`, carrying `status`, parsed `body`, and raw `responseText` for structured downstream handling.
> - `preRecordedArgs.selectedRecordStepId` (stable BPMN step id) replaces the previous index-based `selectedRecordStepIndex` in both `TriggerActionStepDefinitionSchema` and `LoadRelatedRecordStepDefinitionSchema`.
> - `StepExecutionFormatters` gains a `formatTriggerAction` path that distinguishes pending-approval from executed submissions and highlights AI prefill vs. user edits.
> - Risk: `TriggerActionStepDefinitionSchema` no longer coerces invalid `executionType` values to `AutomatedWithConfirmation`; existing configs with unrecognized values will now fail validation.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1708 opened
>
> - Added `ApprovalRequestCreationError` class and wrapped approval request creation in `Action.execute` method with try/catch block to throw the new error type [106db88]
> - Configured `createRemoteAgentClient` to accept and pass `forestServer` connection details including url, token, and renderingId to wire approval request creation [106db88]
> - Added test coverage for `ApprovalRequestCreationError` throwing behavior and `forestServer` configuration wiring [106db88]
> - Added inline comment in `makeCreateApprovalRequest` factory explaining why status attribute is set to null on creation [106db88]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23b2b0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->