### PR TITLE
ci(workflow-executor): notify forestadmin-server to deploy on publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -283,3 +283,31 @@ jobs:
 
       - name: Inspect manifest
         run: docker buildx imagetools inspect ghcr.io/forestadmin/workflow-executor:${{ needs.extract-version.outputs.full }}
+
+  # Notify forestadmin-server so it auto-deploys the new image to production.
+  # Only for the latest STABLE version (is_latest) — never a prerelease or a
+  # rebuild of an older version, which must not regress production.
+  # GITHUB_TOKEN can't dispatch into another repo, so this uses a dedicated token
+  # (fine-grained PAT or GitHub App) with Contents:write on forestadmin-server.
+  notify-server:
+    name: Trigger forestadmin-server prod deploy
+    if: github.event_name != 'pull_request' && needs.extract-version.outputs.is_latest == 'true'
+    needs: [extract-version, merge]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch
+        env:
+          DISPATCH_TOKEN: ${{ secrets.SERVER_DEPLOY_DISPATCH_TOKEN }}
+          VERSION: ${{ needs.extract-version.outputs.full }}
+        run: |
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "::error::SERVER_DEPLOY_DISPATCH_TOKEN is not set — cannot trigger the forestadmin-server prod deploy."
+            exit 1
+          fi
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ForestAdmin/forestadmin-server/dispatches \
+            -d "{\"event_type\":\"workflow-executor-published\",\"client_payload\":{\"version\":\"${VERSION}\"}}"
+          echo "Dispatched workflow-executor-published (version ${VERSION}) to forestadmin-server."


### PR DESCRIPTION
fixes PRD-238

## Summary

Closes the auto-deploy loop for the standalone `workflow-executor` image. The image is published to GHCR by [#1706](https://github.com/ForestAdmin/agent-nodejs/pull/1706), and [forestadmin-server#8336](https://github.com/ForestAdmin/forestadmin-server/pull/8336) already **listens** for a `repository_dispatch` of type `workflow-executor-published` to auto-deploy it to production — but nothing **emitted** that event yet. This adds the emitter.

## What it does

- New `notify-server` job in `docker-publish.yml`, runs after `merge` (the multi-arch manifest is pushed).
- Sends a `repository_dispatch` (`event_type: workflow-executor-published`, `client_payload: { version }`) to `ForestAdmin/forestadmin-server`, which triggers its `deploy-workflow-executor` workflow → production.
- **Guarded by `extract-version.is_latest`**: fires only for the highest **stable** version. A prerelease or a `workflow_dispatch` rebuild of an older version never auto-deploys to prod (same gate already used for the mutable `:latest`/`:major`/`:minor` tags).
- `GITHUB_TOKEN` cannot dispatch into another repository, so the job uses a dedicated secret `SERVER_DEPLOY_DISPATCH_TOKEN`; it fails loudly with a clear error if the secret is missing.

## Required before merge — create the token & secret

The `SERVER_DEPLOY_DISPATCH_TOKEN` secret must exist on this repo. See instructions in the linked thread; it needs `Contents: write` on `forestadmin-server` only.

## Test plan

- [x] YAML validated
- [ ] Secret `SERVER_DEPLOY_DISPATCH_TOKEN` created in agent-nodejs (org or repo)
- [ ] Manual `workflow_dispatch` of the latest stable version → confirm `workflow-executor-published` lands in forestadmin-server and the prod deploy workflow starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Notify forestadmin-server via repository_dispatch on workflow-executor publish
> Adds a `notify-server` job to [docker-publish.yml](.github/workflows/docker-publish.yml) that fires a `workflow-executor-published` repository dispatch to `ForestAdmin/forestadmin-server` after a successful publish. The job runs only on non-PR events where the built version is the latest stable, and passes the published version in the payload. It requires the `SERVER_DEPLOY_DISPATCH_TOKEN` secret and fails explicitly if it is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a6c5e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->