### PR TITLE
feat(agent-bff): reject nested relation field paths in top-level list and count

### DIFF
--- a/packages/agent-bff/src/http/bff-http-error.ts
+++ b/packages/agent-bff/src/http/bff-http-error.ts
@@ -79,3 +79,12 @@ export function missingTimezone(
 export function invalidTimezone(value: string): BffHttpError {
   return new BffHttpError(400, 'invalid_timezone', `Invalid timezone: "${value}"`);
 }
+
+export function relationFieldNotSupported(fields: string[]): BffHttpError {
+  return new BffHttpError(
+    422,
+    'relation_field_not_supported',
+    'Nested relation field paths are not supported on top-level list and count',
+    { fields },
+  );
+}

--- a/packages/agent-bff/src/validation/relation-field-guard.ts
+++ b/packages/agent-bff/src/validation/relation-field-guard.ts
@@ -1,0 +1,15 @@
+import { relationFieldNotSupported } from '../http/bff-http-error';
+
+const RELATION_SEPARATOR = ':';
+
+export default function assertNoRelationFieldPaths(paths: string[]): void {
+  const offending: string[] = [];
+
+  for (const path of paths) {
+    if (path.includes(RELATION_SEPARATOR) && !offending.includes(path)) {
+      offending.push(path);
+    }
+  }
+
+  if (offending.length > 0) throw relationFieldNotSupported(offending);
+}

--- a/packages/agent-bff/test/validation/relation-field-guard.test.ts
+++ b/packages/agent-bff/test/validation/relation-field-guard.test.ts
@@ -1,0 +1,101 @@
+import { type BffHttpError, toErrorBody } from '../../src/http/bff-http-error';
+import assertNoRelationFieldPaths from '../../src/validation/relation-field-guard';
+
+function captureError(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error('expected to throw');
+}
+
+describe('assertNoRelationFieldPaths', () => {
+  it('rejects a nested relation path from a list projection', () => {
+    expect(() => assertNoRelationFieldPaths(['id', 'company:name'])).toThrow(
+      expect.objectContaining({
+        type: 'relation_field_not_supported',
+        status: 422,
+        details: { fields: ['company:name'] },
+      }),
+    );
+  });
+
+  it('rejects a nested relation path from a list filter field', () => {
+    expect(() => assertNoRelationFieldPaths(['owner:email'])).toThrow(
+      expect.objectContaining({
+        type: 'relation_field_not_supported',
+        status: 422,
+        details: { fields: ['owner:email'] },
+      }),
+    );
+  });
+
+  it('rejects a nested relation path from a list sort field', () => {
+    expect(() => assertNoRelationFieldPaths(['company:createdAt'])).toThrow(
+      expect.objectContaining({
+        type: 'relation_field_not_supported',
+        status: 422,
+        details: { fields: ['company:createdAt'] },
+      }),
+    );
+  });
+
+  it('rejects a nested relation path from a count filter field', () => {
+    expect(() => assertNoRelationFieldPaths(['status', 'company:tier'])).toThrow(
+      expect.objectContaining({
+        type: 'relation_field_not_supported',
+        status: 422,
+        details: { fields: ['company:tier'] },
+      }),
+    );
+  });
+
+  it('lists every offending path when several are present', () => {
+    expect(() =>
+      assertNoRelationFieldPaths(['id', 'company:name', 'title', 'owner:email']),
+    ).toThrow(
+      expect.objectContaining({
+        details: { fields: ['company:name', 'owner:email'] },
+      }),
+    );
+  });
+
+  it('reports a single offending path as an array of length 1', () => {
+    const error = captureError(() => assertNoRelationFieldPaths(['company:name']));
+
+    expect((error as BffHttpError).details).toEqual({ fields: ['company:name'] });
+  });
+
+  it('dedupes an offending path seen on two surfaces, keeping first-seen order', () => {
+    expect(() =>
+      assertNoRelationFieldPaths(['company:name', 'id', 'company:name', 'owner:email']),
+    ).toThrow(
+      expect.objectContaining({
+        details: { fields: ['company:name', 'owner:email'] },
+      }),
+    );
+  });
+
+  it('passes through direct field paths unchanged', () => {
+    expect(() => assertNoRelationFieldPaths(['id', 'title', 'createdAt'])).not.toThrow();
+  });
+
+  it('passes through an empty path list', () => {
+    expect(() => assertNoRelationFieldPaths([])).not.toThrow();
+  });
+
+  it('serializes to the wire error envelope with details.fields as an array', () => {
+    const error = captureError(() => assertNoRelationFieldPaths(['company:name', 'owner:email']));
+
+    expect(toErrorBody(error as BffHttpError)).toEqual({
+      error: {
+        type: 'relation_field_not_supported',
+        status: 422,
+        message: 'Nested relation field paths are not supported on top-level list and count',
+        details: { fields: ['company:name', 'owner:email'] },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a pure, syntactic guard in `agent-bff` that rejects any **top-level** list/count field path carrying the relation separator `:` (e.g. `company:name`) with `422 relation_field_not_supported`.

## Why

The agent has an authority gap: a top-level `list` checks browse/scope on the top collection only (`packages/agent/src/routes/access/list.ts`), whereas `listRelated` browse-checks the foreign collection (`list-related.ts`). A relation-target field can thus be projected without the target collection browse/scope check. The BFF must not propagate that gap, so v1 rejects nested relation paths on top-level list/count outright.

## Scope

- `relationFieldNotSupported(fields)` factory on the existing `BffHttpError` contract — envelope `{ error: { type, status, message, details: { fields } } }`, `details.fields` always an array.
- `assertNoRelationFieldPaths(paths)` — throwing guard; offending paths deduped, first-seen order; direct-only and empty input pass through. Syntactic only (no schema/allow-list consulted).
- Guard is internal (imported by path); not exported from the public `index.ts`.

## Non-goals

- Wiring into live list/count handlers (data-endpoints slice / PRD-639).
- `listRelated`/`countRelated`, allow-list validation, capabilities validation.

## Tests

10 focused unit tests: nested path in projection/filter/sort (list) and filter (count); multiple offending; single-as-array; dedupe + order; direct-field & empty pass-through; one `toErrorBody` wire-envelope assertion. Full `agent-bff` suite green (374/374), lint clean.

Fixes PRD-669

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject nested relation field paths in top-level list and count requests
> - Adds [`assertNoRelationFieldPaths`](https://github.com/ForestAdmin/agent-nodejs/pull/1736/files#diff-d5dff585cbbbfecf5fc60610db412c3453cf4ea08e669cd400c6501426622570) that scans field paths for `:` (relation separator) and throws a 422 error listing the offending paths if any are found.
> - Adds a [`relationFieldNotSupported`](https://github.com/ForestAdmin/agent-nodejs/pull/1736/files#diff-74600553bc686d78db3d2c7a16074e0916e788e92797d5ee9a9e3de9130a8b72) error factory producing a `BffHttpError` with status 422, type `relation_field_not_supported`, and the offending fields in `details.fields`.
> - Behavioral Change: top-level list and count requests that include nested relation field paths now return 422 instead of being processed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 843b80c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->