### PR TITLE
fix(agent-client): preserve the server's action error message

### DIFF
--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -21,9 +21,35 @@ import AgentHttpError, { ActionFormValidationError, ActionRequiresApprovalError 
 
 // JSON:API error body the agent returns on a rejected action.
 type ActionErrorBody = {
-  errors?: { name?: string; detail?: string; data?: { roleIdsAllowedToApprove?: number[] } }[];
+  errors?: {
+    name?: string;
+    detail?: string;
+    message?: string;
+    title?: string;
+    data?: { roleIdsAllowedToApprove?: number[] };
+  }[];
+  error?: string;
+  message?: string;
   data?: { roleIdsAllowedToApprove?: number[] };
 };
+
+// Recover the server's message wherever it lives: agents/serializers vary (detail / message / title,
+// nested or top-level, or only the raw text when the body isn't JSON-parsed). Never let a generic
+// fallback hide a real message — only callers with no message at all get one.
+function extractDetail(error: AgentHttpError): string | undefined {
+  const body = (error.body ?? {}) as ActionErrorBody;
+  const first = body.errors?.[0];
+  const message =
+    first?.detail ||
+    first?.message ||
+    first?.title ||
+    body.error ||
+    body.message ||
+    (typeof error.body === 'string' ? error.body : undefined) ||
+    error.responseText;
+
+  return message?.trim() || undefined;
+}
 
 // Translate the transport AgentHttpError into a semantic action error so callers route on meaning.
 // Approval gate = 403 CustomActionRequiresApprovalError; form validation = 400/422; else unchanged.
@@ -31,7 +57,7 @@ function toActionError(error: unknown): unknown {
   if (!(error instanceof AgentHttpError)) return error;
 
   const body = (error.body ?? {}) as ActionErrorBody;
-  const detail = body.errors?.[0]?.detail;
+  const detail = extractDetail(error);
   const isApproval =
     body.errors?.[0]?.name === 'CustomActionRequiresApprovalError' ||
     !!error.responseText?.includes('CustomActionRequiresApprovalError');

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -33,9 +33,6 @@ type ActionErrorBody = {
   data?: { roleIdsAllowedToApprove?: number[] };
 };
 
-// Recover the server's message wherever it lives: agents/serializers vary (detail / message / title,
-// nested or top-level, or only the raw text when the body isn't JSON-parsed). Never let a generic
-// fallback hide a real message — only callers with no message at all get one.
 function extractDetail(error: AgentHttpError): string | undefined {
   const body = (error.body ?? {}) as ActionErrorBody;
   const first = body.errors?.[0];

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -148,6 +148,37 @@ describe('Action', () => {
       });
     });
 
+    it('preserves the server message from errors[0].message when detail is absent', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(400, { errors: [{ message: 'S3 access denied' }] }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'S3 access denied',
+      });
+    });
+
+    it('preserves the server message from the raw responseText when the body has none', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(422, {}, 'Query with filter did not match any records'),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'Query with filter did not match any records',
+      });
+    });
+
+    it('falls back to a generic message only when the server sends nothing', async () => {
+      httpRequester.query.mockRejectedValue(new AgentHttpError(400, {}));
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'The action form values were rejected.',
+      });
+    });
+
     it('should propagate other HTTP errors unchanged', async () => {
       const error = new AgentHttpError(500, null);
       httpRequester.query.mockRejectedValue(error);


### PR DESCRIPTION
## Problem

`toActionError` (added in #1696) collapses **every** 400/422 action failure into `ActionFormValidationError(detail ?? 'The action form values were rejected.')`. When `body.errors[0].detail` is absent, the generic fallback **hides the real server message**.

This surfaced when bumping `@forestadmin/agent-client` on `forestadmin-server`: integration tests that assert the precise action error now fail with the generic string instead:

```
Expected substring: "S3 access denied"
Received message:   "The action form values were rejected."
```

(also "Query with filter did not match any records", "Successfully deleted 1 user(s), but some errors occurred.")

Before the bump, `execute()` let the raw error propagate, so the message reached the caller.

## Fix

New `extractDetail()` recovers the message wherever serializers put it, in order:

`errors[0].detail` → `errors[0].message` → `errors[0].title` → top-level `error` / `message` → body string → `error.responseText` (raw text, last resort).

The generic fallback is used **only** when the server sends nothing. Approval (403) handling is unchanged.

## Why this fixes the CI

If the message were at `errors[0].detail`, the previous code would already have surfaced it and the CI would pass — so it lives elsewhere, at worst in the raw body. `responseText` is the catch-all, and since the failing assertions use `toThrow(<substring>)`, the substring is found even if `responseText` is a JSON string.

## Tests

`action.test.ts`: message preserved from `errors[0].message`, from `responseText`, and the generic fallback only when the body is empty. 43/43 green.

## Follow-up

After merge + publish, re-bump `@forestadmin/agent-client` in `forestadmin-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve server action error messages in agent-client error handling
> Adds an `extractDetail` helper in [action.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1712/files#diff-c434b5b3c0debe1a1c3629c2828238cc6ab1609dce58c3b2f6dae384ef677b81) that checks multiple fields (`errors[0].detail`, `errors[0].message`, `errors[0].title`, top-level `error`/`message`, string body, `responseText`) to derive an error message from `AgentHttpError`. The `toActionError` function now uses this helper instead of only reading `errors[0].detail`, so server-provided error messages are no longer lost when they appear in alternate fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72a5d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->