### PR TITLE
fix(workflow-executor): no record on a global action's approval [PRD-688]

### DIFF
--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -42,6 +42,9 @@ Important rules:
 
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
+  // A global action runs on no record — the executor must not attach one (record_ids stays empty,
+  // so an approval request it triggers isn't wrongly linked to a record).
+  isGlobal?: boolean;
 }
 
 export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<TriggerActionStepDefinition> {
@@ -146,6 +149,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       selectedRecordRef,
       displayName: action.displayName,
       name: action.name,
+      isGlobal: action.type === 'global',
     };
 
     const form = await this.context.agent.getActionForm({
@@ -363,7 +367,9 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       {
         collection: selectedRecordRef.collectionName,
         action: name,
-        id: selectedRecordRef.recordId,
+        // A global action runs on no record: omit the id so it isn't attached (notably to the
+        // approval request it may trigger). Single/bulk actions keep their record.
+        ...(target.isGlobal ? {} : { id: selectedRecordRef.recordId }),
         ...(form && { values: form.values }),
       },
       {

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -72,6 +72,9 @@ export const ActionSchemaSchema = z.object({
   name: z.string().min(1),
   displayName: z.string().min(1),
   endpoint: z.string().min(1),
+  // Action scope. Optional for resilience to orchestrator drift; a 'global' action runs on no
+  // record, so the executor must not attach one (e.g. to an approval request).
+  type: z.enum(['single', 'bulk', 'global']).optional(),
   /** Static form fields. Used as fallback when the agent's /hooks/load route 404s (old Ruby agents). */
   fields: ActionFieldsSchema,
   /** Action lifecycle hooks. Drives agent-client's dynamic form loading. */

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -249,6 +249,36 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
+    it('does NOT attach a record when the action is global', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const context = makeContext({
+        agentPort,
+        // The selected action is global → it runs on no record.
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            actions: [
+              {
+                name: 'send-welcome-email',
+                displayName: 'Send Welcome Email',
+                endpoint: '/forest/actions/send-welcome-email',
+                type: 'global',
+              },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({ executionType: StepExecutionMode.FullyAutomated }),
+      });
+
+      const result = await new TriggerRecordActionStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // The query carries no `id` for a global action.
+      const query = (agentPort.executeAction as jest.Mock).mock.calls[0][0];
+      expect(query).toEqual({ collection: 'customers', action: 'send-welcome-email' });
+      expect('id' in query).toBe(false);
+    });
+
     it('files an approval request (non-blocking success) when the action is approval-gated', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.executeAction as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Problem

A workflow Trigger Action step that triggers a **global** action (one that runs on no record, e.g. "Create new card") was attaching the step's **source record** to the action — so the approval request it files showed a Resource (#3, #4…) that makes no sense for a global action. (The standalone MCP path is already fine: the AI passes no record for a global action.)

## Fix

The executor now reads the action **scope** and omits the record for global actions:
- `types/validated/collection.ts`: `ActionSchema.type` (`'single'|'bulk'|'global'`, optional — resilient to orchestrator drift).
- `trigger-record-action-step-executor.ts`: don't pass `id` when `action.type === 'global'`. Single/bulk actions keep their record.

The `type` is forwarded by the orchestrator in **ForestAdmin/forestadmin-server#8344** (companion PR). If an older orchestrator doesn't send it, `type` is `undefined` → current behavior (no regression).

## Notes

- Stacked on **#1720** (the backend PRD-688 PR) since it shares `trigger-record-action-step-executor.ts`. Retarget to `main` once #1720 merges.
- Tests: full workflow-executor suite passes (1131); added a case asserting no `id` is sent for a global action.

Refs PRD-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix approval record attachment for global actions in workflow executor
> - Global actions run on no record, but the executor was incorrectly attaching a record `id` when calling `agent.executeAction`.
> - Adds an optional `isGlobal` flag to `ActionTarget` and an optional `type` field (`'single' | 'bulk' | 'global'`) to `ActionSchemaSchema` in [collection.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1723/files#diff-b531cab4040638c8075825f7fe7c720b2b72d92f56ff849bff39f9e0824ab2bd).
> - In [trigger-record-action-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1723/files#diff-d2cc1c8cf87052768298283a3ec60c3a7a7bb5cda0accee051a14d2053682439), when `action.type === 'global'`, the `id` field is omitted from the `executeAction` call; single and bulk actions are unchanged.
>
> #### 🖇️ Linked Issues
> Fixes [PRD-688](ticket:linear/PRD-688).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f05e549. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->