### PR TITLE
docs(workflow-executor): document FOREST_EXECUTOR_ENCRYPTION_KEY

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -128,6 +128,20 @@ npx @forestadmin/workflow-executor
 
 ---
 
+## OAuth-protected MCP connectors
+
+When your workflows use OAuth-protected MCP connectors, the executor stores each user's OAuth credentials in its database, encrypted at rest. Provide the encryption key the same way as the other secrets (in `.env`, or with `-e` on `docker run`):
+
+| Variable | Description |
+| --- | --- |
+| `FOREST_EXECUTOR_ENCRYPTION_KEY` | At-rest encryption key (AES-256-GCM) for the OAuth credentials the executor stores. Generate with `openssl rand -hex 32`. Use a **separate** secret from `FOREST_AUTH_SECRET`. The value isn't validated, so use a genuinely random secret. |
+
+- **Required only for OAuth-protected MCP connectors**, and read lazily — an executor that stores no such credentials boots and runs fine without it.
+- **Use the same value on every instance that shares a database.** Otherwise an instance cannot decrypt credentials stored by another.
+- **Treat it as permanent: there is no managed rotation.** Changing it forces every affected user to reconnect their OAuth-protected MCP connectors.
+
+---
+
 ## Testing only
 
 The following modes skip the database requirement but are **not suitable for production** — state is lost on restart.


### PR DESCRIPTION
## What

Documents `FOREST_EXECUTOR_ENCRYPTION_KEY` in the workflow-executor README — a new **"OAuth-protected MCP connectors"** section covering:

- what it encrypts (the OAuth credentials the executor stores, AES-256-GCM at rest)
- how to generate it (`openssl rand -hex 32`) and to keep it separate from `FOREST_AUTH_SECRET`
- using the **same** value across instances that share a database
- its lazy behaviour (while unset, credential storage returns `503` and those connectors stay unavailable; the executor still boots, with a startup warning)
- no managed rotation — changing it forces affected users to reconnect

It complements the one-line entry already in `.env.example`.

## Why

PRD-626 (the docs half of PRD-367): operators deploying the executor with OAuth-protected MCP connectors need a README reference for this variable.

## Base / merge order

Based on the **PRD-692** branch (`feature/prd-692-harden-executor-oauth-runtime-clear-idempotency-phase-on`, #1724) — the top of the OAuth-MCP executor stack, where `FOREST_EXECUTOR_ENCRYPTION_KEY` and the code that reads it already live. Targeting that branch keeps this diff to just the README change. Intended to **merge last**, once PR1 (#1619), PR2 (#1665) and PRD-692 (#1724) are in.

Replaces docs-site PR ForestAdmin/docs#3 (now closed) — the executor's own README, next to the code and `.env.example`, is the right home for an operator-facing deployment variable (and "executor" isn't a concept on the public docs site).

Refs: PRD-626

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `FOREST_EXECUTOR_ENCRYPTION_KEY` in workflow-executor README
> Adds an 'OAuth-protected MCP connectors' section to [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1725/files#diff-84aa4115ae7aaddeae8ef0aa0f2f1fae55b5692e9eb4340a0ec43f2c3c3c0b3b) explaining how the executor encrypts per-user OAuth credentials at rest using `FOREST_EXECUTOR_ENCRYPTION_KEY`. Covers key generation, the requirement to use a separate secret from `FOREST_AUTH_SECRET`, that the key is only needed when OAuth-protected connectors are in use, and that all instances sharing a database must use the same key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1087b4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->