### PR TITLE
feat(agent-bff): expose collection list and count with flat mapping

### DIFF
--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -14,6 +14,7 @@ import createAuthModeMiddleware from './auth/auth-mode-middleware';
 import { parseConfig } from './config/env-config';
 import createCorsMiddleware from './cors/cors-middleware';
 import createPerKeyOriginMiddleware from './cors/per-key-origin';
+import createDataRoutesMiddleware from './data/data-routes-middleware';
 import { extractErrorMessage } from './errors';
 import { unauthorized } from './http/bff-http-error';
 import BFFHttpServer from './http/bff-http-server';
@@ -22,6 +23,7 @@ import ForestServerClient from './oauth/forest-server-client';
 import createOAuthRoutes from './oauth/oauth-routes';
 import createInMemorySessionStore from './oauth/session-store';
 import createTokenCipher from './oauth/token-cipher';
+import createReadModel from './read-model/create-read-model';
 import createTimezoneMiddleware from './timezone/timezone-middleware';
 import version from './version';
 
@@ -152,6 +154,24 @@ function buildApiKeyMiddleware(config: BFFConfig, logger: Logger): Middleware | 
   return createApiKeyMiddleware({ authenticator, logger });
 }
 
+function buildDataRoutesMiddleware(config: BFFConfig, logger: Logger): Middleware {
+  const apiKeyConfig = resolveApiKeyConfig(config);
+
+  if (!apiKeyConfig || !config.agentUrl) {
+    logger('Warn', 'Data endpoints disabled: AGENT_URL or read-model configuration is missing');
+
+    return createAgentStubMiddleware();
+  }
+
+  const { store } = createReadModel({
+    forestServerUrl: apiKeyConfig.forestServerUrl,
+    envSecret: apiKeyConfig.forestEnvSecret,
+    logger,
+  });
+
+  return createDataRoutesMiddleware({ store, agentUrl: config.agentUrl, logger });
+}
+
 function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] {
   const { forestAuthSecret, defaultTimezone } = config;
 
@@ -168,7 +188,7 @@ function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] 
     apiKeyStep,
     createPerKeyOriginMiddleware(),
     createTimezoneMiddleware({ defaultTimezone }),
-    createAgentStubMiddleware(),
+    buildDataRoutesMiddleware(config, logger),
   ];
 
   return chain.map(agentScoped);

--- a/packages/agent-bff/src/data/agent-data-client.ts
+++ b/packages/agent-bff/src/data/agent-data-client.ts
@@ -1,0 +1,35 @@
+import { HttpRequester } from '@forestadmin/agent-client';
+
+export interface AgentDataClientOptions {
+  agentUrl: string;
+  token: string;
+}
+
+export interface AgentDataClient {
+  list(collection: string, query: Record<string, unknown>): Promise<Record<string, unknown>[]>;
+  countRaw(collection: string, query: Record<string, unknown>): Promise<unknown>;
+}
+
+/**
+ * Thin data client bound to a request's agent token. Uses the raw `HttpRequester` (not `Collection`)
+ * so the BFF controls the query params — notably the resolved `timezone` — and can read the count
+ * endpoint's raw payload, which `collection.count()` coerces through `Number()` and loses.
+ */
+export default function createAgentDataClient({
+  agentUrl,
+  token,
+}: AgentDataClientOptions): AgentDataClient {
+  const requester = new HttpRequester(token, { url: agentUrl });
+
+  return {
+    list: (collection, query) =>
+      requester.query({ method: 'get', path: `/forest/${collection}`, query }),
+    countRaw: (collection, query) =>
+      requester.query({
+        method: 'get',
+        path: `/forest/${collection}/count`,
+        query,
+        skipDeserialization: true,
+      }),
+  };
+}

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -23,6 +23,59 @@ export interface CountRequestBody {
 
 export type AgentQuery = Record<string, unknown> & { timezone: string };
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Validate the untyped request body before it reaches the query builders, so malformed shapes
+// (e.g. `projection` or `sort` as a string) surface as 400 invalid_request rather than a 500 from
+// an array method blowing up downstream.
+export function parseListRequest(body: unknown): ListRequestBody {
+  if (!isPlainObject(body)) throw invalidRequest('Request body must be an object');
+
+  const { filter, projection, sort, page } = body;
+
+  if (projection !== undefined) {
+    if (!Array.isArray(projection) || projection.some(field => typeof field !== 'string')) {
+      throw invalidRequest('projection must be an array of field names');
+    }
+  }
+
+  if (sort !== undefined) {
+    const valid =
+      Array.isArray(sort) &&
+      sort.every(
+        clause =>
+          isPlainObject(clause) &&
+          typeof clause.field === 'string' &&
+          (clause.direction === undefined ||
+            clause.direction === 'asc' ||
+            clause.direction === 'desc'),
+      );
+    if (!valid) throw invalidRequest('sort must be an array of { field, direction? }');
+  }
+
+  if (filter !== undefined && !isPlainObject(filter)) {
+    throw invalidRequest('filter must be an object');
+  }
+
+  if (page !== undefined && !isPlainObject(page)) {
+    throw invalidRequest('page must be an object with limit and offset');
+  }
+
+  return body as ListRequestBody;
+}
+
+export function parseCountRequest(body: unknown): CountRequestBody {
+  if (!isPlainObject(body)) throw invalidRequest('Request body must be an object');
+
+  if (body.filter !== undefined && !isPlainObject(body.filter)) {
+    throw invalidRequest('filter must be an object');
+  }
+
+  return body as CountRequestBody;
+}
+
 interface ConditionTreeBranch {
   conditions: unknown[];
 }

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -59,8 +59,18 @@ export function parseListRequest(body: unknown): ListRequestBody {
     throw invalidRequest('filter must be an object');
   }
 
-  if (page !== undefined && !isPlainObject(page)) {
-    throw invalidRequest('page must be an object with limit and offset');
+  if (page !== undefined) {
+    if (!isPlainObject(page)) {
+      throw invalidRequest('page must be an object with limit and offset');
+    }
+
+    if (!Number.isInteger(page.limit) || (page.limit as number) <= 0) {
+      throw invalidRequest('page.limit must be a positive integer');
+    }
+
+    if (!Number.isInteger(page.offset) || (page.offset as number) < 0) {
+      throw invalidRequest('page.offset must be a non-negative integer');
+    }
   }
 
   return body as ListRequestBody;
@@ -112,19 +122,12 @@ function serializeSort(sort: BffSortClause[]): string {
   return sort.map(({ field, direction }) => (direction === 'desc' ? `-${field}` : field)).join(',');
 }
 
+// `parseListRequest` guarantees `limit` > 0 and `offset` >= 0 are integers; this only enforces the
+// page-model rule. The agent paginates by page number/size, so an arbitrary offset that is not a
+// whole multiple of the limit cannot be expressed — reject it rather than return a shifted window.
 function serializePage(page: BffPage): Record<string, number> {
   const { limit, offset } = page;
 
-  if (!Number.isInteger(limit) || limit <= 0) {
-    throw invalidRequest(`Invalid page.limit: ${limit}`);
-  }
-
-  if (!Number.isInteger(offset) || offset < 0) {
-    throw invalidRequest(`Invalid page.offset: ${offset}`);
-  }
-
-  // The agent paginates by page number/size, so an arbitrary offset that is not a whole multiple
-  // of the limit cannot be expressed. Reject it rather than silently return a shifted window.
   if (offset % limit !== 0) {
     throw invalidRequest(`page.offset (${offset}) must be a multiple of page.limit (${limit})`);
   }

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -1,0 +1,119 @@
+import { invalidRequest } from '../http/bff-local-errors';
+
+export interface BffSortClause {
+  field: string;
+  direction?: 'asc' | 'desc';
+}
+
+export interface BffPage {
+  limit: number;
+  offset: number;
+}
+
+export interface ListRequestBody {
+  filter?: unknown;
+  projection?: string[];
+  sort?: BffSortClause[];
+  page?: BffPage;
+}
+
+export interface CountRequestBody {
+  filter?: unknown;
+}
+
+export type AgentQuery = Record<string, unknown> & { timezone: string };
+
+interface ConditionTreeBranch {
+  aggregator: string;
+  conditions: unknown[];
+}
+
+interface ConditionTreeLeaf {
+  field: string;
+}
+
+function isBranch(node: unknown): node is ConditionTreeBranch {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    Array.isArray((node as { conditions?: unknown }).conditions)
+  );
+}
+
+function isLeaf(node: unknown): node is ConditionTreeLeaf {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as { field?: unknown }).field === 'string'
+  );
+}
+
+function collectFilterFields(filter: unknown, acc: string[]): void {
+  if (isBranch(filter)) {
+    filter.conditions.forEach(condition => collectFilterFields(condition, acc));
+  } else if (isLeaf(filter)) {
+    acc.push(filter.field);
+  }
+}
+
+function serializeSort(sort: BffSortClause[]): string {
+  return sort.map(({ field, direction }) => (direction === 'desc' ? `-${field}` : field)).join(',');
+}
+
+function serializePage(page: BffPage): Record<string, number> {
+  const { limit, offset } = page;
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw invalidRequest(`Invalid page.limit: ${limit}`);
+  }
+
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw invalidRequest(`Invalid page.offset: ${offset}`);
+  }
+
+  // The agent paginates by page number/size, so an arbitrary offset that is not a whole multiple
+  // of the limit cannot be expressed. Reject it rather than silently return a shifted window.
+  if (offset % limit !== 0) {
+    throw invalidRequest(`page.offset (${offset}) must be a multiple of page.limit (${limit})`);
+  }
+
+  return { 'page[size]': limit, 'page[number]': offset / limit + 1 };
+}
+
+export function buildListAgentQuery(
+  collection: string,
+  timezone: string,
+  body: ListRequestBody,
+): AgentQuery {
+  const query: AgentQuery = { timezone };
+
+  if (body.filter !== undefined) query.filters = JSON.stringify(body.filter);
+  if (body.projection?.length) query[`fields[${collection}]`] = body.projection.join(',');
+  if (body.sort?.length) query.sort = serializeSort(body.sort);
+  if (body.page) Object.assign(query, serializePage(body.page));
+
+  return query;
+}
+
+export function buildCountAgentQuery(timezone: string, body: CountRequestBody): AgentQuery {
+  const query: AgentQuery = { timezone };
+
+  if (body.filter !== undefined) query.filters = JSON.stringify(body.filter);
+
+  return query;
+}
+
+export function collectListFieldPaths(body: ListRequestBody): string[] {
+  const paths: string[] = [...(body.projection ?? [])];
+  collectFilterFields(body.filter, paths);
+  (body.sort ?? []).forEach(({ field }) => paths.push(field));
+
+  return paths;
+}
+
+export function collectCountFieldPaths(body: CountRequestBody): string[] {
+  const paths: string[] = [];
+  collectFilterFields(body.filter, paths);
+
+  return paths;
+}

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -24,7 +24,6 @@ export interface CountRequestBody {
 export type AgentQuery = Record<string, unknown> & { timezone: string };
 
 interface ConditionTreeBranch {
-  aggregator: string;
   conditions: unknown[];
 }
 

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -15,7 +15,8 @@ import {
 } from './agent-query';
 import { mapCountResponse, mapListResponse } from './response-mappers';
 import { mapAgentError } from '../http/agent-error-mapper';
-import { schemaUnavailable, unknownCollection } from '../http/bff-local-errors';
+import { unauthorized } from '../http/bff-http-error';
+import { invalidRequest, schemaUnavailable, unknownCollection } from '../http/bff-local-errors';
 import SchemaUnavailableError from '../read-model/errors';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
@@ -33,6 +34,16 @@ interface RequestHandlerDeps {
   client: AgentDataClient;
   timezone: string;
   logger: Logger;
+}
+
+type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
+
+function decodeCollection(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw invalidRequest('Malformed collection name in path');
+  }
 }
 
 async function resolveReadModel(store: ReadModelStore): Promise<ReadModel> {
@@ -54,19 +65,14 @@ async function callAgent<T>(fn: () => Promise<T>, logger: Logger): Promise<T> {
   }
 }
 
