### PR TITLE
fix(agent): forward workflow executor responses as raw bytes

### DIFF
--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -124,12 +124,8 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
         const chunks: Uint8Array[] = [];
         res.on('data', chunk => chunks.push(chunk));
         res.on('end', () => {
-          // Forward the executor body as raw bytes. Decoding it as UTF-8 (and JSON-parsing)
-          // corrupted any compressed payload while still forwarding the executor's
-          // `Content-Encoding: gzip` header, so the browser failed with
-          // net::ERR_CONTENT_DECODING_FAILED. Koa sends the Buffer verbatim and recomputes
-          // Content-Length; Content-Type/Content-Encoding are forwarded untouched, keeping a
-          // compressed body and its encoding header consistent.
+          // Raw bytes: decoding as UTF-8 corrupted gzipped bodies while still forwarding
+          // Content-Encoding: gzip, breaking the browser with ERR_CONTENT_DECODING_FAILED.
           resolve({
             status: res.statusCode ?? HttpCode.InternalServerError,
             body: Buffer.concat(chunks),

--- a/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
+++ b/packages/agent/src/routes/workflow/workflow-executor-proxy.ts
@@ -115,7 +115,7 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
     url: URL;
     body: string | undefined;
     headers: OutgoingHttpHeaders;
-  }): Promise<{ status: number; body: unknown; headers: IncomingHttpHeaders }> {
+  }): Promise<{ status: number; body: Buffer; headers: IncomingHttpHeaders }> {
     const { method, url, body, headers } = request;
     const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
 
@@ -124,18 +124,15 @@ export default class WorkflowExecutorProxyRoute extends BaseRoute {
         const chunks: Uint8Array[] = [];
         res.on('data', chunk => chunks.push(chunk));
         res.on('end', () => {
-          const raw = Buffer.concat(chunks).toString('utf-8');
-          let parsed: unknown;
-
-          try {
-            parsed = JSON.parse(raw);
-          } catch {
-            parsed = raw;
-          }
-
+          // Forward the executor body as raw bytes. Decoding it as UTF-8 (and JSON-parsing)
+          // corrupted any compressed payload while still forwarding the executor's
+          // `Content-Encoding: gzip` header, so the browser failed with
+          // net::ERR_CONTENT_DECODING_FAILED. Koa sends the Buffer verbatim and recomputes
+          // Content-Length; Content-Type/Content-Encoding are forwarded untouched, keeping a
+          // compressed body and its encoding header consistent.
           resolve({
             status: res.statusCode ?? HttpCode.InternalServerError,
-            body: parsed,
+            body: Buffer.concat(chunks),
             headers: res.headers,
           });
         });

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -49,9 +49,7 @@ describe('WorkflowExecutorProxyRoute', () => {
           return;
         }
 
-        // Gzip-compressed JSON — mirrors the Beanstalk nginx that sits in front of the executor and
-        // compresses large responses. The proxy must forward the bytes untouched so the body stays
-        // consistent with its Content-Encoding header (else the browser gets ERR_CONTENT_DECODING_FAILED).
+        // Gzip-compressed JSON — mirrors the nginx in front of the executor.
         if (req.url?.includes('gzip-run')) {
           const json = JSON.stringify({ steps: [{ stepId: 'gz', status: 'success' }] });
           res.setHeader('Content-Type', 'application/json');
@@ -117,8 +115,7 @@ describe('WorkflowExecutorProxyRoute', () => {
   const callHandleProxy = (route: WorkflowExecutorProxyRoute, context: unknown) =>
     (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context);
 
-  // The proxy forwards the executor body as raw bytes (Buffer), never a parsed object — decode
-  // for assertions.
+  // The proxy forwards the body as raw bytes (Buffer), never a parsed object.
   const bodyText = (context: { response: { body: unknown } }): string =>
     (context.response.body as Buffer).toString('utf-8');
   const bodyJson = (context: { response: { body: unknown } }): unknown =>
@@ -272,11 +269,8 @@ describe('WorkflowExecutorProxyRoute', () => {
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(200);
-      // The Content-Encoding header is forwarded…
       expect(context.response.get('Content-Encoding')).toBe('gzip');
-      // …and the body is the untouched gzip bytes, so the browser can decode it (regression test
-      // for net::ERR_CONTENT_DECODING_FAILED: the old code decoded the bytes as UTF-8, corrupting
-      // the gzip stream while still advertising Content-Encoding: gzip).
+      // Body is the untouched gzip bytes; the old UTF-8 decode corrupted them.
       const body = context.response.body as Buffer;
       expect(Buffer.isBuffer(body)).toBe(true);
       expect(JSON.parse(zlib.gunzipSync(Uint8Array.from(body)).toString('utf-8'))).toEqual({

--- a/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
+++ b/packages/agent/test/routes/workflow/workflow-executor-proxy.test.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from '@forestadmin/datasource-toolkit';
 import { createMockContext } from '@shopify/jest-koa-mocks';
 import http from 'http';
+import zlib from 'zlib';
 
 import WorkflowExecutorProxyRoute from '../../../src/routes/workflow/workflow-executor-proxy';
 import { RouteType } from '../../../src/types';
@@ -44,6 +45,19 @@ describe('WorkflowExecutorProxyRoute', () => {
           res.setHeader('Content-Type', 'text/plain');
           res.writeHead(200);
           res.end('hello world');
+
+          return;
+        }
+
+        // Gzip-compressed JSON — mirrors the Beanstalk nginx that sits in front of the executor and
+        // compresses large responses. The proxy must forward the bytes untouched so the body stays
+        // consistent with its Content-Encoding header (else the browser gets ERR_CONTENT_DECODING_FAILED).
+        if (req.url?.includes('gzip-run')) {
+          const json = JSON.stringify({ steps: [{ stepId: 'gz', status: 'success' }] });
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader('Content-Encoding', 'gzip');
+          res.writeHead(200);
+          res.end(zlib.gzipSync(json));
 
           return;
         }
@@ -102,6 +116,13 @@ describe('WorkflowExecutorProxyRoute', () => {
 
   const callHandleProxy = (route: WorkflowExecutorProxyRoute, context: unknown) =>
     (route as unknown as { handleProxy: (ctx: unknown) => Promise<void> }).handleProxy(context);
+
+  // The proxy forwards the executor body as raw bytes (Buffer), never a parsed object — decode
+  // for assertions.
+  const bodyText = (context: { response: { body: unknown } }): string =>
+    (context.response.body as Buffer).toString('utf-8');
+  const bodyJson = (context: { response: { body: unknown } }): unknown =>
+    JSON.parse(bodyText(context));
 
   // Build a mock context for the catch-all route: `path` is the wildcard segment, forwarded
   // verbatim to the executor root (so callers address runs as `runs/<id>`).
@@ -168,7 +189,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       expect(receivedMethod).toBe('GET');
       expect(receivedUrl).toBe('/runs/run-123');
       expect(context.response.status).toBe(200);
-      expect(context.response.body).toEqual({ steps: [{ stepId: 's1', status: 'success' }] });
+      expect(bodyJson(context)).toEqual({ steps: [{ stepId: 's1', status: 'success' }] });
     });
 
     test('forwards a POST trigger with the raw body untouched (no reshaping)', async () => {
@@ -183,7 +204,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       expect(receivedMethod).toBe('POST');
       expect(receivedUrl).toBe('/runs/run-456/trigger');
       expect(receivedBody).toBe(rawBody);
-      expect(context.response.body).toEqual({
+      expect(bodyJson(context)).toEqual({
         triggered: true,
         received: { pendingData: { answer: 'yes' } },
       });
@@ -218,7 +239,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(404);
-      expect(context.response.body).toEqual({ error: 'Run not found or unavailable' });
+      expect(bodyJson(context)).toEqual({ error: 'Run not found or unavailable' });
     });
 
     test('forwards a bodyless non-GET cleanly (empty body, no hang)', async () => {
@@ -241,7 +262,26 @@ describe('WorkflowExecutorProxyRoute', () => {
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(200);
-      expect(context.response.body).toBe('hello world');
+      expect(bodyText(context)).toBe('hello world');
+    });
+
+    test('forwards a gzip-compressed executor body without corrupting it', async () => {
+      const route = buildRoute(`http://localhost:${executorPort}`);
+
+      const context = buildContext('runs/gzip-run');
+      await callHandleProxy(route, context);
+
+      expect(context.response.status).toBe(200);
+      // The Content-Encoding header is forwarded…
+      expect(context.response.get('Content-Encoding')).toBe('gzip');
+      // …and the body is the untouched gzip bytes, so the browser can decode it (regression test
+      // for net::ERR_CONTENT_DECODING_FAILED: the old code decoded the bytes as UTF-8, corrupting
+      // the gzip stream while still advertising Content-Encoding: gzip).
+      const body = context.response.body as Buffer;
+      expect(Buffer.isBuffer(body)).toBe(true);
+      expect(JSON.parse(zlib.gunzipSync(Uint8Array.from(body)).toString('utf-8'))).toEqual({
+        steps: [{ stepId: 'gz', status: 'success' }],
+      });
     });
 
     test('passes a 204 empty executor response through without throwing', async () => {
@@ -251,7 +291,7 @@ describe('WorkflowExecutorProxyRoute', () => {
       await callHandleProxy(route, context);
 
       expect(context.response.status).toBe(204);
-      expect(context.response.body).toBe('');
+      expect(bodyText(context)).toBe('');
     });
   });
 


### PR DESCRIPTION
## Problem

In production, opening a workflow run failed intermittently with `net::ERR_CONTENT_DECODING_FAILED` on `GET /forest/_internal/executor/runs/:id`, surfacing in the app as a silent `TypeError: Failed to fetch` (the workflow side panel never loaded).

Server-side everything returned `200`. The corruption was in the **agent's workflow-executor proxy**.

## Root cause

The chain is: `Browser → agent (this proxy) → nginx (Elastic Beanstalk) → executor (koa)`. The Beanstalk nginx gzips the executor's JSON response once it crosses the gzip size threshold — which is why only **large** runs broke (small runs aren't compressed).

`WorkflowExecutorProxyRoute.forwardRequest` did:

```ts
const raw = Buffer.concat(chunks).toString('utf-8'); // ← corrupts gzip bytes
let parsed; try { parsed = JSON.parse(raw); } catch { parsed = raw; }
resolve({ status, body: parsed, headers: res.headers }); // ← still forwards Content-Encoding: gzip
```

So a gzip-compressed body was decoded as UTF-8 (destroying the gzip stream), re-emitted, while the executor's `Content-Encoding: gzip` header was forwarded untouched. The browser tried to gunzip a non-gzip body → `ERR_CONTENT_DECODING_FAILED`. The `// transparent proxy` intent in the code was not actually met: it lossily round-tripped `bytes → utf-8 → JSON → re-serialize`.

## Fix

Forward the executor body as **raw bytes** (`Buffer.concat(chunks)`). Koa sends the `Buffer` verbatim and recomputes `Content-Length`; `Content-Type`/`Content-Encoding` are forwarded untouched, so a compressed body stays consistent with its encoding header. This also makes the proxy genuinely transparent for any content type, not just JSON.

## Testing

- Added a regression test for a gzip-compressed executor response. It **fails on the previous behavior** (`gunzip` throws — exactly the production `ERR_CONTENT_DECODING_FAILED`) and **passes** with this fix.
- Full `workflow-executor-proxy` suite: **25/25 green**, eslint clean.
- The existing body assertions were updated to decode the now-Buffer body (uncompressed JSON, 204, text/plain, POST trigger, error passthrough — all still covered).

## Notes

A temporary monkey-patch of the compiled file was deployed on `forestadmin-server` (Dockerfile `COPY`) to validate on staging; it should be removed once this ships and the `@forestadmin/agent` bump lands there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WorkflowExecutorProxyRoute.forwardRequest` to forward response bodies as raw bytes
> Previously, `forwardRequest` decoded the response body as UTF-8 and attempted a JSON parse, which corrupted gzip-compressed responses that were still forwarded with `Content-Encoding: gzip`. The method now returns the raw concatenated `Buffer` instead, preserving binary and encoded bodies. Tests are updated to read body content from a `Buffer` and a new test verifies that gzip-compressed responses are forwarded intact and remain decodable by clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52f34d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->