### PR TITLE
feat: attach AI reasoning as a comment on approval requests

### DIFF
--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -58,8 +58,15 @@ export default function makeCreateApprovalRequest(options: {
           headers: { 'forest-rendering-id': String(options.renderingId) },
           body: { data: { attributes: { comment: payload.message } } },
         });
-      } catch {
-        /* approval created; the message is optional context */
+      } catch (error) {
+        // The approval already exists; the comment is optional context, so don't fail the
+        // request. Warn (rather than swallow silently) so a persistently broken comments
+        // route — or a bug in this block — is discoverable.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Approval request ${id} created, but posting the reasoning comment failed`,
+          error,
+        );
       }
     }
 

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -7,6 +7,7 @@ export type ApprovalRequestPayload = {
   actionName: string;
   recordIds: (string | number)[];
   inputs: ApprovalRequestInput[];
+  message?: string;
 };
 
 export type CreateApprovalRequest = (
@@ -43,6 +44,25 @@ export default function makeCreateApprovalRequest(options: {
       },
     });
 
-    return body?.data?.id ? { id: String(body.data.id) } : undefined;
+    const id = body?.data?.id ? String(body.data.id) : undefined;
+
+    if (id && payload.message) {
+      // Best-effort: the approval already exists, so a comment failure must not turn the
+      // successful request into an error.
+      try {
+        await ServerUtils.queryWithBearerToken({
+          forestServerUrl: options.forestServerUrl,
+          bearerToken: options.forestServerToken,
+          method: 'post',
+          path: `${APPROVAL_REQUEST_PATH}/${id}/comments`,
+          headers: { 'forest-rendering-id': String(options.renderingId) },
+          body: { data: { attributes: { comment: payload.message } } },
+        });
+      } catch {
+        /* approval created; the message is optional context */
+      }
+    }
+
+    return id ? { id } : undefined;
   };
 }

