### PR TITLE
feat: allow embedded in-mem executor

### DIFF
--- a/packages/agent/src/embedded-workflow-executor.ts
+++ b/packages/agent/src/embedded-workflow-executor.ts
@@ -3,7 +3,7 @@ import type { WorkflowExecutor } from '@forestadmin/workflow-executor';
 
 import path from 'path';
 
-/** Default loopback port for an embedded workflow executor (mirrors the executor CLI's HTTP_PORT). */
+/** Default loopback port for an embedded workflow executor. */
 const DEFAULT_EMBEDDED_EXECUTOR_PORT = 3400;
 
 /**
@@ -55,8 +55,14 @@ export default class EmbeddedWorkflowExecutor {
       );
     }
 
-    const port =
-      embedOptions.port ?? (Number(process.env.HTTP_PORT) || DEFAULT_EMBEDDED_EXECUTOR_PORT);
+    if (embedOptions.inMemory && embedOptions.database) {
+      throw new Error(
+        'addWorkflowExecutor: `inMemory` and `database` are mutually exclusive. The in-memory run ' +
+          'store persists nothing; drop one of the two options.',
+      );
+    }
+
+    const port = embedOptions.port ?? DEFAULT_EMBEDDED_EXECUTOR_PORT;
     this.config = { ...embedOptions, port };
 
     return `http://127.0.0.1:${port}`;
@@ -84,19 +90,9 @@ export default class EmbeddedWorkflowExecutor {
       );
     }
 
-    const database =
-      config.database ?? (process.env.DATABASE_URL ? { uri: process.env.DATABASE_URL } : undefined);
+    const { buildDatabaseExecutor, buildInMemoryExecutor } = await this.importPackage();
 
-    if (!database) {
-      throw new Error(
-        'Embedded workflow executor requires a database to persist run state. Pass `database` to ' +
-          'addWorkflowExecutor() or set the DATABASE_URL environment variable.',
-      );
-    }
-
-    const { buildDatabaseExecutor } = await this.importPackage();
-
-    this.executor = buildDatabaseExecutor({
+    const commonOptions = {
       envSecret: this.options.envSecret,
       authSecret: this.options.authSecret,
       forestServerUrl: this.options.forestServerUrl,
@@ -108,8 +104,32 @@ export default class EmbeddedWorkflowExecutor {
       // Embedded: the host process owns SIGTERM/SIGINT; the executor must not exit it. agent.stop()
       // drains the executor explicitly.
       manageProcessSignals: false,
-      database: database as Parameters<typeof buildDatabaseExecutor>[0]['database'],
-    });
+    };
+
+    if (config.inMemory) {
+      this.options.logger(
+        'Warn',
+        formatLog(
+          'Using an in-memory run store: workflow runs are kept in memory and lost on restart. ' +
+            'Pass a `database` to addWorkflowExecutor() to persist them in production.',
+        ),
+      );
+      this.executor = buildInMemoryExecutor(commonOptions);
+    } else {
+      const { database } = config;
+
+      if (!database) {
+        throw new Error(
+          'Embedded workflow executor requires a database to persist run state. Pass `database` ' +
+            'to addWorkflowExecutor(), or use `inMemory: true`.',
+        );
+      }
+
+      this.executor = buildDatabaseExecutor({
+        ...commonOptions,
+        database: database as Parameters<typeof buildDatabaseExecutor>[0]['database'],
+      });
+    }
 
     await this.executor.start();
     this.options.logger(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -63,9 +63,15 @@ export type AgentOptions = {
  */
 export type WorkflowExecutorEmbedOptions = {
   /**
+   * Use an in-memory run store instead of a database. No database is required, but runs are lost
+   * when the process restarts, so it is not meant for production. Mutually exclusive with
+   * `database`.
+   */
+  inMemory?: boolean;
+  /**
    * Database connection used to persist workflow run state. Accepts a connection URI or a
-   * Sequelize options object. Falls back to the `DATABASE_URL` environment variable when omitted.
-   * The agent throws at startup if neither is provided.
+   * Sequelize options object. The agent throws at startup if it is omitted (unless `inMemory` is
+   * set).
    */
   database?: { uri?: string; [option: string]: unknown };
   /**
@@ -77,7 +83,7 @@ export type WorkflowExecutorEmbedOptions = {
   agentUrl?: string;
   /**
    * Loopback port the embedded executor listens on; the agent proxies to it internally.
-   * Defaults to the `HTTP_PORT` environment variable, or `3400`.
+   * Defaults to `3400`.
    */
   port?: number;
   /** Interval in seconds at which the executor polls the orchestrator for pending steps. */

--- a/packages/agent/test/agent-workflow-executor.test.ts
+++ b/packages/agent/test/agent-workflow-executor.test.ts
@@ -270,10 +270,7 @@ describe('Agent.addWorkflowExecutor', () => {
 
       await agent.start();
 
-      expect(logger).toHaveBeenCalledWith(
-        'Warn',
-        expect.stringContaining('in-memory run store'),
-      );
+      expect(logger).toHaveBeenCalledWith('Warn', expect.stringContaining('in-memory run store'));
     });
 
     test('throws when the agentUrl cannot be derived (not standalone) and is not provided', async () => {

--- a/packages/agent/test/agent-workflow-executor.test.ts
+++ b/packages/agent/test/agent-workflow-executor.test.ts
@@ -21,19 +21,24 @@ jest.mock('@forestadmin/datasource-customizer');
 const mockExecutorStart = jest.fn();
 const mockExecutorStop = jest.fn();
 const mockBuildDatabaseExecutor = jest.fn();
+const mockBuildInMemoryExecutor = jest.fn();
 
 jest.mock('@forestadmin/workflow-executor', () => ({
   __esModule: true,
   buildDatabaseExecutor: (options: unknown) => mockBuildDatabaseExecutor(options),
+  buildInMemoryExecutor: (options: unknown) => mockBuildInMemoryExecutor(options),
 }));
 
 beforeEach(() => {
   jest.clearAllMocks();
-  delete process.env.DATABASE_URL;
-  delete process.env.HTTP_PORT;
 
   mockMakeRoutes.mockReturnValue([{ setupRoutes: mockSetupRoute, bootstrap: mockBootstrap }]);
   mockBuildDatabaseExecutor.mockReturnValue({
+    start: mockExecutorStart,
+    stop: mockExecutorStop,
+    state: 'idle',
+  });
+  mockBuildInMemoryExecutor.mockReturnValue({
     start: mockExecutorStart,
     stop: mockExecutorStop,
     state: 'idle',
@@ -64,15 +69,6 @@ describe('Agent.addWorkflowExecutor', () => {
       expect((agent as any).options.workflowExecutorUrl).toBe('http://127.0.0.1:5005');
     });
 
-    test('falls back to the HTTP_PORT environment variable', () => {
-      process.env.HTTP_PORT = '4567';
-      const agent = new Agent(buildOptions());
-
-      agent.addWorkflowExecutor();
-
-      expect((agent as any).options.workflowExecutorUrl).toBe('http://127.0.0.1:4567');
-    });
-
     test('returns the agent for chaining', () => {
       const agent = new Agent(buildOptions());
 
@@ -94,6 +90,14 @@ describe('Agent.addWorkflowExecutor', () => {
       expect(() => agent.addWorkflowExecutor()).toThrow(
         'Cannot use addWorkflowExecutor together with the workflowExecutorUrl option',
       );
+    });
+
+    test('throws when both inMemory and database are provided', () => {
+      const agent = new Agent(buildOptions());
+
+      expect(() =>
+        agent.addWorkflowExecutor({ inMemory: true, database: { uri: 'postgres://localhost/db' } }),
+      ).toThrow('`inMemory` and `database` are mutually exclusive');
     });
   });
 
@@ -178,18 +182,6 @@ describe('Agent.addWorkflowExecutor', () => {
       );
     });
 
-    test('falls back to the DATABASE_URL environment variable when no database is provided', async () => {
-      process.env.DATABASE_URL = 'postgres://env-host/env-db';
-      const agent = new Agent(buildOptions());
-      agent.addWorkflowExecutor({ agentUrl: 'http://my-agent' });
-
-      await agent.start();
-
-      expect(mockBuildDatabaseExecutor).toHaveBeenCalledWith(
-        expect.objectContaining({ database: { uri: 'postgres://env-host/env-db' } }),
-      );
-    });
-
     test('derives the agentUrl from the standalone server port and prefix', async () => {
       const agent = new Agent(buildOptions());
       agent.addWorkflowExecutor({ database: { uri: 'postgres://localhost/db' } });
@@ -248,6 +240,40 @@ describe('Agent.addWorkflowExecutor', () => {
         'Embedded workflow executor requires a database to persist run state',
       );
       expect(mockBuildDatabaseExecutor).not.toHaveBeenCalled();
+    });
+
+    test('builds an in-memory executor without any database when inMemory is set', async () => {
+      const options = buildOptions();
+      const agent = new Agent(options);
+      agent.addWorkflowExecutor({ agentUrl: 'http://my-agent', inMemory: true, port: 4400 });
+
+      await agent.start();
+
+      expect(mockBuildInMemoryExecutor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          envSecret: options.envSecret,
+          authSecret: options.authSecret,
+          agentUrl: 'http://my-agent',
+          httpPort: 4400,
+          manageProcessSignals: false,
+        }),
+      );
+      // In-memory: the database builder must never be reached.
+      expect(mockBuildDatabaseExecutor).not.toHaveBeenCalled();
+      expect(mockExecutorStart).toHaveBeenCalledTimes(1);
+    });
+
+    test('warns that in-memory runs are not persisted', async () => {
+      const logger = jest.fn();
+      const agent = new Agent(buildOptions({ logger }));
+      agent.addWorkflowExecutor({ agentUrl: 'http://my-agent', inMemory: true });
+
+      await agent.start();
+
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        expect.stringContaining('in-memory run store'),
+      );
     });
 
     test('throws when the agentUrl cannot be derived (not standalone) and is not provided', async () => {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-memory executor mode to `EmbeddedWorkflowExecutor`
> - Adds an `inMemory` flag to `WorkflowExecutorEmbedOptions` that builds the executor via `buildInMemoryExecutor` instead of a database-backed one, logging a warning about non-persistence.
> - Adds mutual exclusivity validation: passing both `inMemory` and `database` throws an error.
> - Removes fallback to `DATABASE_URL` and `HTTP_PORT` env vars; `database` is now required unless `inMemory` is true, and port defaults to 3400.
> - Risk: any callers relying on `DATABASE_URL` or `HTTP_PORT` env var fallbacks will now get an explicit error instead of silent fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eadeb28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->