### PR TITLE
fix(mcp-server): include agent error detail and status in tool errors

### DIFF
--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -17,10 +17,13 @@ function jsonApiDetail(body: unknown, text?: string): string | null {
   return null;
 }
 
-// Turn an agent RPC error into a human-readable message (AgentHttpError detail, else raw message).
+// Turn an agent RPC error into a human-readable message: the JSON:API detail with its HTTP status
+// when one can be extracted, else the raw message (which already carries the status).
 export default function parseAgentError(error: unknown): string | null {
   if (error instanceof AgentHttpError) {
-    return jsonApiDetail(error.body, error.responseText) ?? error.message;
+    const detail = jsonApiDetail(error.body, error.responseText);
+
+    return detail ? `${detail} (HTTP ${error.status})` : error.message;
   }
 
   if (error && typeof error === 'object' && 'message' in error) {

--- a/packages/mcp-server/src/utils/tool-with-logging.ts
+++ b/packages/mcp-server/src/utils/tool-with-logging.ts
@@ -10,6 +10,8 @@ import type {
 
 import { z } from 'zod';
 
+import parseAgentError from './error-parser';
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -114,7 +116,7 @@ export default function registerToolWithLogging<
         let message: string;
 
         try {
-          message = error instanceof Error ? error.message : JSON.stringify(error) ?? String(error);
+          message = parseAgentError(error) ?? JSON.stringify(error) ?? String(error);
         } catch {
           message = String(error);
         }

--- a/packages/mcp-server/test/utils/error-parser.test.ts
+++ b/packages/mcp-server/test/utils/error-parser.test.ts
@@ -3,22 +3,22 @@ import { AgentHttpError } from '@forestadmin/agent-client';
 import parseAgentError from '../../src/utils/error-parser';
 
 describe('parseAgentError', () => {
-  it('extracts the JSON:API detail from the parsed body', () => {
+  it('appends the HTTP status to the JSON:API detail from the parsed body', () => {
     const error = new AgentHttpError(400, {
       errors: [{ name: 'ValidationError', detail: 'Invalid filters provided' }],
     });
 
-    expect(parseAgentError(error)).toBe('Invalid filters provided');
+    expect(parseAgentError(error)).toBe('Invalid filters provided (HTTP 400)');
   });
 
-  it('falls back to parsing responseText when the body is not a parsed object', () => {
+  it('appends the HTTP status to the JSON:API detail parsed from responseText', () => {
     const error = new AgentHttpError(
       400,
       undefined,
       JSON.stringify({ errors: [{ detail: 'From raw text' }] }),
     );
 
-    expect(parseAgentError(error)).toBe('From raw text');
+    expect(parseAgentError(error)).toBe('From raw text (HTTP 400)');
   });
 
   it('returns the generic HTTP message when the body has no JSON:API detail', () => {
@@ -30,6 +30,12 @@ describe('parseAgentError', () => {
   it('returns the generic HTTP message for an empty errors array', () => {
     expect(parseAgentError(new AgentHttpError(422, { errors: [] }))).toBe(
       'Agent responded with HTTP 422',
+    );
+  });
+
+  it('does not append a second HTTP status when the body is not JSON:API', () => {
+    expect(parseAgentError(new AgentHttpError(500, '<html>Internal Server Error</html>'))).toBe(
+      'Agent responded with HTTP 500',
     );
   });
 

--- a/packages/mcp-server/test/utils/tool-with-logging.test.ts
+++ b/packages/mcp-server/test/utils/tool-with-logging.test.ts
@@ -1,3 +1,4 @@
+import { AgentHttpError } from '@forestadmin/agent-client';
 import { z } from 'zod';
 
 import registerToolWithLogging from '../../src/utils/tool-with-logging';
@@ -169,6 +170,46 @@ describe('registerToolWithLogging', () => {
       const result = await registeredHandler({ name: 'test', count: 42 }, {});
       expect(result).toEqual({
         content: [{ type: 'text', text: '[object Object]' }],
+        isError: true,
+      });
+    });
+
+    it('should surface the agent error detail and HTTP status for an AgentHttpError', async () => {
+      const error = new AgentHttpError(422, {
+        errors: [{ name: 'ValidationError', detail: 'The value "reason" is required' }],
+      });
+      const handler = jest.fn().mockRejectedValue(error);
+
+      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
+
+      const result = await registeredHandler({ name: 'test', count: 42 }, {});
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'The value "reason" is required (HTTP 422)' }],
+        isError: true,
+      });
+    });
+
+    it('should return the generic HTTP message without a doubled status when the body is not JSON:API', async () => {
+      const error = new AgentHttpError(500, '<html>Internal Server Error</html>');
+      const handler = jest.fn().mockRejectedValue(error);
+
+      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
+
+      const result = await registeredHandler({ name: 'test', count: 42 }, {});
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Agent responded with HTTP 500' }],
+        isError: true,
+      });
+    });
+
+    it('should use the message of a thrown non-Error object that has one', async () => {
+      const handler = jest.fn().mockRejectedValue({ message: 'boom', code: 'X' });
+
+      registerToolWithLogging(mockMcpServer as never, 'test-tool', toolConfig, handler, mockLogger);
+
+      const result = await registeredHandler({ name: 'test', count: 42 }, {});
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'boom' }],
         isError: true,
       });
     });

--- a/packages/mcp-server/test/utils/with-activity-log.test.ts
+++ b/packages/mcp-server/test/utils/with-activity-log.test.ts
@@ -298,7 +298,7 @@ describe('withActivityLog', () => {
         }),
       ).rejects.toThrow('Context: Invalid field value');
 
-      expect(errorEnhancer).toHaveBeenCalledWith('Invalid field value', agentError);
+      expect(errorEnhancer).toHaveBeenCalledWith('Invalid field value (HTTP 400)', agentError);
     });
   });
 });


