### PR TITLE
feat(workflow-executor): build database connection from split env vars

### DIFF
--- a/packages/workflow-executor/.env.example
+++ b/packages/workflow-executor/.env.example
@@ -18,6 +18,14 @@ AGENT_URL=
 # container with the --in-memory flag (just removing this line crashes on boot).
 DATABASE_URL=postgres://user:password@host.docker.internal:5432/mydb
 
+# Alternatively, leave DATABASE_URL unset and build the connection from parts.
+# DATABASE_URL takes precedence: when it is set, these are ignored.
+# DATABASE_HOST=host.docker.internal
+# DATABASE_NAME=mydb
+# DATABASE_USER=user
+# DATABASE_PASSWORD=password
+# DATABASE_PORT=5432
+
 # ── Optional ──────────────────────────────────────────────────────────────────
 
 # Connect to the database over TLS. Defaults to true (managed Postgres like AWS

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -96,6 +96,33 @@ Both values are already in your agent's environment variables. `FOREST_ENV_SECRE
 
 `AGENT_URL` is the URL where your Forest Admin agent is running (e.g. `http://localhost:3351`).
 
+### Database connection
+
+The Postgres connection can be provided in two ways. If `DATABASE_URL` is set, it
+is used as-is. Otherwise the executor builds the connection string from individual
+parts — handy when your platform exposes credentials as separate variables:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `DATABASE_HOST` | yes | Database host |
+| `DATABASE_NAME` | yes | Database name |
+| `DATABASE_USER` | yes | Database user |
+| `DATABASE_PASSWORD` | no | Database password |
+| `DATABASE_PORT` | no | Database port (default: `5432`) |
+
+```bash
+FOREST_ENV_SECRET="your-env-secret" \
+FOREST_AUTH_SECRET="your-auth-secret" \
+AGENT_URL="https://your-agent-url" \
+DATABASE_HOST="localhost" \
+DATABASE_NAME="mydb" \
+DATABASE_USER="user" \
+DATABASE_PASSWORD="pass" \
+npx @forestadmin/workflow-executor
+```
+
+`DATABASE_URL` takes precedence: when it is set, the individual parts are ignored.
+
 ---
 
 ## Testing only

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -118,8 +118,11 @@ DATABASE_HOST="localhost" \
 DATABASE_NAME="mydb" \
 DATABASE_USER="user" \
 DATABASE_PASSWORD="pass" \
