### PR TITLE
feat(agent): generate the schema without starting the agent

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -457,6 +457,11 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Unlike `start()`, this always rebuilds the schema — even when `isProduction` is
    * true — and writes the typings whenever `typingsPath` is set, regardless of
    * `isProduction`.
+   *
+   * Like the rest of the agent, this does not own the data source connection
+   * lifecycle: a data source that opens a connection pool stays open after this
+   * resolves. In a one-shot script, close your data source (or call
+   * `process.exit()`) once it returns so the process can exit.
    */
   async generateSchemaOnly(): Promise<void> {
     const { logger, schemaPath, typingsPath, typingsMaxDepth } = this.options;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -369,12 +369,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
     }
   }
 
-  private async buildRouterAndSendSchema(): Promise<{
-    router: Router;
-    mcpHttpCallback?: HttpCallback;
-  }> {
-    const { isProduction, logger, typingsPath, typingsMaxDepth } = this.options;
-
+  private async buildNoCodeDataSource(): Promise<DataSource> {
     // It allows to rebuild the full customization stack with no code customizations
     this.nocodeCustomizer = new DataSourceCustomizer<S>({
       ignoreMissingSchemaElementErrors: this.options.ignoreMissingSchemaElementErrors || false,
@@ -383,7 +378,22 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
     this.nocodeCustomizer.addDataSource(this.customizer.getFactory());
     this.nocodeCustomizer.use(this.customizationService.addCustomizations);
 
-    const dataSource = await this.nocodeCustomizer.getDataSource(logger);
+    return this.nocodeCustomizer.getDataSource(this.options.logger);
+  }
+
+  private buildSchemaMeta(): ForestSchema['meta'] {
+    const aiMeta = this.aiProvider?.providers ?? [];
+
+    return SchemaGenerator.buildMetadata(this.customizationService.buildFeatures(), aiMeta).meta;
+  }
+
+  private async buildRouterAndSendSchema(): Promise<{
+    router: Router;
+    mcpHttpCallback?: HttpCallback;
+  }> {
+    const { isProduction, logger, typingsPath, typingsMaxDepth } = this.options;
+
+    const dataSource = await this.buildNoCodeDataSource();
     const [routers] = await Promise.all([
       this.getRouter(dataSource),
       this.sendSchema(dataSource),
@@ -413,13 +423,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
     // Either load the schema from the file system or build it
     let schema: Pick<ForestSchema, 'collections'>;
-
-    // Get the AI configurations for schema metadata
-    const aiMeta = this.aiProvider?.providers ?? [];
-    const { meta } = SchemaGenerator.buildMetadata(
-      this.customizationService.buildFeatures(),
-      aiMeta,
-    );
+    const meta = this.buildSchemaMeta();
 
     // When using experimental no-code features even in production we need to build a new schema
     if (!experimental?.webhookCustomActions && isProduction) {
@@ -437,5 +441,30 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
     // Send schema to forest servers
     await this.options.forestAdminClient.postSchema({ ...schema, meta });
+  }
+
+  /**
+   * Generate the schema (and typings, when `typingsPath` is set) and write them
+   * to disk without starting the agent or sending the schema to Forest Admin servers.
+   *
+   * Useful in a CI/CD pipeline to produce `.forestadmin-schema.json` at build time,
+   * so it can be shipped with the deployed code instead of committed.
+   */
+  async generateSchemaOnly(): Promise<void> {
+    const { logger, schemaPath, typingsPath, typingsMaxDepth } = this.options;
+
+    const dataSource = await this.buildNoCodeDataSource();
+    const schema = await this.schemaGenerator.buildSchema(dataSource);
+    const meta = this.buildSchemaMeta();
+
+    await writeFile(schemaPath, stringify({ ...schema, meta }, { maxLength: 100 }), {
+      encoding: 'utf-8',
+    });
+
+    if (typingsPath) {
+      await this.customizer.updateTypesOnFileSystem(typingsPath, typingsMaxDepth, logger);
+    }
+
+    logger('Info', `Schema written to ${schemaPath}`);
   }
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -453,22 +453,32 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Note: when experimental no-code customizations are enabled, this still fetches
    * their configuration from the Forest API so the generated schema includes them,
    * which requires connectivity to Forest.
+   *
+   * Unlike `start()`, this always rebuilds the schema — even when `isProduction` is
+   * true — and writes the typings whenever `typingsPath` is set, regardless of
+   * `isProduction`.
    */
   async generateSchemaOnly(): Promise<void> {
     const { logger, schemaPath, typingsPath, typingsMaxDepth } = this.options;
 
-    const dataSource = await this.buildNoCodeDataSource();
-    const schema = await this.schemaGenerator.buildSchema(dataSource);
-    const meta = this.buildSchemaMeta();
+    try {
+      const dataSource = await this.buildNoCodeDataSource();
+      const schema = await this.schemaGenerator.buildSchema(dataSource);
+      const meta = this.buildSchemaMeta();
 
-    await writeFile(schemaPath, stringify({ ...schema, meta }, { maxLength: 100 }), {
-      encoding: 'utf-8',
-    });
+      await writeFile(schemaPath, stringify({ ...schema, meta }, { maxLength: 100 }), {
+        encoding: 'utf-8',
+      });
 
-    if (typingsPath) {
-      await this.customizer.updateTypesOnFileSystem(typingsPath, typingsMaxDepth, logger);
+      if (typingsPath) {
+        await this.customizer.updateTypesOnFileSystem(typingsPath, typingsMaxDepth, logger);
+      }
+
+      logger('Info', `Schema written to ${schemaPath}`);
+    } catch (error) {
+      const { message } = error as Error;
+      logger('Error', `Forest Admin schema generation failed: ${message}`);
+      throw error;
     }
-
-    logger('Info', `Schema written to ${schemaPath}`);
   }
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -449,6 +449,10 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    *
    * Useful in a CI/CD pipeline to produce `.forestadmin-schema.json` at build time,
    * so it can be shipped with the deployed code instead of committed.
+   *
+   * Note: when experimental no-code customizations are enabled, this still fetches
+   * their configuration from the Forest API so the generated schema includes them,
+   * which requires connectivity to Forest.
    */
   async generateSchemaOnly(): Promise<void> {
     const { logger, schemaPath, typingsPath, typingsMaxDepth } = this.options;

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -285,6 +285,40 @@ describe('Agent', () => {
         expect(mockLogger).toHaveBeenCalledWith('Info', 'Agent is restarting...');
       });
     });
+
+    describe('generateSchemaOnly', () => {
+      test('should build and write the schema to disk', async () => {
+        const agent = new Agent(options);
+
+        await agent.generateSchemaOnly();
+
+        expect(DataSourceCustomizer.prototype.getDataSource).toHaveBeenCalledTimes(1);
+        const { collections } = JSON.parse(await readFile(options.schemaPath, 'utf8'));
+        expect(collections).toEqual([]);
+      });
+
+      test('should write the typings when typingsPath is set', async () => {
+        const agent = new Agent(options);
+
+        await agent.generateSchemaOnly();
+
+        expect(DataSourceCustomizer.prototype.updateTypesOnFileSystem).toHaveBeenCalledWith(
+          options.typingsPath,
+          options.typingsMaxDepth,
+          options.logger,
+        );
+      });
+
+      test('should neither send the schema to Forest nor build the routes', async () => {
+        const agent = new Agent(options);
+
+        await agent.generateSchemaOnly();
+
+        expect(mockPostSchema).not.toHaveBeenCalled();
+        expect(options.forestAdminClient.subscribeToServerEvents).not.toHaveBeenCalled();
+        expect(mockMakeRoutes).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('Production', () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -10,6 +10,7 @@ import { readFile } from 'fs/promises';
 
 import * as factories from './__factories__';
 import Agent from '../src/agent';
+import SchemaGenerator from '../src/utils/forest-schema/generator';
 
 // Mock routes
 const mockSetupRoute = jest.fn();
@@ -327,6 +328,36 @@ describe('Agent', () => {
         expect(mockPostSchema).not.toHaveBeenCalled();
         expect(options.forestAdminClient.subscribeToServerEvents).not.toHaveBeenCalled();
         expect(mockMakeRoutes).not.toHaveBeenCalled();
+      });
+
+      test('should build the schema in production instead of reading it from disk', async () => {
+        const buildSchema = jest.spyOn(SchemaGenerator.prototype, 'buildSchema');
+        // A path that does not exist: start() would throw "mandatory in production",
+        // generateSchemaOnly must build the schema instead.
+        const agent = new Agent({
+          ...options,
+          isProduction: true,
+          schemaPath: '/tmp/.forest-generate-prod.json',
+        });
+
+        await agent.generateSchemaOnly();
+
+        expect(buildSchema).toHaveBeenCalledTimes(1);
+        const { collections } = JSON.parse(
+          await readFile('/tmp/.forest-generate-prod.json', 'utf8'),
+        );
+        expect(collections).toEqual([]);
+      });
+
+      test('should log an Error and rethrow when generation fails', async () => {
+        const logger = jest.fn();
+        jest
+          .mocked(DataSourceCustomizer.prototype.getDataSource)
+          .mockRejectedValueOnce(new Error('boom'));
+        const agent = new Agent({ ...options, logger });
+
+        await expect(agent.generateSchemaOnly()).rejects.toThrow('boom');
+        expect(logger).toHaveBeenCalledWith('Error', 'Forest Admin schema generation failed: boom');
       });
     });
   });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -287,14 +287,16 @@ describe('Agent', () => {
     });
 
     describe('generateSchemaOnly', () => {
-      test('should build and write the schema to disk', async () => {
-        const agent = new Agent(options);
+      test('should build and write the schema to disk and log where', async () => {
+        const logger = jest.fn();
+        const agent = new Agent({ ...options, logger });
 
         await agent.generateSchemaOnly();
 
-        expect(DataSourceCustomizer.prototype.getDataSource).toHaveBeenCalledTimes(1);
+        expect(DataSourceCustomizer.prototype.getDataSource).toHaveBeenCalledOnceWith(logger);
         const { collections } = JSON.parse(await readFile(options.schemaPath, 'utf8'));
         expect(collections).toEqual([]);
+        expect(logger).toHaveBeenCalledWith('Info', `Schema written to ${options.schemaPath}`);
       });
 
       test('should write the typings when typingsPath is set', async () => {
@@ -302,11 +304,19 @@ describe('Agent', () => {
 
         await agent.generateSchemaOnly();
 
-        expect(DataSourceCustomizer.prototype.updateTypesOnFileSystem).toHaveBeenCalledWith(
+        expect(DataSourceCustomizer.prototype.updateTypesOnFileSystem).toHaveBeenCalledOnceWith(
           options.typingsPath,
           options.typingsMaxDepth,
           options.logger,
         );
+      });
+
+      test('should not write the typings when typingsPath is not set', async () => {
+        const agent = new Agent({ ...options, typingsPath: null });
+
+        await agent.generateSchemaOnly();
+
+        expect(DataSourceCustomizer.prototype.updateTypesOnFileSystem).not.toHaveBeenCalled();
       });
 
       test('should neither send the schema to Forest nor build the routes', async () => {


### PR DESCRIPTION
## What

Adds `agent.generateSchemaOnly()` — the Node.js counterpart of the Ruby `generate_schema_only` / `rails forest_admin:schema:generate` rake task introduced in ForestAdmin/agent-ruby#260.

It builds the datasource and writes `.forestadmin-schema.json` (and the typings, when `typingsPath` is set) to disk **without** booting the HTTP server, subscribing to events, or sending the schema to the Forest API.

## Why

Some users would rather generate the schema **at build time** in their CI/CD pipeline (DB available) and ship it inside the deployed image, instead of committing `.forestadmin-schema.json`. This avoids the two recurring pains with the committed file: frequent merge conflicts, and stale schemas when a dev forgets to regenerate before deploying.

Today the only ways to produce the file in Node are to boot the full agent (which contacts Forest) or to misuse `@forestadmin/agent-testing`. This gives a clean, official primitive.

## Usage

```ts
// generate-schema.ts — run in CI before building the image
const agent = createAgent({ ... })
  .addDataSource(...)
  .customizeCollection(...);

await agent.generateSchemaOnly(); // writes .forestadmin-schema.json, no server, no Forest call
```

The deployed agent still pushes the schema to Forest the usual way at boot (reads the file → `postSchema`, hashcheck-gated), so nothing changes about the push mechanism or rolling deploys.

## Notes

- Extracts `buildNoCodeDataSource()` and `buildSchemaMeta()` so the build logic is shared with `start()`'s `sendSchema` path — **no behavior change to `start`/`restart`**.
- Naming kept homogeneous with the Ruby side (`generate_schema_only`).
- 3 tests added: writes the schema to disk, writes typings when configured, and never calls `postSchema` / `subscribeToServerEvents` / route building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `generateSchemaOnly` method to Agent to write schema without starting the server
> - Adds a new public `generateSchemaOnly()` method on `Agent` in [agent.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1729/files#diff-eef62e2c442eab8851598096a8be46f3fcd271a673817a8361a40bbb60410143) that builds the schema and writes it to disk without starting the server, mounting routes, or posting to Forest Admin servers.
> - Refactors shared logic into two private helpers: `buildNoCodeDataSource()` and `buildSchemaMeta()`, used by both `generateSchemaOnly` and the existing `buildRouterAndSendSchema`/`sendSchema` methods.
> - In production mode, `generateSchemaOnly` builds the schema from the data source instead of loading from disk, matching the behavior of `buildRouterAndSendSchema`.
> - Logs success with the schema path on completion, or logs and rethrows on error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cce2b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->