### PR TITLE
ci(workflow-executor): publish Docker image on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,11 +249,18 @@ jobs:
 
       # The tag-push trigger can't build the image: the release commit carries
       # `[skip ci]`, which GitHub honors on tag pushes too. Dispatch explicitly.
+      # Runs even on a failed release: tags/npm are published partway, so a new
+      # tag still means the image must be built to match. The snapshot guard below
+      # skips the case where the release step never ran (failure before it).
       - name: Trigger workflow-executor Docker image publish (if released)
-        if: success()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          if [ ! -f /tmp/we-tags-before.txt ]; then
+            echo "Pre-release snapshot missing — release step never ran; nothing to publish."
+            exit 0
+          fi
           git tag --list '@forestadmin/workflow-executor@*' | sort > /tmp/we-tags-after.txt
           NEW_TAGS=$(comm -13 /tmp/we-tags-before.txt /tmp/we-tags-after.txt)
           if [ -z "$NEW_TAGS" ]; then
@@ -265,7 +272,7 @@ jobs:
             | sed 's|^@forestadmin/workflow-executor@||' \
             | sort -V | tail -n1)
           echo "workflow-executor@${VERSION} released — dispatching docker-publish.yml."
-          gh workflow run docker-publish.yml --ref main -f version="$VERSION"
+          gh workflow run docker-publish.yml --ref "$GITHUB_REF_NAME" -f version="$VERSION"
 
   publish-api-reference:
     name: Publish API Reference

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,8 @@ jobs:
           fail-on-cache-miss: true
       - name: Disable workspaces-update
         run: npm config set workspaces-update false
+      - name: Snapshot workflow-executor tags (pre-release)
+        run: git tag --list '@forestadmin/workflow-executor@*' | sort > /tmp/we-tags-before.txt
       - name: "Run multi-semantic-release"
         run: "$(yarn bin)/multi-semantic-release --deps.bump=override"
         env:
@@ -244,6 +246,26 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           NPM_CONFIG_PROVENANCE: true
+
+      # The tag-push trigger can't build the image: the release commit carries
+      # `[skip ci]`, which GitHub honors on tag pushes too. Dispatch explicitly.
+      - name: Trigger workflow-executor Docker image publish (if released)
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git tag --list '@forestadmin/workflow-executor@*' | sort > /tmp/we-tags-after.txt
+          NEW_TAGS=$(comm -13 /tmp/we-tags-before.txt /tmp/we-tags-after.txt)
+          if [ -z "$NEW_TAGS" ]; then
+            echo "No new @forestadmin/workflow-executor tag in this run — nothing to publish."
+            exit 0
+          fi
+          # If more than one appears, pick the highest so :latest never regresses.
+          VERSION=$(echo "$NEW_TAGS" \
+            | sed 's|^@forestadmin/workflow-executor@||' \
+            | sort -V | tail -n1)
+          echo "workflow-executor@${VERSION} released — dispatching docker-publish.yml."
+          gh workflow run docker-publish.yml --ref main -f version="$VERSION"
 
   publish-api-reference:
     name: Publish API Reference

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,8 @@
 name: Publish workflow-executor Docker image
 
 on:
-  push:
-    tags:
-      - '@forestadmin/workflow-executor@*'
+  # Releases publish via workflow_dispatch from build.yml's `release` job, not a
+  # tag-push trigger — the release commit's `[skip ci]` would suppress it.
   pull_request:
     # Validate on any change to the executor or to a dependency package's
     # manifest — a dep bump in one of the 5 source packages can drift the
@@ -108,15 +107,10 @@ jobs:
         with:
           # Need all tags to determine whether this is the latest stable version.
           fetch-depth: 0
-      - name: Parse version from tag or input
+      - name: Parse version from input
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            TAG="${{ github.ref_name }}"
-            VERSION="${TAG#@forestadmin/workflow-executor@}"
-          fi
+          VERSION="${{ github.event.inputs.version }}"
           echo "full=$VERSION" >> $GITHUB_OUTPUT
           echo "minor=${VERSION%.*}" >> $GITHUB_OUTPUT
           echo "major=${VERSION%%.*}" >> $GITHUB_OUTPUT
@@ -156,9 +150,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # On manual dispatch, check out the requested version tag so the built
-          # image matches the version it is published under (not the default branch).
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('@forestadmin/workflow-executor@{0}', github.event.inputs.version) || github.ref }}
+          # Build from the requested version's tag, not the default branch.
+          ref: ${{ format('@forestadmin/workflow-executor@{0}', github.event.inputs.version) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem

GHCR is stuck at `workflow-executor:1.9.0` while npm is at `1.9.2`. A normal release never builds the image.

**Root cause:** `docker-publish.yml` triggered on `push: tags: '@forestadmin/workflow-executor@*'`, but `@semantic-release/git` (`.releaserc.js`) makes the release commit message `chore(release): <tag> [skip ci]` and pushes the commit + tag together. GitHub honors `[skip ci]` on the head commit of a push **including tag pushes**, so it cancels the docker-publish run. The `1.9.0` image only exists because it was built manually via `workflow_dispatch`; tags `1.9.1`/`1.9.2` shipped to npm but never produced an image.

We can't drop `[skip ci]` — it's what stops `build.yml` from looping on the release commit.

## Fix

The `release` job in `build.yml` now:
1. snapshots the `@forestadmin/workflow-executor@*` tags **before** `multi-semantic-release`,
2. after the release, diffs the tag list and, if a new version was created, runs `gh workflow run docker-publish.yml -f version=<v>`.

A `workflow_dispatch` event is not subject to skip-ci, so the image is built reliably on every release. The existing `is_latest` logic in `docker-publish.yml` keeps `:latest`/prod-deploy gated to the highest stable version.

The dead `on: push: tags` trigger is **removed** — it could never fire for a real release — along with the tag-parsing branch in `extract-version` and the conditional checkout `ref` it required. `workflow_dispatch` (from the release job, or manual) is now the only release path; `pull_request` still validates.

## Backfill

The missing `1.9.2` image was dispatched manually alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish Docker image for `workflow-executor` on release via workflow dispatch
> - The [build.yml](.github/workflows/build.yml) workflow now snapshots `@forestadmin/workflow-executor` tags before and after the release step, then dispatches [docker-publish.yml](.github/workflows/docker-publish.yml) if a new tag is detected, passing the highest new version.
> - The [docker-publish.yml](.github/workflows/docker-publish.yml) workflow drops its tag-push trigger and now requires an explicit `workflow_dispatch` with a `version` input; the checkout step always uses the tag derived from that input.
> - Behavioral Change: Docker image publishing no longer triggers on tag pushes — it only runs when dispatched by the build workflow or manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d66df2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->