### PR TITLE
refactor(agent-client): move test-only permission overrides to agent-testing

### DIFF
--- a/packages/agent-client/src/domains/remote-agent-client.ts
+++ b/packages/agent-client/src/domains/remote-agent-client.ts
@@ -1,36 +1,8 @@
 import type { ActionEndpointsByCollection } from './action';
 import type HttpRequester from '../http-requester';
-import type { RawTreeWithSources } from '@forestadmin/forestadmin-client';
 
 import Chart from './chart';
 import Collection from './collection';
-
-export type SmartActionPermissionsOverride = Partial<{
-  triggerEnabled: boolean;
-  triggerConditions: RawTreeWithSources;
-  approvalRequired: boolean;
-  approvalRequiredConditions: RawTreeWithSources;
-  userApprovalEnabled: boolean;
-  userApprovalConditions: RawTreeWithSources;
-  selfApprovalEnabled: boolean;
-}>;
-
-export type CollectionPermissionsOverride = Partial<{
-  browseEnabled: boolean;
-  deleteEnabled: boolean;
-  editEnabled: boolean;
-  exportEnabled: boolean;
-  addEnabled: boolean;
-  readEnabled: boolean;
-}>;
-
-export type PermissionsOverride = Record<
-  string,
-  {
-    collection: CollectionPermissionsOverride;
-    actions: Record<string, SmartActionPermissionsOverride>;
-  }
->;
 
 type CollectionName<T> = keyof T & string;
 
