### PR TITLE
docs(workflow-executor): document OpenTelemetry APM in the Docker image

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -48,6 +48,32 @@ docker run -d \
 
 > **Note:** When the executor runs in Docker and your agent runs on the host machine, use `host.docker.internal` instead of `localhost` in `AGENT_URL` and `DATABASE_URL`.
 
+### Observability (OpenTelemetry)
+
+The Docker image ships with [OpenTelemetry](https://opentelemetry.io/) APM built in, and works with any OTLP-compatible backend (Datadog, Grafana Tempo, Jaeger, Honeycomb, etc.). It is **off by default** and turns on automatically as soon as you point it at an OTLP receiver — no code changes or extra installs required. Tracing is set up before the app starts (auto-instrumentation for HTTP, Postgres, etc.) and buffered spans are flushed on graceful shutdown.
+
+Configure it entirely through the standard OTel environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP receiver URL (e.g. `http://collector:4318`). **Tracing stays disabled until this is set.** |
+| `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-workflow-executor`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production,version=1.7.0`. |
+| `OTEL_SDK_DISABLED` | Set to `true` to force-disable tracing even when an endpoint is configured. |
+
+```bash
+docker run -d \
+  -e FOREST_ENV_SECRET="your-env-secret" \
+  -e FOREST_AUTH_SECRET="your-auth-secret" \
+  -e AGENT_URL="http://host.docker.internal:3351" \
+  -e DATABASE_URL="postgres://user:pass@host.docker.internal:5432/mydb" \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT="http://collector:4318" \
+  -p 3400:3400 \
+  ghcr.io/forestadmin/workflow-executor:latest
+```
+
+> **Note:** OpenTelemetry is bundled only in the Docker image. It is not shipped with the npm package (`npx @forestadmin/workflow-executor`).
+
 ---
 
 ## Without Docker


### PR DESCRIPTION
## Summary

The Docker image bundles OpenTelemetry APM (loaded via `--require dist/tracing.js` in the entrypoint, a no-op until `OTEL_EXPORTER_OTLP_ENDPOINT` is set), but the README said nothing about it. This adds an **Observability (OpenTelemetry)** section under the Docker part, consistent with the OTel block already in `.env.example`.

## Changes

- Documents that OTel is built into the Docker image, off by default, and enabled by pointing it at an OTLP receiver.
- Tabulates the four standard env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`) with defaults/behavior.
- Adds a `docker run` example enabling tracing.
- Notes that OTel is Docker-only — not shipped with the npm CLI.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document OpenTelemetry APM environment variables in the workflow-executor Docker image
> Adds an 'Observability (OpenTelemetry)' section to [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1721/files#diff-84aa4115ae7aaddeae8ef0aa0f2f1fae55b5692e9eb4340a0ec43f2c3c3c0b3b) covering the built-in OpenTelemetry APM available in the Docker image. Documents `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `OTEL_SDK_DISABLED` environment variables, and includes a `docker run` example. Notes that OpenTelemetry is bundled only in the Docker image, not in the npm package.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1e3fb1b. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->