### PR TITLE
ci(workflow-executor): auto-deploy new images to forestadmin-server production

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -283,3 +283,19 @@ jobs:
 
       - name: Inspect manifest
         run: docker buildx imagetools inspect ghcr.io/forestadmin/workflow-executor:${{ needs.extract-version.outputs.full }}
+
+      # Notify forestadmin-server to deploy this image to the production executor
+      # env. Only for the latest stable version — prereleases and rebuilds of older
+      # versions never auto-deploy to prod. Requires a PAT with repo scope on
+      # forestadmin-server stored as FORESTADMIN_SERVER_DISPATCH_TOKEN.
+      - name: Trigger production deploy (forestadmin-server)
+        if: needs.extract-version.outputs.is_latest == 'true'
+        env:
+          DISPATCH_TOKEN: ${{ secrets.FORESTADMIN_SERVER_DISPATCH_TOKEN }}
+          VERSION: ${{ needs.extract-version.outputs.full }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ForestAdmin/forestadmin-server/dispatches \
+            -d "$(printf '{"event_type":"workflow-executor-published","client_payload":{"version":"%s"}}' "$VERSION")"


### PR DESCRIPTION
After publishing a new **stable** multi-arch image to GHCR, `repository_dispatch` forestadmin-server (`event_type: workflow-executor-published`, payload `{version}`) so it deploys the image to the **production** executor environment.

- Gated on `is_latest` — only the latest stable version auto-deploys to prod; prereleases and rebuilds of older versions never trigger it.
- Pairs with [ForestAdmin/forestadmin-server#8336](https://github.com/ForestAdmin/forestadmin-server/pull/8336), which handles the `repository_dispatch` (mirror GHCR→ECR + deploy to `forestadmin-workflow-executor-production`).

**Prereq:** add a PAT with `repo` scope on forestadmin-server as the `FORESTADMIN_SERVER_DISPATCH_TOKEN` secret in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-deploy workflow-executor images to forestadmin-server production on latest release
> Adds a step to [docker-publish.yml](.github/workflows/docker-publish.yml) that fires a `repository_dispatch` event to `ForestAdmin/forestadmin-server` when a new latest-stable image is published. The dispatch carries a `workflow-executor-published` event type and the published version, triggering a production deploy in the target repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e410085.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->