### PR TITLE
fix(agent-client): attach role_ids_allowed_to_approve to approval requests [PRD-688]

### DIFF
--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -7,6 +7,7 @@ export type ApprovalRequestPayload = {
   actionName: string;
   recordIds: (string | number)[];
   inputs: ApprovalRequestInput[];
+  roleIdsAllowedToApprove?: number[];
 };
 
 export type CreateApprovalRequest = (
@@ -56,6 +57,7 @@ export default function makeCreateApprovalRequest(options: {
             collection_name: payload.collectionName,
             record_ids: payload.recordIds,
             inputs: payload.inputs,
+            role_ids_allowed_to_approve: payload.roleIdsAllowedToApprove,
           },
         },
       },

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -161,6 +161,7 @@ export default class Action {
             actionName: this.actionName,
             recordIds: this.ids ?? [],
             inputs,
+            roleIdsAllowedToApprove: mapped.roleIdsAllowedToApprove,
           });
         } catch (cause) {
           throw new ApprovalRequestCreationError(cause);

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -23,6 +23,7 @@ describe('makeCreateApprovalRequest', () => {
       actionName: 'refund',
       recordIds: ['1', '2'],
       inputs: [{ name: 'reason', type: 'String', value: 'fraud' }],
+      roleIdsAllowedToApprove: [7, 9],
     });
 
     expect(queryWithBearerToken).toHaveBeenCalledWith({
@@ -40,6 +41,7 @@ describe('makeCreateApprovalRequest', () => {
             collection_name: 'users',
             record_ids: ['1', '2'],
             inputs: [{ name: 'reason', type: 'String', value: 'fraud' }],
+            role_ids_allowed_to_approve: [7, 9],
           },
         },
       },

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -180,6 +180,7 @@ describe('Action', () => {
         actionName: 'send-email',
         recordIds: ['1', '2'],
         inputs: [{ name: 'email', type: 'String', value: 'test@example.com' }],
+        roleIdsAllowedToApprove: [7, 9],
       });
       expect(result).toEqual({ approvalRequested: true });
     });


### PR DESCRIPTION
## Problem

Approvals filed programmatically (MCP server `executeAction`, and the workflow executor) show up in Forest **without an attached resource** — the created approval is malformed.

## Root cause

The Forest server's `POST /api/action-approvals` expects `role_ids_allowed_to_approve` in the payload — the browser engine always sends it (`store.createRecord('action-approval', { …, roleIdsAllowedToApprove })`). The agent-client **already extracts** `roleIdsAllowedToApprove` from the `403 CustomActionRequiresApprovalError` (`domains/action.ts` `toActionError`) but discarded it instead of forwarding it to `createApprovalRequest`. The resulting payload was missing that field.

## Fix

- `ApprovalRequestPayload` gains `roleIdsAllowedToApprove?`.
- `makeCreateApprovalRequest` sends `role_ids_allowed_to_approve` in the JSON:API attributes (alongside `record_ids` / `collection_name` / `inputs`), matching the browser-engine payload.
- `Action.execute()` forwards the value it already has from the mapped `ActionRequiresApprovalError`.

This is the only field that differed from the working browser-engine payload (verified against `forestadmin` `action-approval` model + `custom-action` service). `record_ids` was already correct (`Collection.action` serializes ids via `serializeRecordId`).

## Notes

- Stacked on **#1720** (the backend PRD-688 PR), which this depends on. Base will retarget to `main` once #1720 merges.
- Fixes both the MCP and workflow-executor approval paths (shared agent-client code).

Tests: agent-client (340) + mcp-server (547) pass; build + lint clean.

Refs PRD-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attach `role_ids_allowed_to_approve` to approval request payloads in agent-client
> Adds the optional `roleIdsAllowedToApprove` field to `ApprovalRequestPayload` in [approval-request-creator.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1722/files#diff-d704b87d3695fab8dc0e87cffe034c6b4f9c82b7a4b8b1fdf42b7e9cbcf3c694) and maps it to `role_ids_allowed_to_approve` in the POST body sent to `/api/action-approvals`. The `Action.execute` method in [action.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1722/files#diff-c434b5b3c0debe1a1c3629c2828238cc6ab1609dce58c3b2f6dae384ef677b81) now forwards this field when constructing the approval request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afa0ce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->