### PR DESCRIPTION
## What

MCP tool error results now surface the agent's real error — the JSON:API `errors[0].detail` plus the HTTP status (e.g. `The value "reason" is required (HTTP 422)`) — instead of the generic `Agent responded with HTTP {status}`.

## Why

`registerToolWithLogging`'s catch built the `{ isError: true }` text from `error.message`. For a raw `AgentHttpError` (e.g. `getActionForm`) that was the generic string, leaving the real cause buried in `error.body`.

## Changes

- `error-parser.ts` — `parseAgentError` appends `(HTTP <status>)` to the extracted JSON:API detail; falls back to the raw message (no doubled status) when no detail can be extracted.
- `tool-with-logging.ts` — the catch builds the message via `parseAgentError(error)`, preserving the existing non-`Error` fallback (`JSON.stringify ?? String`).
- Tests updated/extended: `error-parser`, `tool-with-logging`, `with-activity-log`.

## Scope / notes

- Both error paths funnel through `parseAgentError`, so the suffix reaches all `withActivityLog` data tools (`list`/`create`/`update`/`delete`/`associate`/`dissociate`/`listRelated`) and `getActionForm`.
- `executeAction` is unchanged: `agent-client` converts its `AgentHttpError` to semantic `ActionFormValidationError`/`ActionRequiresApprovalError` upstream, dropping the status — out of scope.
- Response envelope unchanged (already MCP-spec-compliant).

Tests: `test/utils` (110) and `test/tools` (244) green; eslint / prettier / tsc clean.

fixes PRD-729

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include HTTP status and JSON:API detail in MCP server tool errors
> - Updates `parseAgentError` in [error-parser.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1739/files#diff-bdf07c04d227d6a9b8d3effff0b56f64207f15a160d4ff0cb39d8de3a3c7eb42) to append the HTTP status code to JSON:API error details, returning `'<detail> (HTTP <status>)'` instead of just `'<detail>'`.
> - Updates `registerToolWithLogging` in [tool-with-logging.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1739/files#diff-1989bb6374348e66de98a0d536b15201ebde9a1430c7f5ded16df0addd68fba6) to use `parseAgentError` in its catch block, surfacing structured error details for `AgentHttpError` instead of a raw stringified error.
> - Behavioral Change: tool error messages now include HTTP status codes when a JSON:API detail is present; consumers parsing error strings may need to account for the new format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9caee51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->