-async function handleList(
-  ctx: Context,
-  body: ListRequestBody,
-  deps: RequestHandlerDeps,
-  primaryKeys: PrimaryKeyField[],
-) {
+async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandlerDeps) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
 
   ctx.status = 200;
-  ctx.body = mapListResponse(deps.collection, records, primaryKeys);
+  ctx.body = mapListResponse(deps.collection, records, deps.primaryKeys);
 }
 
 async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerDeps) {
@@ -94,8 +100,15 @@ export default function createDataRoutesMiddleware({
       return;
     }
 
-    const collection = decodeURIComponent(match[1]);
+    const collection = decodeCollection(match[1]);
     const operation = match[2] as 'list' | 'count';
+
+    // The agent token is minted only on the API-key path; the OAuth path sets a principal but no
+    // agent token yet. Fail closed instead of calling the agent with `Bearer undefined`.
+    // TODO(PRD-637): mint an agent token from the OAuth principal so data routes work in OAuth mode.
+    const token = ctx.state.agentToken as string | undefined;
+    if (!token) throw unauthorized('No agent credentials for this request');
+
     const readModel = await resolveReadModel(store);
 
     if (!readModel.isCollectionAllowed(collection)) {
@@ -108,14 +121,14 @@ export default function createDataRoutesMiddleware({
 
     const deps: RequestHandlerDeps = {
       collection,
-      client: createClient({ agentUrl, token: ctx.state.agentToken as string }),
+      client: createClient({ agentUrl, token }),
       timezone: ctx.state.timezone as string,
       logger,
     };
     const body = (ctx.request.body ?? {}) as ListRequestBody & CountRequestBody;
 
     if (operation === 'list') {
-      await handleList(ctx, body, deps, readModel.getPrimaryKeys(collection));
+      await handleList(ctx, body, { ...deps, primaryKeys: readModel.getPrimaryKeys(collection) });
     } else {
       await handleCount(ctx, body, deps);
     }

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -12,6 +12,8 @@ import {
   buildListAgentQuery,
   collectCountFieldPaths,
   collectListFieldPaths,
+  parseCountRequest,
+  parseListRequest,
 } from './agent-query';
 import { mapCountResponse, mapListResponse } from './response-mappers';
 import { mapAgentError } from '../http/agent-error-mapper';
@@ -125,11 +127,13 @@ export default function createDataRoutesMiddleware({
       timezone: ctx.state.timezone as string,
       logger,
     };
-    const body = (ctx.request.body ?? {}) as ListRequestBody & CountRequestBody;
+    const rawBody = ctx.request.body ?? {};
 
     if (operation === 'list') {
+      const body = parseListRequest(rawBody);
       await handleList(ctx, body, { ...deps, primaryKeys: readModel.getPrimaryKeys(collection) });
     } else {
+      const body = parseCountRequest(rawBody);
       await handleCount(ctx, body, deps);
     }
   };

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -1,8 +1,9 @@
 import type { AgentDataClient, AgentDataClientOptions } from './agent-data-client';
 import type { CountRequestBody, ListRequestBody } from './agent-query';
 import type { Logger } from '../ports/logger-port';
+import type ReadModel from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
-import type { Middleware } from 'koa';
+import type { Context, Middleware } from 'koa';
 
 import defaultCreateAgentDataClient from './agent-data-client';
 import {
@@ -26,13 +27,55 @@ export interface DataRoutesMiddlewareOptions {
   createClient?: (options: AgentDataClientOptions) => AgentDataClient;
 }
 
-async function resolveReadModel(store: ReadModelStore) {
+interface RequestHandlerContext {
+  collection: string;
+  readModel: ReadModel;
+  client: AgentDataClient;
+  timezone: string;
+  logger: Logger;
+}
+
+async function resolveReadModel(store: ReadModelStore): Promise<ReadModel> {
   try {
     return await store.getReadModel();
   } catch (error) {
     if (error instanceof SchemaUnavailableError) throw schemaUnavailable();
     throw error;
   }
+}
+
+// Only the agent call is wrapped: guard, query-building and mapping errors are BFF-origin and must
+// keep their own type, not be recategorized as agent errors.
+async function callAgent<T>(fn: () => Promise<T>, logger: Logger): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    throw mapAgentError(error, { logger });
+  }
+}
+
+async function handleList(ctx: Context, body: ListRequestBody, deps: RequestHandlerContext) {
+  assertNoRelationFieldPaths(collectListFieldPaths(body));
+
+  const query = buildListAgentQuery(deps.collection, deps.timezone, body);
+  const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
+
+  ctx.status = 200;
+  ctx.body = mapListResponse(
+    deps.collection,
+    records,
+    deps.readModel.getPrimaryKeys(deps.collection),
+  );
+}
+
+async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerContext) {
+  assertNoRelationFieldPaths(collectCountFieldPaths(body));
+
+  const query = buildCountAgentQuery(deps.timezone, body);
+  const raw = await callAgent(() => deps.client.countRaw(deps.collection, query), deps.logger);
+
+  ctx.status = 200;
+  ctx.body = mapCountResponse(raw);
 }
 
 export default function createDataRoutesMiddleware({
@@ -52,7 +95,6 @@ export default function createDataRoutesMiddleware({
 
     const collection = decodeURIComponent(match[1]);
     const operation = match[2] as 'list' | 'count';
-
     const readModel = await resolveReadModel(store);
 
     if (!readModel.isCollectionAllowed(collection)) {
@@ -63,41 +105,16 @@ export default function createDataRoutesMiddleware({
       throw unknownCollection(`Unknown collection: ${collection}`);
     }
 
-    const timezone = ctx.state.timezone as string;
-    const token = ctx.state.agentToken as string;
-    const client = createClient({ agentUrl, token });
+    const deps: RequestHandlerContext = {
+      collection,
+      readModel,
+      client: createClient({ agentUrl, token: ctx.state.agentToken as string }),
+      timezone: ctx.state.timezone as string,
+      logger,
+    };
     const body = (ctx.request.body ?? {}) as ListRequestBody & CountRequestBody;
 
-    if (operation === 'list') {
-      assertNoRelationFieldPaths(collectListFieldPaths(body));
-
-      const query = buildListAgentQuery(collection, timezone, body);
-      let records: Record<string, unknown>[];
-
-      try {
-        records = await client.list(collection, query);
-      } catch (error) {
-        throw mapAgentError(error, { logger });
-      }
-
-      ctx.status = 200;
-      ctx.body = mapListResponse(collection, records, readModel.getPrimaryKeys(collection));
-
-      return;
-    }
-
-    assertNoRelationFieldPaths(collectCountFieldPaths(body));
-
-    const query = buildCountAgentQuery(timezone, body);
-    let raw: unknown;
-
-    try {
-      raw = await client.countRaw(collection, query);
-    } catch (error) {
-      throw mapAgentError(error, { logger });
-    }
-
-    ctx.status = 200;
-    ctx.body = mapCountResponse(raw);
+    if (operation === 'list') await handleList(ctx, body, deps);
+    else await handleCount(ctx, body, deps);
   };
 }

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -1,0 +1,103 @@
+import type { AgentDataClient, AgentDataClientOptions } from './agent-data-client';
+import type { CountRequestBody, ListRequestBody } from './agent-query';
+import type { Logger } from '../ports/logger-port';
+import type ReadModelStore from '../read-model/read-model-store';
+import type { Middleware } from 'koa';
+
+import defaultCreateAgentDataClient from './agent-data-client';
+import {
+  buildCountAgentQuery,
+  buildListAgentQuery,
+  collectCountFieldPaths,
+  collectListFieldPaths,
+} from './agent-query';
+import { mapCountResponse, mapListResponse } from './response-mappers';
+import { mapAgentError } from '../http/agent-error-mapper';
+import { schemaUnavailable, unknownCollection } from '../http/bff-local-errors';
+import SchemaUnavailableError from '../read-model/errors';
+import assertNoRelationFieldPaths from '../validation/relation-field-guard';
+
+const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
+
+export interface DataRoutesMiddlewareOptions {
+  store: ReadModelStore;
+  agentUrl: string;
+  logger: Logger;
+  createClient?: (options: AgentDataClientOptions) => AgentDataClient;
+}
+
+async function resolveReadModel(store: ReadModelStore) {
+  try {
+    return await store.getReadModel();
+  } catch (error) {
+    if (error instanceof SchemaUnavailableError) throw schemaUnavailable();
+    throw error;
+  }
+}
+
+export default function createDataRoutesMiddleware({
+  store,
+  agentUrl,
+  logger,
+  createClient = defaultCreateAgentDataClient,
+}: DataRoutesMiddlewareOptions): Middleware {
+  return async function dataRoutesMiddleware(ctx, next) {
+    const match = DATA_ROUTE.exec(ctx.path);
+
+    if (!match || ctx.method !== 'POST') {
+      await next();
+
+      return;
+    }
+
+    const collection = decodeURIComponent(match[1]);
+    const operation = match[2] as 'list' | 'count';
+
+    const readModel = await resolveReadModel(store);
+
+    if (!readModel.isCollectionAllowed(collection)) {
+      // TODO(PRD-671): the read-model exposes a single allow-list (the exposed collections), so it
+      // cannot tell an unknown collection from a known-but-disallowed one. Every absent name maps
+      // to 404 here; `collection_not_allowed` (403) has no local trigger until a distinct exposure
+      // source exists. Escalated on the ticket — revisit when Anthony answers.
+      throw unknownCollection(`Unknown collection: ${collection}`);
+    }
+
+    const timezone = ctx.state.timezone as string;
+    const token = ctx.state.agentToken as string;
+    const client = createClient({ agentUrl, token });
+    const body = (ctx.request.body ?? {}) as ListRequestBody & CountRequestBody;
+
+    if (operation === 'list') {
+      assertNoRelationFieldPaths(collectListFieldPaths(body));
+
+      const query = buildListAgentQuery(collection, timezone, body);
+      let records: Record<string, unknown>[];
+
+      try {
+        records = await client.list(collection, query);
+      } catch (error) {
+        throw mapAgentError(error, { logger });
+      }
+
+      ctx.status = 200;
+      ctx.body = mapListResponse(collection, records, readModel.getPrimaryKeys(collection));
+
+      return;
+    }
+
+    assertNoRelationFieldPaths(collectCountFieldPaths(body));
+
+    const query = buildCountAgentQuery(timezone, body);
+    let raw: unknown;
+
+    try {
+      raw = await client.countRaw(collection, query);
+    } catch (error) {
+      throw mapAgentError(error, { logger });
+    }
+
+    ctx.status = 200;
+    ctx.body = mapCountResponse(raw);
+  };
+}

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -2,6 +2,7 @@ import type { AgentDataClient, AgentDataClientOptions } from './agent-data-clien
 import type { CountRequestBody, ListRequestBody } from './agent-query';
 import type { Logger } from '../ports/logger-port';
 import type ReadModel from '../read-model/read-model';
+import type { PrimaryKeyField } from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
 import type { Context, Middleware } from 'koa';
 
@@ -27,9 +28,8 @@ export interface DataRoutesMiddlewareOptions {
   createClient?: (options: AgentDataClientOptions) => AgentDataClient;
 }
 
-interface RequestHandlerContext {
+interface RequestHandlerDeps {
   collection: string;
-  readModel: ReadModel;
   client: AgentDataClient;
   timezone: string;
   logger: Logger;
@@ -54,21 +54,22 @@ async function callAgent<T>(fn: () => Promise<T>, logger: Logger): Promise<T> {
   }
 }
 
-async function handleList(ctx: Context, body: ListRequestBody, deps: RequestHandlerContext) {
+async function handleList(
+  ctx: Context,
+  body: ListRequestBody,
+  deps: RequestHandlerDeps,
+  primaryKeys: PrimaryKeyField[],
+) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
 
   ctx.status = 200;
-  ctx.body = mapListResponse(
-    deps.collection,
-    records,
-    deps.readModel.getPrimaryKeys(deps.collection),
-  );
+  ctx.body = mapListResponse(deps.collection, records, primaryKeys);
 }
 
-async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerContext) {
+async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerDeps) {
   assertNoRelationFieldPaths(collectCountFieldPaths(body));
 
   const query = buildCountAgentQuery(deps.timezone, body);
@@ -105,16 +106,18 @@ export default function createDataRoutesMiddleware({
       throw unknownCollection(`Unknown collection: ${collection}`);
     }
 
-    const deps: RequestHandlerContext = {
+    const deps: RequestHandlerDeps = {
       collection,
-      readModel,
       client: createClient({ agentUrl, token: ctx.state.agentToken as string }),
       timezone: ctx.state.timezone as string,
       logger,
     };
     const body = (ctx.request.body ?? {}) as ListRequestBody & CountRequestBody;
 
-    if (operation === 'list') await handleList(ctx, body, deps);
-    else await handleCount(ctx, body, deps);
+    if (operation === 'list') {
+      await handleList(ctx, body, deps, readModel.getPrimaryKeys(collection));
+    } else {
+      await handleCount(ctx, body, deps);
+    }
   };
 }

--- a/packages/agent-bff/src/data/pack-id.ts
+++ b/packages/agent-bff/src/data/pack-id.ts
@@ -1,0 +1,37 @@
+import type { PrimaryKeyField } from '../read-model/read-model';
+
+import { mappingError } from '../http/bff-local-errors';
+
+const PACKED_ID_SEPARATOR = '|';
+
+/**
+ * Rebuild the structured primary key of a record from its opaque packed id, mirroring the agent's
+ * `IdUtils.packId`/`unpackId` (`|`-joined values, `Number` columns cast back to numbers). Returns a
+ * `{ pkField: value }` map for `__forest.primaryKey`. Throws a mapping error rather than emitting a
+ * malformed key when the schema lacks key metadata or the packed id shape does not match it.
+ */
+export default function unpackPrimaryKey(
+  packedId: string,
+  primaryKeys: PrimaryKeyField[],
+): Record<string, string | number> {
+  if (primaryKeys.length === 0) {
+    throw mappingError('Cannot build primary key: the collection exposes no key metadata');
+  }
+
+  const values = packedId.split(PACKED_ID_SEPARATOR);
+
+  if (values.length !== primaryKeys.length) {
+    throw mappingError(
+      `Cannot build primary key: expected ${primaryKeys.length} values, found ${values.length}`,
+    );
+  }
+
+  const result: Record<string, string | number> = {};
+
+  primaryKeys.forEach(({ name, type }, index) => {
+    const value = values[index];
+    result[name] = type === 'Number' ? Number(value) : value;
+  });
+
+  return result;
+}

--- a/packages/agent-bff/src/data/pack-id.ts
+++ b/packages/agent-bff/src/data/pack-id.ts
@@ -4,8 +4,7 @@ import { mappingError } from '../http/bff-local-errors';
 
 const PACKED_ID_SEPARATOR = '|';
 
-// The only column type that roundtrips through a non-string value, mirroring the agent's
-// `IdUtils.unpackId`. Centralized so the token is not duplicated as a bare string literal.
+// The only column type unpacked to a number, mirroring the agent's `IdUtils.unpackId`.
 const NUMBER_COLUMN_TYPE = 'Number';
 
 /**

--- a/packages/agent-bff/src/data/pack-id.ts
+++ b/packages/agent-bff/src/data/pack-id.ts
@@ -33,7 +33,22 @@ export default function unpackPrimaryKey(
 
   primaryKeys.forEach(({ name, type }, index) => {
     const value = values[index];
-    result[name] = type === NUMBER_COLUMN_TYPE ? Number(value) : value;
+
+    if (type !== NUMBER_COLUMN_TYPE) {
+      result[name] = value;
+
+      return;
+    }
+
+    const numeric = Number(value);
+
+    if (Number.isNaN(numeric)) {
+      throw mappingError(
+        `Cannot build primary key: invalid numeric value "${value}" for "${name}"`,
+      );
+    }
+
+    result[name] = numeric;
   });
 
   return result;

--- a/packages/agent-bff/src/data/pack-id.ts
+++ b/packages/agent-bff/src/data/pack-id.ts
@@ -4,6 +4,10 @@ import { mappingError } from '../http/bff-local-errors';
 
 const PACKED_ID_SEPARATOR = '|';
 
+// The only column type that roundtrips through a non-string value, mirroring the agent's
+// `IdUtils.unpackId`. Centralized so the token is not duplicated as a bare string literal.
+const NUMBER_COLUMN_TYPE = 'Number';
+
 /**
  * Rebuild the structured primary key of a record from its opaque packed id, mirroring the agent's
  * `IdUtils.packId`/`unpackId` (`|`-joined values, `Number` columns cast back to numbers). Returns a
@@ -30,7 +34,7 @@ export default function unpackPrimaryKey(
 
   primaryKeys.forEach(({ name, type }, index) => {
     const value = values[index];
-    result[name] = type === 'Number' ? Number(value) : value;
+    result[name] = type === NUMBER_COLUMN_TYPE ? Number(value) : value;
   });
 
   return result;

--- a/packages/agent-bff/src/data/response-mappers.ts
+++ b/packages/agent-bff/src/data/response-mappers.ts
@@ -42,10 +42,7 @@ export function mapListResponse(
   return { data, meta: { countStatus: 'not_requested' } };
 }
 
-// The spec allows deriving deactivation from schema metadata first, else the raw agent payload.
-// Neither the Forest schema nor the capabilities response exposes a count flag (the agent decides
-// countability at request time in `access/count.ts`), so the raw payload's `meta.count` marker is
-// the only available signal — schema-first is not implementable without an agent change.
+// meta.count is the only deactivation signal the agent exposes.
 export function mapCountResponse(raw: unknown): CountResponse {
   const body = (typeof raw === 'object' && raw !== null ? raw : {}) as {
     count?: unknown;

--- a/packages/agent-bff/src/data/response-mappers.ts
+++ b/packages/agent-bff/src/data/response-mappers.ts
@@ -1,0 +1,63 @@
+import type { PrimaryKeyField } from '../read-model/read-model';
+
+import unpackPrimaryKey from './pack-id';
+import { mappingError } from '../http/bff-local-errors';
+
+export type CountStatus = 'available' | 'deactivated' | 'not_requested';
+
+export interface ForestRecordMetadata {
+  collection: string;
+  primaryKey: Record<string, string | number>;
+}
+
+export interface ListResponse {
+  data: Array<Record<string, unknown> & { __forest: ForestRecordMetadata }>;
+  meta: { countStatus: 'not_requested' };
+}
+
+export interface CountResponse {
+  count: number | null;
+  countStatus: 'available' | 'deactivated';
+}
+
+const DEACTIVATED = 'deactivated';
+
+export function mapListResponse(
+  collection: string,
+  records: Record<string, unknown>[],
+  primaryKeys: PrimaryKeyField[],
+): ListResponse {
+  const data = records.map(record => {
+    if (record.id === undefined || record.id === null) {
+      throw mappingError('Agent record is missing its id');
+    }
+
+    return {
+      ...record,
+      __forest: {
+        collection,
+        primaryKey: unpackPrimaryKey(String(record.id), primaryKeys),
+      },
+    };
+  });
+
+  return { data, meta: { countStatus: 'not_requested' } };
+}
+
+export function mapCountResponse(raw: unknown): CountResponse {
+  const body = (typeof raw === 'object' && raw !== null ? raw : {}) as {
+    count?: unknown;
+    meta?: { count?: unknown };
+  };
+
+  if (body.meta?.count === DEACTIVATED) {
+    return { count: null, countStatus: 'deactivated' };
+  }
+
+  if (typeof body.count === 'number' && Number.isFinite(body.count)) {
+    return { count: body.count, countStatus: 'available' };
+  }
+
+  // Neither schema metadata nor a usable raw payload: never silently report 0.
+  throw mappingError('Agent count payload has no numeric count and no deactivated marker');
+}

--- a/packages/agent-bff/src/data/response-mappers.ts
+++ b/packages/agent-bff/src/data/response-mappers.ts
@@ -3,8 +3,6 @@ import type { PrimaryKeyField } from '../read-model/read-model';
 import unpackPrimaryKey from './pack-id';
 import { mappingError } from '../http/bff-local-errors';
 
-export type CountStatus = 'available' | 'deactivated' | 'not_requested';
-
 export interface ForestRecordMetadata {
   collection: string;
   primaryKey: Record<string, string | number>;
@@ -44,6 +42,10 @@ export function mapListResponse(
   return { data, meta: { countStatus: 'not_requested' } };
 }
 
+// The spec allows deriving deactivation from schema metadata first, else the raw agent payload.
+// Neither the Forest schema nor the capabilities response exposes a count flag (the agent decides
+// countability at request time in `access/count.ts`), so the raw payload's `meta.count` marker is
+// the only available signal — schema-first is not implementable without an agent change.
 export function mapCountResponse(raw: unknown): CountResponse {
   const body = (typeof raw === 'object' && raw !== null ? raw : {}) as {
     count?: unknown;

--- a/packages/agent-bff/src/http/agent-error-mapper.ts
+++ b/packages/agent-bff/src/http/agent-error-mapper.ts
@@ -133,6 +133,10 @@ function mapFlatBody(status: number, body: unknown, responseText?: string): BffH
 }
 
 export function mapAgentError(error: unknown, { logger }: { logger: Logger }): BffHttpError {
+  // A BFF-origin error that reached here (e.g. thrown inside a caller's agent-call try/catch) keeps
+  // its own type — it must not be recategorized as a transport/agent error.
+  if (error instanceof BffHttpError) return error;
+
   if (!(error instanceof AgentHttpError)) {
     const agentError = parseJsonApiFromMessage(error);
     if (agentError) return mapJsonApiError(agentError, 400, logger);

--- a/packages/agent-bff/src/http/bff-local-errors.ts
+++ b/packages/agent-bff/src/http/bff-local-errors.ts
@@ -28,14 +28,12 @@ export function invalidRequest(message = 'Invalid request', details?: unknown): 
   return new BffHttpError(400, 'invalid_request', message, details);
 }
 
-export function relationFieldNotSupported(
-  message = 'Relation field is not supported',
-): BffHttpError {
-  return new BffHttpError(422, 'relation_field_not_supported', message);
-}
-
 export function mappingError(message = 'Failed to map the agent response'): BffHttpError {
   return new BffHttpError(500, 'mapping_error', message);
+}
+
+export function schemaUnavailable(message = 'The agent schema is unavailable'): BffHttpError {
+  return new BffHttpError(503, 'schema_unavailable', message);
 }
 
 export function unsupportedActionResult(message = 'Unsupported action result'): BffHttpError {

--- a/packages/agent-bff/src/read-model/read-model.ts
+++ b/packages/agent-bff/src/read-model/read-model.ts
@@ -7,6 +7,8 @@ export type RelationTarget =
   | { type: RelationshipType; polymorphic: false; target: string }
   | { type: RelationshipType; polymorphic: true; targets: string[] };
 
+export type PrimaryKeyField = { name: string; type: string };
+
 function toRelationTarget(field: ForestSchemaField): RelationTarget | null {
   if (!field.relationship) return null;
 
@@ -44,6 +46,7 @@ export default class ReadModel {
   private readonly collections: Set<string>;
   private readonly relations: Map<string, Map<string, RelationTarget>>;
   private readonly actionEndpoints: ActionEndpointsByCollection;
+  private readonly primaryKeys: Map<string, PrimaryKeyField[]>;
 
   constructor(collections: ForestSchemaCollection[]) {
     this.collections = new Set();
@@ -51,16 +54,19 @@ export default class ReadModel {
     // Null-prototype so an action/collection named like an Object.prototype member
     // (`toString`, `constructor`, `__proto__`, …) can't falsely pass the allow-list.
     this.actionEndpoints = Object.create(null) as ActionEndpointsByCollection;
+    this.primaryKeys = new Map();
 
     for (const collection of collections) {
       this.collections.add(collection.name);
       this.buildRelations(collection);
       this.buildActionEndpoints(collection);
+      this.buildPrimaryKeys(collection);
     }
 
     // Freeze the exposed structures so a consumer cannot mutate the shared cached read-model.
     deepFreeze(this.actionEndpoints);
     this.relations.forEach(byRelation => byRelation.forEach(deepFreeze));
+    this.primaryKeys.forEach(deepFreeze);
   }
 
   private buildRelations(collection: ForestSchemaCollection): void {
@@ -96,6 +102,16 @@ export default class ReadModel {
     }
   }
 
+  private buildPrimaryKeys(collection: ForestSchemaCollection): void {
+    const keys: PrimaryKeyField[] = [];
+
+    for (const field of collection.fields ?? []) {
+      if (field.isPrimaryKey) keys.push({ name: field.field, type: field.type });
+    }
+
+    this.primaryKeys.set(collection.name, keys);
+  }
+
   isCollectionAllowed(collection: string): boolean {
     return this.collections.has(collection);
   }
@@ -114,5 +130,9 @@ export default class ReadModel {
 
   getActionEndpoints(): ActionEndpointsByCollection {
     return this.actionEndpoints;
+  }
+
+  getPrimaryKeys(collection: string): PrimaryKeyField[] {
+    return this.primaryKeys.get(collection) ?? [];
   }
 }

--- a/packages/agent-bff/test/data/agent-data-client.test.ts
+++ b/packages/agent-bff/test/data/agent-data-client.test.ts
@@ -1,0 +1,52 @@
+import { HttpRequester } from '@forestadmin/agent-client';
+
+import createAgentDataClient from '../../src/data/agent-data-client';
+
+jest.mock('@forestadmin/agent-client');
+
+const mockedHttpRequester = jest.mocked(HttpRequester);
+
+describe('createAgentDataClient', () => {
+  const query = jest.fn();
+
+  beforeEach(() => {
+    query.mockReset();
+    mockedHttpRequester.mockReset();
+    mockedHttpRequester.mockImplementation(() => ({ query } as unknown as HttpRequester));
+  });
+
+  it('should build the requester with the agent url and token', () => {
+    createAgentDataClient({ agentUrl: 'https://agent.example.com', token: 'tok' });
+
+    expect(HttpRequester).toHaveBeenCalledWith('tok', { url: 'https://agent.example.com' });
+  });
+
+  it('should query the list endpoint (deserialized) for the given collection', async () => {
+    query.mockResolvedValue([{ id: '1' }]);
+    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+
+    const result = await client.list('users', { timezone: 'Europe/Paris', filters: '{}' });
+
+    expect(query).toHaveBeenCalledWith({
+      method: 'get',
+      path: '/forest/users',
+      query: { timezone: 'Europe/Paris', filters: '{}' },
+    });
+    expect(result).toEqual([{ id: '1' }]);
+  });
+
+  it('should query the count endpoint with skipDeserialization to read the raw payload', async () => {
+    query.mockResolvedValue({ meta: { count: 'deactivated' } });
+    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+
+    const result = await client.countRaw('users', { timezone: 'Europe/Paris' });
+
+    expect(query).toHaveBeenCalledWith({
+      method: 'get',
+      path: '/forest/users/count',
+      query: { timezone: 'Europe/Paris' },
+      skipDeserialization: true,
+    });
+    expect(result).toEqual({ meta: { count: 'deactivated' } });
+  });
+});

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -3,6 +3,8 @@ import {
   buildListAgentQuery,
   collectCountFieldPaths,
   collectListFieldPaths,
+  parseCountRequest,
+  parseListRequest,
 } from '../../src/data/agent-query';
 
 describe('buildListAgentQuery', () => {
@@ -77,6 +79,42 @@ describe('collectListFieldPaths', () => {
     });
 
     expect(paths).toEqual(['id', 'company:name', 'email', 'owner:email', 'author:name']);
+  });
+});
+
+describe('parseListRequest', () => {
+  it('should accept a well-formed body', () => {
+    const body = {
+      filter: { field: 'email', operator: 'present' },
+      projection: ['id'],
+      sort: [{ field: 'createdAt', direction: 'desc' }],
+      page: { limit: 10, offset: 0 },
+    };
+
+    expect(parseListRequest(body)).toBe(body);
+  });
+
+  it.each([
+    ['a non-object body', 'nope'],
+    ['a string projection', { projection: 'id' }],
+    ['a non-string projection entry', { projection: [1] }],
+    ['a string sort', { sort: 'createdAt' }],
+    ['a sort clause without a field', { sort: [{ direction: 'asc' }] }],
+    ['an invalid sort direction', { sort: [{ field: 'a', direction: 'up' }] }],
+    ['a string filter', { filter: 'id' }],
+    ['a string page', { page: '10' }],
+  ])('should reject %s with 400 invalid_request', (_label, body) => {
+    expect(() => parseListRequest(body)).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
+});
+
+describe('parseCountRequest', () => {
+  it('should reject a string filter with 400 invalid_request', () => {
+    expect(() => parseCountRequest({ filter: 'id' })).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
   });
 });
 

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -68,6 +68,10 @@ describe('buildCountAgentQuery', () => {
       filters: JSON.stringify({ field: 'active', operator: 'equal' }),
     });
   });
+
+  it('should emit only the timezone when no filter is provided', () => {
+    expect(buildCountAgentQuery('UTC', {})).toEqual({ timezone: 'UTC' });
+  });
 });
 
 describe('collectListFieldPaths', () => {

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -122,6 +122,16 @@ describe('parseCountRequest', () => {
       expect.objectContaining({ type: 'invalid_request', status: 400 }),
     );
   });
+
+  it.each([
+    ['null', null],
+    ['a string', 'foo'],
+    ['an array', []],
+  ])('should reject a non-object body (%s) with 400 invalid_request', (_label, body) => {
+    expect(() => parseCountRequest(body)).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
 });
 
 describe('collectCountFieldPaths', () => {

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -1,0 +1,91 @@
+import {
+  buildCountAgentQuery,
+  buildListAgentQuery,
+  collectCountFieldPaths,
+  collectListFieldPaths,
+} from '../../src/data/agent-query';
+
+describe('buildListAgentQuery', () => {
+  it('should always pass the resolved timezone', () => {
+    expect(buildListAgentQuery('users', 'America/New_York', {})).toEqual({
+      timezone: 'America/New_York',
+    });
+  });
+
+  it('should serialize filter, projection, sort and page to agent query params', () => {
+    const query = buildListAgentQuery('users', 'Europe/Paris', {
+      filter: { field: 'email', operator: 'present' },
+      projection: ['id', 'email'],
+      sort: [{ field: 'createdAt', direction: 'desc' }],
+      page: { limit: 20, offset: 40 },
+    });
+
+    expect(query).toEqual({
+      timezone: 'Europe/Paris',
+      filters: JSON.stringify({ field: 'email', operator: 'present' }),
+      'fields[users]': 'id,email',
+      sort: '-createdAt',
+      'page[size]': 20,
+      'page[number]': 3,
+    });
+  });
+
+  it('should default an unspecified sort direction to ascending', () => {
+    const query = buildListAgentQuery('users', 'Europe/Paris', {
+      sort: [{ field: 'name' }, { field: 'age', direction: 'desc' }],
+    });
+
+    expect(query.sort).toBe('name,-age');
+  });
+
+  it('should reject an offset that is not a multiple of the limit', () => {
+    expect(() =>
+      buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 20, offset: 15 } }),
+    ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
+  });
+
+  it('should reject a non-positive limit', () => {
+    expect(() =>
+      buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 0, offset: 0 } }),
+    ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
+  });
+});
+
+describe('buildCountAgentQuery', () => {
+  it('should serialize only the filter and timezone', () => {
+    expect(
+      buildCountAgentQuery('Europe/Paris', { filter: { field: 'active', operator: 'equal' } }),
+    ).toEqual({
+      timezone: 'Europe/Paris',
+      filters: JSON.stringify({ field: 'active', operator: 'equal' }),
+    });
+  });
+});
+
+describe('collectListFieldPaths', () => {
+  it('should collect field paths from projection, filter and sort', () => {
+    const paths = collectListFieldPaths({
+      projection: ['id', 'company:name'],
+      filter: {
+        aggregator: 'and',
+        conditions: [
+          { field: 'email', operator: 'present' },
+          { field: 'owner:email', operator: 'present' },
+        ],
+      },
+      sort: [{ field: 'author:name', direction: 'asc' }],
+    });
+
+    expect(paths).toEqual(['id', 'company:name', 'email', 'owner:email', 'author:name']);
+  });
+});
+
+describe('collectCountFieldPaths', () => {
+  it('should collect field paths from the filter only', () => {
+    const paths = collectCountFieldPaths({
+      filter: { field: 'company:name', operator: 'present' },
+    });
+
+    expect(paths).toEqual(['company:name']);
+  });
+});

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -51,6 +51,12 @@ describe('buildListAgentQuery', () => {
       buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 0, offset: 0 } }),
     ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
   });
+
+  it('should reject a negative offset', () => {
+    expect(() =>
+      buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 10, offset: -10 } }),
+    ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
+  });
 });
 
 describe('buildCountAgentQuery', () => {

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -45,18 +45,6 @@ describe('buildListAgentQuery', () => {
       buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 20, offset: 15 } }),
     ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
   });
-
-  it('should reject a non-positive limit', () => {
-    expect(() =>
-      buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 0, offset: 0 } }),
-    ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
-  });
-
-  it('should reject a negative offset', () => {
-    expect(() =>
-      buildListAgentQuery('users', 'Europe/Paris', { page: { limit: 10, offset: -10 } }),
-    ).toThrow(expect.objectContaining({ type: 'invalid_request', status: 400 }));
-  });
 });
 
 describe('buildCountAgentQuery', () => {
@@ -113,6 +101,9 @@ describe('parseListRequest', () => {
     ['an invalid sort direction', { sort: [{ field: 'a', direction: 'up' }] }],
     ['a string filter', { filter: 'id' }],
     ['a string page', { page: '10' }],
+    ['a non-positive page.limit', { page: { limit: 0, offset: 0 } }],
+    ['a non-integer page.limit', { page: { limit: 2.5, offset: 0 } }],
+    ['a negative page.offset', { page: { limit: 10, offset: -10 } }],
   ])('should reject %s with 400 invalid_request', (_label, body) => {
     expect(() => parseListRequest(body)).toThrow(
       expect.objectContaining({ type: 'invalid_request', status: 400 }),

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -27,14 +27,18 @@ function storeOf(readModel: ReadModel | Error): ReadModelStore {
   } as unknown as ReadModelStore;
 }
 
-function buildApp(store: ReadModelStore, client: Partial<AgentDataClient>) {
+function buildApp(
+  store: ReadModelStore,
+  client: Partial<AgentDataClient>,
+  { agentToken = 'agent-jwt' }: { agentToken?: string | null } = {},
+) {
   const app = new Koa();
   app.silent = true;
   app.use(createErrorMiddleware({ logger: noopLogger }));
   app.use(bodyParser());
   app.use(async (ctx, next) => {
     ctx.state.timezone = TIMEZONE;
-    ctx.state.agentToken = 'agent-jwt';
+    if (agentToken !== null) ctx.state.agentToken = agentToken;
     await next();
   });
   app.use(
@@ -140,6 +144,26 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(503);
       expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+    });
+
+    it('should return 401 when no agent token is available (e.g. OAuth mode)', async () => {
+      const list = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { list }, { agentToken: null });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toMatchObject({ type: 'unauthorized', status: 401 });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for a malformed percent-encoded collection name', async () => {
+      const app = buildApp(storeOf(usersReadModel), { list: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/%E0%A4%A/list').send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
     });
   });
 

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -165,6 +165,19 @@ describe('data routes middleware', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
     });
+
+    it('should return 400 when projection is not an array instead of a 500', async () => {
+      const list = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: 'id' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+      expect(list).not.toHaveBeenCalled();
+    });
   });
 
   describe('count', () => {

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -365,5 +365,27 @@ describe('data routes middleware', () => {
       expect(response.status).toBe(500);
       expect(response.body.error).toMatchObject({ type: 'mapping_error', status: 500 });
     });
+
+    it('should return 400 when the filter is not an object', async () => {
+      const countRaw = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: 'id' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for a malformed percent-encoded collection name', async () => {
+      const app = buildApp(storeOf(usersReadModel), { countRaw: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/%E0%A4%A/count').send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    });
   });
 });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -216,6 +216,21 @@ describe('data routes middleware', () => {
       expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
       expect(list).not.toHaveBeenCalled();
     });
+
+    it('should expose a Number primary key as a number in __forest.primaryKey', async () => {
+      const numericPkReadModel = new ReadModel([
+        collection('metrics', [{ ...column('id'), type: 'Number' }]),
+      ]);
+      const list = jest.fn(async () => [{ id: '42', value: 10 }]);
+      const app = buildApp(storeOf(numericPkReadModel), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/metrics/list').send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body.data[0]).toMatchObject({
+        __forest: { collection: 'metrics', primaryKey: { id: 42 } },
+      });
+    });
   });
 
   describe('count', () => {
@@ -253,6 +268,33 @@ describe('data routes middleware', () => {
         status: 422,
       });
       expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when no agent token is available', async () => {
+      const countRaw = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { countRaw }, { agentToken: null });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toMatchObject({ type: 'unauthorized', status: 401 });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should map an agent failure through the error contract', async () => {
+      const countRaw = jest.fn(async () => {
+        throw new AgentHttpError(
+          404,
+          { errors: [{ status: 404, name: 'NotFoundError' }] },
+          undefined,
+        );
+      });
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'not_found', status: 404 });
     });
   });
 });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -1,0 +1,183 @@
+import type { AgentDataClient } from '../../src/data/agent-data-client';
+import type { Logger } from '../../src/ports/logger-port';
+import type ReadModelStore from '../../src/read-model/read-model-store';
+
+import { AgentHttpError } from '@forestadmin/agent-client';
+import { bodyParser } from '@koa/bodyparser';
+import Koa from 'koa';
+import request from 'supertest';
+
+import createDataRoutesMiddleware from '../../src/data/data-routes-middleware';
+import createErrorMiddleware from '../../src/http/error-middleware';
+import SchemaUnavailableError from '../../src/read-model/errors';
+import ReadModel from '../../src/read-model/read-model';
+import { collection, column } from '../read-model/fixtures';
+
+const TIMEZONE = 'Europe/Paris';
+
+const noopLogger: Logger = () => {};
+
+function storeOf(readModel: ReadModel | Error): ReadModelStore {
+  return {
+    getReadModel: async () => {
+      if (readModel instanceof Error) throw readModel;
+
+      return readModel;
+    },
+  } as unknown as ReadModelStore;
+}
+
+function buildApp(store: ReadModelStore, client: Partial<AgentDataClient>) {
+  const app = new Koa();
+  app.silent = true;
+  app.use(createErrorMiddleware({ logger: noopLogger }));
+  app.use(bodyParser());
+  app.use(async (ctx, next) => {
+    ctx.state.timezone = TIMEZONE;
+    ctx.state.agentToken = 'agent-jwt';
+    await next();
+  });
+  app.use(
+    createDataRoutesMiddleware({
+      store,
+      agentUrl: 'https://agent.example.com',
+      logger: noopLogger,
+      createClient: () => client as AgentDataClient,
+    }),
+  );
+
+  return app;
+}
+
+const usersReadModel = new ReadModel([collection('users', [column('id'), column('email')])]);
+
+describe('data routes middleware', () => {
+  describe('list', () => {
+    it('should return flat records with __forest and meta.countStatus not_requested', async () => {
+      const list = jest.fn(async () => [{ id: '42', email: 'user@example.com' }]);
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['id', 'email'] });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        data: [
+          {
+            id: '42',
+            email: 'user@example.com',
+            __forest: { collection: 'users', primaryKey: { id: '42' } },
+          },
+        ],
+        meta: { countStatus: 'not_requested' },
+      });
+    });
+
+    it('should pass the resolved timezone to the agent query', async () => {
+      const list = jest.fn(async () => []);
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(list).toHaveBeenCalledWith('users', expect.objectContaining({ timezone: TIMEZONE }));
+    });
+
+    it.each([['projection'], ['filter'], ['sort']])(
+      'should reject a nested relation path in %s with 422',
+      async surface => {
+        const bodies: Record<string, object> = {
+          projection: { projection: ['company:name'] },
+          filter: { filter: { field: 'company:name', operator: 'present' } },
+          sort: { sort: [{ field: 'company:name', direction: 'asc' }] },
+        };
+        const list = jest.fn(async () => []);
+        const app = buildApp(storeOf(usersReadModel), { list });
+
+        const response = await request(app.callback())
+          .post('/agent/v1/users/list')
+          .send(bodies[surface]);
+
+        expect(response.status).toBe(422);
+        expect(response.body.error).toMatchObject({
+          type: 'relation_field_not_supported',
+          status: 422,
+          details: { fields: ['company:name'] },
+        });
+        expect(list).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should return 404 for an unknown collection', async () => {
+      const app = buildApp(storeOf(usersReadModel), { list: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/ghosts/list').send({});
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'unknown_collection', status: 404 });
+    });
+
+    it('should map an agent failure through the error contract', async () => {
+      const list = jest.fn(async () => {
+        throw new AgentHttpError(
+          404,
+          { errors: [{ status: 404, name: 'NotFoundError' }] },
+          undefined,
+        );
+      });
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'not_found', status: 404 });
+    });
+
+    it('should return 503 schema_unavailable when the schema cannot be loaded', async () => {
+      const app = buildApp(storeOf(new SchemaUnavailableError()), { list: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(503);
+      expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+    });
+  });
+
+  describe('count', () => {
+    it('should return available with the numeric count', async () => {
+      const countRaw = jest.fn(async () => ({ count: 7 }));
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ count: 7, countStatus: 'available' });
+    });
+
+    it('should return deactivated from the raw agent payload', async () => {
+      const countRaw = jest.fn(async () => ({ meta: { count: 'deactivated' } }));
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ count: null, countStatus: 'deactivated' });
+    });
+
+    it('should reject a nested relation path in the count filter with 422', async () => {
+      const countRaw = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'company:name', operator: 'present' } });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'relation_field_not_supported',
+        status: 422,
+      });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -27,10 +27,18 @@ function storeOf(readModel: ReadModel | Error): ReadModelStore {
   } as unknown as ReadModelStore;
 }
 
+const AGENT_URL = 'https://agent.example.com';
+
 function buildApp(
   store: ReadModelStore,
   client: Partial<AgentDataClient>,
-  { agentToken = 'agent-jwt' }: { agentToken?: string | null } = {},
+  {
+    agentToken = 'agent-jwt',
+    createClient = () => client as AgentDataClient,
+  }: {
+    agentToken?: string | null;
+    createClient?: (options: { agentUrl: string; token: string }) => AgentDataClient;
+  } = {},
 ) {
   const app = new Koa();
   app.silent = true;
@@ -44,9 +52,9 @@ function buildApp(
   app.use(
     createDataRoutesMiddleware({
       store,
-      agentUrl: 'https://agent.example.com',
+      agentUrl: AGENT_URL,
       logger: noopLogger,
-      createClient: () => client as AgentDataClient,
+      createClient,
     }),
   );
   // Terminal sentinel: only reached when the dispatcher passes the request through via next().
@@ -82,6 +90,15 @@ describe('data routes middleware', () => {
       expect(response.status).toBe(418);
       expect(response.body).toEqual({ passthrough: true });
       expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should forward the agent url and resolved token to the data client', async () => {
+      const createClient = jest.fn(() => ({ list: async () => [] } as unknown as AgentDataClient));
+      const app = buildApp(storeOf(usersReadModel), {}, { agentToken: 'jwt-123', createClient });
+
+      await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(createClient).toHaveBeenCalledWith({ agentUrl: AGENT_URL, token: 'jwt-123' });
     });
   });
 
@@ -337,6 +354,16 @@ describe('data routes middleware', () => {
         'users',
         expect.objectContaining({ timezone: TIMEZONE }),
       );
+    });
+
+    it('should return 500 mapping_error when the count payload is unusable', async () => {
+      const countRaw = jest.fn(async () => ({}));
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toMatchObject({ type: 'mapping_error', status: 500 });
     });
   });
 });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -175,6 +175,16 @@ describe('data routes middleware', () => {
       expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
     });
 
+    it('should return 500 mapping_error when an agent record has no id', async () => {
+      const list = jest.fn(async () => [{ email: 'user@example.com' }]);
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toMatchObject({ type: 'mapping_error', status: 500 });
+    });
+
     it('should rethrow a non-schema read-model error as a 500', async () => {
       const app = buildApp(storeOf(new Error('boom')), { list: jest.fn() });
 
@@ -295,6 +305,38 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(404);
       expect(response.body.error).toMatchObject({ type: 'not_found', status: 404 });
+    });
+
+    it('should return 404 for an unknown collection', async () => {
+      const countRaw = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/ghosts/count').send({});
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'unknown_collection', status: 404 });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should return 503 schema_unavailable when the schema cannot be loaded', async () => {
+      const app = buildApp(storeOf(new SchemaUnavailableError()), { countRaw: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(503);
+      expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+    });
+
+    it('should pass the resolved timezone to the agent query', async () => {
+      const countRaw = jest.fn(async () => ({ count: 0 }));
+      const app = buildApp(storeOf(usersReadModel), { countRaw });
+
+      await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(countRaw).toHaveBeenCalledWith(
+        'users',
+        expect.objectContaining({ timezone: TIMEZONE }),
+      );
     });
   });
 });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -49,6 +49,11 @@ function buildApp(
       createClient: () => client as AgentDataClient,
     }),
   );
+  // Terminal sentinel: only reached when the dispatcher passes the request through via next().
+  app.use(async ctx => {
+    ctx.status = 418;
+    ctx.body = { passthrough: true };
+  });
 
   return app;
 }
@@ -56,6 +61,30 @@ function buildApp(
 const usersReadModel = new ReadModel([collection('users', [column('id'), column('email')])]);
 
 describe('data routes middleware', () => {
+  describe('routing', () => {
+    it('should pass non-data paths through to the next middleware', async () => {
+      const list = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/users/other').send({});
+
+      expect(response.status).toBe(418);
+      expect(response.body).toEqual({ passthrough: true });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should pass a non-POST request on a data path through to the next middleware', async () => {
+      const list = jest.fn();
+      const app = buildApp(storeOf(usersReadModel), { list });
+
+      const response = await request(app.callback()).get('/agent/v1/users/list');
+
+      expect(response.status).toBe(418);
+      expect(response.body).toEqual({ passthrough: true });
+      expect(list).not.toHaveBeenCalled();
+    });
+  });
+
   describe('list', () => {
     it('should return flat records with __forest and meta.countStatus not_requested', async () => {
       const list = jest.fn(async () => [{ id: '42', email: 'user@example.com' }]);
@@ -144,6 +173,15 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(503);
       expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+    });
+
+    it('should rethrow a non-schema read-model error as a 500', async () => {
+      const app = buildApp(storeOf(new Error('boom')), { list: jest.fn() });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toMatchObject({ type: 'internal_error', status: 500 });
     });
 
     it('should return 401 when no agent token is available (e.g. OAuth mode)', async () => {

--- a/packages/agent-bff/test/data/pack-id.test.ts
+++ b/packages/agent-bff/test/data/pack-id.test.ts
@@ -1,0 +1,35 @@
+import unpackPrimaryKey from '../../src/data/pack-id';
+
+describe('unpackPrimaryKey', () => {
+  it('should build a single numeric key from the packed id', () => {
+    expect(unpackPrimaryKey('42', [{ name: 'id', type: 'Number' }])).toEqual({ id: 42 });
+  });
+
+  it('should keep a non-Number key as a string', () => {
+    expect(unpackPrimaryKey('a1b2', [{ name: 'uuid', type: 'Uuid' }])).toEqual({ uuid: 'a1b2' });
+  });
+
+  it('should build a composite key casting each segment by its type', () => {
+    expect(
+      unpackPrimaryKey('7|ab', [
+        { name: 'orderId', type: 'Number' },
+        { name: 'sku', type: 'String' },
+      ]),
+    ).toEqual({ orderId: 7, sku: 'ab' });
+  });
+
+  it('should throw a 500 mapping error when the collection exposes no key metadata', () => {
+    expect(() => unpackPrimaryKey('42', [])).toThrow(
+      expect.objectContaining({ type: 'mapping_error', status: 500 }),
+    );
+  });
+
+  it('should throw a 500 mapping error when segment count does not match the keys', () => {
+    expect(() =>
+      unpackPrimaryKey('7', [
+        { name: 'orderId', type: 'Number' },
+        { name: 'sku', type: 'String' },
+      ]),
+    ).toThrow(expect.objectContaining({ type: 'mapping_error', status: 500 }));
+  });
+});

--- a/packages/agent-bff/test/data/pack-id.test.ts
+++ b/packages/agent-bff/test/data/pack-id.test.ts
@@ -24,6 +24,12 @@ describe('unpackPrimaryKey', () => {
     );
   });
 
+  it('should throw a 500 mapping error when a Number segment is not numeric', () => {
+    expect(() => unpackPrimaryKey('abc', [{ name: 'id', type: 'Number' }])).toThrow(
+      expect.objectContaining({ type: 'mapping_error', status: 500 }),
+    );
+  });
+
   it('should throw a 500 mapping error when segment count does not match the keys', () => {
     expect(() =>
       unpackPrimaryKey('7', [

--- a/packages/agent-bff/test/data/response-mappers.test.ts
+++ b/packages/agent-bff/test/data/response-mappers.test.ts
@@ -1,0 +1,75 @@
+import { mapCountResponse, mapListResponse } from '../../src/data/response-mappers';
+
+describe('mapListResponse', () => {
+  it('should return flat records with __forest metadata and countStatus not_requested', () => {
+    const result = mapListResponse(
+      'users',
+      [{ id: '42', email: 'user@example.com' }],
+      [{ name: 'id', type: 'Number' }],
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: '42',
+          email: 'user@example.com',
+          __forest: { collection: 'users', primaryKey: { id: 42 } },
+        },
+      ],
+      meta: { countStatus: 'not_requested' },
+    });
+  });
+
+  it('should return the packed composite id unchanged and expose the structured primaryKey', () => {
+    const result = mapListResponse(
+      'orderLines',
+      [{ id: '7|ab', label: 'Widget' }],
+      [
+        { name: 'orderId', type: 'Number' },
+        { name: 'sku', type: 'String' },
+      ],
+    );
+
+    expect(result.data[0]).toEqual(
+      expect.objectContaining({
+        id: '7|ab',
+        __forest: { collection: 'orderLines', primaryKey: { orderId: 7, sku: 'ab' } },
+      }),
+    );
+  });
+
+  it('should throw a mapping error when a record has no id', () => {
+    expect(() =>
+      mapListResponse('users', [{ email: 'x' }], [{ name: 'id', type: 'Number' }]),
+    ).toThrow(expect.objectContaining({ type: 'mapping_error', status: 500 }));
+  });
+});
+
+describe('mapCountResponse', () => {
+  it('should report available with the numeric count', () => {
+    expect(mapCountResponse({ count: 42 })).toEqual({ count: 42, countStatus: 'available' });
+  });
+
+  it('should report available with zero for an active empty collection', () => {
+    expect(mapCountResponse({ count: 0 })).toEqual({ count: 0, countStatus: 'available' });
+  });
+
+  it('should report deactivated from the raw meta marker', () => {
+    expect(mapCountResponse({ meta: { count: 'deactivated' } })).toEqual({
+      count: null,
+      countStatus: 'deactivated',
+    });
+  });
+
+  it('should throw a mapping error when neither a numeric count nor the marker is present', () => {
+    expect(() => mapCountResponse({})).toThrow(
+      expect.objectContaining({ type: 'mapping_error', status: 500 }),
+    );
+  });
+
+  it('should not trust a NaN count from the lossy helper', () => {
+    expect(() => mapCountResponse({ count: Number.NaN })).toThrow(
+      expect.objectContaining({ type: 'mapping_error', status: 500 }),
+    );
+  });
+});

--- a/packages/agent-bff/test/http/agent-error-mapper.test.ts
+++ b/packages/agent-bff/test/http/agent-error-mapper.test.ts
@@ -1,6 +1,7 @@
 import { AgentHttpError } from '@forestadmin/agent-client';
 
 import { mapAgentError } from '../../src/http/agent-error-mapper';
+import { BffHttpError } from '../../src/http/bff-http-error';
 
 function jsonApiBody(error: {
   name?: string;
@@ -17,6 +18,14 @@ describe('mapAgentError', () => {
 
   beforeEach(() => {
     logger = jest.fn();
+  });
+
+  it('returns a BFF-origin error unchanged instead of recategorizing it', () => {
+    const local = new BffHttpError(422, 'relation_field_not_supported', 'nope', {
+      fields: ['a:b'],
+    });
+
+    expect(mapAgentError(local, { logger })).toBe(local);
   });
 
   it('maps a JSON:API NotFoundError to not_found with its detail and data', () => {

--- a/packages/agent-bff/test/http/bff-local-errors.test.ts
+++ b/packages/agent-bff/test/http/bff-local-errors.test.ts
@@ -3,8 +3,8 @@ import {
   collectionNotAllowed,
   invalidRequest,
   mappingError,
-  relationFieldNotSupported,
   relationNotAllowed,
+  schemaUnavailable,
   unknownAction,
   unknownCollection,
   unknownRelation,
@@ -20,8 +20,8 @@ describe('bff local errors', () => {
     [relationNotAllowed, 'relation_not_allowed', 403],
     [actionNotAllowed, 'action_not_allowed', 403],
     [invalidRequest, 'invalid_request', 400],
-    [relationFieldNotSupported, 'relation_field_not_supported', 422],
     [mappingError, 'mapping_error', 500],
+    [schemaUnavailable, 'schema_unavailable', 503],
     [unsupportedActionResult, 'unsupported_action_result', 501],
   ])('%p builds a %s error with status %d', (factory, type, status) => {
     expect(factory()).toMatchObject({ type, status });

--- a/packages/agent-bff/test/read-model/read-model.test.ts
+++ b/packages/agent-bff/test/read-model/read-model.test.ts
@@ -216,4 +216,35 @@ describe('ReadModel', () => {
       expect(model.isActionAllowed('ghost', 'x')).toBe(false);
     });
   });
+
+  describe('primary keys', () => {
+    it('should expose the primary key field name and type', () => {
+      const model = new ReadModel([
+        collection('users', [{ ...column('id'), type: 'Number', isPrimaryKey: true }]),
+      ]);
+
+      expect(model.getPrimaryKeys('users')).toEqual([{ name: 'id', type: 'Number' }]);
+    });
+
+    it('should expose composite keys in schema field order', () => {
+      const model = new ReadModel([
+        collection('orderLines', [
+          { ...column('orderId'), type: 'Number', isPrimaryKey: true },
+          { ...column('sku'), type: 'String', isPrimaryKey: true },
+          { ...column('label'), isPrimaryKey: false },
+        ]),
+      ]);
+
+      expect(model.getPrimaryKeys('orderLines')).toEqual([
+        { name: 'orderId', type: 'Number' },
+        { name: 'sku', type: 'String' },
+      ]);
+    });
+
+    it('should return an empty array for an unknown collection', () => {
+      const model = new ReadModel([collection('users', [])]);
+
+      expect(model.getPrimaryKeys('ghost')).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## What

Slice 3 of the Forest BFF: expose `POST /v1/:collection/list` and `/count` as flat REST over the agent.

- **list** → `{ data: [{ ...directFields, id, __forest: { collection, primaryKey } }], meta: { countStatus: "not_requested" } }`. `primaryKey` is the opaque packed id unpacked into a typed `{ field: value }` map using the read-model's key metadata (composite ids supported; a composite id without key metadata, or a non-numeric `Number` segment, is surfaced as a mapping error, never guessed).
- **count** → `{ count, countStatus }`. Deactivation is derived from the **raw** agent payload (`meta.count === "deactivated"`), not the lossy `Number()` helper. Active empty collection → `0`/`available`; no usable signal → `mapping_error` (never a silent `0`).
- **Nested-relation guard** (PRD-669) wired on list `projection`/`filter`/`sort` and count `filter` → `422 relation_field_not_supported`.
- **Collection resolution** via the read-model allow-list.
- **Errors** mapped through PRD-670 (`mapAgentError` for agent failures; local envelope for BFF-origin errors, incl. a new `503 schema_unavailable`).
- All agent calls go through the exported `HttpRequester`, so the BFF controls the query params — notably the resolved `timezone` (spec: never lean on agent-client's `Europe/Paris` default).
- Malformed request edges fail as client errors, not 500s: a non-multiple `page.offset` and a malformed percent-encoded collection name both return `400 invalid_request`; a request with no agent token (OAuth mode does not mint one yet — `TODO(PRD-637)`) returns `401` instead of calling the agent with `Bearer undefined`.

Rebased onto `main` now that its dependencies (PRD-668 #1732, PRD-669 #1736, PRD-670 #1738) are merged — the diff is scoped to this ticket's work.

## Open item — 403 not satisfiable in Slice 3

The read-model exposes a single allow-list (the exposed collections), so it cannot distinguish an *unknown* collection from a *known-but-disallowed* one. Every absent name maps to `404 unknown_collection`; `collection_not_allowed` (403) has no local trigger. Documented with a `TODO` in `data-routes-middleware.ts` and escalated on the ticket.

## Tests

Focused tests with a stubbed agent client + read-model: flat mapping + `__forest` + `meta.countStatus`; packed/composite id roundtrip incl. NaN guard; count deactivated vs active-zero vs mapping-error fallback; guard 422 across all four surfaces; 404 resolution; 401 without agent token; 400 on malformed collection / offset; `503 schema_unavailable`; agent failure via the error contract; timezone propagated to the agent query. Package: build + lint + tests green.

Fixes PRD-671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose collection list and count endpoints in agent-bff with flat mapping
> - Adds `/agent/v1/:collection/list` and `/agent/v1/:collection/count` POST endpoints via a new `createDataRoutesMiddleware` in [data-routes-middleware.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1742/files#diff-f72d9e0085f04fbc09b3ee055760d1ab06989a7f7609ff77350b0c92ec43be20), dispatching validated requests to the agent and mapping responses back to BFF format.
> - Adds `createAgentDataClient` in [agent-data-client.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1742/files#diff-18366e30ae76b06475553223d609a9a475fabf8865955f6eb9880ff19c41cb90) to perform `GET /forest/:collection` (list) and `GET /forest/:collection/count` (count) requests against the agent.
> - Validates and serializes list/count request bodies to agent query params in [agent-query.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1742/files#diff-f9e4f9c436e7f894464509bbcbe60f542338d97355ce39ad711d5c2990d80868), enforcing page offset/limit constraints and filter/projection/sort shapes.
> - Maps list responses to include `__forest` metadata with structured primary keys (via `unpackPrimaryKey`) and count responses to `available`/`deactivated` status.
> - Extends `ReadModel` to expose per-collection primary key field names and types via `getPrimaryKeys`.
> - Fixes `mapAgentError` to pass through `BffHttpError` instances unchanged instead of recategorizing them as agent/transport errors.
> - Risk: offset must be an exact multiple of limit; mismatches return 400. Relation field paths in requests return 422.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd14620.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->