### PR TITLE
feat(mcp-server): configurable basePath to avoid host OAuth route collisions

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -4,6 +4,7 @@ import type {
   AgentOptions,
   AgentOptionsWithDefaults,
   HttpCallback,
+  McpRouteMatcher,
   WorkflowExecutorEmbedOptions,
 } from './types';
 import type { AiProviderDefinition } from '@forestadmin/agent-toolkit';
@@ -55,6 +56,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
   /** Whether MCP server should be mounted */
   private mcpEnabled = false;
   private mcpEnabledTools?: ToolName[];
+  private mcpBasePath?: string;
 
   /** In-process workflow executor, created only when addWorkflowExecutor() is called. */
   private embeddedExecutor: EmbeddedWorkflowExecutor | null = null;
@@ -94,12 +96,12 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    */
   async start(): Promise<void> {
     try {
-      const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
+      const { router, mcpHttpCallback, mcpIsMcpRoute } = await this.buildRouterAndSendSchema();
 
       await this.options.forestAdminClient.subscribeToServerEvents();
       this.options.forestAdminClient.onRefreshCustomizations(this.restart.bind(this));
 
-      this.setMcpCallback(mcpHttpCallback ?? null);
+      this.setMcpCallback(mcpHttpCallback ?? null, mcpIsMcpRoute);
       await this.mount(router);
 
       // Boot after mount(): the embedded executor reaches the agent over HTTP, and the
@@ -140,9 +142,9 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
     try {
       // We force sending schema when restarting
-      const { router, mcpHttpCallback } = await this.buildRouterAndSendSchema();
+      const { router, mcpHttpCallback, mcpIsMcpRoute } = await this.buildRouterAndSendSchema();
 
-      this.setMcpCallback(mcpHttpCallback ?? null);
+      this.setMcpCallback(mcpHttpCallback ?? null, mcpIsMcpRoute);
       await this.remount(router);
     } finally {
       this.isRestarting = false;
@@ -247,10 +249,13 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * agent.mountAiMcpServer();
    * // Example: read-only mode (only browse data, no create/update/delete/actions)
    * agent.mountAiMcpServer({ enabledTools: ['describeCollection', 'list', 'listRelated'] });
+   * // Example: scope MCP routes under a prefix to avoid colliding with your app's own OAuth routes
+   * agent.mountAiMcpServer({ basePath: '/ai' });
    */
-  mountAiMcpServer(options?: { enabledTools?: ToolName[] }): this {
+  mountAiMcpServer(options?: { enabledTools?: ToolName[]; basePath?: string }): this {
     this.mcpEnabled = true;
     this.mcpEnabledTools = options?.enabledTools;
+    this.mcpBasePath = options?.basePath;
 
     return this;
   }
@@ -350,9 +355,11 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Create an http handler which can respond to all queries which are expected from an agent.
    * Returns the main router and optional MCP HTTP callback.
    */
-  private async getRouter(
-    dataSource: DataSource,
-  ): Promise<{ router: Router; mcpHttpCallback?: HttpCallback }> {
+  private async getRouter(dataSource: DataSource): Promise<{
+    router: Router;
+    mcpHttpCallback?: HttpCallback;
+    mcpIsMcpRoute?: McpRouteMatcher;
+  }> {
     // Bootstrap app
     const services = makeServices(this.options);
     const routes = this.getRoutes(dataSource, services);
@@ -361,9 +368,11 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
 
     // Initialize MCP server if enabled via mountAiMcpServer()
     let mcpHttpCallback: HttpCallback | undefined;
+    let mcpIsMcpRoute: McpRouteMatcher | undefined;
 
     if (this.mcpEnabled) {
-      mcpHttpCallback = await this.initializeMcpServer();
+      ({ httpCallback: mcpHttpCallback, isMcpRoute: mcpIsMcpRoute } =
+        await this.initializeMcpServer());
     }
 
     // Build main router
@@ -379,7 +388,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
     );
     routes.forEach(route => route.setupRoutes(router));
 
-    return { router, mcpHttpCallback };
+    return { router, mcpHttpCallback, mcpIsMcpRoute };
   }
 
   /**
@@ -387,12 +396,17 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Uses dynamic import to defer loading until mountAiMcpServer() is actually used.
    * This avoids loading the mcp-server dependency at startup for users who don't use MCP.
    */
-  private async initializeMcpServer(): Promise<HttpCallback> {
+  private async initializeMcpServer(): Promise<{
+    httpCallback: HttpCallback;
+    isMcpRoute: McpRouteMatcher;
+  }> {
     const mcpLogger = (level, message) => this.options.logger(level, `[MCP] ${message}`);
 
     try {
       // Dynamic import to defer loading until actually needed
-      const { ForestMCPServer, ForestServerClientImpl } = await import('@forestadmin/mcp-server');
+      const { ForestMCPServer, ForestServerClientImpl, makeIsMcpRoute } = await import(
+        '@forestadmin/mcp-server'
+      );
 
       const forestServerClient = new ForestServerClientImpl(
         this.options.forestAdminClient.schemaService,
@@ -408,13 +422,15 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         logger: mcpLogger,
         forestServerClient,
         enabledTools: this.mcpEnabledTools,
+        mountPath: this.mcpBasePath,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();
+      const isMcpRoute = makeIsMcpRoute(this.mcpBasePath);
 
       mcpLogger('Info', 'Server initialized successfully');
 
-      return httpCallback;
+      return { httpCallback, isMcpRoute };
     } catch (error) {
       const { message } = error as Error;
       mcpLogger('Error', `Failed to initialize MCP server: ${message}`);
@@ -443,6 +459,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
   private async buildRouterAndSendSchema(): Promise<{
     router: Router;
     mcpHttpCallback?: HttpCallback;
+    mcpIsMcpRoute?: McpRouteMatcher;
   }> {
     const { isProduction, logger, typingsPath, typingsMaxDepth } = this.options;
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -249,7 +249,9 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * agent.mountAiMcpServer();
    * // Example: read-only mode (only browse data, no create/update/delete/actions)
    * agent.mountAiMcpServer({ enabledTools: ['describeCollection', 'list', 'listRelated'] });
-   * // Example: scope MCP routes under a prefix to avoid colliding with your app's own OAuth routes
+   * // Example: scope MCP routes under a prefix to avoid colliding with your app's own OAuth routes.
+   * // OAuth discovery metadata stays at the origin root (prefix-suffixed), so root `.well-known`
+   * // traffic must still reach the agent.
    * agent.mountAiMcpServer({ basePath: '/ai' });
    */
   mountAiMcpServer(options?: { enabledTools?: ToolName[]; basePath?: string }): this {
@@ -422,7 +424,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         logger: mcpLogger,
         forestServerClient,
         enabledTools: this.mcpEnabledTools,
-        mountPath: this.mcpBasePath,
+        basePath: this.mcpBasePath,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/src/framework-mounter.ts
+++ b/packages/agent/src/framework-mounter.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { HttpCallback } from './types';
+import type { HttpCallback, McpRouteMatcher } from './types';
 import type { Logger } from '@forestadmin/datasource-toolkit';
 import type net from 'net';
 
@@ -40,8 +40,8 @@ export default class FrameworkMounter {
   /**
    * Set the MCP HTTP callback. Call this before mount() or remount().
    */
-  protected setMcpCallback(callback: HttpCallback | null): void {
-    this.mcpMiddleware.setCallback(callback);
+  protected setMcpCallback(callback: HttpCallback | null, routeMatcher?: McpRouteMatcher): void {
+    this.mcpMiddleware.setCallback(callback, routeMatcher);
   }
 
   protected async mount(router: Router): Promise<void> {

--- a/packages/agent/src/mcp-middleware.ts
+++ b/packages/agent/src/mcp-middleware.ts
@@ -1,4 +1,4 @@
-import type { HttpCallback } from './types';
+import type { HttpCallback, McpRouteMatcher } from './types';
 import type Koa from 'koa';
 
 import expressToKoa from './utils/express-to-koa';
@@ -22,12 +22,11 @@ function isMcpRoute(url: string): boolean {
  */
 export default class McpMiddleware {
   private mcpHttpCallback: HttpCallback | null = null;
+  private routeMatcher: McpRouteMatcher = isMcpRoute;
 
-  /**
-   * Set the MCP HTTP callback. Call this before using the middleware.
-   */
-  setCallback(callback: HttpCallback | null): void {
+  setCallback(callback: HttpCallback | null, routeMatcher?: McpRouteMatcher): void {
     this.mcpHttpCallback = callback;
+    this.routeMatcher = routeMatcher ?? isMcpRoute;
   }
 
   /**
@@ -64,8 +63,7 @@ export default class McpMiddleware {
           next();
         }
       },
-      // MCP routes are at root: /.well-known/*, /oauth/*, /mcp
-      isMcpRoute,
+      url => this.routeMatcher(url),
     );
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -89,6 +89,8 @@ export type AgentOptionsWithDefaults = Readonly<Required<AgentOptions>>;
 
 export type HttpCallback = (req: IncomingMessage, res: ServerResponse, next?: () => void) => void;
 
+export type McpRouteMatcher = (url: string) => boolean;
+
 export enum HttpCode {
   BadRequest = 400,
   Unauthorized = 401,

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -581,6 +581,16 @@ describe('Agent', () => {
       );
     });
 
+    test('should pass basePath to ForestMCPServer as mountPath', async () => {
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const agent = new Agent(options);
+
+      agent.mountAiMcpServer({ basePath: '/mcp' });
+      await agent.start();
+
+      expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ mountPath: '/mcp' }));
+    });
+
     test('should log error when MCP initialization fails', async () => {
       const mockLogger = jest.fn();
       const options = factories.forestAdminHttpDriverOptions.build({ logger: mockLogger });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -581,14 +581,31 @@ describe('Agent', () => {
       );
     });
 
-    test('should pass basePath to ForestMCPServer as mountPath', async () => {
+    test('should pass basePath to ForestMCPServer', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();
       const agent = new Agent(options);
 
       agent.mountAiMcpServer({ basePath: '/mcp' });
       await agent.start();
 
-      expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ mountPath: '/mcp' }));
+      expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ basePath: '/mcp' }));
+    });
+
+    test('threads a basePath-scoped route matcher to the MCP middleware', async () => {
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const agent = new Agent(options);
+      type SetMcpCallback = (cb: unknown, matcher?: (url: string) => boolean) => void;
+      const setMcpCallbackSpy = jest.spyOn(
+        agent as unknown as { setMcpCallback: SetMcpCallback },
+        'setMcpCallback',
+      );
+
+      agent.mountAiMcpServer({ basePath: '/ai' });
+      await agent.start();
+
+      const matcher = setMcpCallbackSpy.mock.calls.at(-1)?.[1];
+      expect(matcher?.('/ai/mcp')).toBe(true);
+      expect(matcher?.('/oauth/token')).toBe(false);
     });
 
     test('should log error when MCP initialization fails', async () => {

--- a/packages/agent/test/mcp-middleware.test.ts
+++ b/packages/agent/test/mcp-middleware.test.ts
@@ -1,0 +1,35 @@
+import McpMiddleware from '../src/mcp-middleware';
+
+describe('McpMiddleware', () => {
+  function makeCtx(url: string) {
+    return { url, req: {}, res: { once: jest.fn() }, respond: true } as any;
+  }
+
+  test('getKoaMiddleware gates requests with the custom route matcher', async () => {
+    const middleware = new McpMiddleware();
+    const callback = jest.fn((req, res, next) => next());
+    middleware.setCallback(callback, url => url.startsWith('/custom'));
+
+    const koaMiddleware = middleware.getKoaMiddleware();
+
+    await koaMiddleware(makeCtx('/mcp'), jest.fn().mockResolvedValue(undefined) as any);
+    expect(callback).not.toHaveBeenCalled();
+
+    await koaMiddleware(makeCtx('/custom/x'), jest.fn().mockResolvedValue(undefined) as any);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to the default root matcher when none is provided', async () => {
+    const middleware = new McpMiddleware();
+    const callback = jest.fn((req, res, next) => next());
+    middleware.setCallback(callback);
+
+    const koaMiddleware = middleware.getKoaMiddleware();
+
+    await koaMiddleware(makeCtx('/api/other'), jest.fn().mockResolvedValue(undefined) as any);
+    expect(callback).not.toHaveBeenCalled();
+
+    await koaMiddleware(makeCtx('/mcp'), jest.fn().mockResolvedValue(undefined) as any);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,7 +1,14 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
 export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
-export { MCP_PATHS, isMcpRoute } from './mcp-paths';
+export {
+  MCP_PATHS,
+  isMcpRoute,
+  makeIsMcpRoute,
+  buildMcpPaths,
+  normalizeMountPath,
+} from './mcp-paths';
+export type { McpRouteMatcher } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {
   ForestServerClient,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,14 +1,7 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
 export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
-export {
-  MCP_PATHS,
-  isMcpRoute,
-  makeIsMcpRoute,
-  buildMcpPaths,
-  normalizeMountPath,
-} from './mcp-paths';
-export type { McpRouteMatcher } from './mcp-paths';
+export { MCP_PATHS, isMcpRoute, makeIsMcpRoute } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {
   ForestServerClient,

--- a/packages/mcp-server/src/mcp-paths.ts
+++ b/packages/mcp-server/src/mcp-paths.ts
@@ -1,7 +1,55 @@
-/** MCP-specific paths that should be handled by the MCP server */
-export const MCP_PATHS = ['/.well-known/', '/oauth/', '/mcp'];
+export type McpRouteMatcher = (url: string) => boolean;
 
-/** Check if a URL is an MCP route */
-export function isMcpRoute(url: string): boolean {
-  return MCP_PATHS.some(p => url === p || url.startsWith(p));
+export function normalizeMountPath(input?: string): string {
+  if (!input) return '';
+
+  const trimmed = input.trim();
+  if (trimmed === '' || trimmed === '/') return '';
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const collapsed = withLeadingSlash.replace(/\/+/g, '/').replace(/\/+$/, '');
+
+  // The prefix is interpolated raw into Express/Koa route patterns AND resolved through
+  // new URL() to advertise the OAuth metadata. Reject anything that makes those diverge:
+  // path-to-regexp metacharacters, or segments new URL() rewrites (backslash, '.', '..', %-escapes).
+  const urlPath = new URL(collapsed.slice(1), 'http://forestadmin.invalid/').pathname.replace(
+    /\/+$/,
+    '',
+  );
+
+  if (/[?#\s\\:*()+%]/.test(collapsed) || urlPath !== collapsed) {
+    throw new Error(
+      `Invalid MCP mount path "${input}": use a plain path prefix like "/mcp" ` +
+        `(no "..", backslashes, %-escapes, or route metacharacters).`,
+    );
+  }
+
+  return collapsed;
 }
+
+/**
+ * Well-known paths stay anchored at the origin root (per RFC 8414/9728) but carry the prefix
+ * as a suffix, so a host's own root OAuth metadata is not claimed.
+ */
+export function buildMcpPaths(prefix = ''): string[] {
+  const normalized = normalizeMountPath(prefix);
+
+  const wellKnown = normalized
+    ? [
+        `/.well-known/oauth-authorization-server${normalized}`,
+        `/.well-known/oauth-protected-resource${normalized}`,
+      ]
+    : ['/.well-known/'];
+
+  return [...wellKnown, `${normalized}/oauth/`, `${normalized}/mcp`];
+}
+
+export function makeIsMcpRoute(prefix = ''): McpRouteMatcher {
+  const paths = buildMcpPaths(prefix);
+
+  return (url: string) => paths.some(p => url === p || url.startsWith(p));
+}
+
+export const MCP_PATHS = buildMcpPaths('');
+
+export const isMcpRoute = makeIsMcpRoute('');

--- a/packages/mcp-server/src/mcp-paths.ts
+++ b/packages/mcp-server/src/mcp-paths.ts
@@ -9,18 +9,13 @@ export function normalizeMountPath(input?: string): string {
   const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
   const collapsed = withLeadingSlash.replace(/\/+/g, '/').replace(/\/+$/, '');
 
-  // The prefix is interpolated raw into Express/Koa route patterns AND resolved through
-  // new URL() to advertise the OAuth metadata. Reject anything that makes those diverge:
-  // path-to-regexp metacharacters, or segments new URL() rewrites (backslash, '.', '..', %-escapes).
-  const urlPath = new URL(collapsed.slice(1), 'http://forestadmin.invalid/').pathname.replace(
-    /\/+$/,
-    '',
-  );
-
-  if (/[?#\s\\:*()+%[\]]/.test(collapsed) || urlPath !== collapsed) {
+  // Allow only unreserved path characters per segment. The prefix is interpolated raw into
+  // Express/Koa route patterns (path-to-regexp) and resolved through new URL() for the OAuth
+  // metadata; an allowlist keeps those two interpretations identical and future-proof.
+  if (!/^(\/[A-Za-z0-9_-]+)+$/.test(collapsed)) {
     throw new Error(
       `Invalid MCP mount path "${input}": use a plain path prefix like "/mcp" ` +
-        `(no "..", backslashes, %-escapes, or route metacharacters).`,
+        `(letters, digits, "-" and "_" only).`,
     );
   }
 
@@ -47,10 +42,13 @@ export function buildMcpPaths(prefix = ''): string[] {
 export function makeIsMcpRoute(prefix = ''): McpRouteMatcher {
   const paths = buildMcpPaths(prefix);
 
-  // Match on a segment boundary so a claimed path like '/ai/mcp' does not shadow an
-  // unrelated host route like '/ai/mcp-dashboard'.
-  return (url: string) =>
-    paths.some(p => url === p || url.startsWith(p.endsWith('/') ? p : `${p}/`));
+  // Match on the pathname (req.url carries the query string) and on a segment boundary, so
+  // '/mcp?x=1' still matches and '/ai/mcp' does not shadow '/ai/mcp-dashboard'.
+  return (url: string) => {
+    const [pathname] = url.split(/[?#]/, 1);
+
+    return paths.some(p => pathname === p || pathname.startsWith(p.endsWith('/') ? p : `${p}/`));
+  };
 }
 
 export const MCP_PATHS = buildMcpPaths('');

--- a/packages/mcp-server/src/mcp-paths.ts
+++ b/packages/mcp-server/src/mcp-paths.ts
@@ -17,7 +17,7 @@ export function normalizeMountPath(input?: string): string {
     '',
   );
 
-  if (/[?#\s\\:*()+%]/.test(collapsed) || urlPath !== collapsed) {
+  if (/[?#\s\\:*()+%[\]]/.test(collapsed) || urlPath !== collapsed) {
     throw new Error(
       `Invalid MCP mount path "${input}": use a plain path prefix like "/mcp" ` +
         `(no "..", backslashes, %-escapes, or route metacharacters).`,
@@ -47,7 +47,10 @@ export function buildMcpPaths(prefix = ''): string[] {
 export function makeIsMcpRoute(prefix = ''): McpRouteMatcher {
   const paths = buildMcpPaths(prefix);
 
-  return (url: string) => paths.some(p => url === p || url.startsWith(p));
+  // Match on a segment boundary so a claimed path like '/ai/mcp' does not shadow an
+  // unrelated host route like '/ai/mcp-dashboard'.
+  return (url: string) =>
+    paths.some(p => url === p || url.startsWith(p.endsWith('/') ? p : `${p}/`));
 }
 
 export const MCP_PATHS = buildMcpPaths('');

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -119,11 +119,13 @@ export interface ForestMCPServerOptions {
   /** List of tool names to enable (allowlist). Only these tools will be exposed. New tools in future releases will NOT be auto-enabled. */
   enabledTools?: ToolName[];
   /**
-   * Opt-in path prefix under which all MCP routes (OAuth, .well-known, /mcp) are mounted,
-   * e.g. '/mcp'. Defaults to the origin root. Use it to avoid colliding with a host app's
-   * own OAuth routes when the server is embedded in an agent.
+   * Opt-in path prefix under which the MCP protocol and OAuth routes are mounted, e.g. '/ai'.
+   * The `.well-known` discovery documents stay at the origin root (per RFC 8414/9728) but are
+   * served at prefix-suffixed paths. Defaults to the origin root. Use it to avoid colliding
+   * with a host app's own OAuth routes when embedded. Requires the agent to be served at the
+   * domain root.
    */
-  mountPath?: string;
+  basePath?: string;
 }
 
 /**
@@ -145,7 +147,7 @@ export default class ForestMCPServer {
   private logger: Logger;
   private collectionNames: string[] = [];
   private enabledTools: Set<ToolName>;
-  private mountPath: string;
+  private basePath: string;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -154,7 +156,7 @@ export default class ForestMCPServer {
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
     this.enabledTools = this.resolveEnabledTools(options);
-    this.mountPath = normalizeMountPath(options?.mountPath);
+    this.basePath = normalizeMountPath(options?.basePath);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -486,14 +488,20 @@ export default class ForestMCPServer {
       );
     }
 
-    const { mountPath: prefix } = this;
-    // Resolve the prefix relatively against a trailing-slash base so a path on the base URL
-    // (e.g. https://host/agent) is preserved rather than dropped by URL resolution.
-    const baseWithSlash = effectiveBaseUrl.href.endsWith('/')
-      ? effectiveBaseUrl
-      : new URL(`${effectiveBaseUrl.href}/`);
-    const mountBase = prefix ? new URL(`${prefix.slice(1)}/`, baseWithSlash) : baseWithSlash;
-    const issuerUrl = prefix ? new URL(prefix.slice(1), baseWithSlash) : baseWithSlash;
+    const { basePath: prefix } = this;
+
+    // OAuth discovery must be served at the origin root, so a mount prefix only works when the
+    // agent itself is at the domain root. Fail loudly rather than advertise URLs we can't serve.
+    if (prefix && effectiveBaseUrl.pathname !== '/') {
+      throw new Error(
+        `MCP basePath "${prefix}" requires the agent to be served at the domain root, but its ` +
+          `base URL has a path ("${effectiveBaseUrl.pathname}"). Remove the basePath or mount ` +
+          `the agent at the root.`,
+      );
+    }
+
+    const mountBase = prefix ? new URL(`${prefix.slice(1)}/`, effectiveBaseUrl) : effectiveBaseUrl;
+    const issuerUrl = prefix ? new URL(prefix.slice(1), effectiveBaseUrl) : effectiveBaseUrl;
 
     const scopesSupported = ['mcp:read', 'mcp:write', 'mcp:action', 'mcp:admin'];
 
@@ -634,8 +642,8 @@ export default class ForestMCPServer {
 
   /**
    * Build and return an HTTP callback that can be used as middleware.
-   * The callback will handle MCP-related routes (/.well-known/*, /oauth/*, /mcp)
-   * and call next() for other routes.
+   * The callback handles the MCP OAuth, `.well-known` and protocol routes (scoped under
+   * `basePath` when set) and calls next() for every other route.
    *
    * @param baseUrl - Optional base URL override. If not provided, will use the
    *                  environmentApiEndpoint from Forest Admin API.
@@ -643,7 +651,7 @@ export default class ForestMCPServer {
    */
   async getHttpCallback(baseUrl?: URL): Promise<HttpCallback> {
     const app = await this.buildExpressApp(baseUrl);
-    const isMcpRoute = makeIsMcpRoute(this.mountPath);
+    const isMcpRoute = makeIsMcpRoute(this.basePath);
 
     return (req, res, next) => {
       const url = req.url || '/';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -554,22 +554,30 @@ export default class ForestMCPServer {
     );
     app.use(`${prefix}/oauth/token`, tokenHandler({ provider: oauthProvider }));
 
-    // Mount metadata router with custom metadata
     // The resourceServerUrl includes the /mcp path to match RFC 9728 requirements.
     const mcpResourceUrl = new URL('mcp', mountBase);
-    app.use(
-      mcpAuthMetadataRouter({
-        oauthMetadata,
-        resourceServerUrl: mcpResourceUrl,
-        scopesSupported,
-      }),
-    );
 
-    // mcpAuthMetadataRouter hardcodes the authorization-server metadata at the root
-    // /.well-known/oauth-authorization-server. With a path-scoped issuer the client fetches it
-    // at the RFC 8414 suffixed path instead, so mount it there ourselves.
     if (prefix) {
+      // Serve both discovery documents ourselves at the RFC 8414/9728 prefix-suffixed paths.
+      // mcpAuthMetadataRouter would additionally mount the authorization-server metadata at the
+      // bare origin root, which would shadow a host app's own root discovery.
+      app.use(
+        `/.well-known/oauth-protected-resource${mcpResourceUrl.pathname}`,
+        metadataHandler({
+          resource: mcpResourceUrl.href,
+          authorization_servers: [oauthMetadata.issuer],
+          scopes_supported: scopesSupported,
+        }),
+      );
       app.use(`/.well-known/oauth-authorization-server${prefix}`, metadataHandler(oauthMetadata));
+    } else {
+      app.use(
+        mcpAuthMetadataRouter({
+          oauthMetadata,
+          resourceServerUrl: mcpResourceUrl,
+          scopesSupported,
+        }),
+      );
     }
 
     app.use(allowedMethods(['POST']));

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -487,9 +487,13 @@ export default class ForestMCPServer {
     }
 
     const { mountPath: prefix } = this;
-    // Relative resolution (not leading-slash) so a base path on effectiveBaseUrl is preserved.
-    const mountBase = prefix ? new URL(`${prefix.slice(1)}/`, effectiveBaseUrl) : effectiveBaseUrl;
-    const issuerUrl = prefix ? new URL(prefix.slice(1), effectiveBaseUrl) : effectiveBaseUrl;
+    // Resolve the prefix relatively against a trailing-slash base so a path on the base URL
+    // (e.g. https://host/agent) is preserved rather than dropped by URL resolution.
+    const baseWithSlash = effectiveBaseUrl.href.endsWith('/')
+      ? effectiveBaseUrl
+      : new URL(`${effectiveBaseUrl.href}/`);
+    const mountBase = prefix ? new URL(`${prefix.slice(1)}/`, baseWithSlash) : baseWithSlash;
+    const issuerUrl = prefix ? new URL(prefix.slice(1), baseWithSlash) : baseWithSlash;
 
     const scopesSupported = ['mcp:read', 'mcp:write', 'mcp:action', 'mcp:admin'];
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import type { ForestServerClient } from './http-client';
 import type { Express } from 'express';
 
 import { authorizationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/authorize.js';
+import { metadataHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/metadata.js';
 import { tokenHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/token.js';
 import { allowedMethods } from '@modelcontextprotocol/sdk/server/auth/middleware/allowedMethods.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
@@ -21,7 +22,7 @@ import * as http from 'http';
 
 import ForestOAuthProvider from './forest-oauth-provider';
 import { createForestServerClient } from './http-client';
-import { isMcpRoute } from './mcp-paths';
+import { makeIsMcpRoute, normalizeMountPath } from './mcp-paths';
 import declareAssociateTool from './tools/associate';
 import declareCreateTool from './tools/create';
 import declareDeleteTool from './tools/delete';
@@ -117,6 +118,12 @@ export interface ForestMCPServerOptions {
   forestServerClient?: ForestServerClient;
   /** List of tool names to enable (allowlist). Only these tools will be exposed. New tools in future releases will NOT be auto-enabled. */
   enabledTools?: ToolName[];
+  /**
+   * Opt-in path prefix under which all MCP routes (OAuth, .well-known, /mcp) are mounted,
+   * e.g. '/mcp'. Defaults to the origin root. Use it to avoid colliding with a host app's
+   * own OAuth routes when the server is embedded in an agent.
+   */
+  mountPath?: string;
 }
 
 /**
@@ -138,6 +145,7 @@ export default class ForestMCPServer {
   private logger: Logger;
   private collectionNames: string[] = [];
   private enabledTools: Set<ToolName>;
+  private mountPath: string;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -146,6 +154,7 @@ export default class ForestMCPServer {
     this.authSecret = options?.authSecret;
     this.logger = options?.logger || defaultLogger;
     this.enabledTools = this.resolveEnabledTools(options);
+    this.mountPath = normalizeMountPath(options?.mountPath);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -477,13 +486,18 @@ export default class ForestMCPServer {
       );
     }
 
+    const { mountPath: prefix } = this;
+    // Relative resolution (not leading-slash) so a base path on effectiveBaseUrl is preserved.
+    const mountBase = prefix ? new URL(`${prefix.slice(1)}/`, effectiveBaseUrl) : effectiveBaseUrl;
+    const issuerUrl = prefix ? new URL(prefix.slice(1), effectiveBaseUrl) : effectiveBaseUrl;
+
     const scopesSupported = ['mcp:read', 'mcp:write', 'mcp:action', 'mcp:admin'];
 
     // Create OAuth metadata with custom registration_endpoint pointing to Forest Admin
     const oauthMetadata = createOAuthMetadata({
       provider: oauthProvider,
-      issuerUrl: effectiveBaseUrl,
-      baseUrl: effectiveBaseUrl,
+      issuerUrl,
+      baseUrl: issuerUrl,
       scopesSupported,
     });
 
@@ -491,8 +505,8 @@ export default class ForestMCPServer {
     oauthMetadata.response_types_supported = ['code'];
     oauthMetadata.code_challenge_methods_supported = ['S256'];
 
-    oauthMetadata.token_endpoint = `${effectiveBaseUrl.href}oauth/token`;
-    oauthMetadata.authorization_endpoint = `${effectiveBaseUrl.href}oauth/authorize`;
+    oauthMetadata.token_endpoint = `${mountBase.href}oauth/token`;
+    oauthMetadata.authorization_endpoint = `${mountBase.href}oauth/authorize`;
     // Override registration_endpoint to point to Forest Admin server
     oauthMetadata.registration_endpoint = `${this.forestServerUrl}/oauth/register`;
     // Remove revocation_endpoint from metadata (not supported)
@@ -521,17 +535,16 @@ export default class ForestMCPServer {
     });
 
     app.use(
-      '/oauth/authorize',
+      `${prefix}/oauth/authorize`,
       authorizationHandler({
         provider: oauthProvider,
       }),
     );
-    app.use('/oauth/token', tokenHandler({ provider: oauthProvider }));
+    app.use(`${prefix}/oauth/token`, tokenHandler({ provider: oauthProvider }));
 
     // Mount metadata router with custom metadata
-    // The resourceServerUrl should include the /mcp path to match RFC 9728 requirements.
-    // This creates the .well-known/oauth-protected-resource/mcp endpoint.
-    const mcpResourceUrl = new URL('mcp', effectiveBaseUrl);
+    // The resourceServerUrl includes the /mcp path to match RFC 9728 requirements.
+    const mcpResourceUrl = new URL('mcp', mountBase);
     app.use(
       mcpAuthMetadataRouter({
         oauthMetadata,
@@ -540,15 +553,24 @@ export default class ForestMCPServer {
       }),
     );
 
+    // mcpAuthMetadataRouter hardcodes the authorization-server metadata at the root
+    // /.well-known/oauth-authorization-server. With a path-scoped issuer the client fetches it
+    // at the RFC 8414 suffixed path instead, so mount it there ourselves.
+    if (prefix) {
+      app.use(`/.well-known/oauth-authorization-server${prefix}`, metadataHandler(oauthMetadata));
+    }
+
     app.use(allowedMethods(['POST']));
 
     app.post(
-      '/mcp',
+      `${prefix}/mcp`,
       requireBearerAuth({
         verifier: oauthProvider,
         requiredScopes: ['mcp:read'],
-        resourceMetadataUrl: new URL('/.well-known/oauth-protected-resource/mcp', effectiveBaseUrl)
-          .href,
+        resourceMetadataUrl: new URL(
+          `/.well-known/oauth-protected-resource${mcpResourceUrl.pathname}`,
+          effectiveBaseUrl,
+        ).href,
       }),
       (req, res) => {
         this.handleMcpRequest(req, res).catch(error => {
@@ -617,6 +639,7 @@ export default class ForestMCPServer {
    */
   async getHttpCallback(baseUrl?: URL): Promise<HttpCallback> {
     const app = await this.buildExpressApp(baseUrl);
+    const isMcpRoute = makeIsMcpRoute(this.mountPath);
 
     return (req, res, next) => {
       const url = req.url || '/';

--- a/packages/mcp-server/test/mcp-paths.test.ts
+++ b/packages/mcp-server/test/mcp-paths.test.ts
@@ -31,6 +31,7 @@ describe('mcp-paths', () => {
       '/mcp*',
       '/tenant/:id',
       '/m%20cp',
+      '/foo[bar]',
     ])('throws for %p (would desync routes from advertised metadata)', input => {
       expect(() => normalizeMountPath(input)).toThrow(/Invalid MCP mount path/);
     });
@@ -76,8 +77,8 @@ describe('mcp-paths', () => {
       },
     );
 
-    it('isMcpRoute passes through unrelated routes', () => {
-      expect(isMcpRoute('/api/other')).toBe(false);
+    it.each(['/api/other', '/mcp-dashboard'])('isMcpRoute passes through %p', url => {
+      expect(isMcpRoute(url)).toBe(false);
     });
   });
 
@@ -100,6 +101,8 @@ describe('mcp-paths', () => {
       '/.well-known/oauth-authorization-server',
       '/.well-known/oauth-protected-resource',
       '/api/other',
+      '/mcp/mcp-dashboard',
+      '/.well-known/oauth-protected-resource/mcp-dashboard',
     ])('passes through host route %p', url => {
       expect(matches(url)).toBe(false);
     });

--- a/packages/mcp-server/test/mcp-paths.test.ts
+++ b/packages/mcp-server/test/mcp-paths.test.ts
@@ -32,6 +32,9 @@ describe('mcp-paths', () => {
       '/tenant/:id',
       '/m%20cp',
       '/foo[bar]',
+      '/a!b',
+      '/m|b',
+      '/m^b',
     ])('throws for %p (would desync routes from advertised metadata)', input => {
       expect(() => normalizeMountPath(input)).toThrow(/Invalid MCP mount path/);
     });
@@ -70,7 +73,7 @@ describe('mcp-paths', () => {
       expect(MCP_PATHS).toEqual(['/.well-known/', '/oauth/', '/mcp']);
     });
 
-    it.each(['/.well-known/oauth-authorization-server', '/oauth/token', '/mcp'])(
+    it.each(['/.well-known/oauth-authorization-server', '/oauth/token', '/mcp', '/mcp?foo=1'])(
       'isMcpRoute claims %p',
       url => {
         expect(isMcpRoute(url)).toBe(true);
@@ -87,6 +90,7 @@ describe('mcp-paths', () => {
 
     it.each([
       '/mcp/mcp',
+      '/mcp/mcp?x=1',
       '/mcp/oauth/authorize',
       '/mcp/oauth/token',
       '/.well-known/oauth-authorization-server/mcp',

--- a/packages/mcp-server/test/mcp-paths.test.ts
+++ b/packages/mcp-server/test/mcp-paths.test.ts
@@ -1,0 +1,107 @@
+import {
+  MCP_PATHS,
+  buildMcpPaths,
+  isMcpRoute,
+  makeIsMcpRoute,
+  normalizeMountPath,
+} from '../src/mcp-paths';
+
+describe('mcp-paths', () => {
+  describe('normalizeMountPath', () => {
+    it.each([undefined, '', '/', '  '])('returns "" for %p (root default)', input => {
+      expect(normalizeMountPath(input)).toBe('');
+    });
+
+    it.each([
+      ['mcp', '/mcp'],
+      ['/mcp', '/mcp'],
+      ['/mcp/', '/mcp'],
+      ['//mcp//', '/mcp'],
+      ['/api/mcp', '/api/mcp'],
+    ])('normalizes %p to %p', (input, expected) => {
+      expect(normalizeMountPath(input)).toBe(expected);
+    });
+
+    it.each([
+      '/m?cp',
+      '/m#cp',
+      '/m cp',
+      '/mcp\\admin',
+      '/a/../mcp',
+      '/mcp*',
+      '/tenant/:id',
+      '/m%20cp',
+    ])('throws for %p (would desync routes from advertised metadata)', input => {
+      expect(() => normalizeMountPath(input)).toThrow(/Invalid MCP mount path/);
+    });
+  });
+
+  describe('buildMcpPaths', () => {
+    it('claims the root well-known namespace by default', () => {
+      expect(buildMcpPaths('')).toEqual(['/.well-known/', '/oauth/', '/mcp']);
+    });
+
+    it('claims prefix-suffixed well-known paths under a prefix', () => {
+      expect(buildMcpPaths('/mcp')).toEqual([
+        '/.well-known/oauth-authorization-server/mcp',
+        '/.well-known/oauth-protected-resource/mcp',
+        '/mcp/oauth/',
+        '/mcp/mcp',
+      ]);
+    });
+
+    it('claims nested prefix paths', () => {
+      expect(buildMcpPaths('/api/mcp')).toEqual([
+        '/.well-known/oauth-authorization-server/api/mcp',
+        '/.well-known/oauth-protected-resource/api/mcp',
+        '/api/mcp/oauth/',
+        '/api/mcp/mcp',
+      ]);
+    });
+
+    it('normalizes a raw (un-normalized) prefix on entry', () => {
+      expect(buildMcpPaths('mcp/')).toEqual(buildMcpPaths('/mcp'));
+    });
+  });
+
+  describe('default exports (root)', () => {
+    it('MCP_PATHS matches the historical root paths', () => {
+      expect(MCP_PATHS).toEqual(['/.well-known/', '/oauth/', '/mcp']);
+    });
+
+    it.each(['/.well-known/oauth-authorization-server', '/oauth/token', '/mcp'])(
+      'isMcpRoute claims %p',
+      url => {
+        expect(isMcpRoute(url)).toBe(true);
+      },
+    );
+
+    it('isMcpRoute passes through unrelated routes', () => {
+      expect(isMcpRoute('/api/other')).toBe(false);
+    });
+  });
+
+  describe('makeIsMcpRoute with prefix /mcp', () => {
+    const matches = makeIsMcpRoute('/mcp');
+
+    it.each([
+      '/mcp/mcp',
+      '/mcp/oauth/authorize',
+      '/mcp/oauth/token',
+      '/.well-known/oauth-authorization-server/mcp',
+      '/.well-known/oauth-protected-resource/mcp/mcp',
+    ])('claims prefixed route %p', url => {
+      expect(matches(url)).toBe(true);
+    });
+
+    it.each([
+      '/oauth/token',
+      '/mcp',
+      '/.well-known/oauth-authorization-server',
+      '/.well-known/oauth-protected-resource',
+      '/api/other',
+    ])('passes through host route %p', url => {
+      expect(matches(url)).toBe(false);
+    });
+  });
+});

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2565,7 +2565,7 @@ describe('mountPath prefix', () => {
         envSecret: 'ENV_SECRET',
         authSecret: 'AUTH_SECRET',
         forestServerClient: createMockForestServerClient(),
-        mountPath: '/mcp',
+        basePath: '/mcp',
       });
       app = await server.buildExpressApp(new URL('http://localhost:3000'));
     });
@@ -2579,13 +2579,19 @@ describe('mountPath prefix', () => {
         'http://localhost:3000/mcp/oauth/authorize',
       );
       expect(response.body.token_endpoint).toBe('http://localhost:3000/mcp/oauth/token');
+      // registration_endpoint must stay the unprefixed Forest server URL.
+      expect(response.body.registration_endpoint).toBe(
+        'https://api.forestadmin.com/oauth/register',
+      );
     });
 
-    it('serves protected-resource metadata under the prefixed resource path', async () => {
+    it('serves protected-resource metadata pointing at the prefixed issuer', async () => {
       const response = await request(app).get('/.well-known/oauth-protected-resource/mcp/mcp');
 
       expect(response.status).toBe(200);
       expect(response.body.resource).toBe('http://localhost:3000/mcp/mcp');
+      // authorization_servers is the field the client follows to reach the issuer.
+      expect(response.body.authorization_servers).toEqual(['http://localhost:3000/mcp']);
     });
 
     it('mounts the MCP endpoint at the prefixed path with a prefixed resource metadata url', async () => {
@@ -2611,7 +2617,7 @@ describe('mountPath prefix', () => {
         envSecret: 'ENV_SECRET',
         authSecret: 'AUTH_SECRET',
         forestServerClient: createMockForestServerClient(),
-        mountPath: '/api/mcp',
+        basePath: '/api/mcp',
       });
       const app = await server.buildExpressApp(new URL('http://localhost:3000'));
 
@@ -2627,18 +2633,17 @@ describe('mountPath prefix', () => {
       expect(mcp.status).toBe(401);
     });
 
-    it('preserves a base path on the origin even without a trailing slash', async () => {
+    it('rejects a basePath when the base URL is not at the domain root', async () => {
       const server = new ForestMCPServer({
         envSecret: 'ENV_SECRET',
         authSecret: 'AUTH_SECRET',
         forestServerClient: createMockForestServerClient(),
-        mountPath: '/mcp',
+        basePath: '/mcp',
       });
-      const app = await server.buildExpressApp(new URL('http://localhost:3000/agent'));
 
-      const metadata = await request(app).get('/.well-known/oauth-authorization-server/mcp');
-      expect(metadata.body.issuer).toBe('http://localhost:3000/agent/mcp');
-      expect(metadata.body.token_endpoint).toBe('http://localhost:3000/agent/mcp/oauth/token');
+      await expect(server.buildExpressApp(new URL('http://localhost:3000/agent'))).rejects.toThrow(
+        /requires the agent to be served at the domain root/,
+      );
     });
   });
 
@@ -2652,7 +2657,7 @@ describe('mountPath prefix', () => {
         envSecret: 'ENV_SECRET',
         authSecret: 'AUTH_SECRET',
         forestServerClient: createMockForestServerClient(),
-        mountPath: '/mcp',
+        basePath: '/mcp',
       });
       callback = await server.getHttpCallback(new URL('http://localhost:3000'));
     });

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2627,14 +2627,14 @@ describe('mountPath prefix', () => {
       expect(mcp.status).toBe(401);
     });
 
-    it('preserves a base path on the origin when it has a trailing slash', async () => {
+    it('preserves a base path on the origin even without a trailing slash', async () => {
       const server = new ForestMCPServer({
         envSecret: 'ENV_SECRET',
         authSecret: 'AUTH_SECRET',
         forestServerClient: createMockForestServerClient(),
         mountPath: '/mcp',
       });
-      const app = await server.buildExpressApp(new URL('http://localhost:3000/agent/'));
+      const app = await server.buildExpressApp(new URL('http://localhost:3000/agent'));
 
       const metadata = await request(app).get('/.well-known/oauth-authorization-server/mcp');
       expect(metadata.body.issuer).toBe('http://localhost:3000/agent/mcp');

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2528,6 +2528,169 @@ describe('getHttpCallback', () => {
   });
 });
 
+describe('mountPath prefix', () => {
+  const originalFetch = global.fetch;
+
+  function mockForestFetch(): void {
+    const mockFetchServer = new MockServer();
+    mockFetchServer
+      .get('/liana/environment', {
+        data: { id: '12345', attributes: { api_endpoint: 'https://api.example.com' } },
+      })
+      .get('/liana/forest-schema', {
+        data: [
+          {
+            id: 'users',
+            type: 'collections',
+            attributes: { name: 'users', fields: [{ field: 'id', type: 'Number' }] },
+          },
+        ],
+        meta: { liana: 'forest-express-sequelize', liana_version: '9.0.0', liana_features: null },
+      })
+      .get(/\/oauth\/register\//, { error: 'Client not found' }, 404);
+
+    global.fetch = mockFetchServer.fetch;
+  }
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('metadata and routes under /mcp', () => {
+    let app: Awaited<ReturnType<ForestMCPServer['buildExpressApp']>>;
+
+    beforeEach(async () => {
+      mockForestFetch();
+      const server = new ForestMCPServer({
+        envSecret: 'ENV_SECRET',
+        authSecret: 'AUTH_SECRET',
+        forestServerClient: createMockForestServerClient(),
+        mountPath: '/mcp',
+      });
+      app = await server.buildExpressApp(new URL('http://localhost:3000'));
+    });
+
+    it('serves authorization-server metadata at the RFC 8414 suffixed path with prefixed endpoints', async () => {
+      const response = await request(app).get('/.well-known/oauth-authorization-server/mcp');
+
+      expect(response.status).toBe(200);
+      expect(response.body.issuer).toBe('http://localhost:3000/mcp');
+      expect(response.body.authorization_endpoint).toBe(
+        'http://localhost:3000/mcp/oauth/authorize',
+      );
+      expect(response.body.token_endpoint).toBe('http://localhost:3000/mcp/oauth/token');
+    });
+
+    it('serves protected-resource metadata under the prefixed resource path', async () => {
+      const response = await request(app).get('/.well-known/oauth-protected-resource/mcp/mcp');
+
+      expect(response.status).toBe(200);
+      expect(response.body.resource).toBe('http://localhost:3000/mcp/mcp');
+    });
+
+    it('mounts the MCP endpoint at the prefixed path with a prefixed resource metadata url', async () => {
+      const response = await request(app)
+        .post('/mcp/mcp')
+        .set('Content-Type', 'application/json')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+
+      expect(response.status).toBe(401);
+      expect(response.headers['www-authenticate']).toContain(
+        '/.well-known/oauth-protected-resource/mcp/mcp',
+      );
+    });
+  });
+
+  describe('nested prefix and base-path resolution', () => {
+    beforeEach(() => {
+      mockForestFetch();
+    });
+
+    it('scopes routes and metadata under a nested prefix', async () => {
+      const server = new ForestMCPServer({
+        envSecret: 'ENV_SECRET',
+        authSecret: 'AUTH_SECRET',
+        forestServerClient: createMockForestServerClient(),
+        mountPath: '/api/mcp',
+      });
+      const app = await server.buildExpressApp(new URL('http://localhost:3000'));
+
+      const metadata = await request(app).get('/.well-known/oauth-authorization-server/api/mcp');
+      expect(metadata.status).toBe(200);
+      expect(metadata.body.issuer).toBe('http://localhost:3000/api/mcp');
+      expect(metadata.body.token_endpoint).toBe('http://localhost:3000/api/mcp/oauth/token');
+
+      const mcp = await request(app)
+        .post('/api/mcp/mcp')
+        .set('Content-Type', 'application/json')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+      expect(mcp.status).toBe(401);
+    });
+
+    it('preserves a base path on the origin when it has a trailing slash', async () => {
+      const server = new ForestMCPServer({
+        envSecret: 'ENV_SECRET',
+        authSecret: 'AUTH_SECRET',
+        forestServerClient: createMockForestServerClient(),
+        mountPath: '/mcp',
+      });
+      const app = await server.buildExpressApp(new URL('http://localhost:3000/agent/'));
+
+      const metadata = await request(app).get('/.well-known/oauth-authorization-server/mcp');
+      expect(metadata.body.issuer).toBe('http://localhost:3000/agent/mcp');
+      expect(metadata.body.token_endpoint).toBe('http://localhost:3000/agent/mcp/oauth/token');
+    });
+  });
+
+  describe('getHttpCallback route filtering under /mcp', () => {
+    let callback: (req: http.IncomingMessage, res: http.ServerResponse, next?: () => void) => void;
+    let callbackServer: http.Server;
+
+    beforeEach(async () => {
+      mockForestFetch();
+      const server = new ForestMCPServer({
+        envSecret: 'ENV_SECRET',
+        authSecret: 'AUTH_SECRET',
+        forestServerClient: createMockForestServerClient(),
+        mountPath: '/mcp',
+      });
+      callback = await server.getHttpCallback(new URL('http://localhost:3000'));
+    });
+
+    afterEach(async () => {
+      await shutDownHttpServer(callbackServer);
+    });
+
+    it('delegates the prefixed MCP endpoint to the Express app', async () => {
+      callbackServer = http.createServer(callback);
+      callbackServer.listen(0);
+      await new Promise(resolve => {
+        callbackServer.on('listening', resolve);
+      });
+
+      const response = await request(callbackServer)
+        .post('/mcp/mcp')
+        .set('Content-Type', 'application/json')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+
+      expect(response.status).toBe(401);
+    });
+
+    it.each(['/oauth/token', '/mcp', '/.well-known/oauth-authorization-server', '/api/other'])(
+      'passes host route %p through to next()',
+      url => {
+        const req = { url } as http.IncomingMessage;
+        const res = {} as http.ServerResponse;
+        const next = jest.fn();
+
+        callback(req, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+});
+
 describe('handleMcpRequest cleanup', () => {
   const originalFetch = global.fetch;
   let cleanupServer: ForestMCPServer;

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2528,7 +2528,7 @@ describe('getHttpCallback', () => {
   });
 });
 
-describe('mountPath prefix', () => {
+describe('basePath prefix', () => {
   const originalFetch = global.fetch;
 
   function mockForestFetch(): void {

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2594,6 +2594,14 @@ describe('mountPath prefix', () => {
       expect(response.body.authorization_servers).toEqual(['http://localhost:3000/mcp']);
     });
 
+    it('does not serve authorization-server metadata at the bare origin root', async () => {
+      const response = await request(app).get('/.well-known/oauth-authorization-server');
+
+      // The root discovery document is left to the host app, not shadowed by the MCP server.
+      expect(response.status).not.toBe(200);
+      expect(response.body.issuer).toBeUndefined();
+    });
+
     it('mounts the MCP endpoint at the prefixed path with a prefixed resource metadata url', async () => {
       const response = await request(app)
         .post('/mcp/mcp')


### PR DESCRIPTION
## Context

When the MCP server is embedded via `agent.mountAiMcpServer()`, it registers its OAuth (`/oauth/authorize`, `/oauth/token`), `.well-known/*` and `/mcp` routes **at the host root**. If the host app already does OAuth, the MCP server **overrides its routes** and breaks the app's authentication (reported by a customer). The only workaround today is running the MCP server standalone.

This PR adds an **opt-in `basePath`** option that scopes every MCP route under a prefix, so the MCP server coexists with the host's OAuth.

```ts
agent.mountAiMcpServer({ basePath: '/ai' }); // routes under /ai/*
agent.mountAiMcpServer();                     // default: root, unchanged
```

## How it works

- The prefix is applied to the active routes (`/ai/oauth/authorize`, `/ai/oauth/token`, `/ai/mcp`) and, per RFC 8414/9728, as a **suffix** to the root-anchored well-known paths (`/.well-known/oauth-authorization-server/ai`). The MCP client discovers all endpoints dynamically from the advertised metadata, so no path is hardcoded on the client side.
- The authorization-server metadata is mounted manually at the suffixed path because the SDK's `mcpAuthMetadataRouter` only serves it at the root.
- **Default (no `basePath`) is byte-identical** to the previous behavior — zero breaking change for deployed MCP servers.

⚠️ `basePath: '/mcp'` yields the MCP endpoint at `/mcp/mcp` (the prefix applies to all routes). A distinct prefix like `/ai` avoids the doubling — to be documented.

## Validation

`normalizeMountPath` rejects any input that `new URL()` would rewrite differently from the raw-string route mounts (backslash, `..`, `%`-escapes, path-to-regexp metacharacters), preventing a silent advertised-vs-mounted route desync at this user-facing trust boundary.

## Tests

- `mcp-paths.test.ts` (new): normalization, validation rejects, prefixed/nested path building, idempotence
- `server.test.ts`: prefix-mode metadata + endpoints + `WWW-Authenticate`, `getHttpCallback` route filtering (host routes pass through, prefixed routes delegated), nested `/api/mcp`, base-path preservation
- `mcp-middleware.test.ts` (new): Koa matcher gating
- `agent.test.ts`: `basePath` threading

mcp-server: 593 tests pass. Reviewed with the pr-review-toolkit agents + skeptic pass; findings addressed.

## Definition of Done

### General

- [x] Explicit title following Conventional Commits
- [x] Test manually the implemented changes
- [x] Validate the code quality

### Security

- [x] Consider the security impact — input validation added at the `basePath` trust boundary; default behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `basePath` to `ForestMCPServer` to avoid OAuth route collisions with the host app
> - Adds an optional `mountPath` to `ForestMCPServerOptions` that scopes all MCP routes (`/oauth`, `/.well-known`, `/mcp`) under a URL prefix, avoiding collisions with host app routes.
> - Introduces `normalizeMountPath`, `buildMcpPaths`, and `makeIsMcpRoute` in [mcp-paths.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1737/files#diff-53973bdee82330bf78536c987252e943f34d14dd93b88066697528d8483aa0bf) to validate prefixes, construct prefixed route lists, and match routes at segment boundaries.
> - `ForestMCPServer.buildExpressApp` mounts OAuth and MCP endpoints under the prefix and serves RFC 8414 authorization-server metadata at the prefixed `.well-known` path instead of the host root.
> - The `McpMiddleware` and `FrameworkMounter` are updated to accept a custom route matcher so that only prefixed MCP routes are intercepted by the middleware.
> - Behavioral Change: the default (no prefix) `isMcpRoute` now uses segment-boundary semantics, so paths like `/mcp-dashboard` no longer match as MCP routes.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1737 opened
>
> - Removed re-exports of `buildMcpPaths`, `normalizeMountPath`, and `McpRouteMatcher` type from `mcp-server` package [8f18b83]
> - Added validation in `ForestMCPServer.buildExpressApp` that throws an error when a `basePath` is configured but the effective base URL contains a non-root pathname [c293175]
> - Restricted accepted characters in mount path validation within `normalizeMountPath` function to only allow letters, digits, hyphens, and underscores per segment using regex pattern `^(\/[A-Za-z0-9_-]+)+$` [c293175]
> - Modified `makeIsMcpRoute` function to extract pathname by splitting on query string and fragment delimiters before performing route matching [c293175]
> - Renamed `mountPath` option to `basePath` throughout `mcp-server` package in `ForestMCPServerOptions` interface, `ForestMCPServer` class field, and all call sites in `agent` package [c293175]
> - Updated documentation in `ForestMCPServerOptions` and `Agent.mountAiMcpServer` JSDoc to clarify that well-known OAuth discovery endpoints remain at origin root while OAuth and MCP protocol routes are mounted under the `basePath` [c293175]
> - Modified OAuth discovery metadata serving in `ForestMCPServer.buildExpressApp` to conditionally mount endpoints based on prefix presence [77cd41e]
> - Added test verifying authorization-server metadata is not served at bare origin root when prefix is configured [77cd41e]
> - Renamed Jest describe block in `mcp-server` test suite from 'mountPath prefix' to 'basePath prefix' [5d1e2c8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d872b93.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->