@@ -39,49 +11,14 @@ export default class RemoteAgentClient<
 > extends Chart {
   protected actionEndpoints?: ActionEndpointsByCollection;
 
-  private overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
-
   constructor(params?: {
     actionEndpoints?: ActionEndpointsByCollection;
     httpRequester: HttpRequester;
-    overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
   }) {
     super();
     if (!params) return;
     this.httpRequester = params.httpRequester;
     this.actionEndpoints = params.actionEndpoints;
-    this.overridePermissions = params.overridePermissions;
-  }
-
-  async overrideCollectionPermission(
-    collectionName: CollectionName<TypingsSchema>,
-    permissions: CollectionPermissionsOverride,
-  ) {
-    await this.overridePermissions?.({
-      [collectionName]: {
-        collection: permissions,
-        actions: {},
-      },
-    });
-  }
-
-  async overrideActionPermission(
-    collectionName: CollectionName<TypingsSchema>,
-    actionName: string,
-    permissions: SmartActionPermissionsOverride,
-  ) {
-    await this.overridePermissions?.({
-      [collectionName]: {
-        collection: {},
-        actions: {
-          [actionName]: permissions,
-        },
-      },
-    });
-  }
-
-  async clearPermissionOverride() {
-    await this.overridePermissions?.({});
   }
 
   collection(name: CollectionName<TypingsSchema>): Collection {

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -1,9 +1,4 @@
 import type { ActionEndpointsByCollection } from './domains/action';
-import type {
-  CollectionPermissionsOverride,
-  PermissionsOverride,
-  SmartActionPermissionsOverride,
-} from './domains/remote-agent-client';
 
 import ActionFieldJson from './action-fields/action-field-json';
 import ActionFieldStringList from './action-fields/action-field-string-list';
@@ -20,15 +15,9 @@ export {
   ActionRequiresApprovalError,
   ActionFormValidationError,
 };
-export type {
-  ActionEndpointsByCollection,
-  CollectionPermissionsOverride,
-  PermissionsOverride,
-  SmartActionPermissionsOverride,
-};
+export type { ActionEndpointsByCollection };
 
 export function createRemoteAgentClient(params: {
-  overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
   actionEndpoints?: ActionEndpointsByCollection;
   token?: string;
   url: string;
@@ -38,7 +27,6 @@ export function createRemoteAgentClient(params: {
   return new RemoteAgentClient({
     actionEndpoints: params.actionEndpoints,
     httpRequester,
-    overridePermissions: params.overridePermissions,
   });
 }
 

--- a/packages/agent-client/test/domains/remote-agent-client.test.ts
+++ b/packages/agent-client/test/domains/remote-agent-client.test.ts
@@ -7,7 +7,6 @@ jest.mock('../../src/http-requester');
 describe('RemoteAgentClient', () => {
   let httpRequester: jest.Mocked<HttpRequester>;
   let client: RemoteAgentClient;
-  let overridePermissionsMock: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -15,7 +14,6 @@ describe('RemoteAgentClient', () => {
       query: jest.fn(),
       stream: jest.fn(),
     } as any;
-    overridePermissionsMock = jest.fn().mockResolvedValue(undefined);
     client = new RemoteAgentClient({
       httpRequester,
       actionEndpoints: {
@@ -29,7 +27,6 @@ describe('RemoteAgentClient', () => {
           },
         },
       },
-      overridePermissions: overridePermissionsMock,
     });
   });
 
@@ -53,84 +50,6 @@ describe('RemoteAgentClient', () => {
     it('should pass action endpoints to collection', () => {
       const collection = client.collection('users');
       expect(collection).toBeDefined();
-    });
-  });
-
-  describe('overrideCollectionPermission', () => {
-    it('should call overridePermissions with collection permissions', async () => {
-      await client.overrideCollectionPermission('users', {
-        browseEnabled: true,
-        editEnabled: false,
-      });
-
-      expect(overridePermissionsMock).toHaveBeenCalledWith({
-        users: {
-          collection: {
-            browseEnabled: true,
-            editEnabled: false,
-          },
-          actions: {},
-        },
-      });
-    });
-
-    it('should not throw if overridePermissions is not provided', async () => {
-      const clientWithoutOverride = new RemoteAgentClient({
-        httpRequester,
-      });
-
-      await expect(
-        clientWithoutOverride.overrideCollectionPermission('users', { browseEnabled: true }),
-      ).resolves.toBeUndefined();
-    });
-  });
-
-  describe('overrideActionPermission', () => {
-    it('should call overridePermissions with action permissions', async () => {
-      await client.overrideActionPermission('users', 'sendEmail', {
-        triggerEnabled: true,
-        approvalRequired: true,
-      });
-
-      expect(overridePermissionsMock).toHaveBeenCalledWith({
-        users: {
-          collection: {},
-          actions: {
-            sendEmail: {
-              triggerEnabled: true,
-              approvalRequired: true,
-            },
-          },
-        },
-      });
-    });
-
-    it('should not throw if overridePermissions is not provided', async () => {
-      const clientWithoutOverride = new RemoteAgentClient({
-        httpRequester,
-      });
-
-      await expect(
-        clientWithoutOverride.overrideActionPermission('users', 'sendEmail', {
-          triggerEnabled: true,
-        }),
-      ).resolves.toBeUndefined();
-    });
-  });
-
-  describe('clearPermissionOverride', () => {
-    it('should call overridePermissions with empty object', async () => {
-      await client.clearPermissionOverride();
-
-      expect(overridePermissionsMock).toHaveBeenCalledWith({});
-    });
-
-    it('should not throw if overridePermissions is not provided', async () => {
-      const clientWithoutOverride = new RemoteAgentClient({
-        httpRequester,
-      });
-
-      await expect(clientWithoutOverride.clearPermissionOverride()).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/agent-client/test/index.test.ts
+++ b/packages/agent-client/test/index.test.ts
@@ -42,25 +42,6 @@ describe('createRemoteAgentClient', () => {
     expect(collection).toBeDefined();
   });
 
-  it('should pass overridePermissions function to the client', async () => {
-    const overridePermissions = jest.fn().mockResolvedValue(undefined);
-
-    const client = createRemoteAgentClient({
-      url: 'https://api.example.com',
-      token: 'test-token',
-      overridePermissions,
-    });
-
-    await client.overrideCollectionPermission('users' as any, { browseEnabled: true });
-
-    expect(overridePermissions).toHaveBeenCalledWith({
-      users: {
-        collection: { browseEnabled: true },
-        actions: {},
-      },
-    });
-  });
-
   it('should provide a working client that can access collections', () => {
     const client = createRemoteAgentClient({
       url: 'https://api.example.com',

--- a/packages/agent-testing/src/forest-server-sandbox.ts
+++ b/packages/agent-testing/src/forest-server-sandbox.ts
@@ -2,7 +2,7 @@ import type {
   CollectionPermissionsOverride,
   PermissionsOverride,
   SmartActionPermissionsOverride,
-} from '@forestadmin/agent-client';
+} from './permission-overrides';
 import type { ForestSchema } from '@forestadmin/forestadmin-client';
 import type {
   EnvironmentCollectionPermissionsV4,

--- a/packages/agent-testing/src/index.ts
+++ b/packages/agent-testing/src/index.ts
@@ -1,6 +1,6 @@
+import type { PermissionsOverride } from './permission-overrides';
 import type { TestableAgentOptions } from './types';
 import type { Agent } from '@forestadmin/agent';
-import type { PermissionsOverride } from '@forestadmin/agent-client';
 import type { TSchema } from '@forestadmin/datasource-customizer';
 import type { ForestSchema } from '@forestadmin/forestadmin-client';
 

--- a/packages/agent-testing/src/permission-overrides.ts
+++ b/packages/agent-testing/src/permission-overrides.ts
@@ -1,0 +1,28 @@
+import type { RawTreeWithSources } from '@forestadmin/forestadmin-client';
+
+export type SmartActionPermissionsOverride = Partial<{
+  triggerEnabled: boolean;
+  triggerConditions: RawTreeWithSources;
+  approvalRequired: boolean;
+  approvalRequiredConditions: RawTreeWithSources;
+  userApprovalEnabled: boolean;
+  userApprovalConditions: RawTreeWithSources;
+  selfApprovalEnabled: boolean;
+}>;
+
+export type CollectionPermissionsOverride = Partial<{
+  browseEnabled: boolean;
+  deleteEnabled: boolean;
+  editEnabled: boolean;
+  exportEnabled: boolean;
+  addEnabled: boolean;
+  readEnabled: boolean;
+}>;
+
+export type PermissionsOverride = Record<
+  string,
+  {
+    collection: CollectionPermissionsOverride;
+    actions: Record<string, SmartActionPermissionsOverride>;
+  }
+>;

--- a/packages/agent-testing/src/testable-agent-base.ts
+++ b/packages/agent-testing/src/testable-agent-base.ts
@@ -1,12 +1,62 @@
+import type {
+  CollectionPermissionsOverride,
+  PermissionsOverride,
+  SmartActionPermissionsOverride,
+} from './permission-overrides';
+import type { ActionEndpointsByCollection, HttpRequester } from '@forestadmin/agent-client';
 import type { TSchema } from '@forestadmin/datasource-customizer';
 
 import { RemoteAgentClient } from '@forestadmin/agent-client';
 
 import Benchmark from './benchmark';
 
+type CollectionName<T> = keyof T & string;
+
 export default class TestableAgentBase<
   TypingsSchema extends TSchema = TSchema,
 > extends RemoteAgentClient<TypingsSchema> {
+  private readonly overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
+
+  constructor(params?: {
+    actionEndpoints?: ActionEndpointsByCollection;
+    httpRequester: HttpRequester;
+    overridePermissions?: (permissions: PermissionsOverride) => Promise<void>;
+  }) {
+    super(params);
+    this.overridePermissions = params?.overridePermissions;
+  }
+
+  async overrideCollectionPermission(
+    collectionName: CollectionName<TypingsSchema>,
+    permissions: CollectionPermissionsOverride,
+  ) {
+    await this.overridePermissions?.({
+      [collectionName]: {
+        collection: permissions,
+        actions: {},
+      },
+    });
+  }
+
+  async overrideActionPermission(
+    collectionName: CollectionName<TypingsSchema>,
+    actionName: string,
+    permissions: SmartActionPermissionsOverride,
+  ) {
+    await this.overridePermissions?.({
+      [collectionName]: {
+        collection: {},
+        actions: {
+          [actionName]: permissions,
+        },
+      },
+    });
+  }
+
+  async clearPermissionOverride() {
+    await this.overridePermissions?.({});
+  }
+
   benchmark(): Benchmark {
     return new Benchmark();
   }

--- a/packages/agent-testing/test/testable-agent-base.test.ts
+++ b/packages/agent-testing/test/testable-agent-base.test.ts
@@ -1,0 +1,85 @@
+import type { PermissionsOverride } from '../src/permission-overrides';
+import type { HttpRequester } from '@forestadmin/agent-client';
+
+import TestableAgentBase from '../src/testable-agent-base';
+
+describe('TestableAgentBase', () => {
+  let overridePermissions: jest.Mock<Promise<void>, [PermissionsOverride]>;
+  let client: TestableAgentBase;
+
+  beforeEach(() => {
+    overridePermissions = jest.fn().mockResolvedValue(undefined);
+    client = new TestableAgentBase({
+      httpRequester: {} as unknown as HttpRequester,
+      overridePermissions,
+    });
+  });
+
+  describe('overrideCollectionPermission', () => {
+    it('should call overridePermissions with collection permissions', async () => {
+      await client.overrideCollectionPermission('users', {
+        browseEnabled: true,
+        editEnabled: false,
+      });
+
+      expect(overridePermissions).toHaveBeenCalledWith({
+        users: {
+          collection: { browseEnabled: true, editEnabled: false },
+          actions: {},
+        },
+      });
+    });
+
+    it('should not throw when overridePermissions is not provided', async () => {
+      const clientWithout = new TestableAgentBase({
+        httpRequester: {} as unknown as HttpRequester,
+      });
+
+      await expect(
+        clientWithout.overrideCollectionPermission('users', { browseEnabled: true }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('overrideActionPermission', () => {
+    it('should call overridePermissions with action permissions', async () => {
+      await client.overrideActionPermission('users', 'sendEmail', {
+        triggerEnabled: true,
+        approvalRequired: true,
+      });
+
+      expect(overridePermissions).toHaveBeenCalledWith({
+        users: {
+          collection: {},
+          actions: { sendEmail: { triggerEnabled: true, approvalRequired: true } },
+        },
+      });
+    });
+
+    it('should not throw when overridePermissions is not provided', async () => {
+      const clientWithout = new TestableAgentBase({
+        httpRequester: {} as unknown as HttpRequester,
+      });
+
+      await expect(
+        clientWithout.overrideActionPermission('users', 'sendEmail', { triggerEnabled: true }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearPermissionOverride', () => {
+    it('should call overridePermissions with an empty object', async () => {
+      await client.clearPermissionOverride();
+
+      expect(overridePermissions).toHaveBeenCalledWith({});
+    });
+
+    it('should not throw when overridePermissions is not provided', async () => {
+      const clientWithout = new TestableAgentBase({
+        httpRequester: {} as unknown as HttpRequester,
+      });
+
+      await expect(clientWithout.clearPermissionOverride()).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Context

The permission-override mechanism on `RemoteAgentClient` — the `overridePermissions` field, the `overrideCollectionPermission` / `overrideActionPermission` / `clearPermissionOverride` methods, and the `*PermissionsOverride` types — is **purely a test affordance**. Its only consumer is `agent-testing` (sandbox + `createAgentTestClient`).

In production (`mcp-server`, `workflow-executor`) `overridePermissions` is always `undefined`, so these public methods are **no-ops polluting the prod client API**.

## Change

Move the whole block to `TestableAgentBase` (agent-testing), its sole consumer:

- **agent-client**: remove the field, the 3 methods, the 3 types from `RemoteAgentClient`, and the dead `overridePermissions` param from `createRemoteAgentClient` (no caller — `agent-testing` uses `new TestableAgentBase(...)`, not the factory).
- **agent-testing**: `TestableAgentBase` now owns `overridePermissions` + the override methods; the types live in a new `permission-overrides.ts` module, imported by `forest-server-sandbox.ts` and `createAgentTestClient`.
- Tests for the override methods moved from `agent-client` to a new `agent-testing/test/testable-agent-base.test.ts`.

## Breaking change

`@forestadmin/agent-client` no longer exports the `overridePermissions` option of `createRemoteAgentClient`, nor the `PermissionsOverride` / `CollectionPermissionsOverride` / `SmartActionPermissionsOverride` types. These were test-only — consumers should use `@forestadmin/agent-testing`. No known production consumer used them (verified: only `agent-testing` imported them).

## Tests
- agent-client: 317 pass (override tests removed).
- agent-testing: new `testable-agent-base.test.ts` 6 pass (moved override tests).
- Both build; mcp-server builds against the trimmed agent-client. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move permission override types and methods from `agent-client` to `agent-testing`
> - Removes `overrideCollectionPermission`, `overrideActionPermission`, `clearPermissionOverride`, and related types from `RemoteAgentClient` in [agent-client](https://github.com/ForestAdmin/agent-nodejs/pull/1709/files#diff-65d9932f10a9f736e365c2f269193f9852942d11687056e1cf6c9bd4da95a658) and its public exports.
> - Moves these capabilities into a new `TestableAgentBase` subclass in [agent-testing](https://github.com/ForestAdmin/agent-nodejs/pull/1709/files#diff-684feec9a15445deee7ceffb0eeb3ed23ee9a9e15bde5a102c78795cb837413c), which accepts an `overridePermissions` callback and re-implements the three override methods.
> - Extracts the permission override types into a local [permission-overrides.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1709/files#diff-a475757029a53598c4ace7a775f9db7bbe9d88d3fd2bf13bd9c0bf85f4b248e0) module so `agent-testing` no longer depends on `agent-client` for them.
> - Risk: `createRemoteAgentClient` no longer accepts `overridePermissions`; callers relying on this parameter must switch to `TestableAgentBase`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized feaed65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->