--- a/packages/agent-client/src/approval-request-creator.ts
+++ b/packages/agent-client/src/approval-request-creator.ts
@@ -46,9 +46,8 @@ export default function makeCreateApprovalRequest(options: {
 
     const id = body?.data?.id ? String(body.data.id) : undefined;
 
+    // Best-effort: the approval already exists, so a comment failure must not fail the request.
     if (id && payload.message) {
-      // Best-effort: the approval already exists, so a comment failure must not turn the
-      // successful request into an error.
       try {
         await ServerUtils.queryWithBearerToken({
           forestServerUrl: options.forestServerUrl,
@@ -59,9 +58,6 @@ export default function makeCreateApprovalRequest(options: {
           body: { data: { attributes: { comment: payload.message } } },
         });
       } catch (error) {
-        // The approval already exists; the comment is optional context, so don't fail the
-        // request. Warn (rather than swallow silently) so a persistently broken comments
-        // route — or a bug in this block — is discoverable.
         // eslint-disable-next-line no-console
         console.warn(
           `Approval request ${id} created, but posting the reasoning comment failed`,

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -123,7 +123,10 @@ export default class Action {
     this.createApprovalRequest = createApprovalRequest;
   }
 
-  async execute(signedApprovalRequest?: Record<string, unknown>): Promise<ActionExecuteResult> {
+  async execute(
+    signedApprovalRequest?: Record<string, unknown>,
+    approvalRequestMessage?: string,
+  ): Promise<ActionExecuteResult> {
     const requestBody = {
       data: {
         attributes: {
@@ -161,6 +164,7 @@ export default class Action {
             actionName: this.actionName,
             recordIds: this.ids ?? [],
             inputs,
+            ...(approvalRequestMessage && { message: approvalRequestMessage }),
           });
         } catch (cause) {
           throw new ApprovalRequestCreationError(cause);

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -84,9 +84,8 @@ export type BaseActionContext = {
 };
 
 export type ActionExecuteOptions = {
-  // Signed approval token replayed when an approver confirms an approval-gated action.
   signedApprovalRequest?: Record<string, unknown>;
-  // AI reasoning attached as a comment on the approval request when the action is approval-gated.
+  // Posted as a comment on the approval request when the action is approval-gated.
   approvalRequestMessage?: string;
 };
 

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -83,6 +83,13 @@ export type BaseActionContext = {
   recordIds?: RecordId[];
 };
 
+export type ActionExecuteOptions = {
+  // Signed approval token replayed when an approver confirms an approval-gated action.
+  signedApprovalRequest?: Record<string, unknown>;
+  // AI reasoning attached as a comment on the approval request when the action is approval-gated.
+  approvalRequestMessage?: string;
+};
+
 export type ActionExecuteResult =
   | { success: string; html?: string }
   | { approvalRequested: true; approvalRequest?: { id: string } };
@@ -123,10 +130,8 @@ export default class Action {
     this.createApprovalRequest = createApprovalRequest;
   }
 
-  async execute(
-    signedApprovalRequest?: Record<string, unknown>,
-    approvalRequestMessage?: string,
-  ): Promise<ActionExecuteResult> {
+  async execute(options: ActionExecuteOptions = {}): Promise<ActionExecuteResult> {
+    const { signedApprovalRequest, approvalRequestMessage } = options;
     const requestBody = {
       data: {
         attributes: {

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -95,10 +95,11 @@ describe('makeCreateApprovalRequest', () => {
     expect(queryWithBearerToken).toHaveBeenCalledTimes(1);
   });
 
-  it('still returns the approval id when posting the comment fails', async () => {
+  it('still returns the approval id (and warns) when posting the comment fails', async () => {
     queryWithBearerToken
       .mockResolvedValueOnce({ data: { id: 'req_42' } })
       .mockRejectedValueOnce(new Error('comments route down'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const create = makeCreateApprovalRequest({
       forestServerUrl: 'https://api.forestadmin.com',
       forestServerToken: 'server-token',
@@ -114,6 +115,8 @@ describe('makeCreateApprovalRequest', () => {
     });
 
     expect(result).toEqual({ id: 'req_42' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('req_42'), expect.any(Error));
+    warn.mockRestore();
   });
 
   it('returns the approval id read from the server response data.id', async () => {

--- a/packages/agent-client/test/approval-request-creator.test.ts
+++ b/packages/agent-client/test/approval-request-creator.test.ts
@@ -46,6 +46,76 @@ describe('makeCreateApprovalRequest', () => {
     });
   });
 
+  it('posts the message as a comment on the created approval', async () => {
+    queryWithBearerToken.mockResolvedValueOnce({ data: { id: 'req_42' } });
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    const result = await create({
+      collectionName: 'users',
+      actionName: 'refund',
+      recordIds: ['1'],
+      inputs: [],
+      message: 'Refund requested by AI: duplicate payment detected',
+    });
+
+    expect(queryWithBearerToken).toHaveBeenCalledTimes(2);
+    expect(queryWithBearerToken).toHaveBeenLastCalledWith({
+      forestServerUrl: 'https://api.forestadmin.com',
+      bearerToken: 'server-token',
+      method: 'post',
+      path: '/api/action-approvals/req_42/comments',
+      headers: { 'forest-rendering-id': '42' },
+      body: {
+        data: { attributes: { comment: 'Refund requested by AI: duplicate payment detected' } },
+      },
+    });
+    expect(result).toEqual({ id: 'req_42' });
+  });
+
+  it('skips the comment when no approval id came back', async () => {
+    queryWithBearerToken.mockResolvedValueOnce({ data: {} });
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    await create({
+      collectionName: 'users',
+      actionName: 'refund',
+      recordIds: ['1'],
+      inputs: [],
+      message: 'some reasoning',
+    });
+
+    expect(queryWithBearerToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns the approval id when posting the comment fails', async () => {
+    queryWithBearerToken
+      .mockResolvedValueOnce({ data: { id: 'req_42' } })
+      .mockRejectedValueOnce(new Error('comments route down'));
+    const create = makeCreateApprovalRequest({
+      forestServerUrl: 'https://api.forestadmin.com',
+      forestServerToken: 'server-token',
+      renderingId: 42,
+    });
+
+    const result = await create({
+      collectionName: 'users',
+      actionName: 'refund',
+      recordIds: ['1'],
+      inputs: [],
+      message: 'some reasoning',
+    });
+
+    expect(result).toEqual({ id: 'req_42' });
+  });
+
   it('returns the approval id read from the server response data.id', async () => {
     queryWithBearerToken.mockResolvedValue({ data: { id: 'req_42', type: 'action-approvals' } });
     const create = makeCreateApprovalRequest({

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -184,6 +184,32 @@ describe('Action', () => {
       expect(result).toEqual({ approvalRequested: true });
     });
 
+    it('forwards the approval message to the approval request creator', async () => {
+      fieldsFormStates.getFields.mockReturnValue([] as any);
+      const createApprovalRequest = jest.fn().mockResolvedValue(undefined);
+      const approvalAction = new Action(
+        'users',
+        'send-email',
+        httpRequester,
+        '/forest/actions/send-email',
+        fieldsFormStates,
+        ['1'],
+        undefined,
+        createApprovalRequest,
+      );
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(403, {
+          errors: [{ name: 'CustomActionRequiresApprovalError', detail: 'Needs approval' }],
+        }),
+      );
+
+      await approvalAction.execute(undefined, 'AI reasoning: user asked for a resend');
+
+      expect(createApprovalRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'AI reasoning: user asked for a resend' }),
+      );
+    });
+
     it('includes the approval request id when the creator returns one', async () => {
       fieldsFormStates.getFields.mockReturnValue([] as any);
       const createApprovalRequest = jest.fn().mockResolvedValue({ id: 'req_42' });

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -106,7 +106,7 @@ describe('Action', () => {
       httpRequester.query.mockResolvedValue({ success: 'Action executed' });
       const signedApprovalRequest = { token: 'approval-token', requesterId: '123' };
 
-      await action.execute(signedApprovalRequest);
+      await action.execute({ signedApprovalRequest });
 
       expect(httpRequester.query).toHaveBeenCalledWith({
         method: 'post',
@@ -203,7 +203,9 @@ describe('Action', () => {
         }),
       );
 
-      await approvalAction.execute(undefined, 'AI reasoning: user asked for a resend');
+      await approvalAction.execute({
+        approvalRequestMessage: 'AI reasoning: user asked for a resend',
+      });
 
       expect(createApprovalRequest).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'AI reasoning: user asked for a resend' }),

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -74,7 +74,7 @@ If you call executeAction with missing required fields, it will return an error 
             await action.setFields(options.values);
           }
 
-          const result = await action.execute(undefined, options.reasoning);
+          const result = await action.execute({ approvalRequestMessage: options.reasoning });
 
           if ('approvalRequested' in result) {
             return {

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -2,6 +2,8 @@ import type { ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { z } from 'zod';
+
 import { createActionArgumentShape } from '../utils/action-helpers';
 import { buildClientWithActions } from '../utils/agent-caller';
 import registerToolWithLogging from '../utils/tool-with-logging';
@@ -12,6 +14,7 @@ interface ExecuteActionArgument {
   actionName: string;
   recordIds: (string | number)[] | null;
   values?: Record<string, unknown>;
+  reasoning?: string;
 }
 
 export default function declareExecuteActionTool(
@@ -20,7 +23,16 @@ export default function declareExecuteActionTool(
   logger: Logger,
   collectionNames: string[] = [],
 ): string {
-  const argumentShape = createActionArgumentShape(collectionNames);
+  const argumentShape = {
+    ...createActionArgumentShape(collectionNames),
+    reasoning: z
+      .string()
+      .optional()
+      .describe(
+        'A clear explanation of why you are executing this action. ' +
+          'Shown to the approver when the action requires an approval — always provide it.',
+      ),
+  };
 
   return registerToolWithLogging(
     mcpServer,
@@ -62,7 +74,7 @@ If you call executeAction with missing required fields, it will return an error 
             await action.setFields(options.values);
           }
 
-          const result = await action.execute();
+          const result = await action.execute(undefined, options.reasoning);
 
           if ('approvalRequested' in result) {
             return {

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -332,6 +332,34 @@ describe('declareExecuteActionTool', () => {
       });
     });
 
+    it('should forward the reasoning to execute so it reaches the approval request', async () => {
+      const mockExecute = jest.fn().mockResolvedValue({ approvalRequested: true });
+      const mockAction = jest.fn().mockResolvedValue({
+        execute: mockExecute,
+        setFields: jest.fn().mockResolvedValue(undefined),
+      });
+      const mockCollection = jest.fn().mockReturnValue({ action: mockAction });
+      mockBuildClientWithActions.mockResolvedValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClientWithActions>);
+
+      await registeredToolHandler(
+        {
+          collectionName: 'users',
+          actionName: 'refund',
+          recordIds: [1],
+          reasoning: 'Duplicate payment detected on order #42',
+        },
+        mockExtra,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        undefined,
+        'Duplicate payment detected on order #42',
+      );
+    });
+
     describe('activity logging', () => {
       beforeEach(() => {
         const mockExecute = jest.fn().mockResolvedValue({ success: 'Action executed' });

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -354,10 +354,9 @@ describe('declareExecuteActionTool', () => {
         mockExtra,
       );
 
-      expect(mockExecute).toHaveBeenCalledWith(
-        undefined,
-        'Duplicate payment detected on order #42',
-      );
+      expect(mockExecute).toHaveBeenCalledWith({
+        approvalRequestMessage: 'Duplicate payment detected on order #42',
+      });
     });
 
     describe('activity logging', () => {

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -230,7 +230,7 @@ export default class AgentClientAgentPort implements AgentPort {
   }
 
   async executeAction(
-    { collection, action, id, values }: ExecuteActionQuery,
+    { collection, action, id, values, approvalMessage }: ExecuteActionQuery,
     { user, forestServerToken }: ActionCaller,
   ): Promise<ExecuteActionResult> {
     return this.callAgent('executeAction', async () => {
@@ -249,7 +249,7 @@ export default class AgentClientAgentPort implements AgentPort {
       }
 
       try {
-        const executeResult = await act.execute();
+        const executeResult = await act.execute(undefined, approvalMessage);
 
         return typeof executeResult === 'object' &&
           executeResult !== null &&

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -249,7 +249,7 @@ export default class AgentClientAgentPort implements AgentPort {
       }
 
       try {
-        const executeResult = await act.execute(undefined, approvalMessage);
+        const executeResult = await act.execute({ approvalRequestMessage: approvalMessage });
 
         return typeof executeResult === 'object' &&
           executeResult !== null &&

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -43,6 +43,9 @@ Important rules:
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
   isGlobal?: boolean;
+  // AI reasoning (or the step prompt as fallback) forwarded to the approval request
+  // when the action is approval-gated, so the approver sees why it was triggered.
+  approvalMessage?: string;
 }
 
 export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<TriggerActionStepDefinition> {
@@ -141,18 +144,24 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       : await this.resolveRecordRef(await this.getAvailableRecordRefs(), step.prompt);
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const recordedAction = preRecordedArgs?.actionName;
-    const actionName = recordedAction ?? (await this.selectAction(schema, step.prompt)).actionName;
+    const selection = recordedAction
+      ? { actionName: recordedAction }
+      : await this.selectAction(schema, step.prompt);
+    const { actionName } = selection;
     const action = this.findActionByTechnicalName(schema, actionName);
 
     if (!action) {
       throw new ActionNotFoundError(actionName, schema.collectionName);
     }
 
+    const approvalMessage = ('reasoning' in selection && selection.reasoning) || step.prompt;
+
     const target: ActionTarget = {
       selectedRecordRef,
       displayName: action.displayName,
       name: action.name,
       isGlobal: action.type === 'global',
+      ...(approvalMessage && { approvalMessage }),
     };
 
     const form = await this.context.agent.getActionForm({
@@ -377,6 +386,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         // Global actions run on no record — omit the id so the approval isn't linked to one.
         ...(target.isGlobal ? {} : { id: selectedRecordRef.recordId }),
         ...(form && { values: form.values }),
+        ...(target.approvalMessage && { approvalMessage: target.approvalMessage }),
       },
       {
         beforeCall: () =>
@@ -485,7 +495,7 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
   private async selectAction(
     schema: CollectionSchema,
     prompt: string | undefined,
-  ): Promise<{ actionName: string }> {
+  ): Promise<{ actionName: string; reasoning?: string }> {
     const tool = this.buildSelectActionTool(schema);
     const messages = [
       this.buildContextMessage(),
@@ -497,12 +507,12 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       new HumanMessage(`**Request**: ${prompt ?? 'Trigger the relevant action.'}`),
     ];
 
-    const { actionName } = await this.invokeWithTool<{ actionName: string; reasoning: string }>(
-      messages,
-      tool,
-    );
+    const { actionName, reasoning } = await this.invokeWithTool<{
+      actionName: string;
+      reasoning: string;
+    }>(messages, tool);
 
-    return { actionName: this.findAction(schema, actionName)?.name ?? actionName };
+    return { actionName: this.findAction(schema, actionName)?.name ?? actionName, reasoning };
   }
 
   private buildSelectActionTool(schema: CollectionSchema): DynamicStructuredTool {

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -43,8 +43,6 @@ Important rules:
 interface ActionTarget extends ActionRef {
   selectedRecordRef: RecordRef;
   isGlobal?: boolean;
-  // AI reasoning (or the step prompt as fallback) forwarded to the approval request
-  // when the action is approval-gated, so the approver sees why it was triggered.
   approvalMessage?: string;
 }
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -43,8 +43,7 @@ export type ExecuteActionQuery = {
   // Pre-filled form values. Set on the form before execution, going through the agent's
   // normal server-side validation — no bypass. Omitted for formless actions.
   values?: Record<string, unknown>;
-  // AI explanation attached to the approval request when the action is approval-gated,
-  // so the approver sees why the action was triggered.
+  // AI reasoning, posted as a comment on the approval request when the action is approval-gated.
   approvalMessage?: string;
 };
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -43,6 +43,9 @@ export type ExecuteActionQuery = {
   // Pre-filled form values. Set on the form before execution, going through the agent's
   // normal server-side validation — no bypass. Omitted for formless actions.
   values?: Record<string, unknown>;
+  // AI explanation attached to the approval request when the action is approval-gated,
+  // so the approver sees why the action was triggered.
+  approvalMessage?: string;
 };
 
 export type GetActionFormQuery = {

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -797,10 +797,9 @@ describe('AgentClientAgentPort', () => {
         { user },
       );
 
-      expect(mockAction.execute).toHaveBeenCalledWith(
-        undefined,
-        'AI reasoning: resend requested by the workflow',
-      );
+      expect(mockAction.execute).toHaveBeenCalledWith({
+        approvalRequestMessage: 'AI reasoning: resend requested by the workflow',
+      });
     });
 
     it('wires the forestServer connection into agent-client when a server token is supplied', async () => {

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -784,6 +784,25 @@ describe('AgentClientAgentPort', () => {
       expect(result).toEqual({ approvalRequested: true, approvalRequest: { id: 'req_42' } });
     });
 
+    it('forwards the approvalMessage to execute so it reaches the approval request', async () => {
+      mockAction.execute.mockResolvedValue({ approvalRequested: true });
+
+      await port.executeAction(
+        {
+          collection: 'users',
+          action: 'sendEmail',
+          id: [1],
+          approvalMessage: 'AI reasoning: resend requested by the workflow',
+        },
+        { user },
+      );
+
+      expect(mockAction.execute).toHaveBeenCalledWith(
+        undefined,
+        'AI reasoning: resend requested by the workflow',
+      );
+    });
+
     it('wires the forestServer connection into agent-client when a server token is supplied', async () => {
       const portWithServer = new AgentClientAgentPort({
         agentUrl: 'http://localhost:3310',

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -227,7 +227,12 @@ describe('TriggerRecordActionStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
-        { collection: 'customers', action: 'send-welcome-email', id: [42] },
+        {
+          collection: 'customers',
+          action: 'send-welcome-email',
+          id: [42],
+          approvalMessage: 'User requested welcome email',
+        },
         { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(
@@ -274,7 +279,11 @@ describe('TriggerRecordActionStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       // The query carries no `id` for a global action.
       const query = (agentPort.executeAction as jest.Mock).mock.calls[0][0];
-      expect(query).toEqual({ collection: 'customers', action: 'send-welcome-email' });
+      expect(query).toEqual({
+        collection: 'customers',
+        action: 'send-welcome-email',
+        approvalMessage: 'User requested welcome email',
+      });
       expect('id' in query).toBe(false);
     });
 
@@ -1176,7 +1185,12 @@ describe('TriggerRecordActionStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
-        { collection: 'customers', action: 'archive', id: [42] },
+        {
+          collection: 'customers',
+          action: 'archive',
+          id: [42],
+          approvalMessage: 'User wants to archive',
+        },
         { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
     });
@@ -1206,7 +1220,12 @@ describe('TriggerRecordActionStepExecutor', () => {
 
       expect(result.stepOutcome.status).toBe('success');
       expect(agentPort.executeAction).toHaveBeenCalledWith(
-        { collection: 'customers', action: 'archive', id: [42] },
+        {
+          collection: 'customers',
+          action: 'archive',
+          id: [42],
+          approvalMessage: 'fallback to technical name',
+        },
         { user: expect.objectContaining({ id: 1 }), forestServerToken: undefined },
       );
     });
@@ -1589,6 +1608,30 @@ describe('TriggerRecordActionStepExecutor', () => {
         expect.objectContaining({
           executionParams: { displayName: 'Send Welcome Email', name: 'send-welcome-email' },
         }),
+      );
+    });
+
+    it('falls back to the step prompt as approvalMessage when the action is pre-recorded', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const mockModel = makeMockModel();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { actionName: 'send-welcome-email' },
+        }),
+      });
+      const executor = new TriggerRecordActionStepExecutor(context);
+
+      await executor.execute();
+
+      expect(agentPort.executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          approvalMessage: 'Send a welcome email to the customer',
+        }),
+        expect.anything(),
       );
     });
 

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -253,6 +253,48 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
+    it('falls back to the step prompt as approvalMessage when the AI returns no reasoning', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const mockModel = makeMockModel({ actionName: 'Send Welcome Email' });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          prompt: 'Send a welcome email to the customer',
+        }),
+      });
+      const executor = new TriggerRecordActionStepExecutor(context);
+
+      await executor.execute();
+
+      expect(agentPort.executeAction).toHaveBeenCalledWith(
+        expect.objectContaining({ approvalMessage: 'Send a welcome email to the customer' }),
+        expect.anything(),
+      );
+    });
+
+    it('omits approvalMessage when the AI returns no reasoning and there is no prompt', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });
+      const mockModel = makeMockModel({ actionName: 'Send Welcome Email' });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          prompt: undefined,
+        }),
+      });
+      const executor = new TriggerRecordActionStepExecutor(context);
+
+      await executor.execute();
+
+      const query = (agentPort.executeAction as jest.Mock).mock.calls[0][0];
+      expect('approvalMessage' in query).toBe(false);
+    });
+
     it('does NOT attach a record when the action is global', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.executeAction as jest.Mock).mockResolvedValue({ result: { ok: true } });


### PR DESCRIPTION
## Context

When an AI triggers a custom action that requires approval — via the MCP `executeAction` tool or the workflow-executor `trigger-action` step — the created approval request carried **no explanation**. The approver saw a bare request with no idea why the AI triggered it.

This PR lets the AI attach its reasoning, surfaced as a **comment** on the approval request.

## Why a comment (not an attribute)

Checked the Forest server (`forestadmin-server`): `POST /api/action-approvals` only validates `status / action_name / collection_name / record_ids / inputs` — any extra attribute is dropped, and the `actionApproval` model has no message field. The free-text channel is the dedicated **`actionApprovalComment`** resource (`POST /api/action-approvals/:id/comments`, `data.attributes.comment`), same auth stack as creation. So the message is posted there.

## Changes

- **agent-client**
  - `Action.execute(signedApprovalRequest?, approvalRequestMessage?)` forwards an optional message.
  - `makeCreateApprovalRequest` posts the message to `/api/action-approvals/:id/comments` after the approval is created — **best-effort**: a comment failure never turns the successful approval into an error.
- **mcp-server** — `executeAction` exposes an optional `reasoning` field (LLM-facing description asks it to always explain why), forwarded to `execute()`. Covers direct MCP use and the workflow `mcp` step.
- **workflow-executor** — the `trigger-action` step captures the AI action-selection `reasoning` (previously **discarded** in `selectAction`), falling back to the step prompt for pre-recorded actions, and threads it through `ExecuteActionQuery.approvalMessage`. Reasoning stays out of `StepOutcome` (privacy invariant preserved).

## Tests

- agent-client: comment posted with correct path/body; skipped when no approval id; approval id still returned when the comment POST fails.
- mcp-server: `reasoning` forwarded to `execute()`.
- workflow-executor: `approvalMessage` transmitted to the port; AI reasoning captured; prompt fallback for pre-recorded actions.

All suites green (agent-client 344, mcp-server 548, workflow-executor 1155), builds + lint clean.

## Verification

Verified end-to-end against a local agent + Forest server: triggering the approval-gated `Create new card` action via MCP with a `reasoning` creates the approval request with the reasoning shown as a comment in the front. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attach AI reasoning as a comment on approval requests
> - When an action requires approval, the AI's reasoning (or the step prompt as a fallback) is now posted as a comment on the created approval request.
> - `Action.execute` in [action.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1733/files#diff-c434b5b3c0debe1a1c3629c2828238cc6ab1609dce58c3b2f6dae384ef677b81) now accepts an options object with an optional `approvalRequestMessage`; after creating the approval request, a follow-up POST is made to `/api/action-approvals/{id}/comments`.
> - The MCP `executeAction` tool gains an optional `reasoning` input field that is forwarded through to the approval request comment.
> - The `TriggerRecordActionStepExecutor` derives the approval message from the AI selection's reasoning, falling back to the step prompt, and omits the message if neither is available.
> - Risk: comment posting is best-effort — failures are swallowed with `console.warn` and do not affect the approval request result. Callers previously passing a bare `signedApprovalRequest` to `Action.execute` must now wrap it in an options object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 787b9be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->