### PR TITLE
feat(agent-bff): map agent errors to the BFF error contract

### DIFF
--- a/packages/agent-bff/package.json
+++ b/packages/agent-bff/package.json
@@ -31,6 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@forestadmin/agent-client": "1.10.1",
     "@forestadmin/forestadmin-client": "1.40.4",
     "@koa/bodyparser": "^6.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -51,6 +51,7 @@ const FALLBACK_TYPE_BY_STATUS: Record<number, string> = {
 interface AgentJsonApiError {
   name?: string;
   detail?: string;
+  message?: string;
   status?: number;
   data?: unknown;
 }
@@ -67,9 +68,13 @@ function firstJsonApiError(body: unknown): AgentJsonApiError | undefined {
   return Array.isArray(errors) ? (errors[0] as AgentJsonApiError) : undefined;
 }
 
-function mapJsonApiError(agentError: AgentJsonApiError, logger: Logger): BffHttpError {
-  const status = agentError.status ?? STATUS_BAD_REQUEST;
-  const message = agentError.detail ?? DEFAULT_ERROR_MESSAGE;
+function mapJsonApiError(
+  agentError: AgentJsonApiError,
+  fallbackStatus: number,
+  logger: Logger,
+): BffHttpError {
+  const status = agentError.status ?? fallbackStatus;
+  const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
 
   if (agentError.name !== undefined) {
     const type = AGENT_ERROR_TYPE_MAP[agentError.name];
@@ -112,7 +117,7 @@ function mapFlatBody(status: number, body: unknown): BffHttpError {
 export function mapAgentError(error: unknown, { logger }: { logger: Logger }): BffHttpError {
   if (!(error instanceof AgentHttpError)) {
     const agentError = parseJsonApiFromMessage(error);
-    if (agentError) return mapJsonApiError(agentError, logger);
+    if (agentError) return mapJsonApiError(agentError, STATUS_BAD_REQUEST, logger);
 
     const message = error instanceof Error ? error.message : DEFAULT_NETWORK_MESSAGE;
 
@@ -128,7 +133,7 @@ export function mapAgentError(error: unknown, { logger }: { logger: Logger }): B
   }
 
   const agentError = firstJsonApiError(error.body);
-  if (agentError) return mapJsonApiError(agentError, logger);
+  if (agentError) return mapJsonApiError(agentError, error.status, logger);
 
   return mapFlatBody(error.status, error.body);
 }

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -101,7 +101,7 @@ function parseJsonApiFromMessage(error: unknown): AgentJsonApiError | undefined 
   }
 }
 
-function mapFlatBody(status: number, body: unknown): BffHttpError {
+function mapFlatBody(status: number, body: unknown, responseText?: string): BffHttpError {
   const flat = (typeof body === 'object' && body !== null ? body : {}) as {
     error?: unknown;
     message?: unknown;
@@ -109,6 +109,7 @@ function mapFlatBody(status: number, body: unknown): BffHttpError {
   const message =
     (typeof flat.error === 'string' ? flat.error : undefined) ??
     (typeof flat.message === 'string' ? flat.message : undefined) ??
+    (typeof responseText === 'string' && responseText !== '' ? responseText : undefined) ??
     DEFAULT_ERROR_MESSAGE;
 
   return new BffHttpError(status, fallbackTypeByStatus(status), message);
@@ -135,5 +136,5 @@ export function mapAgentError(error: unknown, { logger }: { logger: Logger }): B
   const agentError = firstJsonApiError(error.body);
   if (agentError) return mapJsonApiError(agentError, error.status, logger);
 
-  return mapFlatBody(error.status, error.body);
+  return mapFlatBody(error.status, error.body, error.responseText);
 }

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -1,0 +1,127 @@
+import type { Logger } from '../ports/logger-port';
+
+import { AgentHttpError } from '@forestadmin/agent-client';
+
+import { BffHttpError } from './bff-http-error';
+
+const STATUS_BAD_REQUEST = 400;
+const STATUS_UNAUTHORIZED = 401;
+const STATUS_FORBIDDEN = 403;
+const STATUS_NOT_FOUND = 404;
+const STATUS_UNPROCESSABLE = 422;
+const STATUS_TOO_MANY_REQUESTS = 429;
+const STATUS_SERVER_ERROR = 500;
+const STATUS_BAD_GATEWAY = 502;
+const STATUS_SERVICE_UNAVAILABLE = 503;
+
+const TYPE_INVALID_REQUEST = 'invalid_request';
+const TYPE_UNAUTHORIZED = 'unauthorized';
+const TYPE_FORBIDDEN = 'forbidden';
+const TYPE_NOT_FOUND = 'not_found';
+const TYPE_UNPROCESSABLE = 'unprocessable_entity';
+const TYPE_TOO_MANY_REQUESTS = 'too_many_requests';
+const TYPE_NETWORK_ERROR = 'network_error';
+const TYPE_AGENT_UNAVAILABLE = 'agent_unavailable';
+
+const DEFAULT_NETWORK_MESSAGE = 'The agent could not be reached';
+const DEFAULT_UNAVAILABLE_MESSAGE = 'The agent is unavailable';
+const DEFAULT_ERROR_MESSAGE = 'Unexpected error';
+
+export const AGENT_ERROR_TYPE_MAP: Record<string, string> = {
+  ValidationError: 'validation_error',
+  BadRequestError: TYPE_INVALID_REQUEST,
+  UnauthorizedError: TYPE_UNAUTHORIZED,
+  ForbiddenError: TYPE_FORBIDDEN,
+  NotFoundError: TYPE_NOT_FOUND,
+  UnprocessableError: TYPE_UNPROCESSABLE,
+  TooManyRequestsError: TYPE_TOO_MANY_REQUESTS,
+};
+
+const FALLBACK_TYPE_BY_STATUS: Record<number, string> = {
+  [STATUS_BAD_REQUEST]: TYPE_INVALID_REQUEST,
+  [STATUS_UNAUTHORIZED]: TYPE_UNAUTHORIZED,
+  [STATUS_FORBIDDEN]: TYPE_FORBIDDEN,
+  [STATUS_NOT_FOUND]: TYPE_NOT_FOUND,
+  [STATUS_UNPROCESSABLE]: TYPE_UNPROCESSABLE,
+  [STATUS_TOO_MANY_REQUESTS]: TYPE_TOO_MANY_REQUESTS,
+};
+
+interface AgentJsonApiError {
+  name?: string;
+  detail?: string;
+  status?: number;
+  data?: unknown;
+}
+
+function fallbackTypeByStatus(status: number, name?: string, logger?: Logger): string {
+  if (name !== undefined && logger !== undefined) {
+    logger('Warn', 'Unmapped agent error name, falling back to status', { name, status });
+  }
+
+  return FALLBACK_TYPE_BY_STATUS[status] ?? TYPE_INVALID_REQUEST;
+}
+
+function firstJsonApiError(body: unknown): AgentJsonApiError | undefined {
+  if (typeof body !== 'object' || body === null) return undefined;
+
+  const { errors } = body as { errors?: unknown };
+
+  return Array.isArray(errors) ? (errors[0] as AgentJsonApiError) : undefined;
+}
+
+function mapJsonApiError(agentError: AgentJsonApiError, logger: Logger): BffHttpError {
+  const status = agentError.status ?? STATUS_BAD_REQUEST;
+  const message = agentError.detail ?? DEFAULT_ERROR_MESSAGE;
+  const type =
+    (agentError.name !== undefined ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined) ??
+    fallbackTypeByStatus(status, agentError.name, logger);
+
+  return new BffHttpError(status, type, message, agentError.data);
+}
+
+function parseJsonApiFromMessage(error: unknown): AgentJsonApiError | undefined {
+  if (!(error instanceof Error)) return undefined;
+
+  try {
+    return firstJsonApiError(JSON.parse(error.message));
+  } catch {
+    return undefined;
+  }
+}
+
+function mapFlatBody(status: number, body: unknown): BffHttpError {
+  const flat = (typeof body === 'object' && body !== null ? body : {}) as {
+    error?: unknown;
+    message?: unknown;
+  };
+  const message =
+    (typeof flat.error === 'string' ? flat.error : undefined) ??
+    (typeof flat.message === 'string' ? flat.message : undefined) ??
+    DEFAULT_ERROR_MESSAGE;
+
+  return new BffHttpError(status, fallbackTypeByStatus(status), message);
+}
+
+export function mapAgentError(error: unknown, { logger }: { logger: Logger }): BffHttpError {
+  if (!(error instanceof AgentHttpError)) {
+    const agentError = parseJsonApiFromMessage(error);
+    if (agentError) return mapJsonApiError(agentError, logger);
+
+    const message = error instanceof Error ? error.message : DEFAULT_NETWORK_MESSAGE;
+
+    return new BffHttpError(STATUS_BAD_GATEWAY, TYPE_NETWORK_ERROR, message);
+  }
+
+  if (error.status >= STATUS_SERVER_ERROR) {
+    return new BffHttpError(
+      STATUS_SERVICE_UNAVAILABLE,
+      TYPE_AGENT_UNAVAILABLE,
+      DEFAULT_UNAVAILABLE_MESSAGE,
+    );
+  }
+
+  const agentError = firstJsonApiError(error.body);
+  if (agentError) return mapJsonApiError(agentError, logger);
+
+  return mapFlatBody(error.status, error.body);
+}

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -65,6 +65,14 @@ function fallbackTypeByStatus(status: number): string {
   return FALLBACK_TYPE_BY_STATUS[status] ?? TYPE_INVALID_REQUEST;
 }
 
+function agentUnavailable(): BffHttpError {
+  return new BffHttpError(
+    STATUS_SERVICE_UNAVAILABLE,
+    TYPE_AGENT_UNAVAILABLE,
+    DEFAULT_UNAVAILABLE_MESSAGE,
+  );
+}
+
 function firstJsonApiError(body: unknown): AgentJsonApiError | undefined {
   if (typeof body !== 'object' || body === null) return undefined;
 
@@ -79,6 +87,11 @@ function mapJsonApiError(
   logger: Logger,
 ): BffHttpError {
   const status = coerceStatus(agentError.status, fallbackStatus);
+
+  // Normalize a 5xx here too (not only in the AgentHttpError branch), so a wrapped-message error
+  // carrying a 5xx JSON:API body is reported as agent_unavailable, not a client-error type.
+  if (status >= STATUS_SERVER_ERROR) return agentUnavailable();
+
   const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
   const mappedType = agentError.name ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined;
 
@@ -137,13 +150,7 @@ export function mapAgentError(error: unknown, { logger }: { logger: Logger }): B
     return new BffHttpError(STATUS_BAD_GATEWAY, TYPE_NETWORK_ERROR, message);
   }
 
-  if (error.status >= STATUS_SERVER_ERROR) {
-    return new BffHttpError(
-      STATUS_SERVICE_UNAVAILABLE,
-      TYPE_AGENT_UNAVAILABLE,
-      DEFAULT_UNAVAILABLE_MESSAGE,
-    );
-  }
+  if (error.status >= STATUS_SERVER_ERROR) return agentUnavailable();
 
   const agentError = firstJsonApiError(error.body);
   if (agentError) return mapJsonApiError(agentError, error.status, logger);

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -3,7 +3,6 @@ import type { Logger } from '../ports/logger-port';
 import { AgentHttpError } from '@forestadmin/agent-client';
 
 import { BffHttpError } from './bff-http-error';
-import { mappingError } from './bff-local-errors';
 
 const STATUS_BAD_REQUEST = 400;
 const STATUS_UNAUTHORIZED = 401;
@@ -81,20 +80,24 @@ function mapJsonApiError(
 ): BffHttpError {
   const status = coerceStatus(agentError.status, fallbackStatus);
   const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
+  const mappedType = agentError.name ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined;
 
-  if (agentError.name !== undefined) {
-    const type = AGENT_ERROR_TYPE_MAP[agentError.name];
-
-    if (type === undefined) {
-      logger('Error', 'Unmapped agent error name', { name: agentError.name, status });
-
-      return mappingError(`Unmapped agent error name: ${agentError.name}`);
-    }
-
-    return new BffHttpError(status, type, message, agentError.data);
+  // An unknown agent name (e.g. a ValidationError subclass like MissingCollectionError, whose
+  // `name` is its own class name) keeps the agent's real status/category via the status-derived
+  // type instead of collapsing to a 500. Log it so a curated mapping can be added.
+  if (agentError.name && mappedType === undefined) {
+    logger('Warn', 'Unmapped agent error name; using status-derived type', {
+      name: agentError.name,
+      status,
+    });
   }
 
-  return new BffHttpError(status, fallbackTypeByStatus(status), message, agentError.data);
+  return new BffHttpError(
+    status,
+    mappedType ?? fallbackTypeByStatus(status),
+    message,
+    agentError.data,
+  );
 }
 
 function parseJsonApiFromMessage(error: unknown): AgentJsonApiError | undefined {
@@ -126,6 +129,9 @@ export function mapAgentError(error: unknown, { logger }: { logger: Logger }): B
     const agentError = parseJsonApiFromMessage(error);
     if (agentError) return mapJsonApiError(agentError, STATUS_BAD_REQUEST, logger);
 
+    // No HTTP response: treated as a transport failure reaching the agent. Callers must scope their
+    // try/catch to the agent call so a local BFF bug surfaces as a 500 through the error middleware
+    // rather than being mislabelled network_error here.
     const message = error instanceof Error ? error.message : DEFAULT_NETWORK_MESSAGE;
 
     return new BffHttpError(STATUS_BAD_GATEWAY, TYPE_NETWORK_ERROR, message);

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -4,16 +4,6 @@ import { AgentHttpError } from '@forestadmin/agent-client';
 
 import { BffHttpError } from './bff-http-error';
 
-const STATUS_BAD_REQUEST = 400;
-const STATUS_UNAUTHORIZED = 401;
-const STATUS_FORBIDDEN = 403;
-const STATUS_NOT_FOUND = 404;
-const STATUS_UNPROCESSABLE = 422;
-const STATUS_TOO_MANY_REQUESTS = 429;
-const STATUS_SERVER_ERROR = 500;
-const STATUS_BAD_GATEWAY = 502;
-const STATUS_SERVICE_UNAVAILABLE = 503;
-
 const TYPE_INVALID_REQUEST = 'invalid_request';
 const TYPE_VALIDATION_ERROR = 'validation_error';
 const TYPE_UNAUTHORIZED = 'unauthorized';
@@ -24,11 +14,22 @@ const TYPE_TOO_MANY_REQUESTS = 'too_many_requests';
 const TYPE_NETWORK_ERROR = 'network_error';
 const TYPE_AGENT_UNAVAILABLE = 'agent_unavailable';
 
+type BffErrorType =
+  | typeof TYPE_INVALID_REQUEST
+  | typeof TYPE_VALIDATION_ERROR
+  | typeof TYPE_UNAUTHORIZED
+  | typeof TYPE_FORBIDDEN
+  | typeof TYPE_NOT_FOUND
+  | typeof TYPE_UNPROCESSABLE
+  | typeof TYPE_TOO_MANY_REQUESTS
+  | typeof TYPE_NETWORK_ERROR
+  | typeof TYPE_AGENT_UNAVAILABLE;
+
 const DEFAULT_NETWORK_MESSAGE = 'The agent could not be reached';
 const DEFAULT_UNAVAILABLE_MESSAGE = 'The agent is unavailable';
 const DEFAULT_ERROR_MESSAGE = 'Unexpected error';
 
-export const AGENT_ERROR_TYPE_MAP: Record<string, string> = {
+export const AGENT_ERROR_TYPE_MAP: Record<string, BffErrorType> = {
   ValidationError: TYPE_VALIDATION_ERROR,
   BadRequestError: TYPE_INVALID_REQUEST,
   UnauthorizedError: TYPE_UNAUTHORIZED,
@@ -38,13 +39,13 @@ export const AGENT_ERROR_TYPE_MAP: Record<string, string> = {
   TooManyRequestsError: TYPE_TOO_MANY_REQUESTS,
 };
 
-const FALLBACK_TYPE_BY_STATUS: Record<number, string> = {
-  [STATUS_BAD_REQUEST]: TYPE_INVALID_REQUEST,
-  [STATUS_UNAUTHORIZED]: TYPE_UNAUTHORIZED,
-  [STATUS_FORBIDDEN]: TYPE_FORBIDDEN,
-  [STATUS_NOT_FOUND]: TYPE_NOT_FOUND,
-  [STATUS_UNPROCESSABLE]: TYPE_UNPROCESSABLE,
-  [STATUS_TOO_MANY_REQUESTS]: TYPE_TOO_MANY_REQUESTS,
+const FALLBACK_TYPE_BY_STATUS: Record<number, BffErrorType> = {
+  400: TYPE_INVALID_REQUEST,
+  401: TYPE_UNAUTHORIZED,
+  403: TYPE_FORBIDDEN,
+  404: TYPE_NOT_FOUND,
+  422: TYPE_UNPROCESSABLE,
+  429: TYPE_TOO_MANY_REQUESTS,
 };
 
 interface AgentJsonApiError {
@@ -61,16 +62,12 @@ function coerceStatus(status: number | string | undefined, fallback: number): nu
   return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : fallback;
 }
 
-function fallbackTypeByStatus(status: number): string {
+function fallbackTypeByStatus(status: number): BffErrorType {
   return FALLBACK_TYPE_BY_STATUS[status] ?? TYPE_INVALID_REQUEST;
 }
 
 function agentUnavailable(): BffHttpError {
-  return new BffHttpError(
-    STATUS_SERVICE_UNAVAILABLE,
-    TYPE_AGENT_UNAVAILABLE,
-    DEFAULT_UNAVAILABLE_MESSAGE,
-  );
+  return new BffHttpError(503, TYPE_AGENT_UNAVAILABLE, DEFAULT_UNAVAILABLE_MESSAGE);
 }
 
 function firstJsonApiError(body: unknown): AgentJsonApiError | undefined {
@@ -87,13 +84,11 @@ function mapJsonApiError(
   logger: Logger,
 ): BffHttpError {
   const bodyStatus = coerceStatus(agentError.status, fallbackStatus);
-  // A JSON:API error status must be a 4xx/5xx. If the body reports a non-error code (e.g. 200),
-  // trust the enclosing status instead so an upstream failure is never surfaced as a 2xx/3xx.
-  const status = bodyStatus >= STATUS_BAD_REQUEST ? bodyStatus : fallbackStatus;
+  // Never surface an upstream failure as a 2xx/3xx: ignore a non-error body status.
+  const status = bodyStatus >= 400 ? bodyStatus : fallbackStatus;
 
-  // Normalize a 5xx here too (not only in the AgentHttpError branch), so a wrapped-message error
-  // carrying a 5xx JSON:API body is reported as agent_unavailable, not a client-error type.
-  if (status >= STATUS_SERVER_ERROR) return agentUnavailable();
+  // The wrapped-message path skips the outer AgentHttpError 5xx check, so normalize here too.
+  if (status >= 500) return agentUnavailable();
 
   const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
   const mappedType = agentError.name ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined;
@@ -143,17 +138,20 @@ function mapFlatBody(status: number, body: unknown, responseText?: string): BffH
 export function mapAgentError(error: unknown, { logger }: { logger: Logger }): BffHttpError {
   if (!(error instanceof AgentHttpError)) {
     const agentError = parseJsonApiFromMessage(error);
-    if (agentError) return mapJsonApiError(agentError, STATUS_BAD_REQUEST, logger);
+    if (agentError) return mapJsonApiError(agentError, 400, logger);
 
-    // No HTTP response: treated as a transport failure reaching the agent. Callers must scope their
-    // try/catch to the agent call so a local BFF bug surfaces as a 500 through the error middleware
-    // rather than being mislabelled network_error here.
-    const message = error instanceof Error ? error.message : DEFAULT_NETWORK_MESSAGE;
+    // No HTTP response: treated as a transport failure reaching the agent. Log the real cause but
+    // return a generic message — transport errors embed internal topology (hostnames/IPs) that must
+    // not leak to the client. Callers must scope their try/catch to the agent call so a local BFF
+    // bug surfaces as a 500 through the error middleware rather than being mislabelled here.
+    logger('Warn', 'Agent transport failure mapped to network_error', {
+      cause: error instanceof Error ? error.message : String(error),
+    });
 
-    return new BffHttpError(STATUS_BAD_GATEWAY, TYPE_NETWORK_ERROR, message);
+    return new BffHttpError(502, TYPE_NETWORK_ERROR, DEFAULT_NETWORK_MESSAGE);
   }
 
-  if (error.status >= STATUS_SERVER_ERROR) return agentUnavailable();
+  if (error.status >= 500) return agentUnavailable();
 
   const agentError = firstJsonApiError(error.body);
   if (agentError) return mapJsonApiError(agentError, error.status, logger);

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -93,9 +93,6 @@ function mapJsonApiError(
   const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
   const mappedType = agentError.name ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined;
 
-  // An unknown agent name (e.g. a ValidationError subclass like MissingCollectionError, whose
-  // `name` is its own class name) keeps the agent's real status/category via the status-derived
-  // type instead of collapsing to a 500. Log it so a curated mapping can be added.
   if (agentError.name && mappedType === undefined) {
     logger('Warn', 'Unmapped agent error name; using status-derived type', {
       name: agentError.name,

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -3,6 +3,7 @@ import type { Logger } from '../ports/logger-port';
 import { AgentHttpError } from '@forestadmin/agent-client';
 
 import { BffHttpError } from './bff-http-error';
+import { mappingError } from './bff-local-errors';
 
 const STATUS_BAD_REQUEST = 400;
 const STATUS_UNAUTHORIZED = 401;
@@ -15,6 +16,7 @@ const STATUS_BAD_GATEWAY = 502;
 const STATUS_SERVICE_UNAVAILABLE = 503;
 
 const TYPE_INVALID_REQUEST = 'invalid_request';
+const TYPE_VALIDATION_ERROR = 'validation_error';
 const TYPE_UNAUTHORIZED = 'unauthorized';
 const TYPE_FORBIDDEN = 'forbidden';
 const TYPE_NOT_FOUND = 'not_found';
@@ -28,7 +30,7 @@ const DEFAULT_UNAVAILABLE_MESSAGE = 'The agent is unavailable';
 const DEFAULT_ERROR_MESSAGE = 'Unexpected error';
 
 export const AGENT_ERROR_TYPE_MAP: Record<string, string> = {
-  ValidationError: 'validation_error',
+  ValidationError: TYPE_VALIDATION_ERROR,
   BadRequestError: TYPE_INVALID_REQUEST,
   UnauthorizedError: TYPE_UNAUTHORIZED,
   ForbiddenError: TYPE_FORBIDDEN,
@@ -53,11 +55,7 @@ interface AgentJsonApiError {
   data?: unknown;
 }
 
-function fallbackTypeByStatus(status: number, name?: string, logger?: Logger): string {
-  if (name !== undefined && logger !== undefined) {
-    logger('Warn', 'Unmapped agent error name, falling back to status', { name, status });
-  }
-
+function fallbackTypeByStatus(status: number): string {
   return FALLBACK_TYPE_BY_STATUS[status] ?? TYPE_INVALID_REQUEST;
 }
 
@@ -72,11 +70,20 @@ function firstJsonApiError(body: unknown): AgentJsonApiError | undefined {
 function mapJsonApiError(agentError: AgentJsonApiError, logger: Logger): BffHttpError {
   const status = agentError.status ?? STATUS_BAD_REQUEST;
   const message = agentError.detail ?? DEFAULT_ERROR_MESSAGE;
-  const type =
-    (agentError.name !== undefined ? AGENT_ERROR_TYPE_MAP[agentError.name] : undefined) ??
-    fallbackTypeByStatus(status, agentError.name, logger);
 
-  return new BffHttpError(status, type, message, agentError.data);
+  if (agentError.name !== undefined) {
+    const type = AGENT_ERROR_TYPE_MAP[agentError.name];
+
+    if (type === undefined) {
+      logger('Error', 'Unmapped agent error name', { name: agentError.name, status });
+
+      return mappingError(`Unmapped agent error name: ${agentError.name}`);
+    }
+
+    return new BffHttpError(status, type, message, agentError.data);
+  }
+
+  return new BffHttpError(status, fallbackTypeByStatus(status), message, agentError.data);
 }
 
 function parseJsonApiFromMessage(error: unknown): AgentJsonApiError | undefined {

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -86,7 +86,10 @@ function mapJsonApiError(
   fallbackStatus: number,
   logger: Logger,
 ): BffHttpError {
-  const status = coerceStatus(agentError.status, fallbackStatus);
+  const bodyStatus = coerceStatus(agentError.status, fallbackStatus);
+  // A JSON:API error status must be a 4xx/5xx. If the body reports a non-error code (e.g. 200),
+  // trust the enclosing status instead so an upstream failure is never surfaced as a 2xx/3xx.
+  const status = bodyStatus >= STATUS_BAD_REQUEST ? bodyStatus : fallbackStatus;
 
   // Normalize a 5xx here too (not only in the AgentHttpError branch), so a wrapped-message error
   // carrying a 5xx JSON:API body is reported as agent_unavailable, not a client-error type.

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -52,8 +52,14 @@ interface AgentJsonApiError {
   name?: string;
   detail?: string;
   message?: string;
-  status?: number;
+  status?: number | string;
   data?: unknown;
+}
+
+function coerceStatus(status: number | string | undefined, fallback: number): number {
+  const parsed = typeof status === 'string' ? Number(status) : status;
+
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : fallback;
 }
 
 function fallbackTypeByStatus(status: number): string {
@@ -73,7 +79,7 @@ function mapJsonApiError(
   fallbackStatus: number,
   logger: Logger,
 ): BffHttpError {
-  const status = agentError.status ?? fallbackStatus;
+  const status = coerceStatus(agentError.status, fallbackStatus);
   const message = agentError.detail ?? agentError.message ?? DEFAULT_ERROR_MESSAGE;
 
   if (agentError.name !== undefined) {

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -142,8 +142,10 @@ export function mapAgentError(error: unknown, { logger }: { logger: Logger }): B
 
     // No HTTP response: treated as a transport failure reaching the agent. Log the real cause but
     // return a generic message — transport errors embed internal topology (hostnames/IPs) that must
-    // not leak to the client. Callers must scope their try/catch to the agent call so a local BFF
-    // bug surfaces as a 500 through the error middleware rather than being mislabelled here.
+    // not leak to the client. Semantic agent-client errors (action form validation / approval
+    // outcomes) are NOT transport failures: the action endpoint catches and maps those before this
+    // fallback. Callers must scope their try/catch to the agent call so a local BFF bug surfaces as
+    // a 500 through the error middleware rather than being mislabelled here.
     logger('Warn', 'Agent transport failure mapped to network_error', {
       cause: error instanceof Error ? error.message : String(error),
     });

--- a/packages/agent-bff/src/http/bff-local-errors.ts
+++ b/packages/agent-bff/src/http/bff-local-errors.ts
@@ -1,0 +1,43 @@
+import { BffHttpError } from './bff-http-error';
+
+export function unknownCollection(message = 'Unknown collection'): BffHttpError {
+  return new BffHttpError(404, 'unknown_collection', message);
+}
+
+export function unknownRelation(message = 'Unknown relation'): BffHttpError {
+  return new BffHttpError(404, 'unknown_relation', message);
+}
+
+export function unknownAction(message = 'Unknown action'): BffHttpError {
+  return new BffHttpError(404, 'unknown_action', message);
+}
+
+export function collectionNotAllowed(message = 'Collection is not allowed'): BffHttpError {
+  return new BffHttpError(403, 'collection_not_allowed', message);
+}
+
+export function relationNotAllowed(message = 'Relation is not allowed'): BffHttpError {
+  return new BffHttpError(403, 'relation_not_allowed', message);
+}
+
+export function actionNotAllowed(message = 'Action is not allowed'): BffHttpError {
+  return new BffHttpError(403, 'action_not_allowed', message);
+}
+
+export function invalidRequest(message = 'Invalid request', details?: unknown): BffHttpError {
+  return new BffHttpError(400, 'invalid_request', message, details);
+}
+
+export function relationFieldNotSupported(
+  message = 'Relation field is not supported',
+): BffHttpError {
+  return new BffHttpError(422, 'relation_field_not_supported', message);
+}
+
+export function mappingError(message = 'Failed to map the agent response'): BffHttpError {
+  return new BffHttpError(500, 'mapping_error', message);
+}
+
+export function unsupportedActionResult(message = 'Unsupported action result'): BffHttpError {
+  return new BffHttpError(501, 'unsupported_action_result', message);
+}

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -1,6 +1,6 @@
 import { AgentHttpError } from '@forestadmin/agent-client';
 
-import { AGENT_ERROR_TYPE_MAP, mapAgentError } from '../../src/http/agent-error-mapper';
+import { mapAgentError } from '../../src/http/agent-error-mapper';
 
 function jsonApiBody(error: { name?: string; detail?: string; status?: number; data?: unknown }) {
   return { errors: [error] };
@@ -29,7 +29,15 @@ describe('mapAgentError', () => {
     });
   });
 
-  it.each(Object.entries(AGENT_ERROR_TYPE_MAP))('maps agent name %s to type %s', (name, type) => {
+  it.each([
+    ['ValidationError', 'validation_error'],
+    ['BadRequestError', 'invalid_request'],
+    ['UnauthorizedError', 'unauthorized'],
+    ['ForbiddenError', 'forbidden'],
+    ['NotFoundError', 'not_found'],
+    ['UnprocessableError', 'unprocessable_entity'],
+    ['TooManyRequestsError', 'too_many_requests'],
+  ])('maps agent name %s to type %s', (name, type) => {
     const status = 422;
     const error = new AgentHttpError(status, jsonApiBody({ name, status, detail: 'd' }));
 
@@ -72,7 +80,7 @@ describe('mapAgentError', () => {
     expect(result).toMatchObject({ type: 'invalid_request', status: 400, message: 'boom' });
   });
 
-  it('falls back to invalid_request and warns for an unmapped name', () => {
+  it('maps an unmapped agent error name to mapping_error (500) and logs it', () => {
     const error = new AgentHttpError(
       400,
       jsonApiBody({ name: 'MissingCollectionError', status: 400, detail: 'gone' }),
@@ -80,9 +88,9 @@ describe('mapAgentError', () => {
 
     const result = mapAgentError(error, { logger });
 
-    expect(result).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(result).toMatchObject({ type: 'mapping_error', status: 500 });
     expect(logger).toHaveBeenCalledWith(
-      'Warn',
+      'Error',
       expect.any(String),
       expect.objectContaining({ name: 'MissingCollectionError' }),
     );

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -93,6 +93,16 @@ describe('mapAgentError', () => {
     expect(result).toMatchObject({ type: 'forbidden', status: 403, message: 'nope' });
   });
 
+  it('normalizes a wrapped-message JSON:API 5xx to agent_unavailable (503)', () => {
+    const error = new Error(
+      JSON.stringify(jsonApiBody({ name: 'InternalServerError', status: 503, detail: 'down' })),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'agent_unavailable', status: 503 });
+  });
+
   it('maps a transport failure to network_error (502)', () => {
     const result = mapAgentError(new Error('ECONNREFUSED'), { logger });
 

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -129,19 +129,40 @@ describe('mapAgentError', () => {
     });
   });
 
-  it('maps an unmapped agent error name to mapping_error (500) and logs it', () => {
+  it('maps an unmapped agent error name to the status-derived type (preserving status) and logs it', () => {
     const error = new AgentHttpError(
       400,
-      jsonApiBody({ name: 'MissingCollectionError', status: 400, detail: 'gone' }),
+      jsonApiBody({
+        name: 'MissingCollectionError',
+        status: 400,
+        detail: 'gone',
+        data: { field: 'x' },
+      }),
     );
 
     const result = mapAgentError(error, { logger });
 
-    expect(result).toMatchObject({ type: 'mapping_error', status: 500 });
+    expect(result).toMatchObject({
+      type: 'invalid_request',
+      status: 400,
+      message: 'gone',
+      details: { field: 'x' },
+    });
     expect(logger).toHaveBeenCalledWith(
-      'Error',
+      'Warn',
       expect.any(String),
-      expect.objectContaining({ name: 'MissingCollectionError' }),
+      expect.objectContaining({ name: 'MissingCollectionError', status: 400 }),
     );
+  });
+
+  it('maps an unmapped agent error name with an unmapped status to invalid_request', () => {
+    const error = new AgentHttpError(
+      418,
+      jsonApiBody({ name: 'TeapotError', status: 418, detail: 'nope' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'invalid_request', status: 418 });
   });
 });

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -1,0 +1,90 @@
+import { AgentHttpError } from '@forestadmin/agent-client';
+
+import { AGENT_ERROR_TYPE_MAP, mapAgentError } from '../../src/http/agent-error-mapper';
+
+function jsonApiBody(error: { name?: string; detail?: string; status?: number; data?: unknown }) {
+  return { errors: [error] };
+}
+
+describe('mapAgentError', () => {
+  let logger: jest.Mock;
+
+  beforeEach(() => {
+    logger = jest.fn();
+  });
+
+  it('maps a JSON:API NotFoundError to not_found with its detail and data', () => {
+    const error = new AgentHttpError(
+      404,
+      jsonApiBody({ name: 'NotFoundError', status: 404, detail: 'x', data: { id: 1 } }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({
+      type: 'not_found',
+      status: 404,
+      message: 'x',
+      details: { id: 1 },
+    });
+  });
+
+  it.each(Object.entries(AGENT_ERROR_TYPE_MAP))('maps agent name %s to type %s', (name, type) => {
+    const status = 422;
+    const error = new AgentHttpError(status, jsonApiBody({ name, status, detail: 'd' }));
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type, status });
+  });
+
+  it('parses a JSON:API body carried in a plain Error message', () => {
+    const error = new Error(
+      JSON.stringify(jsonApiBody({ name: 'ForbiddenError', status: 403, detail: 'nope' })),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'forbidden', status: 403, message: 'nope' });
+  });
+
+  it('maps a transport failure to network_error (502)', () => {
+    const result = mapAgentError(new Error('ECONNREFUSED'), { logger });
+
+    expect(result).toMatchObject({ type: 'network_error', status: 502 });
+  });
+
+  it('normalizes an agent 500 to agent_unavailable (503)', () => {
+    const result = mapAgentError(new AgentHttpError(500, {}), { logger });
+
+    expect(result).toMatchObject({ type: 'agent_unavailable', status: 503 });
+  });
+
+  it('normalizes an agent 503 to agent_unavailable (503)', () => {
+    const result = mapAgentError(new AgentHttpError(503, {}), { logger });
+
+    expect(result).toMatchObject({ type: 'agent_unavailable', status: 503 });
+  });
+
+  it('maps a flat native-action body to invalid_request (400) using body.error', () => {
+    const result = mapAgentError(new AgentHttpError(400, { error: 'boom' }), { logger });
+
+    expect(result).toMatchObject({ type: 'invalid_request', status: 400, message: 'boom' });
+  });
+
+  it('falls back to invalid_request and warns for an unmapped name', () => {
+    const error = new AgentHttpError(
+      400,
+      jsonApiBody({ name: 'MissingCollectionError', status: 400, detail: 'gone' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      expect.any(String),
+      expect.objectContaining({ name: 'MissingCollectionError' }),
+    );
+  });
+});

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -114,10 +114,46 @@ describe('mapAgentError', () => {
     expect(result).toMatchObject({ type: 'agent_unavailable', status: 503 });
   });
 
-  it('maps a transport failure to network_error (502)', () => {
-    const result = mapAgentError(new Error('ECONNREFUSED'), { logger });
+  it('normalizes a 5xx JSON:API body inside an AgentHttpError whose outer status is not 5xx', () => {
+    const error = new AgentHttpError(400, jsonApiBody({ name: 'X', status: 503, detail: 'down' }));
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'agent_unavailable', status: 503 });
+  });
+
+  it('maps a transport failure to network_error (502) with a generic message and logs the cause', () => {
+    const result = mapAgentError(new Error('connect ECONNREFUSED 10.0.4.23:8080'), { logger });
+
+    expect(result).toMatchObject({
+      type: 'network_error',
+      status: 502,
+      message: 'The agent could not be reached',
+    });
+    expect(result.message).not.toContain('10.0.4.23');
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      expect.any(String),
+      expect.objectContaining({ cause: 'connect ECONNREFUSED 10.0.4.23:8080' }),
+    );
+  });
+
+  it('maps valid JSON without an errors array to network_error and logs it', () => {
+    const result = mapAgentError(new Error('{"foo":"bar"}'), { logger });
 
     expect(result).toMatchObject({ type: 'network_error', status: 502 });
+    expect(logger).toHaveBeenCalledWith('Warn', expect.any(String), expect.anything());
+  });
+
+  it('falls back to the enclosing status when the JSON:API status is non-numeric', () => {
+    const error = new AgentHttpError(
+      404,
+      jsonApiBody({ name: 'NotFoundError', status: 'abc', detail: 'x' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'not_found', status: 404 });
   });
 
   it('normalizes an agent 500 to agent_unavailable (503)', () => {
@@ -136,6 +172,12 @@ describe('mapAgentError', () => {
     const result = mapAgentError(new AgentHttpError(400, { error: 'boom' }), { logger });
 
     expect(result).toMatchObject({ type: 'invalid_request', status: 400, message: 'boom' });
+  });
+
+  it('uses body.message when a flat body has no error field', () => {
+    const result = mapAgentError(new AgentHttpError(400, { message: 'from message' }), { logger });
+
+    expect(result).toMatchObject({ type: 'invalid_request', status: 400, message: 'from message' });
   });
 
   it('falls back to responseText when the agent body is not a JSON error object', () => {

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -2,7 +2,13 @@ import { AgentHttpError } from '@forestadmin/agent-client';
 
 import { mapAgentError } from '../../src/http/agent-error-mapper';
 
-function jsonApiBody(error: { name?: string; detail?: string; status?: number; data?: unknown }) {
+function jsonApiBody(error: {
+  name?: string;
+  detail?: string;
+  message?: string;
+  status?: number;
+  data?: unknown;
+}) {
   return { errors: [error] };
 }
 
@@ -44,6 +50,25 @@ describe('mapAgentError', () => {
     const result = mapAgentError(error, { logger });
 
     expect(result).toMatchObject({ type, status });
+  });
+
+  it('uses the outer AgentHttpError status when the JSON:API error omits it', () => {
+    const error = new AgentHttpError(403, jsonApiBody({ name: 'ForbiddenError', detail: 'no' }));
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'forbidden', status: 403 });
+  });
+
+  it('falls back to the JSON:API message when detail is absent', () => {
+    const error = new AgentHttpError(
+      404,
+      jsonApiBody({ name: 'NotFoundError', status: 404, message: 'gone' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'not_found', status: 404, message: 'gone' });
   });
 
   it('parses a JSON:API body carried in a plain Error message', () => {

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -105,6 +105,18 @@ describe('mapAgentError', () => {
     expect(result).toMatchObject({ type: 'invalid_request', status: 400, message: 'boom' });
   });
 
+  it('falls back to responseText when the agent body is not a JSON error object', () => {
+    const result = mapAgentError(new AgentHttpError(400, 'oops', 'Bad things happened'), {
+      logger,
+    });
+
+    expect(result).toMatchObject({
+      type: 'invalid_request',
+      status: 400,
+      message: 'Bad things happened',
+    });
+  });
+
   it('maps an unmapped agent error name to mapping_error (500) and logs it', () => {
     const error = new AgentHttpError(
       400,

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -6,7 +6,7 @@ function jsonApiBody(error: {
   name?: string;
   detail?: string;
   message?: string;
-  status?: number;
+  status?: number | string;
   data?: unknown;
 }) {
   return { errors: [error] };
@@ -50,6 +50,18 @@ describe('mapAgentError', () => {
     const result = mapAgentError(error, { logger });
 
     expect(result).toMatchObject({ type, status });
+  });
+
+  it('coerces a spec-compliant string JSON:API status to a number', () => {
+    const error = new AgentHttpError(
+      404,
+      jsonApiBody({ name: 'NotFoundError', status: '404', detail: 'x' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'not_found', status: 404 });
+    expect(typeof result.status).toBe('number');
   });
 
   it('uses the outer AgentHttpError status when the JSON:API error omits it', () => {

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -93,6 +93,17 @@ describe('mapAgentError', () => {
     expect(result).toMatchObject({ type: 'forbidden', status: 403, message: 'nope' });
   });
 
+  it('ignores a non-error JSON:API status and keeps the enclosing error status', () => {
+    const error = new AgentHttpError(
+      404,
+      jsonApiBody({ name: 'NotFoundError', status: 200, detail: 'gone' }),
+    );
+
+    const result = mapAgentError(error, { logger });
+
+    expect(result).toMatchObject({ type: 'not_found', status: 404 });
+  });
+
   it('normalizes a wrapped-message JSON:API 5xx to agent_unavailable (503)', () => {
     const error = new Error(
       JSON.stringify(jsonApiBody({ name: 'InternalServerError', status: 503, detail: 'down' })),

--- a/packages/agent-bff/test/http/bff-local-errors.test.ts
+++ b/packages/agent-bff/test/http/bff-local-errors.test.ts
@@ -1,0 +1,37 @@
+import {
+  actionNotAllowed,
+  collectionNotAllowed,
+  invalidRequest,
+  mappingError,
+  relationFieldNotSupported,
+  relationNotAllowed,
+  unknownAction,
+  unknownCollection,
+  unknownRelation,
+  unsupportedActionResult,
+} from '../../src/http/bff-local-errors';
+
+describe('bff local errors', () => {
+  it.each([
+    [unknownCollection, 'unknown_collection', 404],
+    [unknownRelation, 'unknown_relation', 404],
+    [unknownAction, 'unknown_action', 404],
+    [collectionNotAllowed, 'collection_not_allowed', 403],
+    [relationNotAllowed, 'relation_not_allowed', 403],
+    [actionNotAllowed, 'action_not_allowed', 403],
+    [invalidRequest, 'invalid_request', 400],
+    [relationFieldNotSupported, 'relation_field_not_supported', 422],
+    [mappingError, 'mapping_error', 500],
+    [unsupportedActionResult, 'unsupported_action_result', 501],
+  ])('%p builds a %s error with status %d', (factory, type, status) => {
+    expect(factory()).toMatchObject({ type, status });
+  });
+
+  it('carries details on invalidRequest', () => {
+    expect(invalidRequest('bad', { field: 'x' })).toMatchObject({
+      type: 'invalid_request',
+      status: 400,
+      details: { field: 'x' },
+    });
+  });
+});


### PR DESCRIPTION
## Context

Slice-3 BFF data/action endpoints (PRD-671..674) need one shared error layer producing the BFF envelope `{ error: { type, status, message, details? } }`, so consumers branch on `error.type` + `error.status`, never on a message substring. This ships first and is a hard dependency of every Slice-3 endpoint ticket.

## What this adds

- **`src/http/agent-error-mapper.ts`** — `mapAgentError(error, { logger }): BffHttpError`:
  - transport failure (raw error, not an `AgentHttpError`) → `network_error` (502), with a **generic message** (the real cause is logged, never sent to the client, to avoid leaking internal hostnames/IPs)
  - agent 5xx → `agent_unavailable` (503, normalized — including a 5xx `errors[0].status` carried in a non-5xx response)
  - JSON:API `errors[0]` → type from an explicit name registry (`NotFoundError`→`not_found`, …); status from `errors[0].status` (ignored if not `>= 400`, falling back to the outer `AgentHttpError.status`); `message` from `detail` (then `message`); `details` from `data`
  - **unknown agent name → status-derived type (preserving `errors[0].status`) + a `Warn` log** (an unrecognized name keeps the agent's real status/category instead of collapsing to a 500; the log surfaces it so an explicit registry entry can be added)
  - defensive parse of an `Error` whose message is a JSON `{ errors: [...] }` string
- **`src/http/bff-local-errors.ts`** — the complete registry of BFF-local factories the Slice-3 endpoints emit: `unknown_*` (404), `*_not_allowed` (403), `invalid_request` (400), `relation_field_not_supported` (422), `mapping_error` (500), `unsupported_action_result` (501).
- **`package.json`** — adds `@forestadmin/agent-client` (the committed BFF→agent transport; `AgentHttpError` is the mapper input).

Produced `BffHttpError` instances flow through the existing `error-middleware` unchanged. No barrel exports: in-package endpoints import relatively.

## Notes / deviations from the ticket text

The ticket and the global spec were stale on three points; the implementation follows the actual code:
- agent-client throws a typed `AgentHttpError` (not `Error(JSON.stringify(...))`); the string case is kept as a defensive fallback.
- Agent JSON:API errors carry `data`, not `meta`/`source`; `details` is sourced from `data`.
- Agent error names are suffixed (`NotFoundError`, not `NotFound`), so an explicit registry replaces literal snake_case.

Deliberate contract choices (unspecified by the spec):
- `network_error`=502 / `agent_unavailable`=503.
- An unmapped agent error name resolves to the **status-derived type** (e.g. a 400 subclass like `MissingCollectionError` → `invalid_request` 400), never collapsing to a generic 500, and is logged at `Warn` so a curated registry entry can be added. This preserves the agent's real status and category for unrecognized names.
- An error is never surfaced with a 2xx/3xx status: a non-error `errors[0].status` is ignored in favour of the enclosing status.

## Tests

- `test/http/agent-error-mapper.test.ts` — registry coverage, JSON-in-message parse, outer-status fallback, non-numeric status fallback, message/`body.message` fallback, transport→502 (generic message + logged cause), 5xx→503 (both paths), non-error status ignored, unmapped-name→status-derived+`Warn` log.
- `test/http/bff-local-errors.test.ts` — every factory + details.

Full suite: 400/400 pass; build + lint clean.

Fixes PRD-670

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map agent errors to the BFF error contract in agent-bff
> - Adds [`mapAgentError`](https://github.com/ForestAdmin/agent-nodejs/pull/1738/files#diff-a3c0bd78457b1e43f7ef93c35845f76e9288b89d8436f9309f70f3f4686fdfe4) to translate thrown agent errors into `BffHttpError` objects: transport failures become 502 `network_error`, agent 5xx become 503 `agent_unavailable`, JSON:API errors map to typed BFF errors, and flat bodies fall back to status-derived types.
> - Adds [`bff-local-errors.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1738/files#diff-17ef6d6375ad74add39660a47a81a280d4c60876a2ca346204fc7929c614ee26) with factory functions for BFF-local errors (e.g. `unknownCollection`, `invalidRequest`, `mappingError`) using predefined types and status codes.
> - Adds `@forestadmin/agent-client` as a runtime dependency for `AgentHttpError` detection.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1738 opened
>
> - Removed explanatory comment block from `mapJsonApiError` function [99067b1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc1d08e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
