### PR TITLE
feat(workflow-executor): approval requests on Full AI / Automatic trigger actions [PRD-688]

### DIFF
--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -20,8 +20,7 @@ type ApprovalCreateResponse = {
   id?: string | number;
 };
 
-// Server response shape isn't pinned yet: try the likely id locations, never throw (a missing id
-// just means no deep-link).
+// Server response shape isn't pinned; try the likely id locations, never throw.
 function extractApprovalId(body: ApprovalCreateResponse | undefined): { id: string } | undefined {
   const candidate =
     body?.data?.id ??

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -15,22 +15,14 @@ export type CreateApprovalRequest = (
 
 const APPROVAL_REQUEST_PATH = '/api/action-approvals';
 
-// The Forest server returns the created approval as JSON:API; the id is the resource id.
-type ApprovalCreateResponse = { data?: { id?: string | number } };
-
-function extractApprovalId(body: ApprovalCreateResponse | undefined): { id: string } | undefined {
-  const id = body?.data?.id;
-
-  return id ? { id: String(id) } : undefined;
-}
-
 export default function makeCreateApprovalRequest(options: {
   forestServerUrl: string;
   forestServerToken: string;
   renderingId: number | string;
 }): CreateApprovalRequest {
   return async payload => {
-    const body = await ServerUtils.queryWithBearerToken<ApprovalCreateResponse>({
+    // JSON:API create response — the created approval's id is the resource id (data.id).
+    const body = await ServerUtils.queryWithBearerToken<{ data?: { id?: string | number } }>({
       forestServerUrl: options.forestServerUrl,
       bearerToken: options.forestServerToken,
       method: 'post',
@@ -51,6 +43,6 @@ export default function makeCreateApprovalRequest(options: {
       },
     });
 
-    return extractApprovalId(body);
+    return body?.data?.id ? { id: String(body.data.id) } : undefined;
   };
 }

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -9,9 +9,30 @@ export type ApprovalRequestPayload = {
   inputs: ApprovalRequestInput[];
 };
 
-export type CreateApprovalRequest = (payload: ApprovalRequestPayload) => Promise<void>;
+export type CreateApprovalRequest = (
+  payload: ApprovalRequestPayload,
+) => Promise<{ id: string } | undefined>;
 
 const APPROVAL_REQUEST_PATH = '/api/action-approvals';
+
+type ApprovalCreateResponse = {
+  data?: { id?: string | number; attributes?: { reference?: string; requestId?: string } };
+  id?: string | number;
+};
+
+// Server response shape isn't pinned yet: try the likely id locations, never throw (a missing id
+// just means no deep-link).
+function extractApprovalId(body: ApprovalCreateResponse | undefined): { id: string } | undefined {
+  const candidate =
+    body?.data?.id ??
+    body?.data?.attributes?.reference ??
+    body?.data?.attributes?.requestId ??
+    body?.id;
+
+  if (candidate === undefined || candidate === null || candidate === '') return undefined;
+
+  return { id: String(candidate) };
+}
 
 export default function makeCreateApprovalRequest(options: {
   forestServerUrl: string;
@@ -19,7 +40,7 @@ export default function makeCreateApprovalRequest(options: {
   renderingId: number | string;
 }): CreateApprovalRequest {
   return async payload => {
-    await ServerUtils.queryWithBearerToken({
+    const body = await ServerUtils.queryWithBearerToken<ApprovalCreateResponse>({
       forestServerUrl: options.forestServerUrl,
       bearerToken: options.forestServerToken,
       method: 'post',
@@ -39,5 +60,7 @@ export default function makeCreateApprovalRequest(options: {
         },
       },
     });
+
+    return extractApprovalId(body);
   };
 }

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -15,22 +15,13 @@ export type CreateApprovalRequest = (
 
 const APPROVAL_REQUEST_PATH = '/api/action-approvals';
 
-type ApprovalCreateResponse = {
-  data?: { id?: string | number; attributes?: { reference?: string; requestId?: string } };
-  id?: string | number;
-};
+// The Forest server returns the created approval as JSON:API; the id is the resource id.
+type ApprovalCreateResponse = { data?: { id?: string | number } };
 
-// Server response shape isn't pinned; try the likely id locations, never throw.
 function extractApprovalId(body: ApprovalCreateResponse | undefined): { id: string } | undefined {
-  const candidate =
-    body?.data?.id ??
-    body?.data?.attributes?.reference ??
-    body?.data?.attributes?.requestId ??
-    body?.id;
+  const id = body?.data?.id;
 
-  if (candidate === undefined || candidate === null || candidate === '') return undefined;
-
-  return { id: String(candidate) };
+  return id ? { id: String(id) } : undefined;
 }
 
 export default function makeCreateApprovalRequest(options: {

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -83,7 +83,9 @@ export type BaseActionContext = {
   recordIds?: RecordId[];
 };
 
-export type ActionExecuteResult = { success: string; html?: string } | { approvalRequested: true };
+export type ActionExecuteResult =
+  | { success: string; html?: string }
+  | { approvalRequested: true; approvalRequest?: { id: string } };
 
 export type ActionEndpointsByCollection = {
   [collectionName: string]: {
@@ -151,8 +153,10 @@ export default class Action {
           value: field.getValue(),
         }));
 
+        let approvalRequest: { id: string } | undefined;
+
         try {
-          await this.createApprovalRequest({
+          approvalRequest = await this.createApprovalRequest({
             collectionName: this.collectionName,
             actionName: this.actionName,
             recordIds: this.ids ?? [],
@@ -162,7 +166,7 @@ export default class Action {
           throw new ApprovalRequestCreationError(cause);
         }
 
-        return { approvalRequested: true };
+        return { approvalRequested: true, ...(approvalRequest && { approvalRequest }) };
       }
 
       throw mapped;

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -45,4 +45,35 @@ describe('makeCreateApprovalRequest', () => {
       },
     });
   });
+
+  it('returns the approval id read from the server response data.id', async () => {
+    queryWithBearerToken.mockResolvedValue({ data: { id: 'req_42', type: 'action-approvals' } });
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    const result = await create({
+      collectionName: 'users',
+      actionName: 'refund',
+      recordIds: ['1'],
+      inputs: [],
+    });
+
+    expect(result).toEqual({ id: 'req_42' });
+  });
+
+  it('returns undefined (no throw) when the response carries no usable id', async () => {
+    queryWithBearerToken.mockResolvedValue({ data: { attributes: { status: 'pending' } } });
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    await expect(
+      create({ collectionName: 'users', actionName: 'refund', recordIds: ['1'], inputs: [] }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -184,6 +184,30 @@ describe('Action', () => {
       expect(result).toEqual({ approvalRequested: true });
     });
 
+    it('includes the approval request id when the creator returns one', async () => {
+      fieldsFormStates.getFields.mockReturnValue([] as any);
+      const createApprovalRequest = jest.fn().mockResolvedValue({ id: 'req_42' });
+      const approvalAction = new Action(
+        'users',
+        'send-email',
+        httpRequester,
+        '/forest/actions/send-email',
+        fieldsFormStates,
+        ['1'],
+        undefined,
+        createApprovalRequest,
+      );
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [{ name: 'CustomActionRequiresApprovalError', detail: 'Needs approval' }],
+        }),
+      );
+
+      const result = await approvalAction.execute();
+
+      expect(result).toEqual({ approvalRequested: true, approvalRequest: { id: 'req_42' } });
+    });
+
     it('throws ApprovalRequestCreationError when filing the approval request fails', async () => {
       fieldsFormStates.getFields.mockReturnValue([] as any);
       const createApprovalRequest = jest.fn().mockRejectedValue(new Error('forest server down'));

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -3,6 +3,7 @@ import type {
   ActionFormField,
   AgentPort,
   ExecuteActionQuery,
+  ExecuteActionResult,
   GetActionFormInfoQuery,
   GetActionFormQuery,
   GetRecordQuery,
@@ -19,6 +20,7 @@ import type { ActionEndpointsByCollection, SelectOptions } from '@forestadmin/ag
 import {
   ActionFormValidationError as ClientActionFormValidationError,
   ActionRequiresApprovalError as ClientActionRequiresApprovalError,
+  ApprovalRequestCreationError as ClientApprovalRequestCreationError,
   HttpRequester,
   createRemoteAgentClient,
 } from '@forestadmin/agent-client';
@@ -29,6 +31,7 @@ import {
   ActionRequiresApprovalError,
   AgentPortError,
   AgentProbeError,
+  ApprovalRequestCreationError,
   RecordNotFoundError,
   WorkflowExecutorError,
   extractErrorMessage,
@@ -43,6 +46,10 @@ function mapActionExecutionError(action: string, cause: unknown): unknown {
 
   if (cause instanceof ClientActionFormValidationError) {
     return new ActionFormValidationError(action, cause);
+  }
+
+  if (cause instanceof ClientApprovalRequestCreationError) {
+    return new ApprovalRequestCreationError(action, cause);
   }
 
   return cause;
@@ -74,11 +81,18 @@ export default class AgentClientAgentPort implements AgentPort {
   private readonly agentUrl: string;
   private readonly authSecret: string;
   private readonly schemaCache: SchemaCache;
+  private readonly forestServerUrl?: string;
 
-  constructor(params: { agentUrl: string; authSecret: string; schemaCache: SchemaCache }) {
+  constructor(params: {
+    agentUrl: string;
+    authSecret: string;
+    schemaCache: SchemaCache;
+    forestServerUrl?: string;
+  }) {
     this.agentUrl = params.agentUrl;
     this.authSecret = params.authSecret;
     this.schemaCache = params.schemaCache;
+    this.forestServerUrl = params.forestServerUrl;
   }
 
   async getRecord({ collection, id, fields }: GetRecordQuery, user: StepUser): Promise<RecordData> {
@@ -217,9 +231,10 @@ export default class AgentClientAgentPort implements AgentPort {
   async executeAction(
     { collection, action, id, values }: ExecuteActionQuery,
     user: StepUser,
-  ): Promise<unknown> {
+    forestServerToken?: string,
+  ): Promise<ExecuteActionResult> {
     return this.callAgent('executeAction', async () => {
-      const client = this.createClient(user);
+      const client = this.createClient(user, forestServerToken);
       const recordIds = id?.length ? [id] : [];
       const act = await client.collection(collection).action(action, { recordIds });
 
@@ -234,7 +249,18 @@ export default class AgentClientAgentPort implements AgentPort {
       }
 
       try {
-        return await act.execute();
+        const executeResult = await act.execute();
+
+        return typeof executeResult === 'object' &&
+          executeResult !== null &&
+          'approvalRequested' in executeResult
+          ? {
+              approvalRequested: true,
+              ...(executeResult.approvalRequest && {
+                approvalRequest: executeResult.approvalRequest,
+              }),
+            }
+          : { result: executeResult };
       } catch (cause) {
         throw mapActionExecutionError(action, cause);
       }
@@ -311,11 +337,20 @@ export default class AgentClientAgentPort implements AgentPort {
     );
   }
 
-  private createClient(user: StepUser) {
+  private createClient(user: StepUser, forestServerToken?: string) {
     return createRemoteAgentClient({
       url: this.agentUrl,
       token: this.mintToken(user),
       actionEndpoints: this.buildActionEndpoints(user.renderingId),
+      ...(this.forestServerUrl && forestServerToken
+        ? {
+            forestServer: {
+              serverUrl: this.forestServerUrl,
+              serverToken: forestServerToken,
+              renderingId: user.renderingId,
+            },
+          }
+        : {}),
     });
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -1,4 +1,5 @@
 import type {
+  ActionCaller,
   ActionForm,
   ActionFormField,
   AgentPort,
@@ -230,8 +231,7 @@ export default class AgentClientAgentPort implements AgentPort {
 
   async executeAction(
     { collection, action, id, values }: ExecuteActionQuery,
-    user: StepUser,
-    forestServerToken?: string,
+    { user, forestServerToken }: ActionCaller,
   ): Promise<ExecuteActionResult> {
     return this.callAgent('executeAction', async () => {
       const client = this.createClient(user, forestServerToken);

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -285,7 +285,8 @@ export default class AgentClientAgentPort implements AgentPort {
   ): Promise<ActionForm> {
     return this.callAgent('getActionForm', async () => {
       const client = this.createClient(user);
-      const act = await client.collection(collection).action(action, { recordIds: [id] });
+      const recordIds = id?.length ? [id] : [];
+      const act = await client.collection(collection).action(action, { recordIds });
 
       // Soft-apply so dependent fields are revealed by change hooks; unknown fields (dropped by a
       // prior hook) come back in skippedFields rather than throwing (mirrors MCP get-action-form).

--- a/packages/workflow-executor/src/adapters/step-outcome-to-update-step-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-outcome-to-update-step-mapper.ts
@@ -32,6 +32,10 @@ export default function toUpdateStepRequest(
     context.selectedOption = outcome.selectedOption;
   }
 
+  if (outcome.type === 'record' && outcome.approvalRequest !== undefined) {
+    context.approvalRequest = outcome.approvalRequest;
+  }
+
   const attributes: ServerStepHistoryUpdate = {
     done: outcome.status !== 'awaiting-input',
     context,

--- a/packages/workflow-executor/src/build-workflow-executor.ts
+++ b/packages/workflow-executor/src/build-workflow-executor.ts
@@ -105,6 +105,7 @@ function buildCommonDependencies(options: ExecutorOptions) {
     agentUrl: options.agentUrl,
     authSecret: options.authSecret,
     schemaCache,
+    forestServerUrl,
   });
 
   const activityLogsService = new ActivityLogsService(new ForestHttpApi(), {

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -155,6 +155,18 @@ export class ActionRequiresApprovalError extends WorkflowExecutorError {
   }
 }
 
+// The action is approval-gated but filing the approval request failed — neither executed nor
+// approved, so it's a real step failure (distinct from ActionRequiresApprovalError, the upfront gate).
+export class ApprovalRequestCreationError extends WorkflowExecutorError {
+  constructor(actionName: string, cause?: unknown) {
+    super(
+      `Action "${actionName}" requires an approval, but the approval request could not be created`,
+      'This action requires an approval, but the approval request could not be created. Please retry.',
+    );
+    this.cause = cause;
+  }
+}
+
 export class RunStorePortError extends UnavailableError {
   constructor(operation: string, cause: unknown) {
     super(

--- a/packages/workflow-executor/src/errors.ts
+++ b/packages/workflow-executor/src/errors.ts
@@ -155,8 +155,7 @@ export class ActionRequiresApprovalError extends WorkflowExecutorError {
   }
 }
 
-// The action is approval-gated but filing the approval request failed — neither executed nor
-// approved, so it's a real step failure (distinct from ActionRequiresApprovalError, the upfront gate).
+// Approval-gated action whose approval request couldn't be filed — neither executed nor approved.
 export class ApprovalRequestCreationError extends WorkflowExecutorError {
   constructor(actionName: string, cause?: unknown) {
     super(

--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -3,6 +3,7 @@ import type {
   ActionForm,
   AgentPort,
   ExecuteActionQuery,
+  ExecuteActionResult,
   GetActionFormInfoQuery,
   GetActionFormQuery,
   GetRecordQuery,
@@ -22,6 +23,7 @@ export interface AgentWithLogDeps {
   schemaResolver: SchemaResolver;
   user: StepUser;
   activityLog: ActivityLog;
+  forestServerToken?: string;
 }
 
 // Wraps AgentPort and runs each data-access call through the ActivityLog so it records an
@@ -37,11 +39,14 @@ export default class AgentWithLog {
 
   private readonly activityLog: ActivityLog;
 
+  private readonly forestServerToken?: string;
+
   constructor(deps: AgentWithLogDeps) {
     this.agentPort = deps.agentPort;
     this.schemaResolver = deps.schemaResolver;
     this.user = deps.user;
     this.activityLog = deps.activityLog;
+    this.forestServerToken = deps.forestServerToken;
   }
 
   async getRecord(query: GetRecordQuery): Promise<RecordData> {
@@ -95,7 +100,7 @@ export default class AgentWithLog {
     );
   }
 
-  async executeAction(query: ExecuteActionQuery, opts: WriteOptions): Promise<unknown> {
+  async executeAction(query: ExecuteActionQuery, opts: WriteOptions): Promise<ExecuteActionResult> {
     const { collectionId } = await this.resolveSchema(query.collection);
 
     return this.activityLog.track(
@@ -107,7 +112,7 @@ export default class AgentWithLog {
         label: `triggered the action "${query.action}"`,
       },
       {
-        operation: () => this.agentPort.executeAction(query, this.user),
+        operation: () => this.agentPort.executeAction(query, this.user, this.forestServerToken),
         beforeCall: opts.beforeCall,
       },
     );

--- a/packages/workflow-executor/src/executors/agent-with-log.ts
+++ b/packages/workflow-executor/src/executors/agent-with-log.ts
@@ -112,7 +112,11 @@ export default class AgentWithLog {
         label: `triggered the action "${query.action}"`,
       },
       {
-        operation: () => this.agentPort.executeAction(query, this.user, this.forestServerToken),
+        operation: () =>
+          this.agentPort.executeAction(query, {
+            user: this.user,
+            forestServerToken: this.forestServerToken,
+          }),
         beforeCall: opts.beforeCall,
       },
     );

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -148,8 +148,6 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     }
   }
 
-  // Outcome-shape extensions specific to a step family (e.g. condition's selectedOption,
-  // record's approvalRequest) live on the concrete override, not here.
   protected abstract buildOutcomeResult(outcome: {
     status: StepStatus;
     error?: string;

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -148,10 +148,11 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
     }
   }
 
+  // Outcome-shape extensions specific to a step family (e.g. condition's selectedOption,
+  // record's approvalRequest) live on the concrete override, not here.
   protected abstract buildOutcomeResult(outcome: {
     status: StepStatus;
     error?: string;
-    approvalRequest?: { id: string };
   }): StepExecutionResult;
 
   protected async findPendingExecution<TExec extends ConfirmableStepExecutionData>(

--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -151,6 +151,7 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   protected abstract buildOutcomeResult(outcome: {
     status: StepStatus;
     error?: string;
+    approvalRequest?: { id: string };
   }): StepExecutionResult;
 
   protected async findPendingExecution<TExec extends ConfirmableStepExecutionData>(

--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -21,6 +21,7 @@ export default abstract class RecordStepExecutor<
   protected buildOutcomeResult(outcome: {
     status: RecordStepStatus;
     error?: string;
+    approvalRequest?: { id: string };
   }): StepExecutionResult {
     return {
       stepOutcome: {

--- a/packages/workflow-executor/src/executors/record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/record-step-executor.ts
@@ -21,7 +21,6 @@ export default abstract class RecordStepExecutor<
   protected buildOutcomeResult(outcome: {
     status: RecordStepStatus;
     error?: string;
-    approvalRequest?: { id: string };
   }): StepExecutionResult {
     return {
       stepOutcome: {

--- a/packages/workflow-executor/src/executors/step-executor-factory.ts
+++ b/packages/workflow-executor/src/executors/step-executor-factory.ts
@@ -59,6 +59,7 @@ export default class StepExecutorFactory {
     activityLogPort: ActivityLogPort,
     fetchRemoteTools: (mcpServerId: string) => Promise<FetchRemoteToolsResult>,
     incomingPendingData?: unknown,
+    forestServerToken?: string,
   ): Promise<IStepExecutor> {
     try {
       const context = StepExecutorFactory.buildContext(
@@ -66,6 +67,7 @@ export default class StepExecutorFactory {
         contextConfig,
         activityLogPort,
         incomingPendingData,
+        forestServerToken,
       );
 
       switch (step.stepDefinition.type) {
@@ -134,6 +136,7 @@ export default class StepExecutorFactory {
     cfg: StepContextConfig,
     activityLogPort: ActivityLogPort,
     incomingPendingData?: unknown,
+    forestServerToken?: string,
   ): ExecutionContext {
     const schemaResolver = new SchemaResolver(
       cfg.schemaCache,
@@ -161,6 +164,7 @@ export default class StepExecutorFactory {
         schemaResolver,
         user: step.user,
         activityLog,
+        forestServerToken,
       }),
       activityLog,
       runStore: cfg.runStore,

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -42,15 +42,11 @@ Important rules:
 
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
-  // A global action runs on no record — the executor must not attach one (record_ids stays empty,
-  // so an approval request it triggers isn't wrongly linked to a record).
   isGlobal?: boolean;
 }
 
 export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<TriggerActionStepDefinition> {
-  // Trigger Action is the only record step that can report an approval request. Carry it on a
-  // dedicated override so the shared record builder stays free of the approval concept; the parent
-  // spreads the outcome through, so the id lands on the (record) StepOutcome.
+  // approvalRequest lives here, off the shared record builder; super spreads it onto the outcome.
   protected override buildOutcomeResult(outcome: {
     status: RecordStepStatus;
     error?: string;
@@ -367,8 +363,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       {
         collection: selectedRecordRef.collectionName,
         action: name,
-        // A global action runs on no record: omit the id so it isn't attached (notably to the
-        // approval request it may trigger). Single/bulk actions keep their record.
+        // Global actions run on no record — omit the id so the approval isn't linked to one.
         ...(target.isGlobal ? {} : { id: selectedRecordRef.recordId }),
         ...(form && { values: form.values }),
       },

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -151,7 +151,9 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     const form = await this.context.agent.getActionForm({
       collection: selectedRecordRef.collectionName,
       action: target.name,
-      id: selectedRecordRef.recordId,
+      // Global actions run on no record — building the form against one yields the wrong
+      // record-scoped defaults/dynamic fields (must match executeAction, which omits the id too).
+      ...(target.isGlobal ? {} : { id: selectedRecordRef.recordId }),
     });
     const hasForm = form.fields.length > 0;
 
@@ -172,6 +174,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       selectedRecordRef,
       target.name,
       form,
+      target.isGlobal,
     );
     const reviewState = { fields: filledForm.fields, aiFilledValues };
 
@@ -228,6 +231,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     recordRef: RecordRef,
     action: string,
     initialForm: ActionForm,
+    isGlobal?: boolean,
   ): Promise<{ aiFilledValues: AiFilledFormValue[]; form: ActionForm }> {
     const MAX_ITERATIONS = 3;
     const accumulator: Record<string, unknown> = {};
@@ -260,7 +264,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       form = await this.context.agent.getActionForm({
         collection: recordRef.collectionName,
         action,
-        id: recordRef.recordId,
+        ...(isGlobal ? {} : { id: recordRef.recordId }),
         values: accumulator,
       });
 

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types/step-execution-data';
 import type { ActionSchema, CollectionSchema, RecordRef } from '../types/validated/collection';
 import type { TriggerActionStepDefinition } from '../types/validated/step-definition';
+import type { RecordStepStatus } from '../types/validated/step-outcome';
 
 import { DynamicStructuredTool, HumanMessage, SystemMessage } from '@forestadmin/ai-proxy';
 import { z } from 'zod';
@@ -44,6 +45,17 @@ interface ActionTarget extends ActionRef {
 }
 
 export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<TriggerActionStepDefinition> {
+  // Trigger Action is the only record step that can report an approval request. Carry it on a
+  // dedicated override so the shared record builder stays free of the approval concept; the parent
+  // spreads the outcome through, so the id lands on the (record) StepOutcome.
+  protected override buildOutcomeResult(outcome: {
+    status: RecordStepStatus;
+    error?: string;
+    approvalRequest?: { id: string };
+  }): StepExecutionResult {
+    return super.buildOutcomeResult(outcome);
+  }
+
   protected override async checkIdempotency(): Promise<StepExecutionResult | null> {
     const existing = await this.findPendingExecution<TriggerRecordActionStepExecutionData>(
       'trigger-action',

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -42,6 +42,9 @@ Important rules:
 
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
+  // A global action runs on no record — the executor must not attach one (record_ids stays empty,
+  // so an approval request it triggers isn't wrongly linked to a record).
+  isGlobal?: boolean;
 }
 
 export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<TriggerActionStepDefinition> {
@@ -146,6 +149,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       selectedRecordRef,
       displayName: action.displayName,
       name: action.name,
+      isGlobal: action.type === 'global',
     };
 
     const form = await this.context.agent.getActionForm({
@@ -363,7 +367,9 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       {
         collection: selectedRecordRef.collectionName,
         action: name,
-        id: selectedRecordRef.recordId,
+        // A global action runs on no record: omit the id so it isn't attached (notably to the
+        // approval request it may trigger). Single/bulk actions keep their record.
+        ...(target.isGlobal ? {} : { id: selectedRecordRef.recordId }),
         ...(form && { values: form.values }),
       },
       {

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -50,7 +50,16 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     );
 
     if (existing?.idempotencyPhase === 'done') {
-      return this.buildOutcomeResult({ status: 'success' });
+      const result = existing.executionResult;
+      const approvalRequest =
+        result && !('skipped' in result) && result.submissionOutcome === 'pending-approval'
+          ? result.approvalRequest
+          : undefined;
+
+      return this.buildOutcomeResult({
+        status: 'success',
+        ...(approvalRequest && { approvalRequest }),
+      });
     }
 
     if (existing?.idempotencyPhase === 'executing') {
@@ -338,7 +347,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   ): Promise<StepExecutionResult> {
     const { selectedRecordRef, displayName, name } = target;
 
-    const actionResult = await this.context.agent.executeAction(
+    const outcome = await this.context.agent.executeAction(
       {
         collection: selectedRecordRef.collectionName,
         action: name,
@@ -356,20 +365,42 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       },
     );
 
+    const submission = form && {
+      submittedBy: 'ai' as const,
+      submittedValues: form.values,
+      ...(form.aiFilledValues.length && { aiFilledValues: form.aiFilledValues }),
+    };
+
+    if ('approvalRequested' in outcome) {
+      await this.context.runStore.saveStepExecution(this.context.runId, {
+        type: 'trigger-action',
+        stepIndex: this.context.stepIndex,
+        executionParams: { displayName, name },
+        executionResult: {
+          success: true,
+          submissionOutcome: 'pending-approval',
+          ...(submission || { submittedBy: 'ai' as const }),
+          ...(outcome.approvalRequest && { approvalRequest: outcome.approvalRequest }),
+        },
+        selectedRecordRef,
+        idempotencyPhase: 'done',
+      });
+
+      return this.buildOutcomeResult({
+        status: 'success',
+        ...(outcome.approvalRequest && { approvalRequest: outcome.approvalRequest }),
+      });
+    }
+
     await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'trigger-action',
       stepIndex: this.context.stepIndex,
       executionParams: { displayName, name },
       executionResult: {
         success: true,
-        actionResult,
+        actionResult: outcome.result,
         // Form-bearing Full AI: record what the executor submitted.
-        ...(form && {
-          submissionOutcome: 'executed',
-          submittedBy: 'ai',
-          submittedValues: form.values,
-          ...(form.aiFilledValues.length && { aiFilledValues: form.aiFilledValues }),
-        }),
+        ...(submission && { submissionOutcome: 'executed', ...submission }),
       },
       selectedRecordRef,
       idempotencyPhase: 'done',

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -62,10 +62,17 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
 
     if (existing?.idempotencyPhase === 'done') {
       const result = existing.executionResult;
-      const approvalRequest =
-        result && !('skipped' in result) && result.submissionOutcome === 'pending-approval'
-          ? result.approvalRequest
-          : undefined;
+      const isPendingApproval =
+        result && !('skipped' in result) && result.submissionOutcome === 'pending-approval';
+      const approvalRequest = isPendingApproval ? result.approvalRequest : undefined;
+
+      if (isPendingApproval && !approvalRequest) {
+        this.context.logger(
+          'Warn',
+          'Replayed a pending-approval step with no approval id; no deep-link available.',
+          { stepIndex: this.context.stepIndex, renderingId: this.context.user.renderingId },
+        );
+      }
 
       return this.buildOutcomeResult({
         status: 'success',
@@ -389,6 +396,20 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     };
 
     if ('approvalRequested' in outcome) {
+      if (!outcome.approvalRequest) {
+        // The approval exists server-side but no id came back — the step still succeeds, but
+        // there's no deep-link to surface. Log it so the missing link isn't a silent mystery.
+        this.context.logger(
+          'Warn',
+          'Approval request created but the server returned no id; the step has no approval deep-link.',
+          {
+            collectionName: selectedRecordRef.collectionName,
+            actionName: name,
+            renderingId: this.context.user.renderingId,
+          },
+        );
+      }
+
       await this.context.runStore.saveStepExecution(this.context.runId, {
         type: 'trigger-action',
         stepIndex: this.context.stepIndex,

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -48,7 +48,8 @@ export type ExecuteActionQuery = {
 export type GetActionFormQuery = {
   collection: string;
   action: string;
-  id: Id[];
+  // Omitted for global actions (no record context), like ExecuteActionQuery.
+  id?: Id[];
   // Optional values to apply before reading the form back (fires the change hooks so dependent
   // fields appear/update). Soft-applied: unknown fields are reported in `skippedFields`.
   values?: Record<string, unknown>;

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -79,6 +79,10 @@ export type GetActionFormInfoQuery = { collection: string; action: string; id: I
 
 export type ResolvePolymorphicTypeQuery = { collection: string; id: Id[]; relation: string };
 
+export type ExecuteActionResult =
+  | { approvalRequested: true; approvalRequest?: { id: string } }
+  | { result: unknown };
+
 export interface AgentPort {
   getRecord(query: GetRecordQuery, user: StepUser): Promise<RecordData>;
   updateRecord(query: UpdateRecordQuery, user: StepUser): Promise<RecordData>;
@@ -94,7 +98,11 @@ export interface AgentPort {
     query: ResolvePolymorphicTypeQuery,
     user: StepUser,
   ): Promise<{ type: string; id: string } | null>;
-  executeAction(query: ExecuteActionQuery, user: StepUser): Promise<unknown>;
+  executeAction(
+    query: ExecuteActionQuery,
+    user: StepUser,
+    forestServerToken?: string,
+  ): Promise<ExecuteActionResult>;
   // Old Ruby agents with hooks.load=false return 404; agent-client falls back to the fields
   // passed via ActionEndpointsByCollection (populated from the orchestrator's schema).
   getActionFormInfo(query: GetActionFormInfoQuery, user: StepUser): Promise<{ hasForm: boolean }>;

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -83,6 +83,9 @@ export type ExecuteActionResult =
   | { approvalRequested: true; approvalRequest?: { id: string } }
   | { result: unknown };
 
+// Kept off StepUser: mintToken splats StepUser into the agent JWT, a token there would leak.
+export type ActionCaller = { user: StepUser; forestServerToken?: string };
+
 export interface AgentPort {
   getRecord(query: GetRecordQuery, user: StepUser): Promise<RecordData>;
   updateRecord(query: UpdateRecordQuery, user: StepUser): Promise<RecordData>;
@@ -98,11 +101,7 @@ export interface AgentPort {
     query: ResolvePolymorphicTypeQuery,
     user: StepUser,
   ): Promise<{ type: string; id: string } | null>;
-  executeAction(
-    query: ExecuteActionQuery,
-    user: StepUser,
-    forestServerToken?: string,
-  ): Promise<ExecuteActionResult>;
+  executeAction(query: ExecuteActionQuery, caller: ActionCaller): Promise<ExecuteActionResult>;
   // Old Ruby agents with hooks.load=false return 404; agent-client falls back to the fields
   // passed via ActionEndpointsByCollection (populated from the orchestrator's schema).
   getActionFormInfo(query: GetActionFormInfoQuery, user: StepUser): Promise<{ hasForm: boolean }>;

--- a/packages/workflow-executor/src/runner.ts
+++ b/packages/workflow-executor/src/runner.ts
@@ -315,6 +315,7 @@ export default class Runner {
           this.config.activityLogPortFactory.forRun(currentToken),
           mcpServerId => this.remoteToolFetcher.fetch(mcpServerId),
           currentIncomingData,
+          currentToken,
         );
         result = await executor.execute();
       } catch (error) {

--- a/packages/workflow-executor/src/types/step-execution-data.ts
+++ b/packages/workflow-executor/src/types/step-execution-data.ts
@@ -126,6 +126,7 @@ export interface TriggerRecordActionStepExecutionData
         // Who submitted the action (audit): 'ai' = Full AI (executor), 'user' = AI-assisted
         // (human via the native front). Absent for formless/legacy flows.
         submittedBy?: 'ai' | 'user';
+        approvalRequest?: { id: string };
       }
     | { skipped: true };
   pendingData?: TriggerActionPendingData;

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -72,8 +72,6 @@ export const ActionSchemaSchema = z.object({
   name: z.string().min(1),
   displayName: z.string().min(1),
   endpoint: z.string().min(1),
-  // Action scope. Optional for resilience to orchestrator drift; a 'global' action runs on no
-  // record, so the executor must not attach one (e.g. to an approval request).
   type: z.enum(['single', 'bulk', 'global']).optional(),
   /** Static form fields. Used as fallback when the agent's /hooks/load route 404s (old Ruby agents). */
   fields: ActionFieldsSchema,

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -72,6 +72,9 @@ export const ActionSchemaSchema = z.object({
   name: z.string().min(1),
   displayName: z.string().min(1),
   endpoint: z.string().min(1),
+  // Action scope. Optional for resilience to orchestrator drift; a 'global' action runs on no
+  // record, so the executor must not attach one (e.g. to an approval request).
+  type: z.enum(['single', 'bulk', 'global']).optional(),
   /** Static form fields. Used as fallback when the agent's /hooks/load route 404s (old Ruby agents). */
   fields: ActionFieldsSchema,
   /** Action lifecycle hooks. Drives agent-client's dynamic form loading. */

--- a/packages/workflow-executor/src/types/validated/step-outcome.ts
+++ b/packages/workflow-executor/src/types/validated/step-outcome.ts
@@ -39,6 +39,7 @@ export const RecordStepOutcomeSchema = z
     ...baseOutcomeFields,
     type: z.literal('record'),
     status: RecordStepStatusSchema,
+    approvalRequest: z.object({ id: z.string() }).optional(),
   })
   .strict();
 export type RecordStepOutcome = z.infer<typeof RecordStepOutcomeSchema>;

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -4,6 +4,7 @@ import type { StepUser } from '../../src/types/execution-context';
 import {
   AgentHttpError,
   ActionRequiresApprovalError as ClientApprovalError,
+  ApprovalRequestCreationError as ClientApprovalRequestCreationError,
   ActionFormValidationError as ClientFormValidationError,
   HttpRequester,
   createRemoteAgentClient,
@@ -16,6 +17,7 @@ import {
   ActionRequiresApprovalError,
   AgentPortError,
   AgentProbeError,
+  ApprovalRequestCreationError,
   RecordNotFoundError,
 } from '../../src/errors';
 import SchemaCache from '../../src/schema-cache';
@@ -49,10 +51,18 @@ jest.mock('@forestadmin/agent-client', () => {
     }
   }
 
+  class MockApprovalRequestCreationError extends Error {
+    constructor(public readonly cause?: unknown) {
+      super('The approval request could not be created.');
+      this.name = 'ApprovalRequestCreationError';
+    }
+  }
+
   return {
     AgentHttpError: MockAgentHttpError,
     ActionRequiresApprovalError: MockActionRequiresApprovalError,
     ActionFormValidationError: MockActionFormValidationError,
+    ApprovalRequestCreationError: MockApprovalRequestCreationError,
     createRemoteAgentClient: jest.fn(),
     HttpRequester: { is404Error: jest.fn() },
   };
@@ -743,7 +753,7 @@ describe('AgentClientAgentPort', () => {
   });
 
   describe('executeAction', () => {
-    it('should forward the RecordId array to agent-client and call execute', async () => {
+    it('should forward the RecordId array to agent-client and normalize the executed result', async () => {
       mockAction.execute.mockResolvedValue({ success: 'done' });
 
       const result = await port.executeAction(
@@ -756,7 +766,77 @@ describe('AgentClientAgentPort', () => {
       );
 
       expect(mockCollection.action).toHaveBeenCalledWith('sendEmail', { recordIds: [[1]] });
-      expect(result).toEqual({ success: 'done' });
+      // The opaque executed result is wrapped under `result` (port contract).
+      expect(result).toEqual({ result: { success: 'done' } });
+    });
+
+    it('normalizes an approval-gated submit into approvalRequested + the approval id', async () => {
+      mockAction.execute.mockResolvedValue({
+        approvalRequested: true,
+        approvalRequest: { id: 'req_42' },
+      });
+
+      const result = await port.executeAction(
+        { collection: 'users', action: 'sendEmail', id: [1] },
+        user,
+      );
+
+      expect(result).toEqual({ approvalRequested: true, approvalRequest: { id: 'req_42' } });
+    });
+
+    it('wires the forestServer connection into agent-client when a server token is supplied', async () => {
+      const portWithServer = new AgentClientAgentPort({
+        agentUrl: 'http://localhost:3310',
+        authSecret: 'test-secret',
+        schemaCache: (port as unknown as { schemaCache: SchemaCache }).schemaCache,
+        forestServerUrl: 'https://api.forestadmin.com',
+      });
+      mockAction.execute.mockResolvedValue({ success: 'done' });
+
+      await portWithServer.executeAction(
+        { collection: 'users', action: 'sendEmail', id: [1] },
+        user,
+        'server-token',
+      );
+
+      expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          forestServer: {
+            serverUrl: 'https://api.forestadmin.com',
+            serverToken: 'server-token',
+            renderingId: 1,
+          },
+        }),
+      );
+    });
+
+    it('omits the forestServer connection when no server token is supplied', async () => {
+      const portWithServer = new AgentClientAgentPort({
+        agentUrl: 'http://localhost:3310',
+        authSecret: 'test-secret',
+        schemaCache: (port as unknown as { schemaCache: SchemaCache }).schemaCache,
+        forestServerUrl: 'https://api.forestadmin.com',
+      });
+      mockAction.execute.mockResolvedValue({ success: 'done' });
+
+      await portWithServer.executeAction(
+        { collection: 'users', action: 'sendEmail', id: [1] },
+        user,
+      );
+
+      expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
+        expect.not.objectContaining({ forestServer: expect.anything() }),
+      );
+    });
+
+    it('maps an approval-request creation failure to ApprovalRequestCreationError', async () => {
+      mockAction.execute.mockRejectedValue(
+        new ClientApprovalRequestCreationError(new Error('forest server down')),
+      );
+
+      await expect(
+        port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, user),
+      ).rejects.toBeInstanceOf(ApprovalRequestCreationError);
     });
 
     it('should call execute with empty recordIds when ids is not provided', async () => {

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -762,7 +762,7 @@ describe('AgentClientAgentPort', () => {
           action: 'sendEmail',
           id: [1],
         },
-        user,
+        { user },
       );
 
       expect(mockCollection.action).toHaveBeenCalledWith('sendEmail', { recordIds: [[1]] });
@@ -778,7 +778,7 @@ describe('AgentClientAgentPort', () => {
 
       const result = await port.executeAction(
         { collection: 'users', action: 'sendEmail', id: [1] },
-        user,
+        { user },
       );
 
       expect(result).toEqual({ approvalRequested: true, approvalRequest: { id: 'req_42' } });
@@ -795,8 +795,7 @@ describe('AgentClientAgentPort', () => {
 
       await portWithServer.executeAction(
         { collection: 'users', action: 'sendEmail', id: [1] },
-        user,
-        'server-token',
+        { user, forestServerToken: 'server-token' },
       );
 
       expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
@@ -821,7 +820,7 @@ describe('AgentClientAgentPort', () => {
 
       await portWithServer.executeAction(
         { collection: 'users', action: 'sendEmail', id: [1] },
-        user,
+        { user },
       );
 
       expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
@@ -835,14 +834,14 @@ describe('AgentClientAgentPort', () => {
       );
 
       await expect(
-        port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, user),
+        port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, { user }),
       ).rejects.toBeInstanceOf(ApprovalRequestCreationError);
     });
 
     it('should call execute with empty recordIds when ids is not provided', async () => {
       mockAction.execute.mockResolvedValue(undefined);
 
-      await port.executeAction({ collection: 'users', action: 'archive' }, user);
+      await port.executeAction({ collection: 'users', action: 'archive' }, { user });
 
       expect(mockCollection.action).toHaveBeenCalledWith('archive', { recordIds: [] });
       expect(mockAction.execute).toHaveBeenCalled();
@@ -852,7 +851,7 @@ describe('AgentClientAgentPort', () => {
       mockAction.execute.mockRejectedValue(new Error('Action failed'));
 
       await expect(
-        port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, user),
+        port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, { user }),
       ).rejects.toThrow('Action failed');
     });
 
@@ -861,7 +860,7 @@ describe('AgentClientAgentPort', () => {
 
       await port.executeAction(
         { collection: 'users', action: 'refund', id: [1], values: { amount: 50 } },
-        user,
+        { user },
       );
 
       expect(mockAction.setFields).toHaveBeenCalledWith({ amount: 50 });
@@ -874,7 +873,7 @@ describe('AgentClientAgentPort', () => {
       await expect(
         port.executeAction(
           { collection: 'users', action: 'refund', id: [1], values: { x: 1 } },
-          user,
+          { user },
         ),
       ).rejects.toBeInstanceOf(ActionFormValidationError);
       expect(mockAction.execute).not.toHaveBeenCalled();
@@ -884,7 +883,7 @@ describe('AgentClientAgentPort', () => {
       mockAction.execute.mockRejectedValue(new ClientApprovalError('Needs approval', [7, 9]));
 
       const error = await port
-        .executeAction({ collection: 'users', action: 'refund', id: [1] }, user)
+        .executeAction({ collection: 'users', action: 'refund', id: [1] }, { user })
         .catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ActionRequiresApprovalError);
@@ -895,7 +894,7 @@ describe('AgentClientAgentPort', () => {
       mockAction.execute.mockRejectedValue(new ClientFormValidationError('invalid'));
 
       await expect(
-        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),
+        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, { user }),
       ).rejects.toBeInstanceOf(ActionFormValidationError);
     });
 
@@ -905,7 +904,7 @@ describe('AgentClientAgentPort', () => {
       );
 
       await expect(
-        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, user),
+        port.executeAction({ collection: 'users', action: 'refund', id: [1] }, { user }),
       ).rejects.toBeInstanceOf(AgentPortError);
     });
   });
@@ -1029,7 +1028,7 @@ describe('AgentClientAgentPort', () => {
         schemaCache,
       });
 
-      await customPort.executeAction({ collection: 'users', action: 'refund', id: [1] }, user);
+      await customPort.executeAction({ collection: 'users', action: 'refund', id: [1] }, { user });
 
       expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1049,7 +1048,7 @@ describe('AgentClientAgentPort', () => {
 
     it('falls back to neutral hooks/fields when the schema omits them', async () => {
       // Default schema in beforeEach has no hooks/fields on actions.
-      await port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, user);
+      await port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, { user });
 
       expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -965,6 +965,15 @@ describe('AgentClientAgentPort', () => {
       expect(form.requiredFields).toEqual([]);
       expect(mockAction.tryToSetFields).not.toHaveBeenCalled();
     });
+
+    it('builds the form against no record when the id is omitted (global action)', async () => {
+      mockAction.getFields.mockReturnValue([]);
+
+      await port.getActionForm({ collection: 'users', action: 'archive' }, user);
+
+      // Parity with executeAction: a global action carries no recordId.
+      expect(mockCollection.action).toHaveBeenCalledWith('archive', { recordIds: [] });
+    });
   });
 
   describe('getActionFormInfo', () => {

--- a/packages/workflow-executor/test/adapters/step-outcome-to-update-step-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-outcome-to-update-step-mapper.test.ts
@@ -119,6 +119,36 @@ describe('toUpdateStepRequest', () => {
     expect(body.executionStatus).toEqual({ type: 'success' });
   });
 
+  it('forwards approvalRequest in the context for a pending-approval record outcome', () => {
+    const outcome: StepOutcome = {
+      type: 'record',
+      stepId: 'step-1',
+      stepIndex: 1,
+      status: 'success',
+      approvalRequest: { id: 'req_42' },
+    };
+
+    const body = toUpdateStepRequest('42', outcome);
+
+    expect(body.stepUpdate.attributes.context).toEqual({
+      status: 'success',
+      approvalRequest: { id: 'req_42' },
+    });
+  });
+
+  it('omits approvalRequest from the context when the record outcome has none', () => {
+    const outcome: StepOutcome = {
+      type: 'record',
+      stepId: 'step-1',
+      stepIndex: 1,
+      status: 'success',
+    };
+
+    const body = toUpdateStepRequest('42', outcome);
+
+    expect(body.stepUpdate.attributes.context).not.toHaveProperty('approvalRequest');
+  });
+
   it('maps an mcp awaiting-input outcome like a record', () => {
     const outcome: StepOutcome = {
       type: 'mcp',

--- a/packages/workflow-executor/test/build-workflow-executor.test.ts
+++ b/packages/workflow-executor/test/build-workflow-executor.test.ts
@@ -88,6 +88,7 @@ describe('buildInMemoryExecutor', () => {
       agentUrl: 'http://localhost:3310',
       authSecret: 'test-secret',
       schemaCache: expect.any(SchemaCache),
+      forestServerUrl: 'https://api.forestadmin.com',
     });
   });
 

--- a/packages/workflow-executor/test/executors/agent-with-log.test.ts
+++ b/packages/workflow-executor/test/executors/agent-with-log.test.ts
@@ -257,8 +257,7 @@ describe('AgentWithLog', () => {
 
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'send-email', id: [42] },
-        expect.objectContaining({ id: 1 }),
-        'server-token',
+        { user: expect.objectContaining({ id: 1 }), forestServerToken: 'server-token' },
       );
     });
   });

--- a/packages/workflow-executor/test/executors/agent-with-log.test.ts
+++ b/packages/workflow-executor/test/executors/agent-with-log.test.ts
@@ -245,6 +245,22 @@ describe('AgentWithLog', () => {
         expect.objectContaining({ action: 'action', type: 'write', recordId: [42] }),
       );
     });
+
+    it('forwards the forestServerToken to the port (enables approval-request creation)', async () => {
+      const { deps, agentPort } = makeDeps({ forestServerToken: 'server-token' });
+      const agent = new AgentWithLog(deps);
+
+      await agent.executeAction(
+        { collection: 'customers', action: 'send-email', id: [42] },
+        { beforeCall: async () => undefined },
+      );
+
+      expect(agentPort.executeAction).toHaveBeenCalledWith(
+        { collection: 'customers', action: 'send-email', id: [42] },
+        expect.objectContaining({ id: 1 }),
+        'server-token',
+      );
+    });
   });
 
   describe('getActionFormInfo (unaudited passthrough)', () => {

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -47,7 +47,7 @@ function makeMockAgentPort(): AgentPort {
     getRecord: jest.fn(),
     updateRecord: jest.fn(),
     getRelatedData: jest.fn(),
-    executeAction: jest.fn().mockResolvedValue(undefined),
+    executeAction: jest.fn().mockResolvedValue({ result: undefined }),
     getActionFormInfo: jest.fn().mockResolvedValue({ hasForm: false }),
     // Default: a formless action (no fields) — matches the prior behavior of most tests.
     getActionForm: jest
@@ -207,7 +207,9 @@ describe('TriggerRecordActionStepExecutor', () => {
   describe('executionType=FullyAutomated: trigger direct (Branch B)', () => {
     it('triggers the action and returns success', async () => {
       const agentPort = makeMockAgentPort();
-      (agentPort.executeAction as jest.Mock).mockResolvedValue({ message: 'Email sent' });
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({
+        result: { message: 'Email sent' },
+      });
       const mockModel = makeMockModel({
         actionName: 'Send Welcome Email',
         reasoning: 'User requested welcome email',
@@ -227,6 +229,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'send-welcome-email', id: [42] },
         expect.objectContaining({ id: 1 }),
+        undefined,
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -245,12 +248,99 @@ describe('TriggerRecordActionStepExecutor', () => {
         }),
       );
     });
+
+    it('files an approval request (non-blocking success) when the action is approval-gated', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({
+        approvalRequested: true,
+        approvalRequest: { id: 'req_42' },
+      });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      // Non-blocking: the run continues (success), not awaiting-input.
+      expect(result.stepOutcome).toEqual(
+        expect.objectContaining({ status: 'success', approvalRequest: { id: 'req_42' } }),
+      );
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({
+          executionResult: {
+            success: true,
+            submissionOutcome: 'pending-approval',
+            submittedBy: 'ai',
+            approvalRequest: { id: 'req_42' },
+          },
+        }),
+      );
+      // No action result was produced — the action did not execute.
+      const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)![1];
+      expect('actionResult' in saved.executionResult).toBe(false);
+    });
+
+    it('records pending-approval without an id when the server returned none', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ approvalRequested: true });
+      const runStore = makeMockRunStore();
+      const context = makeContext({
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect('approvalRequest' in result.stepOutcome).toBe(false);
+      const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)![1];
+      expect(saved.executionResult.submissionOutcome).toBe('pending-approval');
+      expect('approvalRequest' in saved.executionResult).toBe(false);
+    });
+
+    it('rebuilds the approval outcome on idempotent replay (phase=done)', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'trigger-action',
+            stepIndex: 0,
+            idempotencyPhase: 'done',
+            executionResult: {
+              success: true,
+              submissionOutcome: 'pending-approval',
+              submittedBy: 'ai',
+              approvalRequest: { id: 'req_42' },
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({
+        agentPort,
+        runStore,
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome).toEqual(
+        expect.objectContaining({ status: 'success', approvalRequest: { id: 'req_42' } }),
+      );
+      // Replay must NOT re-trigger the action.
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
   });
 
   describe('operation activity log', () => {
     it('logs the action against the acted record and its collection, not the trigger', async () => {
       const agentPort = makeMockAgentPort();
-      (agentPort.executeAction as jest.Mock).mockResolvedValue({ ok: true });
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
       const activityLogPort = {
         createPending: jest.fn().mockResolvedValue({ id: 'log-1', index: '0' }),
         markSucceeded: jest.fn().mockResolvedValue(undefined),
@@ -328,7 +418,7 @@ describe('TriggerRecordActionStepExecutor', () => {
         ]),
       });
       const agentPort = makeMockAgentPort();
-      (agentPort.executeAction as jest.Mock).mockResolvedValue({ ok: true });
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
       const activityLogPort = {
         createPending: jest.fn().mockResolvedValue({ id: 'log-1', index: '0' }),
         markSucceeded: jest.fn().mockResolvedValue(undefined),
@@ -689,7 +779,7 @@ describe('TriggerRecordActionStepExecutor', () => {
     it('fills every required field then submits the action with the AI values', async () => {
       const agentPort = makeMockAgentPort();
       mockFillThenComplete(agentPort);
-      (agentPort.executeAction as jest.Mock).mockResolvedValue({ success: 'ok' });
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { success: 'ok' } });
       const runStore = makeMockRunStore();
 
       const result = await new TriggerRecordActionStepExecutor(
@@ -700,6 +790,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'send-welcome-email', values: { amount: 50 } }),
         expect.anything(),
+        undefined,
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -930,6 +1021,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'archive', id: [42] },
         expect.objectContaining({ id: 1 }),
+        undefined,
       );
     });
 
@@ -960,6 +1052,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'archive', id: [42] },
         expect.objectContaining({ id: 1 }),
+        undefined,
       );
     });
   });
@@ -1333,6 +1426,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'send-welcome-email' }),
         context.user,
+        undefined,
       );
       // Pre-recorded reference is the technical name; the persisted displayName is resolved
       // from the schema, not received on the wire.
@@ -1417,6 +1511,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'archive' }),
         context.user,
+        undefined,
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -1591,6 +1686,7 @@ describe('TriggerRecordActionStepExecutor', () => {
           id: [42],
         }),
         context.user,
+        undefined,
       );
     });
 

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -278,6 +278,54 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect('id' in query).toBe(false);
     });
 
+    it('builds the form without a record id for a global action', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.getActionForm as jest.Mock)
+        .mockResolvedValueOnce({
+          fields: [{ name: 'amount', type: 'Number', isRequired: true }],
+          canExecute: false,
+          requiredFields: ['amount'],
+          skippedFields: [],
+        })
+        .mockResolvedValueOnce({
+          fields: [{ name: 'amount', type: 'Number', isRequired: true, value: 50 }],
+          canExecute: true,
+          requiredFields: [],
+          skippedFields: [],
+        });
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const context = makeContext({
+        model: makeMockModel({ values: { amount: 50 } }, 'fill_action_form').model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            actions: [
+              {
+                name: 'send-welcome-email',
+                displayName: 'Send Welcome Email',
+                endpoint: '/forest/actions/send-welcome-email',
+                type: 'global',
+              },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+
+      await new TriggerRecordActionStepExecutor(context).execute();
+
+      // Both the detection call and the AI-fill re-fetch must build the form against no record.
+      const { calls } = (agentPort.getActionForm as jest.Mock).mock;
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+      calls.forEach(([formQuery]) => expect('id' in formQuery).toBe(false));
+    });
+
     it('files an approval request (non-blocking success) when the action is approval-gated', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.executeAction as jest.Mock).mockResolvedValue({

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -228,8 +228,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'send-welcome-email', id: [42] },
-        expect.objectContaining({ id: 1 }),
-        undefined,
+        { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -819,8 +818,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'send-welcome-email', values: { amount: 50 } }),
-        expect.anything(),
-        undefined,
+        { user: expect.anything(), forestServerToken: undefined },
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -1050,8 +1048,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'archive', id: [42] },
-        expect.objectContaining({ id: 1 }),
-        undefined,
+        { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
     });
 
@@ -1081,8 +1078,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         { collection: 'customers', action: 'archive', id: [42] },
-        expect.objectContaining({ id: 1 }),
-        undefined,
+        { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
     });
   });
@@ -1455,8 +1451,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(mockModel.bindTools).not.toHaveBeenCalled();
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'send-welcome-email' }),
-        context.user,
-        undefined,
+        { user: context.user, forestServerToken: undefined },
       );
       // Pre-recorded reference is the technical name; the persisted displayName is resolved
       // from the schema, not received on the wire.
@@ -1540,8 +1535,7 @@ describe('TriggerRecordActionStepExecutor', () => {
       // Triggers action A ('archive'), not action B ('send' / displayName 'archive').
       expect(agentPort.executeAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'archive' }),
-        context.user,
-        undefined,
+        { user: context.user, forestServerToken: undefined },
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
         'run-1',
@@ -1715,8 +1709,7 @@ describe('TriggerRecordActionStepExecutor', () => {
           action: 'send-welcome-email',
           id: [42],
         }),
-        context.user,
-        undefined,
+        { user: context.user, forestServerToken: undefined },
       );
     });
 

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -249,6 +249,36 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
+    it('does NOT attach a record when the action is global', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const context = makeContext({
+        agentPort,
+        // The selected action is global → it runs on no record.
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            actions: [
+              {
+                name: 'send-welcome-email',
+                displayName: 'Send Welcome Email',
+                endpoint: '/forest/actions/send-welcome-email',
+                type: 'global',
+              },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // The query carries no `id` for a global action.
+      const query = (agentPort.executeAction as jest.Mock).mock.calls[0][0];
+      expect(query).toEqual({ collection: 'customers', action: 'send-welcome-email' });
+      expect('id' in query).toBe(false);
+    });
+
     it('files an approval request (non-blocking success) when the action is approval-gated', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.executeAction as jest.Mock).mockResolvedValue({

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -440,6 +440,38 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(agentPort.executeAction).not.toHaveBeenCalled();
     });
 
+    it('warns and rebuilds success on replay of a pending-approval step with no approval id', async () => {
+      const logger = jest.fn();
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'trigger-action',
+            stepIndex: 0,
+            idempotencyPhase: 'done',
+            executionResult: {
+              success: true,
+              submissionOutcome: 'pending-approval',
+              submittedBy: 'ai',
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({ agentPort, runStore, logger });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(result.stepOutcome).not.toHaveProperty('approvalRequest');
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        expect.stringContaining('no approval id'),
+        expect.anything(),
+      );
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
+
     it('rebuilds a success outcome on replay (phase=done) when the step was skipped', async () => {
       const runStore = makeMockRunStore({
         getStepExecutions: jest.fn().mockResolvedValue([

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -412,6 +412,55 @@ describe('TriggerRecordActionStepExecutor', () => {
       // Replay must NOT re-trigger the action.
       expect(agentPort.executeAction).not.toHaveBeenCalled();
     });
+
+    it('rebuilds an executed outcome on replay (phase=done) without an approvalRequest', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'trigger-action',
+            stepIndex: 0,
+            idempotencyPhase: 'done',
+            executionResult: {
+              success: true,
+              submissionOutcome: 'executed',
+              submittedBy: 'ai',
+              actionResult: { ok: true },
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({ agentPort, runStore });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(result.stepOutcome).not.toHaveProperty('approvalRequest');
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
+
+    it('rebuilds a success outcome on replay (phase=done) when the step was skipped', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'trigger-action',
+            stepIndex: 0,
+            idempotencyPhase: 'done',
+            executionResult: { skipped: true },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({ agentPort, runStore });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(result.stepOutcome).not.toHaveProperty('approvalRequest');
+      expect(agentPort.executeAction).not.toHaveBeenCalled();
+    });
   });
 
   describe('operation activity log', () => {

--- a/packages/workflow-executor/test/integration/workflow-execution.test.ts
+++ b/packages/workflow-executor/test/integration/workflow-execution.test.ts
@@ -166,7 +166,7 @@ function createMockAgentPort(): jest.Mocked<AgentPort> {
     getRelatedData: jest.fn().mockResolvedValue([]),
     getSingleRelatedData: jest.fn().mockResolvedValue(null),
     resolvePolymorphicType: jest.fn().mockResolvedValue(null),
-    executeAction: jest.fn().mockResolvedValue(undefined),
+    executeAction: jest.fn().mockResolvedValue({ result: undefined }),
     getActionFormInfo: jest.fn().mockResolvedValue({ hasForm: false }),
     getActionForm: jest
       .fn()

--- a/packages/workflow-executor/test/runner.test.ts
+++ b/packages/workflow-executor/test/runner.test.ts
@@ -1255,6 +1255,7 @@ describe('chain', () => {
       expect.anything(),
       expect.any(Function),
       { userConfirmed: true },
+      'token-0',
     );
     expect(createSpy).toHaveBeenNthCalledWith(
       2,
@@ -1263,6 +1264,7 @@ describe('chain', () => {
       expect.anything(),
       expect.any(Function),
       undefined,
+      'token-1',
     );
 
     createSpy.mockRestore();
@@ -2350,6 +2352,7 @@ describe('triggerPoll with options', () => {
       expect.anything(),
       expect.any(Function),
       { userConfirmed: true, value: 'new' },
+      'test-forest-token',
     );
 
     createSpy.mockRestore();
@@ -2379,6 +2382,7 @@ describe('triggerPoll with options', () => {
       expect.anything(),
       expect.any(Function),
       undefined,
+      'test-forest-token',
     );
 
     createSpy.mockRestore();


### PR DESCRIPTION
## Context

**PRD-688** (backend / executor half, single PR per repo). In the legacy browser engine, triggering an approval-gated action created the approval on the frontend. With the backend migration, **Automatic & Full AI** Trigger Action steps run on the executor, which didn't create the approval — a regression. This PR makes the executor file the approval request (non-blocking) and handles action scope correctly.

## What it does

1. **Create the approval request** when the triggering user's role requires it — instead of executing — and report the step as **`success`** (the run continues; the process owner adds an explicit stop if needed). The created approval id is forwarded to the front via the `StepOutcome` (`context.approvalRequest.id`) so it can deep-link.
2. **Global actions carry no record.** A global action runs on no record, so the executor no longer attaches its source record (the approval would otherwise show a nonsensical Resource). Single/bulk actions keep their record. Relies on the action `type` forwarded by the orchestrator (ForestAdmin/forestadmin-server#8344); degrades safely if absent.
3. **Approval-creation failure** → step `error` with a dedicated `ApprovalRequestCreationError`.

## Key changes

- **agent-client**: `makeCreateApprovalRequest` returns the created approval id (defensive extraction); `Action.execute()` bubbles `{ approvalRequested, approvalRequest }`.
- **workflow-executor**: wire `forestServer` (per-step `forestServerToken` threaded runner → factory → AgentWithLog → port); typed `ExecuteActionResult`; the trigger-action executor branches on approval (persists `pending-approval`, no `actionResult`), omits the record for global actions, reconstructs the approval id on idempotent replay; outcome + update-step mapper carry `approvalRequest`.

## Architecture note

`approvalRequest` is contained to the trigger-action executor: a dedicated `buildOutcomeResult` override (mirroring condition's `selectedOption`), not the shared base/record builders. The action-scope decision stays in the executor and reduces to "id present or not" at the port boundary — lower layers stay generic.

## Verification

agent-client (340) · mcp-server (547) · workflow-executor (1131) tests pass; build + lint clean.

Frontend half: ForestAdmin/forestadmin#9804. Orchestrator (forwards action `type`): ForestAdmin/forestadmin-server#8344.

fixes PRD-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add approval request handling for Full AI and Automatic trigger actions
> - When an action requires approval, `TriggerRecordActionStepExecutor` now persists a `pending-approval` result and returns a success outcome instead of blocking, optionally including the approval request id for deep-linking.
> - `AgentClientAgentPort.executeAction` returns a normalized `ExecuteActionResult` union distinguishing executed results from approval-gated submissions, and wires Forest server connectivity when a `forestServerToken` is provided.
> - Global actions (type `'global'`) are now supported: record id is omitted when building forms and executing actions.
> - Idempotent replay of completed `pending-approval` steps restores the saved `approvalRequest` id without re-triggering execution.
> - The `forestServerToken` is propagated from each dispatch through `Runner` → `StepExecutorFactory` → `AgentWithLog` → `AgentClientAgentPort` to enable approval request creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized baa7964.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->