+DATABASE_SSL="false" \
 npx @forestadmin/workflow-executor
 ```
+
+`DATABASE_SSL` defaults to `true` (managed Postgres requires TLS); set it to `false` for a local database without TLS.
 
 `DATABASE_URL` takes precedence: when it is set, the individual parts are ignored.
 

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -189,8 +189,10 @@ function buildDatabaseUrlFromParts(env: NodeJS.ProcessEnv): string | undefined {
   const port = parsePositiveIntEnv('DATABASE_PORT', DATABASE_PORT) ?? DEFAULT_DATABASE_PORT;
   const user = encodeURIComponent(DATABASE_USER as string);
   const auth = DATABASE_PASSWORD ? `${user}:${encodeURIComponent(DATABASE_PASSWORD)}` : user;
+  const rawHost = DATABASE_HOST as string;
+  const host = rawHost.includes(':') && !rawHost.startsWith('[') ? `[${rawHost}]` : rawHost;
 
-  return `postgres://${auth}@${DATABASE_HOST}:${port}/${DATABASE_NAME}`;
+  return `postgres://${auth}@${host}:${port}/${DATABASE_NAME}`;
 }
 
 function resolveDatabaseUrl(env: NodeJS.ProcessEnv): string | undefined {

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -201,7 +201,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
   const requiredBase = ['FOREST_ENV_SECRET', 'FOREST_AUTH_SECRET', 'AGENT_URL'] as const;
   const missing: string[] = requiredBase.filter(key => !env[key]);
 
-  const databaseUrl = resolveDatabaseUrl(env);
+  const databaseUrl = args.inMemory ? undefined : resolveDatabaseUrl(env);
 
   if (!args.inMemory && !databaseUrl) {
     missing.push(

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -169,12 +169,44 @@ function parseAiConfig(env: NodeJS.ProcessEnv): AiConfiguration[] | undefined {
   ];
 }
 
+const DEFAULT_DATABASE_PORT = 5432;
+const DATABASE_PARTS = ['DATABASE_HOST', 'DATABASE_NAME', 'DATABASE_USER'] as const;
+
+function buildDatabaseUrlFromParts(env: NodeJS.ProcessEnv): string | undefined {
+  const { DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD } = env;
+
+  if (DATABASE_PARTS.every(key => !env[key])) return undefined;
+
+  const missing = DATABASE_PARTS.filter(key => !env[key]);
+
+  if (missing.length > 0) {
+    throw new ConfigurationError(
+      `When DATABASE_URL is not set, the connection is built from parts; ` +
+        `also set: ${missing.join(', ')}.`,
+    );
+  }
+
+  const port = parsePositiveIntEnv('DATABASE_PORT', DATABASE_PORT) ?? DEFAULT_DATABASE_PORT;
+  const user = encodeURIComponent(DATABASE_USER as string);
+  const auth = DATABASE_PASSWORD ? `${user}:${encodeURIComponent(DATABASE_PASSWORD)}` : user;
+
+  return `postgres://${auth}@${DATABASE_HOST}:${port}/${DATABASE_NAME}`;
+}
+
+function resolveDatabaseUrl(env: NodeJS.ProcessEnv): string | undefined {
+  return env.DATABASE_URL || buildDatabaseUrlFromParts(env);
+}
+
 export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig {
   const requiredBase = ['FOREST_ENV_SECRET', 'FOREST_AUTH_SECRET', 'AGENT_URL'] as const;
   const missing: string[] = requiredBase.filter(key => !env[key]);
 
-  if (!args.inMemory && !env.DATABASE_URL) {
-    missing.push('DATABASE_URL (required unless --in-memory)');
+  const databaseUrl = resolveDatabaseUrl(env);
+
+  if (!args.inMemory && !databaseUrl) {
+    missing.push(
+      'DATABASE_URL (or DATABASE_HOST, DATABASE_NAME, DATABASE_USER); required unless --in-memory',
+    );
   }
 
   if (missing.length > 0) {
@@ -205,7 +237,7 @@ export function readEnvConfig(env: NodeJS.ProcessEnv, args: CliArgs): CliConfig 
 
   return {
     executorOptions,
-    databaseUrl: env.DATABASE_URL,
+    databaseUrl,
     // Defaults to true: managed Postgres (RDS, Supabase, Railway…) requires TLS.
     // Set DATABASE_SSL=false for a local/dev database without TLS.
     databaseSsl: parseBooleanEnv('DATABASE_SSL', env.DATABASE_SSL, true),
@@ -230,6 +262,13 @@ Required environment variables:
   FOREST_AUTH_SECRET  JWT signing secret (shared with your agent)
   AGENT_URL           URL of your running Forest Admin agent
   DATABASE_URL        Postgres connection string (not needed with --in-memory)
+
+Database connection (use DATABASE_URL, or build it from parts when it is unset):
+  DATABASE_HOST         Database host
+  DATABASE_NAME         Database name
+  DATABASE_USER         Database user
+  DATABASE_PASSWORD     Database password (optional)
+  DATABASE_PORT         Database port (default: ${DEFAULT_DATABASE_PORT})
 
 Optional environment variables:
   DATABASE_SSL          Connect to the database over TLS (default: true; set "false" for a local DB without TLS)

--- a/packages/workflow-executor/src/cli-core.ts
+++ b/packages/workflow-executor/src/cli-core.ts
@@ -191,8 +191,9 @@ function buildDatabaseUrlFromParts(env: NodeJS.ProcessEnv): string | undefined {
   const auth = DATABASE_PASSWORD ? `${user}:${encodeURIComponent(DATABASE_PASSWORD)}` : user;
   const rawHost = DATABASE_HOST as string;
   const host = rawHost.includes(':') && !rawHost.startsWith('[') ? `[${rawHost}]` : rawHost;
+  const database = encodeURIComponent(DATABASE_NAME as string);
 
-  return `postgres://${auth}@${host}:${port}/${DATABASE_NAME}`;
+  return `postgres://${auth}@${host}:${port}/${database}`;
 }
 
 function resolveDatabaseUrl(env: NodeJS.ProcessEnv): string | undefined {

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -360,6 +360,38 @@ describe('readEnvConfig', () => {
       expect(config.databaseUrl).toBe('postgres://user@[::1]:5432/mydb');
     });
 
+    it('url-encodes special characters in the database name', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'my db/prod',
+          DATABASE_USER: 'user',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user@db.example.com:5432/my%20db%2Fprod');
+    });
+
+    it('treats all-empty parts as absent and reports the missing database vars', () => {
+      expect(() =>
+        readEnvConfig(
+          { ...baseEnvNoUrl, DATABASE_HOST: '', DATABASE_NAME: '', DATABASE_USER: '' },
+          args,
+        ),
+      ).toThrow(/DATABASE_URL \(or DATABASE_HOST, DATABASE_NAME, DATABASE_USER\)/);
+    });
+
+    it('treats a present-but-empty part as absent and throws the some-but-not-all error', () => {
+      expect(() =>
+        readEnvConfig(
+          { ...baseEnvNoUrl, DATABASE_HOST: '', DATABASE_NAME: 'mydb', DATABASE_USER: 'user' },
+          args,
+        ),
+      ).toThrow(/built from parts; also set: DATABASE_HOST/);
+    });
+
     it('url-encodes special characters in the user and password', () => {
       const config = readEnvConfig(
         {
@@ -684,6 +716,29 @@ describe('runCli', () => {
     );
     expect(factories.buildInMemory).not.toHaveBeenCalled();
     expect(executor.start).toHaveBeenCalled();
+  });
+
+  it('passes a URI built from split DB parts through to buildDatabase', async () => {
+    const { factories } = makeFactories();
+    const env = { ...baseEnv };
+    delete env.DATABASE_URL;
+    await runCli(
+      [],
+      {
+        ...env,
+        DATABASE_HOST: 'db.example.com',
+        DATABASE_NAME: 'mydb',
+        DATABASE_USER: 'user',
+        DATABASE_SSL: 'false',
+      },
+      factories,
+    );
+
+    expect(factories.buildDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: { uri: 'postgres://user@db.example.com:5432/mydb' },
+      }),
+    );
   });
 
   it('enables TLS (no cert verification) on the database when DATABASE_SSL=true', async () => {

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -332,6 +332,34 @@ describe('readEnvConfig', () => {
       expect(config.databaseUrl).toBe('postgres://user@db.example.com:5432/mydb');
     });
 
+    it('brackets an IPv6 host so the connection URI is well-formed', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: '2001:db8::1',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user@[2001:db8::1]:5432/mydb');
+    });
+
+    it('does not double-bracket an already-bracketed IPv6 host', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: '[::1]',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user@[::1]:5432/mydb');
+    });
+
     it('url-encodes special characters in the user and password', () => {
       const config = readEnvConfig(
         {

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -390,6 +390,16 @@ describe('readEnvConfig', () => {
         /DATABASE_URL \(or DATABASE_HOST, DATABASE_NAME, DATABASE_USER\)/,
       );
     });
+
+    it('ignores database parts in --in-memory mode and does not throw on partial parts', () => {
+      const config = readEnvConfig(
+        { ...baseEnvNoUrl, DATABASE_HOST: 'db.example.com' },
+        { ...args, inMemory: true },
+      );
+
+      expect(config.mode).toBe('in-memory');
+      expect(config.databaseUrl).toBeUndefined();
+    });
   });
 
   it('builds aiConfigurations when AI vars are set', () => {

--- a/packages/workflow-executor/test/cli.test.ts
+++ b/packages/workflow-executor/test/cli.test.ts
@@ -279,6 +279,119 @@ describe('readEnvConfig', () => {
     expect(() => readEnvConfig({}, { ...args, inMemory: true })).toThrow(/FOREST_ENV_SECRET/);
   });
 
+  describe('database connection from parts', () => {
+    const baseEnvNoUrl = (() => {
+      const env = { ...baseEnv };
+      delete env.DATABASE_URL;
+
+      return env;
+    })();
+
+    it('builds the connection string from parts when DATABASE_URL is unset', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+          DATABASE_PASSWORD: 'pass',
+          DATABASE_PORT: '6543',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user:pass@db.example.com:6543/mydb');
+    });
+
+    it('defaults the port to 5432 when DATABASE_PORT is unset', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+          DATABASE_PASSWORD: 'pass',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user:pass@db.example.com:5432/mydb');
+    });
+
+    it('omits the password segment when DATABASE_PASSWORD is unset', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://user@db.example.com:5432/mydb');
+    });
+
+    it('url-encodes special characters in the user and password', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnvNoUrl,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'u@ser',
+          DATABASE_PASSWORD: 'p@ss:word',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://u%40ser:p%40ss%3Aword@db.example.com:5432/mydb');
+    });
+
+    it('prefers DATABASE_URL over the individual parts when both are set', () => {
+      const config = readEnvConfig(
+        {
+          ...baseEnv,
+          DATABASE_HOST: 'db.example.com',
+          DATABASE_NAME: 'mydb',
+          DATABASE_USER: 'user',
+        },
+        args,
+      );
+
+      expect(config.databaseUrl).toBe('postgres://u:p@localhost:5432/wfe');
+    });
+
+    it('throws ConfigurationError when only some parts are set', () => {
+      expect(() =>
+        readEnvConfig({ ...baseEnvNoUrl, DATABASE_HOST: 'db.example.com' }, args),
+      ).toThrow(ConfigurationError);
+      expect(() =>
+        readEnvConfig({ ...baseEnvNoUrl, DATABASE_HOST: 'db.example.com' }, args),
+      ).toThrow(/DATABASE_NAME, DATABASE_USER/);
+    });
+
+    it('throws ConfigurationError when DATABASE_PORT is non-numeric', () => {
+      expect(() =>
+        readEnvConfig(
+          {
+            ...baseEnvNoUrl,
+            DATABASE_HOST: 'db.example.com',
+            DATABASE_NAME: 'mydb',
+            DATABASE_USER: 'user',
+            DATABASE_PORT: 'abc',
+          },
+          args,
+        ),
+      ).toThrow(/DATABASE_PORT must be a positive integer/);
+    });
+
+    it('reports the missing database vars when neither DATABASE_URL nor parts are set', () => {
+      expect(() => readEnvConfig(baseEnvNoUrl, args)).toThrow(
+        /DATABASE_URL \(or DATABASE_HOST, DATABASE_NAME, DATABASE_USER\)/,
+      );
+    });
+  });
+
   it('builds aiConfigurations when AI vars are set', () => {
     const config = readEnvConfig(
       { ...baseEnv, AI_PROVIDER: 'anthropic', AI_MODEL: 'claude', AI_API_KEY: 'sk-xxx' },


### PR DESCRIPTION
## What

Let the workflow-executor CLI accept the Postgres connection either as a single `DATABASE_URL` **or** as split parts, for clients/platforms that expose database credentials as separate variables.

Resolution order:
- If `DATABASE_URL` is set → use it as-is (parts ignored).
- Otherwise → build the connection string from `DATABASE_HOST`, `DATABASE_NAME`, `DATABASE_USER` (required), `DATABASE_PASSWORD` (optional), `DATABASE_PORT` (optional, default `5432`).

If neither is provided (and not `--in-memory`), the startup error now lists both options. Partial parts raise a `ConfigurationError` naming exactly which parts are missing. User/password are URL-encoded so special characters are safe.

## Changes

- `src/cli-core.ts` — `resolveDatabaseUrl` / `buildDatabaseUrlFromParts`; updated missing-var message and `--help` text.
- `test/cli.test.ts` — new cases: build from parts, default port, no-password, URL-encoding, `DATABASE_URL` precedence, partial-parts error, non-numeric port, missing-vars message.
- `README.md` / `.env.example` — document the split variables.

## Testing

- `yarn workspace @forestadmin/workflow-executor lint` — clean (pre-existing warnings only)
- `yarn workspace @forestadmin/workflow-executor build` — passes
- `yarn workspace @forestadmin/workflow-executor test -- test/cli.test.ts` — 93 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build database connection URL from split env vars in workflow-executor
> - Adds `buildDatabaseUrlFromParts` and `resolveDatabaseUrl` helpers in [cli-core.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1727/files#diff-1605eabb559b21939e3b8d15b4a7a4c933da2a7cd5190022502db6ecaf93b396) to construct a Postgres URI from `DATABASE_HOST`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`, and `DATABASE_PORT` when `DATABASE_URL` is not set.
> - `DATABASE_URL` takes precedence when both are present; port defaults to 5432; password is optional; user/password are URL-encoded; IPv6 hosts are bracketed automatically.
> - `readEnvConfig` now validates that either `DATABASE_URL` or the three required parts (`DATABASE_HOST`, `DATABASE_NAME`, `DATABASE_USER`) are present, with updated error messaging; database vars are ignored in `--in-memory` mode.
> - Documents the two configuration approaches and precedence rules in [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1727/files#diff-84aa4115ae7aaddeae8ef0aa0f2f1fae55b5692e9eb4340a0ec43f2c3c3c0b3b) and [.env.example](https://github.com/ForestAdmin/agent-nodejs/pull/1727/files#diff-3a80e30ba98ef4aad58f8b208bc3a403357b99bbfd0d39a5affb7ea884c52501).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1727 opened
>
> - Modified `buildDatabaseUrlFromParts` function in `workflow-executor` package to URL-encode database names when constructing postgres connection URIs from discrete environment variables [2ff18ad]
> - Added test coverage in `workflow-executor` package for database URL construction and environment variable configuration edge cases [2ff18ad]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef63830.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->