### PR TITLE
feat(mcp-server): dispatch mounted tool calls to the agent in-process

### DIFF
--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -15,8 +15,31 @@ function parseJson(text: string | undefined): unknown {
   }
 }
 
+// Any transport reaching the agent must build this exact AgentHttpError shape — the approval-gate
+// detection in domains/action.ts routes on it.
+export function buildAgentHttpError(status: number, body: unknown, text?: string): AgentHttpError {
+  const hasBody = !!body && typeof body === 'object' && Object.keys(body).length > 0;
+
+  return new AgentHttpError(status, hasBody ? body : parseJson(text), text);
+}
+
+export async function deserializeAgentBody<Data>(
+  deserializer: Deserializer,
+  body: unknown,
+  text: string | undefined,
+  skipDeserialization?: boolean,
+): Promise<Data> {
+  if (skipDeserialization) return body as Data;
+
+  try {
+    return (await deserializer.deserialize(body)) as Data;
+  } catch {
+    return (body ?? text) as Data;
+  }
+}
+
 export default class HttpRequester {
-  private readonly deserializer: Deserializer;
+  protected readonly deserializer: Deserializer;
 
   private get baseUrl() {
     const prefix = this.options.prefix ? `/${this.options.prefix}` : '';
@@ -62,25 +85,20 @@ export default class HttpRequester {
 
       const response = await req;
 
-      if (skipDeserialization) {
-        return response.body as Data;
-      }
-
-      try {
-        return (await this.deserializer.deserialize(response.body)) as Data;
-      } catch {
-        return (response.body ?? response.text) as Data;
-      }
+      return await deserializeAgentBody<Data>(
+        this.deserializer,
+        response.body,
+        response.text,
+        skipDeserialization,
+      );
     } catch (error) {
       const res = (error as { response?: { status?: number; body?: unknown; text?: string } })
         .response;
       if (!res) throw error; // network/timeout/abort → no HTTP response, propagate raw
 
       const text = typeof res.text === 'string' ? res.text : undefined;
-      const hasBody =
-        !!res.body && typeof res.body === 'object' && Object.keys(res.body).length > 0;
 
-      throw new AgentHttpError(res.status ?? 0, hasBody ? res.body : parseJson(text), text);
+      throw buildAgentHttpError(res.status ?? 0, res.body, text);
     }
   }
 

--- a/packages/agent-client/src/http-requester.ts
+++ b/packages/agent-client/src/http-requester.ts
@@ -15,29 +15,6 @@ function parseJson(text: string | undefined): unknown {
   }
 }
 
-// Any transport reaching the agent must build this exact AgentHttpError shape — the approval-gate
-// detection in domains/action.ts routes on it.
-export function buildAgentHttpError(status: number, body: unknown, text?: string): AgentHttpError {
-  const hasBody = !!body && typeof body === 'object' && Object.keys(body).length > 0;
-
-  return new AgentHttpError(status, hasBody ? body : parseJson(text), text);
-}
-
-export async function deserializeAgentBody<Data>(
-  deserializer: Deserializer,
-  body: unknown,
-  text: string | undefined,
-  skipDeserialization?: boolean,
-): Promise<Data> {
-  if (skipDeserialization) return body as Data;
-
-  try {
-    return (await deserializer.deserialize(body)) as Data;
-  } catch {
-    return (body ?? text) as Data;
-  }
-}
-
 export default class HttpRequester {
   protected readonly deserializer: Deserializer;
 
@@ -52,6 +29,28 @@ export default class HttpRequester {
     private readonly options: { prefix?: string; url: string },
   ) {
     this.deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
+  }
+
+  // Any transport reaching the agent must build this exact AgentHttpError shape — the approval-gate
+  // detection in domains/action.ts routes on it. Shared with in-process transports via subclassing.
+  protected buildError(status: number, body: unknown, text?: string): AgentHttpError {
+    const hasBody = !!body && typeof body === 'object' && Object.keys(body).length > 0;
+
+    return new AgentHttpError(status, hasBody ? body : parseJson(text), text);
+  }
+
+  protected async deserialize<Data>(
+    body: unknown,
+    text: string | undefined,
+    skipDeserialization?: boolean,
+  ): Promise<Data> {
+    if (skipDeserialization) return body as Data;
+
+    try {
+      return (await this.deserializer.deserialize(body)) as Data;
+    } catch {
+      return (body ?? text) as Data;
+    }
   }
 
   async query<Data = unknown>({
@@ -85,12 +84,7 @@ export default class HttpRequester {
 
       const response = await req;
 
-      return await deserializeAgentBody<Data>(
-        this.deserializer,
-        response.body,
-        response.text,
-        skipDeserialization,
-      );
+      return await this.deserialize<Data>(response.body, response.text, skipDeserialization);
     } catch (error) {
       const res = (error as { response?: { status?: number; body?: unknown; text?: string } })
         .response;
@@ -98,7 +92,7 @@ export default class HttpRequester {
 
       const text = typeof res.text === 'string' ? res.text : undefined;
 
-      throw buildAgentHttpError(res.status ?? 0, res.body, text);
+      throw this.buildError(res.status ?? 0, res.body, text);
     }
   }
 

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -14,7 +14,7 @@ import AgentHttpError, {
   ActionRequiresApprovalError,
   ApprovalRequestCreationError,
 } from './errors';
-import HttpRequester from './http-requester';
+import HttpRequester, { buildAgentHttpError, deserializeAgentBody } from './http-requester';
 
 export {
   ActionFieldJson,
@@ -22,6 +22,8 @@ export {
   makeCreateApprovalRequest,
   RemoteAgentClient,
   HttpRequester,
+  buildAgentHttpError,
+  deserializeAgentBody,
   AgentHttpError,
   ActionRequiresApprovalError,
   ActionFormValidationError,
@@ -46,8 +48,10 @@ export function createRemoteAgentClient(params: {
    * agent (e.g. tests). `serverUrl` is the Forest server, distinct from the agent `url` above.
    */
   forestServer?: { serverUrl: string; serverToken: string; renderingId: number | string };
+  httpRequester?: HttpRequester;
 }) {
-  const httpRequester = new HttpRequester(params.token, { url: params.url });
+  const httpRequester =
+    params.httpRequester ?? new HttpRequester(params.token, { url: params.url });
 
   return new RemoteAgentClient({
     actionEndpoints: params.actionEndpoints,

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -14,7 +14,7 @@ import AgentHttpError, {
   ActionRequiresApprovalError,
   ApprovalRequestCreationError,
 } from './errors';
-import HttpRequester, { buildAgentHttpError, deserializeAgentBody } from './http-requester';
+import HttpRequester from './http-requester';
 
 export {
   ActionFieldJson,
@@ -22,8 +22,6 @@ export {
   makeCreateApprovalRequest,
   RemoteAgentClient,
   HttpRequester,
-  buildAgentHttpError,
-  deserializeAgentBody,
   AgentHttpError,
   ActionRequiresApprovalError,
   ActionFormValidationError,

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -29,6 +29,7 @@
     "jsonwebtoken": "^9.0.3",
     "koa": "^3.0.1",
     "koa-jwt": "^4.0.4",
+    "light-my-request": "^5.14.0",
     "luxon": "^3.2.1",
     "object-hash": "^3.0.0",
     "superagent": "^10.3.0",

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,7 +57,6 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
   private mcpEnabled = false;
   private mcpEnabledTools?: ToolName[];
   private mcpBasePath?: string;
-  private mcpAgentUrl?: string;
 
   /** In-process workflow executor, created only when addWorkflowExecutor() is called. */
   private embeddedExecutor: EmbeddedWorkflowExecutor | null = null;
@@ -254,19 +253,11 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * // OAuth discovery metadata stays at the origin root (prefix-suffixed), so root `.well-known`
    * // traffic must still reach the agent.
    * agent.mountAiMcpServer({ basePath: '/ai' });
-   * // Example: in a self-hosted setup, keep the tools' callbacks to the agent on the internal
-   * // network instead of the public URL Forest has for this environment.
-   * agent.mountAiMcpServer({ agentUrl: 'http://forest-agent.internal:3310' });
    */
-  mountAiMcpServer(options?: {
-    enabledTools?: ToolName[];
-    basePath?: string;
-    agentUrl?: string;
-  }): this {
+  mountAiMcpServer(options?: { enabledTools?: ToolName[]; basePath?: string }): this {
     this.mcpEnabled = true;
     this.mcpEnabledTools = options?.enabledTools;
     this.mcpBasePath = options?.basePath;
-    this.mcpAgentUrl = options?.agentUrl;
 
     return this;
   }
@@ -434,7 +425,6 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         forestServerClient,
         enabledTools: this.mcpEnabledTools,
         basePath: this.mcpBasePath,
-        agentUrl: this.mcpAgentUrl,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -244,6 +244,10 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Enable MCP (Model Context Protocol) server support.
    * This allows AI assistants to interact with your Forest Admin data.
    *
+   * Tool calls reach your data in-process (no socket), so they bypass any middleware you mounted
+   * in front of the agent (rate limiting, request logging, WAF): only the agent's own JWT auth and
+   * permission checks run on them.
+   *
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/ai/mcp-server}
    * @example
    * agent.mountAiMcpServer();
@@ -432,6 +436,10 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
       const isMcpRoute = makeIsMcpRoute(this.mcpBasePath);
 
       mcpLogger('Info', 'Server initialized successfully');
+      mcpLogger(
+        'Info',
+        'Tool calls dispatch in-process and skip any middleware mounted in front of the agent',
+      );
 
       return { httpCallback, isMcpRoute };
     } catch (error) {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -244,9 +244,9 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * Enable MCP (Model Context Protocol) server support.
    * This allows AI assistants to interact with your Forest Admin data.
    *
-   * Tool calls reach your data in-process (no socket), so they bypass any middleware you mounted
-   * in front of the agent (rate limiting, request logging, WAF): only the agent's own JWT auth and
-   * permission checks run on them.
+   * Tool calls reach your data in-process (no socket), so they skip any host-app middleware you
+   * mounted in front of the agent (rate limiting, request logging, WAF). The agent's own JWT auth
+   * and permission checks still run on them, and the inbound MCP request itself is unaffected.
    *
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/ai/mcp-server}
    * @example

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -57,6 +57,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
   private mcpEnabled = false;
   private mcpEnabledTools?: ToolName[];
   private mcpBasePath?: string;
+  private mcpAgentUrl?: string;
 
   /** In-process workflow executor, created only when addWorkflowExecutor() is called. */
   private embeddedExecutor: EmbeddedWorkflowExecutor | null = null;
@@ -253,11 +254,19 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
    * // OAuth discovery metadata stays at the origin root (prefix-suffixed), so root `.well-known`
    * // traffic must still reach the agent.
    * agent.mountAiMcpServer({ basePath: '/ai' });
+   * // Example: in a self-hosted setup, keep the tools' callbacks to the agent on the internal
+   * // network instead of the public URL Forest has for this environment.
+   * agent.mountAiMcpServer({ agentUrl: 'http://forest-agent.internal:3310' });
    */
-  mountAiMcpServer(options?: { enabledTools?: ToolName[]; basePath?: string }): this {
+  mountAiMcpServer(options?: {
+    enabledTools?: ToolName[];
+    basePath?: string;
+    agentUrl?: string;
+  }): this {
     this.mcpEnabled = true;
     this.mcpEnabledTools = options?.enabledTools;
     this.mcpBasePath = options?.basePath;
+    this.mcpAgentUrl = options?.agentUrl;
 
     return this;
   }
@@ -425,6 +434,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         forestServerClient,
         enabledTools: this.mcpEnabledTools,
         basePath: this.mcpBasePath,
+        agentUrl: this.mcpAgentUrl,
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -425,6 +425,7 @@ export default class Agent<S extends TSchema = TSchema> extends FrameworkMounter
         forestServerClient,
         enabledTools: this.mcpEnabledTools,
         basePath: this.mcpBasePath,
+        agentDispatcher: this.getInProcessDispatcher(),
       });
 
       const httpCallback = await mcpServer.getHttpCallback();

--- a/packages/agent/src/framework-mounter.ts
+++ b/packages/agent/src/framework-mounter.ts
@@ -50,8 +50,7 @@ export default class FrameworkMounter {
 
   /**
    * Dispatcher that runs agent-client requests against the agent's own `/forest` stack in-memory.
-   * Its handler is rebuilt on every (re)mount; the `/forest` prefix is fixed (not the external
-   * mount prefix) because agent-client hardcodes `/forest/...` paths.
+   * The handler is rebuilt on every (re)mount so a captured reference never goes stale.
    */
   protected getInProcessDispatcher(): InProcessDispatcher {
     if (!this.inProcessHookRegistered) {

--- a/packages/agent/src/framework-mounter.ts
+++ b/packages/agent/src/framework-mounter.ts
@@ -25,7 +25,7 @@ export default class FrameworkMounter {
 
   private readonly fastifyAdapter: FastifyAdapter;
   private readonly mcpMiddleware: McpMiddleware;
-  private readonly inProcessDispatcher = new InProcessDispatcher();
+  private readonly inProcessDispatcher: InProcessDispatcher;
   private inProcessHookRegistered = false;
 
   /** Compute the prefix that the main router should be mounted at in the client's application */
@@ -38,6 +38,7 @@ export default class FrameworkMounter {
     this.logger = logger;
     this.fastifyAdapter = new FastifyAdapter(logger);
     this.mcpMiddleware = new McpMiddleware();
+    this.inProcessDispatcher = new InProcessDispatcher(logger);
   }
 
   /**

--- a/packages/agent/src/framework-mounter.ts
+++ b/packages/agent/src/framework-mounter.ts
@@ -9,6 +9,7 @@ import Koa from 'koa';
 import path from 'path';
 
 import FastifyAdapter from './fastify-adapter';
+import InProcessDispatcher from './mcp-in-process-dispatcher';
 import McpMiddleware from './mcp-middleware';
 
 export default class FrameworkMounter {
@@ -24,6 +25,8 @@ export default class FrameworkMounter {
 
   private readonly fastifyAdapter: FastifyAdapter;
   private readonly mcpMiddleware: McpMiddleware;
+  private readonly inProcessDispatcher = new InProcessDispatcher();
+  private inProcessHookRegistered = false;
 
   /** Compute the prefix that the main router should be mounted at in the client's application */
   private get completeMountPrefix(): string {
@@ -42,6 +45,23 @@ export default class FrameworkMounter {
    */
   protected setMcpCallback(callback: HttpCallback | null, routeMatcher?: McpRouteMatcher): void {
     this.mcpMiddleware.setCallback(callback, routeMatcher);
+  }
+
+  /**
+   * Dispatcher that runs agent-client requests against the agent's own `/forest` stack in-memory.
+   * Its handler is rebuilt on every (re)mount; the `/forest` prefix is fixed (not the external
+   * mount prefix) because agent-client hardcodes `/forest/...` paths.
+   */
+  protected getInProcessDispatcher(): InProcessDispatcher {
+    if (!this.inProcessHookRegistered) {
+      this.inProcessHookRegistered = true;
+      this.onEachStart.push(async driverRouter => {
+        const router = new Router({ prefix: '/forest' }).use(driverRouter.routes());
+        this.inProcessDispatcher.setHandler(new Koa().use(router.routes()).callback());
+      });
+    }
+
+    return this.inProcessDispatcher;
   }
 
   protected async mount(router: Router): Promise<void> {

--- a/packages/agent/src/mcp-in-process-dispatcher.ts
+++ b/packages/agent/src/mcp-in-process-dispatcher.ts
@@ -1,3 +1,5 @@
+import type { Logger } from '@forestadmin/datasource-toolkit';
+import type { InProcessAgentDispatcher } from '@forestadmin/mcp-server';
 import type { RequestListener } from 'http';
 
 import inject, { type InjectOptions, type InjectPayload } from 'light-my-request';
@@ -8,10 +10,14 @@ export type InProcessRequest = {
   headers: Record<string, string>;
   query?: Record<string, unknown>;
   payload?: unknown;
+  timeoutMs?: number;
 };
 
 // Superagent-shaped so agent-client's HttpRequester helpers parse it identically.
 export type InProcessResponse = { status: number; body: unknown; text: string };
+
+// Matches superagent's HTTP path, which times out after 10s (HttpRequester.query/stream).
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 function toStringQuery(query: Record<string, unknown>): Record<string, string> {
   const result: Record<string, string> = {};
@@ -28,8 +34,10 @@ function toStringQuery(query: Record<string, unknown>): Record<string, string> {
  * mounted MCP server's tool calls run through the real auth/permission/logging middleware.
  * `setHandler` is refreshed on every (re)mount, so a captured reference never goes stale.
  */
-export default class InProcessDispatcher {
+export default class InProcessDispatcher implements InProcessAgentDispatcher {
   private handler: RequestListener | null = null;
+
+  constructor(private readonly logger?: Logger) {}
 
   setHandler(handler: RequestListener | null): void {
     this.handler = handler;
@@ -41,27 +49,52 @@ export default class InProcessDispatcher {
     headers,
     query,
     payload,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
   }: InProcessRequest): Promise<InProcessResponse> {
     if (!this.handler) {
       throw new Error('Cannot dispatch to the agent in-process: it is not mounted yet.');
     }
 
-    const response = await inject(this.handler, {
-      method: method.toUpperCase() as InjectOptions['method'],
-      url: path,
-      headers,
-      ...(query && { query: toStringQuery(query) }),
-      ...(payload !== undefined && { payload: payload as InjectPayload }),
+    // No socket to abort, so a hung agent handler would hang the tool call forever without this.
+    const response = await this.injectWithTimeout(
+      {
+        method: method.toUpperCase() as InjectOptions['method'],
+        url: path,
+        headers,
+        ...(query && { query: toStringQuery(query) }),
+        ...(payload !== undefined && { payload: payload as InjectPayload }),
+      },
+      timeoutMs,
+    );
+
+    return { status: response.statusCode, body: this.parseBody(response), text: response.payload };
+  }
+
+  private async injectWithTimeout(options: InjectOptions, timeoutMs: number) {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`In-process dispatch timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
     });
 
-    let body: unknown;
+    try {
+      return await Promise.race([inject(this.handler as RequestListener, options), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private parseBody(response: { payload: string }): unknown {
+    if (response.payload === '') return undefined;
 
     try {
-      body = response.json();
-    } catch {
-      body = undefined;
-    }
+      return JSON.parse(response.payload);
+    } catch (error) {
+      this.logger?.('Warn', `In-process dispatch received a non-JSON response body: ${error}`);
 
-    return { status: response.statusCode, body, text: response.payload };
+      return undefined;
+    }
   }
 }

--- a/packages/agent/src/mcp-in-process-dispatcher.ts
+++ b/packages/agent/src/mcp-in-process-dispatcher.ts
@@ -8,11 +8,10 @@ import type { RequestListener } from 'http';
 
 import inject, { type InjectOptions, type InjectPayload } from 'light-my-request';
 
-// Single-sourced from mcp-server (the dispatcher contract) — no re-declaration to drift.
 export type InProcessRequest = InProcessDispatchRequest;
 export type InProcessResponse = InProcessDispatchResponse;
 
-// Matches superagent's HTTP path, which times out after 10s (HttpRequester.query).
+// Matches the HTTP path's 10s bound (HttpRequester.query).
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 function toStringQuery(query: Record<string, unknown>): Record<string, string> {
@@ -28,7 +27,6 @@ function toStringQuery(query: Record<string, unknown>): Record<string, string> {
 /**
  * Dispatches an agent-client request into the agent's own Koa stack in-memory (no socket), so a
  * mounted MCP server's tool calls run through the real auth/permission/logging middleware.
- * `setHandler` is refreshed on every (re)mount, so a captured reference never goes stale.
  */
 export default class InProcessDispatcher implements InProcessAgentDispatcher {
   private handler: RequestListener | null = null;

--- a/packages/agent/src/mcp-in-process-dispatcher.ts
+++ b/packages/agent/src/mcp-in-process-dispatcher.ts
@@ -63,7 +63,11 @@ export default class InProcessDispatcher implements InProcessAgentDispatcher {
       timeoutMs,
     );
 
-    return { status: response.statusCode, body: this.parseBody(response), text: response.payload };
+    return {
+      status: response.statusCode,
+      body: this.parseBody(response.payload, response.statusCode),
+      text: response.payload,
+    };
   }
 
   private async injectWithTimeout(options: InjectOptions, timeoutMs: number) {
@@ -75,20 +79,38 @@ export default class InProcessDispatcher implements InProcessAgentDispatcher {
       );
     });
 
+    const injection = inject(this.handler as RequestListener, options);
+    // If the timeout wins the race, `injection` is left unobserved; swallow+log a late settlement so
+    // a handler that rejects after the timeout can't surface as an unhandledRejection.
+    injection.catch(error =>
+      this.logger?.(
+        'Warn',
+        `In-process handler settled after the ${timeoutMs}ms timeout: ${error}`,
+      ),
+    );
+
     try {
-      return await Promise.race([inject(this.handler as RequestListener, options), timeout]);
+      return await Promise.race([injection, timeout]);
     } finally {
       if (timer) clearTimeout(timer);
     }
   }
 
-  private parseBody(response: { payload: string }): unknown {
-    if (response.payload === '') return undefined;
+  private parseBody(payload: string, status: number): unknown {
+    if (payload === '') return undefined;
 
     try {
-      return JSON.parse(response.payload);
-    } catch (error) {
-      this.logger?.('Warn', `In-process dispatch received a non-JSON response body: ${error}`);
+      return JSON.parse(payload);
+    } catch {
+      const preview = payload.length > 200 ? `${payload.slice(0, 200)}…` : payload;
+      const message = `In-process dispatch received a non-JSON ${status} response body: ${preview}`;
+
+      // A 2xx must carry a JSON:API body here; a non-JSON success body means misbehaving middleware
+      // (HTML, redirect) — fail loudly rather than hand the tool `undefined`. On 4xx+ the raw text
+      // is preserved by the error path (buildError falls back to parseJson(text)), so drop the body.
+      if (status < 400) throw new Error(message);
+
+      this.logger?.('Warn', message);
 
       return undefined;
     }

--- a/packages/agent/src/mcp-in-process-dispatcher.ts
+++ b/packages/agent/src/mcp-in-process-dispatcher.ts
@@ -1,22 +1,18 @@
 import type { Logger } from '@forestadmin/datasource-toolkit';
-import type { InProcessAgentDispatcher } from '@forestadmin/mcp-server';
+import type {
+  InProcessAgentDispatcher,
+  InProcessDispatchRequest,
+  InProcessDispatchResponse,
+} from '@forestadmin/mcp-server';
 import type { RequestListener } from 'http';
 
 import inject, { type InjectOptions, type InjectPayload } from 'light-my-request';
 
-export type InProcessRequest = {
-  method: string;
-  path: string;
-  headers: Record<string, string>;
-  query?: Record<string, unknown>;
-  payload?: unknown;
-  timeoutMs?: number;
-};
+// Single-sourced from mcp-server (the dispatcher contract) — no re-declaration to drift.
+export type InProcessRequest = InProcessDispatchRequest;
+export type InProcessResponse = InProcessDispatchResponse;
 
-// Superagent-shaped so agent-client's HttpRequester helpers parse it identically.
-export type InProcessResponse = { status: number; body: unknown; text: string };
-
-// Matches superagent's HTTP path, which times out after 10s (HttpRequester.query/stream).
+// Matches superagent's HTTP path, which times out after 10s (HttpRequester.query).
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 function toStringQuery(query: Record<string, unknown>): Record<string, string> {

--- a/packages/agent/src/mcp-in-process-dispatcher.ts
+++ b/packages/agent/src/mcp-in-process-dispatcher.ts
@@ -1,0 +1,67 @@
+import type { RequestListener } from 'http';
+
+import inject, { type InjectOptions, type InjectPayload } from 'light-my-request';
+
+export type InProcessRequest = {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  query?: Record<string, unknown>;
+  payload?: unknown;
+};
+
+// Superagent-shaped so agent-client's HttpRequester helpers parse it identically.
+export type InProcessResponse = { status: number; body: unknown; text: string };
+
+function toStringQuery(query: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) result[key] = String(value);
+  }
+
+  return result;
+}
+
+/**
+ * Dispatches an agent-client request into the agent's own Koa stack in-memory (no socket), so a
+ * mounted MCP server's tool calls run through the real auth/permission/logging middleware.
+ * `setHandler` is refreshed on every (re)mount, so a captured reference never goes stale.
+ */
+export default class InProcessDispatcher {
+  private handler: RequestListener | null = null;
+
+  setHandler(handler: RequestListener | null): void {
+    this.handler = handler;
+  }
+
+  async request({
+    method,
+    path,
+    headers,
+    query,
+    payload,
+  }: InProcessRequest): Promise<InProcessResponse> {
+    if (!this.handler) {
+      throw new Error('Cannot dispatch to the agent in-process: it is not mounted yet.');
+    }
+
+    const response = await inject(this.handler, {
+      method: method.toUpperCase() as InjectOptions['method'],
+      url: path,
+      headers,
+      ...(query && { query: toStringQuery(query) }),
+      ...(payload !== undefined && { payload: payload as InjectPayload }),
+    });
+
+    let body: unknown;
+
+    try {
+      body = response.json();
+    } catch {
+      body = undefined;
+    }
+
+    return { status: response.statusCode, body, text: response.payload };
+  }
+}

--- a/packages/agent/test/agent-integration.test.ts
+++ b/packages/agent/test/agent-integration.test.ts
@@ -606,7 +606,7 @@ describe('Agent Integration Tests', () => {
         try {
           const token = createTestToken({ scopes: ['mcp:read'], renderingId: 1 });
 
-          await superagent
+          const response = await superagent
             .post(`${testContext.baseUrl}/mcp`)
             .set('Authorization', `Bearer ${token}`)
             .set('Content-Type', 'application/json')
@@ -618,6 +618,7 @@ describe('Agent Integration Tests', () => {
               params: { name: 'list', arguments: { collectionName: 'users' } },
             });
 
+          expect(response.status).toBe(200);
           expect(requestSpy).toHaveBeenCalledWith(
             expect.objectContaining({ method: 'get', path: '/forest/users' }),
           );

--- a/packages/agent/test/agent-integration.test.ts
+++ b/packages/agent/test/agent-integration.test.ts
@@ -594,6 +594,37 @@ describe('Agent Integration Tests', () => {
           lastName: 'Wilson',
         });
       });
+
+      it('dispatches the tool call to the agent in-process, not over a socket', async () => {
+        const dispatcher = (
+          testContext.agent as unknown as {
+            getInProcessDispatcher: () => { request: (...args: unknown[]) => Promise<unknown> };
+          }
+        ).getInProcessDispatcher();
+        const requestSpy = jest.spyOn(dispatcher, 'request');
+
+        try {
+          const token = createTestToken({ scopes: ['mcp:read'], renderingId: 1 });
+
+          await superagent
+            .post(`${testContext.baseUrl}/mcp`)
+            .set('Authorization', `Bearer ${token}`)
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'text/event-stream, application/json')
+            .send({
+              jsonrpc: '2.0',
+              method: 'tools/call',
+              id: 3,
+              params: { name: 'list', arguments: { collectionName: 'users' } },
+            });
+
+          expect(requestSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'get', path: '/forest/users' }),
+          );
+        } finally {
+          requestSpy.mockRestore();
+        }
+      });
     });
 
     describe('Routes coexistence', () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -591,6 +591,18 @@ describe('Agent', () => {
       expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ basePath: '/mcp' }));
     });
 
+    test('should pass agentUrl to ForestMCPServer', async () => {
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const agent = new Agent(options);
+
+      agent.mountAiMcpServer({ agentUrl: 'http://forest-agent.internal:3310' });
+      await agent.start();
+
+      expect(mcpServerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ agentUrl: 'http://forest-agent.internal:3310' }),
+      );
+    });
+
     test('threads a basePath-scoped route matcher to the MCP middleware', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();
       const agent = new Agent(options);

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -591,18 +591,6 @@ describe('Agent', () => {
       expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ basePath: '/mcp' }));
     });
 
-    test('should pass agentUrl to ForestMCPServer', async () => {
-      const options = factories.forestAdminHttpDriverOptions.build();
-      const agent = new Agent(options);
-
-      agent.mountAiMcpServer({ agentUrl: 'http://forest-agent.internal:3310' });
-      await agent.start();
-
-      expect(mcpServerSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ agentUrl: 'http://forest-agent.internal:3310' }),
-      );
-    });
-
     test('threads a basePath-scoped route matcher to the MCP middleware', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();
       const agent = new Agent(options);

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -591,6 +591,20 @@ describe('Agent', () => {
       expect(mcpServerSpy).toHaveBeenCalledWith(expect.objectContaining({ basePath: '/mcp' }));
     });
 
+    test('passes an in-process agentDispatcher to ForestMCPServer', async () => {
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const agent = new Agent(options);
+
+      agent.mountAiMcpServer();
+      await agent.start();
+
+      expect(mcpServerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentDispatcher: expect.objectContaining({ request: expect.any(Function) }),
+        }),
+      );
+    });
+
     test('threads a basePath-scoped route matcher to the MCP middleware', async () => {
       const options = factories.forestAdminHttpDriverOptions.build();
       const agent = new Agent(options);

--- a/packages/agent/test/mcp-in-process-dispatcher.rejection.test.ts
+++ b/packages/agent/test/mcp-in-process-dispatcher.rejection.test.ts
@@ -1,0 +1,39 @@
+import type { RequestListener } from 'http';
+
+const mockInject = jest.fn();
+
+jest.mock('light-my-request', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockInject(...args),
+}));
+
+// eslint-disable-next-line import/first
+import InProcessDispatcher from '../src/mcp-in-process-dispatcher';
+
+describe('InProcessDispatcher — injection rejection safety', () => {
+  it('observes a late injection rejection (logs it) instead of leaking an unhandled rejection', async () => {
+    const logger = jest.fn();
+    // inject() rejects after the timeout has already won the race — the losing promise must not
+    // become an unhandledRejection.
+    mockInject.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error('inject blew up')), 30);
+      }),
+    );
+    const dispatcher = new InProcessDispatcher(logger);
+    dispatcher.setHandler((() => {}) as unknown as RequestListener);
+
+    await expect(
+      dispatcher.request({ method: 'get', path: '/x', headers: {}, timeoutMs: 10 }),
+    ).rejects.toThrow(/timed out after 10ms/);
+
+    await new Promise(resolve => {
+      setTimeout(resolve, 40);
+    });
+
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      expect.stringContaining('settled after the 10ms timeout'),
+    );
+  });
+});

--- a/packages/agent/test/mcp-in-process-dispatcher.test.ts
+++ b/packages/agent/test/mcp-in-process-dispatcher.test.ts
@@ -159,9 +159,8 @@ describe('InProcessDispatcher', () => {
     expect(response.body).toBeUndefined();
   });
 
-  it('warns and returns an undefined body when a non-empty response body is not JSON', async () => {
-    const logger = jest.fn();
-    const dispatcher = new InProcessDispatcher(logger);
+  it('throws when a 2xx response body is not JSON (misbehaving middleware)', async () => {
+    const dispatcher = new InProcessDispatcher(jest.fn());
     dispatcher.setHandler(
       handlerFor(r =>
         r.get('/broken', ctx => {
@@ -171,11 +170,33 @@ describe('InProcessDispatcher', () => {
       ),
     );
 
-    const response = await dispatcher.request({ method: 'get', path: '/broken', headers: {} });
+    await expect(
+      dispatcher.request({ method: 'get', path: '/broken', headers: {} }),
+    ).rejects.toThrow(/non-JSON 200 response body: not json/);
+  });
 
+  it('warns and returns an undefined body for a non-JSON error (4xx+) body', async () => {
+    const logger = jest.fn();
+    const dispatcher = new InProcessDispatcher(logger);
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/gateway', ctx => {
+          ctx.status = 502;
+          ctx.type = 'text/plain';
+          ctx.body = 'gateway boom';
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({ method: 'get', path: '/gateway', headers: {} });
+
+    expect(response.status).toBe(502);
     expect(response.body).toBeUndefined();
-    expect(response.text).toBe('not json');
-    expect(logger).toHaveBeenCalledWith('Warn', expect.stringContaining('non-JSON response body'));
+    expect(response.text).toBe('gateway boom');
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      expect.stringContaining('non-JSON 502 response body: gateway boom'),
+    );
   });
 
   it('reflects a handler swap (remount) instead of a stale reference', async () => {

--- a/packages/agent/test/mcp-in-process-dispatcher.test.ts
+++ b/packages/agent/test/mcp-in-process-dispatcher.test.ts
@@ -1,0 +1,104 @@
+import Router from '@koa/router';
+import Koa from 'koa';
+
+import InProcessDispatcher from '../src/mcp-in-process-dispatcher';
+
+function handlerFor(build: (router: Router) => void) {
+  const router = new Router();
+  build(router);
+
+  return new Koa().use(router.routes()).callback();
+}
+
+describe('InProcessDispatcher', () => {
+  it('throws when no handler is mounted yet', async () => {
+    const dispatcher = new InProcessDispatcher();
+
+    await expect(dispatcher.request({ method: 'get', path: '/ping', headers: {} })).rejects.toThrow(
+      /not mounted/,
+    );
+  });
+
+  it('dispatches to the handler and returns status, body and text', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/ping', ctx => {
+          ctx.body = { pong: true };
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({ method: 'get', path: '/ping', headers: {} });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ pong: true });
+    expect(JSON.parse(response.text)).toEqual({ pong: true });
+  });
+
+  it('forwards headers (e.g. Authorization) to the handler', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/whoami', ctx => {
+          ctx.body = { auth: ctx.headers.authorization };
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({
+      method: 'get',
+      path: '/whoami',
+      headers: { Authorization: 'Bearer tok' },
+    });
+
+    expect(response.body).toEqual({ auth: 'Bearer tok' });
+  });
+
+  it('forwards query params and preserves non-2xx status', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/q', ctx => {
+          ctx.status = 422;
+          ctx.body = { got: ctx.query.foo };
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({
+      method: 'get',
+      path: '/q',
+      headers: {},
+      query: { foo: 'bar' },
+    });
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({ got: 'bar' });
+  });
+
+  it('reflects a handler swap (remount) instead of a stale reference', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/v', ctx => {
+          ctx.body = { v: 1 };
+        }),
+      ),
+    );
+    expect((await dispatcher.request({ method: 'get', path: '/v', headers: {} })).body).toEqual({
+      v: 1,
+    });
+
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/v', ctx => {
+          ctx.body = { v: 2 };
+        }),
+      ),
+    );
+    expect((await dispatcher.request({ method: 'get', path: '/v', headers: {} })).body).toEqual({
+      v: 2,
+    });
+  });
+});

--- a/packages/agent/test/mcp-in-process-dispatcher.test.ts
+++ b/packages/agent/test/mcp-in-process-dispatcher.test.ts
@@ -1,3 +1,4 @@
+import bodyParser from '@koa/bodyparser';
 import Router from '@koa/router';
 import Koa from 'koa';
 
@@ -106,6 +107,31 @@ describe('InProcessDispatcher', () => {
       received: { name: 'Ada' },
       contentType: 'application/json',
     });
+  });
+
+  it('preserves router-level middleware (bodyParser) so a mutating body reaches the route parsed', async () => {
+    // Mirrors FrameworkMounter.getInProcessDispatcher(): a `/forest`-prefixed router wrapping a
+    // driver router that carries bodyParser via `router.use()` (as agent.ts does). Guards against
+    // a regression where the wrapping drops router-level middleware and mutating tool calls
+    // (create/update/…) reach the route with an unparsed body.
+    const driver = new Router();
+    driver.use(bodyParser({ parsedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'] }));
+    driver.post('/users', ctx => {
+      ctx.body = { got: ctx.request.body };
+    });
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      new Koa().use(new Router({ prefix: '/forest' }).use(driver.routes()).routes()).callback(),
+    );
+
+    const response = await dispatcher.request({
+      method: 'post',
+      path: '/forest/users',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { email: 'in@process.dev' },
+    });
+
+    expect(response.body).toEqual({ got: { email: 'in@process.dev' } });
   });
 
   it('rejects when the handler does not respond within the timeout', async () => {

--- a/packages/agent/test/mcp-in-process-dispatcher.test.ts
+++ b/packages/agent/test/mcp-in-process-dispatcher.test.ts
@@ -77,6 +77,81 @@ describe('InProcessDispatcher', () => {
     expect(response.body).toEqual({ got: 'bar' });
   });
 
+  it('forwards the payload and content-type to the handler (mutating call)', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.post('/echo', async ctx => {
+          const raw = await new Promise<string>(resolve => {
+            let data = '';
+            ctx.req.on('data', chunk => {
+              data += chunk;
+            });
+            ctx.req.on('end', () => resolve(data));
+          });
+
+          ctx.body = { received: JSON.parse(raw), contentType: ctx.headers['content-type'] };
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({
+      method: 'post',
+      path: '/echo',
+      headers: { 'Content-Type': 'application/json' },
+      payload: { name: 'Ada' },
+    });
+
+    expect(response.body).toEqual({
+      received: { name: 'Ada' },
+      contentType: 'application/json',
+    });
+  });
+
+  it('rejects when the handler does not respond within the timeout', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(handlerFor(r => r.get('/hang', () => new Promise(() => {}))));
+
+    await expect(
+      dispatcher.request({ method: 'get', path: '/hang', headers: {}, timeoutMs: 50 }),
+    ).rejects.toThrow(/timed out after 50ms/);
+  });
+
+  it('returns an undefined body for an empty (204) response', async () => {
+    const dispatcher = new InProcessDispatcher();
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.delete('/x', ctx => {
+          ctx.status = 204;
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({ method: 'delete', path: '/x', headers: {} });
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeUndefined();
+  });
+
+  it('warns and returns an undefined body when a non-empty response body is not JSON', async () => {
+    const logger = jest.fn();
+    const dispatcher = new InProcessDispatcher(logger);
+    dispatcher.setHandler(
+      handlerFor(r =>
+        r.get('/broken', ctx => {
+          ctx.type = 'text/plain';
+          ctx.body = 'not json';
+        }),
+      ),
+    );
+
+    const response = await dispatcher.request({ method: 'get', path: '/broken', headers: {} });
+
+    expect(response.body).toBeUndefined();
+    expect(response.text).toBe('not json');
+    expect(logger).toHaveBeenCalledWith('Warn', expect.stringContaining('non-JSON response body'));
+  });
+
   it('reflects a handler swap (remount) instead of a stale reference', async () => {
     const dispatcher = new InProcessDispatcher();
     dispatcher.setHandler(

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -10,6 +10,7 @@ const server = new ForestMCPServer({
   envSecret: process.env.FOREST_ENV_SECRET,
   authSecret: process.env.FOREST_AUTH_SECRET,
   enabledTools: parseToolList(process.env.FOREST_MCP_ENABLED_TOOLS),
+  agentUrl: process.env.FOREST_AGENT_URL,
 });
 
 server.run().catch(error => {

--- a/packages/mcp-server/src/forest-oauth-provider.ts
+++ b/packages/mcp-server/src/forest-oauth-provider.ts
@@ -30,6 +30,7 @@ export interface ForestOAuthProviderOptions {
   envSecret: string;
   authSecret: string;
   logger: Logger;
+  agentUrl?: string;
 }
 
 /**
@@ -43,6 +44,7 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
   private forestClient: ForestAdminClient;
   private environmentId?: number;
   private environmentApiEndpoint?: string;
+  private agentUrl?: string;
   private logger: Logger;
 
   constructor({
@@ -51,16 +53,32 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
     envSecret,
     authSecret,
     logger,
+    agentUrl,
   }: ForestOAuthProviderOptions) {
     this.forestServerUrl = forestServerUrl;
     this.forestAppUrl = forestAppUrl;
     this.envSecret = envSecret;
     this.authSecret = authSecret;
     this.logger = logger;
+    this.agentUrl = ForestOAuthProvider.normalizeAgentUrl(agentUrl);
     this.forestClient = createForestAdminClient({
       forestServerUrl: this.forestServerUrl,
       envSecret: this.envSecret,
     });
+  }
+
+  private static normalizeAgentUrl(agentUrl?: string): string | undefined {
+    if (!agentUrl) return undefined;
+
+    try {
+      // eslint-disable-next-line no-new
+      new URL(agentUrl);
+    } catch {
+      throw new Error(`Invalid agentUrl "${agentUrl}": it must be an absolute URL.`);
+    }
+
+    // agent-client concatenates the path directly onto this URL, so drop any trailing slash.
+    return agentUrl.replace(/\/+$/, '');
   }
 
   async initialize(): Promise<void> {
@@ -408,7 +426,9 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
           userId: decoded.id,
           email: decoded.email,
           renderingId: decoded.renderingId,
-          environmentApiEndpoint: this.environmentApiEndpoint,
+          // Tools call back into the agent at this URL. Prefer the configured internal agentUrl
+          // (self-hosted) and fall back to the environment's public api_endpoint.
+          environmentApiEndpoint: this.agentUrl ?? this.environmentApiEndpoint,
           forestServerToken: decoded.serverToken,
         },
       };

--- a/packages/mcp-server/src/forest-oauth-provider.ts
+++ b/packages/mcp-server/src/forest-oauth-provider.ts
@@ -70,15 +70,28 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
   private static normalizeAgentUrl(agentUrl?: string): string | undefined {
     if (!agentUrl) return undefined;
 
+    let parsed: URL;
+
     try {
-      // eslint-disable-next-line no-new
-      new URL(agentUrl);
+      parsed = new URL(agentUrl);
     } catch {
-      throw new Error(`Invalid agentUrl "${agentUrl}": it must be an absolute URL.`);
+      throw new Error(`Invalid agentUrl "${agentUrl}": it must be an absolute http(s) URL.`);
     }
 
-    // agent-client concatenates the path directly onto this URL, so drop any trailing slash.
-    return agentUrl.replace(/\/+$/, '');
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Invalid agentUrl "${agentUrl}": only http and https are supported.`);
+    }
+
+    // agent-client concatenates the request path directly onto this URL, so a query string or
+    // fragment would swallow it — reject them, and return the parsed (whitespace-normalized)
+    // form rather than the raw input. Drop any trailing slash to avoid a double slash on join.
+    if (parsed.search || parsed.hash) {
+      throw new Error(
+        `Invalid agentUrl "${agentUrl}": it must not contain a query string or fragment.`,
+      );
+    }
+
+    return parsed.href.replace(/\/+$/, '');
   }
 
   async initialize(): Promise<void> {

--- a/packages/mcp-server/src/forest-oauth-provider.ts
+++ b/packages/mcp-server/src/forest-oauth-provider.ts
@@ -24,14 +24,13 @@ import {
 } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import jsonwebtoken from 'jsonwebtoken';
 
-import normalizeAgentUrl from './utils/normalize-agent-url';
-
 export interface ForestOAuthProviderOptions {
   forestServerUrl: string;
   forestAppUrl: string;
   envSecret: string;
   authSecret: string;
   logger: Logger;
+  // Pre-normalized by the caller (ForestMCPServer); not re-validated here.
   agentUrl?: string;
 }
 
@@ -62,7 +61,7 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
     this.envSecret = envSecret;
     this.authSecret = authSecret;
     this.logger = logger;
-    this.agentUrl = normalizeAgentUrl(agentUrl);
+    this.agentUrl = agentUrl;
     this.forestClient = createForestAdminClient({
       forestServerUrl: this.forestServerUrl,
       envSecret: this.envSecret,

--- a/packages/mcp-server/src/forest-oauth-provider.ts
+++ b/packages/mcp-server/src/forest-oauth-provider.ts
@@ -24,6 +24,8 @@ import {
 } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import jsonwebtoken from 'jsonwebtoken';
 
+import normalizeAgentUrl from './utils/normalize-agent-url';
+
 export interface ForestOAuthProviderOptions {
   forestServerUrl: string;
   forestAppUrl: string;
@@ -60,38 +62,11 @@ export default class ForestOAuthProvider implements OAuthServerProvider {
     this.envSecret = envSecret;
     this.authSecret = authSecret;
     this.logger = logger;
-    this.agentUrl = ForestOAuthProvider.normalizeAgentUrl(agentUrl);
+    this.agentUrl = normalizeAgentUrl(agentUrl);
     this.forestClient = createForestAdminClient({
       forestServerUrl: this.forestServerUrl,
       envSecret: this.envSecret,
     });
-  }
-
-  private static normalizeAgentUrl(agentUrl?: string): string | undefined {
-    if (!agentUrl) return undefined;
-
-    let parsed: URL;
-
-    try {
-      parsed = new URL(agentUrl);
-    } catch {
-      throw new Error(`Invalid agentUrl "${agentUrl}": it must be an absolute http(s) URL.`);
-    }
-
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error(`Invalid agentUrl "${agentUrl}": only http and https are supported.`);
-    }
-
-    // agent-client concatenates the request path directly onto this URL, so a query string or
-    // fragment would swallow it — reject them, and return the parsed (whitespace-normalized)
-    // form rather than the raw input. Drop any trailing slash to avoid a double slash on join.
-    if (parsed.search || parsed.hash) {
-      throw new Error(
-        `Invalid agentUrl "${agentUrl}": it must not contain a query string or fragment.`,
-      );
-    }
-
-    return parsed.href.replace(/\/+$/, '');
   }
 
   async initialize(): Promise<void> {

--- a/packages/mcp-server/src/in-process-agent-dispatcher.ts
+++ b/packages/mcp-server/src/in-process-agent-dispatcher.ts
@@ -7,5 +7,6 @@ export interface InProcessAgentDispatcher {
     headers: Record<string, string>;
     query?: Record<string, unknown>;
     payload?: unknown;
+    timeoutMs?: number;
   }): Promise<{ status: number; body: unknown; text: string }>;
 }

--- a/packages/mcp-server/src/in-process-agent-dispatcher.ts
+++ b/packages/mcp-server/src/in-process-agent-dispatcher.ts
@@ -1,0 +1,11 @@
+// Structural contract satisfied by the agent's InProcessDispatcher. Declared here (not imported
+// from @forestadmin/agent) to avoid a dependency cycle — agent already depends on mcp-server.
+export interface InProcessAgentDispatcher {
+  request(request: {
+    method: string;
+    path: string;
+    headers: Record<string, string>;
+    query?: Record<string, unknown>;
+    payload?: unknown;
+  }): Promise<{ status: number; body: unknown; text: string }>;
+}

--- a/packages/mcp-server/src/in-process-agent-dispatcher.ts
+++ b/packages/mcp-server/src/in-process-agent-dispatcher.ts
@@ -1,12 +1,18 @@
 // Structural contract satisfied by the agent's InProcessDispatcher. Declared here (not imported
 // from @forestadmin/agent) to avoid a dependency cycle — agent already depends on mcp-server.
+// The agent imports these request/response types rather than re-declaring their shape.
+export type InProcessDispatchRequest = {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  query?: Record<string, unknown>;
+  payload?: unknown;
+  timeoutMs?: number;
+};
+
+// Superagent-shaped so agent-client's HttpRequester parse helpers read it identically.
+export type InProcessDispatchResponse = { status: number; body: unknown; text: string };
+
 export interface InProcessAgentDispatcher {
-  request(request: {
-    method: string;
-    path: string;
-    headers: Record<string, string>;
-    query?: Record<string, unknown>;
-    payload?: unknown;
-    timeoutMs?: number;
-  }): Promise<{ status: number; body: unknown; text: string }>;
+  request(request: InProcessDispatchRequest): Promise<InProcessDispatchResponse>;
 }

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -1,10 +1,6 @@
 import type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
 
-import {
-  HttpRequester,
-  buildAgentHttpError,
-  deserializeAgentBody,
-} from '@forestadmin/agent-client';
+import { HttpRequester } from '@forestadmin/agent-client';
 
 /**
  * HttpRequester that reaches the agent in-process (via the dispatcher) instead of over the network.
@@ -54,8 +50,8 @@ export default class InProcessHttpRequester extends HttpRequester {
       timeoutMs: maxTimeAllowed,
     });
 
-    if (status >= 400) throw buildAgentHttpError(status, responseBody, text);
+    if (status >= 400) throw this.buildError(status, responseBody, text);
 
-    return deserializeAgentBody<Data>(this.deserializer, responseBody, text, skipDeserialization);
+    return this.deserialize<Data>(responseBody, text, skipDeserialization);
   }
 }

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -1,0 +1,65 @@
+import type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
+
+import {
+  HttpRequester,
+  buildAgentHttpError,
+  deserializeAgentBody,
+} from '@forestadmin/agent-client';
+
+/**
+ * HttpRequester that reaches the agent in-process (via the dispatcher) instead of over the network.
+ * Reuses agent-client's shared parse helpers so the deserialized results and AgentHttpError shape
+ * are identical to the HTTP path — keeping approval-gate detection and error handling unchanged.
+ */
+export default class InProcessHttpRequester extends HttpRequester {
+  constructor(
+    private readonly bearerToken: string,
+    private readonly dispatcher: InProcessAgentDispatcher,
+  ) {
+    // Base url is unused: query()/stream() are overridden to dispatch in-process.
+    super(bearerToken, { url: 'http://in-process.agent' });
+  }
+
+  override async query<Data = unknown>({
+    method,
+    path,
+    body,
+    query,
+    contentType,
+    skipDeserialization,
+  }: {
+    method: 'get' | 'post' | 'put' | 'delete';
+    path: string;
+    body?: Record<string, unknown>;
+    query?: Record<string, unknown>;
+    maxTimeAllowed?: number;
+    contentType?: 'application/json' | 'text/csv';
+    skipDeserialization?: boolean;
+  }): Promise<Data> {
+    const {
+      status,
+      body: responseBody,
+      text,
+    } = await this.dispatcher.request({
+      method,
+      path,
+      headers: {
+        Authorization: `Bearer ${this.bearerToken}`,
+        'Content-Type': contentType ?? 'application/json',
+        Accept: contentType ?? 'application/json',
+      },
+      query: { timezone: 'Europe/Paris', ...query },
+      payload: body,
+    });
+
+    if (status >= 400) throw buildAgentHttpError(status, responseBody, text);
+
+    return deserializeAgentBody<Data>(this.deserializer, responseBody, text, skipDeserialization);
+  }
+
+  override async stream(): Promise<void> {
+    throw new Error(
+      'CSV export is not supported when the MCP server runs in-process in the agent.',
+    );
+  }
+}

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -16,7 +16,7 @@ export default class InProcessHttpRequester extends HttpRequester {
     private readonly bearerToken: string,
     private readonly dispatcher: InProcessAgentDispatcher,
   ) {
-    // Base url is unused: query()/stream() are overridden to dispatch in-process.
+    // Base url is unused: query() is overridden to dispatch in-process.
     super(bearerToken, { url: 'http://in-process.agent' });
   }
 
@@ -57,11 +57,5 @@ export default class InProcessHttpRequester extends HttpRequester {
     if (status >= 400) throw buildAgentHttpError(status, responseBody, text);
 
     return deserializeAgentBody<Data>(this.deserializer, responseBody, text, skipDeserialization);
-  }
-
-  override async stream(): Promise<void> {
-    throw new Error(
-      'CSV export is not supported when the MCP server runs in-process in the agent.',
-    );
   }
 }

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -12,8 +12,15 @@ export default class InProcessHttpRequester extends HttpRequester {
     private readonly bearerToken: string,
     private readonly dispatcher: InProcessAgentDispatcher,
   ) {
-    // Base url is unused: query() is overridden to dispatch in-process.
+    // Sentinel base url that never reaches the network: query() dispatches in-process and stream()
+    // throws below, so nothing ever resolves this host.
     super(bearerToken, { url: 'http://in-process.agent' });
+  }
+
+  // CSV export is not supported in-process; throw eagerly rather than let the inherited stream()
+  // fire a doomed request at the sentinel host (a ~10s hang). No MCP tool streams today.
+  override async stream(): Promise<void> {
+    throw new Error('CSV streaming is not supported over the in-process MCP transport');
   }
 
   override async query<Data = unknown>({

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -3,22 +3,19 @@ import type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
 import { HttpRequester } from '@forestadmin/agent-client';
 
 /**
- * HttpRequester that reaches the agent in-process (via the dispatcher) instead of over the network.
- * Reuses agent-client's shared parse helpers so the deserialized results and AgentHttpError shape
- * are identical to the HTTP path — keeping approval-gate detection and error handling unchanged.
+ * HttpRequester that reaches the agent in-process (via the dispatcher) instead of over the network,
+ * reusing HttpRequester's parse helpers so results and error shape stay identical to the HTTP path.
  */
 export default class InProcessHttpRequester extends HttpRequester {
   constructor(
     private readonly bearerToken: string,
     private readonly dispatcher: InProcessAgentDispatcher,
   ) {
-    // Sentinel base url that never reaches the network: query() dispatches in-process and stream()
-    // throws below, so nothing ever resolves this host.
+    // Sentinel host that never reaches the network: query() dispatches in-process, stream() throws.
     super(bearerToken, { url: 'http://in-process.agent' });
   }
 
-  // CSV export is not supported in-process; throw eagerly rather than let the inherited stream()
-  // fire a doomed request at the sentinel host (a ~10s hang). No MCP tool streams today.
+  // CSV export is not supported in-process; throw rather than fire a doomed request at the sentinel.
   override async stream(): Promise<void> {
     throw new Error('CSV streaming is not supported over the in-process MCP transport');
   }

--- a/packages/mcp-server/src/in-process-http-requester.ts
+++ b/packages/mcp-server/src/in-process-http-requester.ts
@@ -25,6 +25,7 @@ export default class InProcessHttpRequester extends HttpRequester {
     path,
     body,
     query,
+    maxTimeAllowed,
     contentType,
     skipDeserialization,
   }: {
@@ -50,6 +51,7 @@ export default class InProcessHttpRequester extends HttpRequester {
       },
       query: { timezone: 'Europe/Paris', ...query },
       payload: body,
+      timeoutMs: maxTimeAllowed,
     });
 
     if (status >= 400) throw buildAgentHttpError(status, responseBody, text);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,7 +1,11 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
 export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
-export type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
+export type {
+  InProcessAgentDispatcher,
+  InProcessDispatchRequest,
+  InProcessDispatchResponse,
+} from './in-process-agent-dispatcher';
 export { MCP_PATHS, isMcpRoute, makeIsMcpRoute } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,6 +1,7 @@
 // Library exports only - no side effects
 export { default as ForestMCPServer } from './server';
 export type { ForestMCPServerOptions, HttpCallback, ToolName } from './server';
+export type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
 export { MCP_PATHS, isMcpRoute, makeIsMcpRoute } from './mcp-paths';
 export { ForestServerClientImpl, createForestServerClient } from './http-client';
 export type {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -128,9 +128,8 @@ export interface ForestMCPServerOptions {
    */
   basePath?: string;
   /**
-   * Internal URL the MCP tools use to call back into the agent's data layer, e.g.
-   * 'http://forest-agent.internal:3310'. Defaults to the environment's public `api_endpoint`.
-   * Only affects the tool→agent channel; the advertised OAuth URLs stay public.
+   * Standalone MCP server only (set via FOREST_AGENT_URL). Internal URL the tools use to reach
+   * the agent's data layer, defaulting to the environment's public `api_endpoint`.
    */
   agentUrl?: string;
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -3,6 +3,8 @@
 import './polyfills';
 
 import type { ForestServerClient } from './http-client';
+import type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
+import type { ToolContext } from './tool-context';
 import type { Express } from 'express';
 
 import { authorizationHandler } from '@modelcontextprotocol/sdk/server/auth/handlers/authorize.js';
@@ -132,6 +134,11 @@ export interface ForestMCPServerOptions {
    * the agent's data layer, defaulting to the environment's public `api_endpoint`.
    */
   agentUrl?: string;
+  /**
+   * Set by the agent when mounted: tool calls then dispatch to the agent in-process (no socket)
+   * instead of reaching its public `api_endpoint` over HTTP.
+   */
+  agentDispatcher?: InProcessAgentDispatcher;
 }
 
 /**
@@ -155,6 +162,7 @@ export default class ForestMCPServer {
   private enabledTools: Set<ToolName>;
   private basePath: string;
   private agentUrl?: string;
+  private agentDispatcher?: InProcessAgentDispatcher;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -165,6 +173,7 @@ export default class ForestMCPServer {
     this.enabledTools = this.resolveEnabledTools(options);
     this.basePath = normalizeMountPath(options?.basePath);
     this.agentUrl = normalizeAgentUrl(options?.agentUrl);
+    this.agentDispatcher = options?.agentDispatcher;
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -196,87 +205,24 @@ export default class ForestMCPServer {
       icons: [{ src: LOGO_URL, mimeType: 'image/png' }],
     });
 
+    const ctx: ToolContext = {
+      forestServerClient: this.forestServerClient,
+      logger: this.logger,
+      collectionNames: this.collectionNames,
+      agentDispatcher: this.agentDispatcher,
+    };
+
     const allTools: Array<{ name: ToolName; register: () => string }> = [
-      {
-        name: 'describeCollection',
-        register: () =>
-          declareDescribeCollectionTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
-      {
-        name: 'list',
-        register: () =>
-          declareListTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      },
-      {
-        name: 'listRelated',
-        register: () =>
-          declareListRelatedTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
-      {
-        name: 'create',
-        register: () =>
-          declareCreateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      },
-      {
-        name: 'update',
-        register: () =>
-          declareUpdateTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      },
-      {
-        name: 'delete',
-        register: () =>
-          declareDeleteTool(mcpServer, this.forestServerClient, this.logger, this.collectionNames),
-      },
-      {
-        name: 'associate',
-        register: () =>
-          declareAssociateTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
-      {
-        name: 'dissociate',
-        register: () =>
-          declareDissociateTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
-      {
-        name: 'getActionForm',
-        register: () =>
-          declareGetActionFormTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
-      {
-        name: 'executeAction',
-        register: () =>
-          declareExecuteActionTool(
-            mcpServer,
-            this.forestServerClient,
-            this.logger,
-            this.collectionNames,
-          ),
-      },
+      { name: 'describeCollection', register: () => declareDescribeCollectionTool(mcpServer, ctx) },
+      { name: 'list', register: () => declareListTool(mcpServer, ctx) },
+      { name: 'listRelated', register: () => declareListRelatedTool(mcpServer, ctx) },
+      { name: 'create', register: () => declareCreateTool(mcpServer, ctx) },
+      { name: 'update', register: () => declareUpdateTool(mcpServer, ctx) },
+      { name: 'delete', register: () => declareDeleteTool(mcpServer, ctx) },
+      { name: 'associate', register: () => declareAssociateTool(mcpServer, ctx) },
+      { name: 'dissociate', register: () => declareDissociateTool(mcpServer, ctx) },
+      { name: 'getActionForm', register: () => declareGetActionFormTool(mcpServer, ctx) },
+      { name: 'executeAction', register: () => declareExecuteActionTool(mcpServer, ctx) },
     ];
 
     const enabledToolEntries = allTools.filter(tool => this.enabledTools.has(tool.name));

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -126,6 +126,20 @@ export interface ForestMCPServerOptions {
    * domain root.
    */
   basePath?: string;
+  /**
+   * URL the MCP tools use to call back into the agent's data layer (list/create/execute actions…).
+   *
+   * By default this is the environment's public `api_endpoint` (as registered in Forest), which
+   * means every tool call leaves over the public internet — even when the MCP server is mounted
+   * inside the agent (same process). Set `agentUrl` to an internal address (e.g. a loopback port
+   * or a Kubernetes service URL) to keep that traffic on your private network in self-hosted
+   * deployments.
+   *
+   * This only affects the internal tool→agent channel. The advertised OAuth URLs (issuer,
+   * `.well-known` metadata, authorize/token endpoints) stay public so external MCP clients can
+   * still authenticate.
+   */
+  agentUrl?: string;
 }
 
 /**
@@ -148,6 +162,7 @@ export default class ForestMCPServer {
   private collectionNames: string[] = [];
   private enabledTools: Set<ToolName>;
   private basePath: string;
+  private agentUrl?: string;
 
   constructor(options?: ForestMCPServerOptions) {
     this.forestServerUrl = options?.forestServerUrl || 'https://api.forestadmin.com';
@@ -157,6 +172,7 @@ export default class ForestMCPServer {
     this.logger = options?.logger || defaultLogger;
     this.enabledTools = this.resolveEnabledTools(options);
     this.basePath = normalizeMountPath(options?.basePath);
+    this.agentUrl = options?.agentUrl;
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();
@@ -475,6 +491,7 @@ export default class ForestMCPServer {
       envSecret,
       authSecret,
       logger: this.logger,
+      agentUrl: this.agentUrl,
     });
     await oauthProvider.initialize();
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -33,6 +33,7 @@ import declareGetActionFormTool from './tools/get-action-form';
 import declareListTool from './tools/list';
 import declareListRelatedTool from './tools/list-related';
 import declareUpdateTool from './tools/update';
+import normalizeAgentUrl from './utils/normalize-agent-url';
 import { fetchForestSchema, getCollectionNames } from './utils/schema-fetcher';
 import interceptResponseForErrorLogging from './utils/sse-error-logger';
 import { NAME, VERSION } from './version';
@@ -127,17 +128,9 @@ export interface ForestMCPServerOptions {
    */
   basePath?: string;
   /**
-   * URL the MCP tools use to call back into the agent's data layer (list/create/execute actions…).
-   *
-   * By default this is the environment's public `api_endpoint` (as registered in Forest), which
-   * means every tool call leaves over the public internet — even when the MCP server is mounted
-   * inside the agent (same process). Set `agentUrl` to an internal address (e.g. a loopback port
-   * or a Kubernetes service URL) to keep that traffic on your private network in self-hosted
-   * deployments.
-   *
-   * This only affects the internal tool→agent channel. The advertised OAuth URLs (issuer,
-   * `.well-known` metadata, authorize/token endpoints) stay public so external MCP clients can
-   * still authenticate.
+   * Internal URL the MCP tools use to call back into the agent's data layer, e.g.
+   * 'http://forest-agent.internal:3310'. Defaults to the environment's public `api_endpoint`.
+   * Only affects the tool→agent channel; the advertised OAuth URLs stay public.
    */
   agentUrl?: string;
 }
@@ -172,7 +165,7 @@ export default class ForestMCPServer {
     this.logger = options?.logger || defaultLogger;
     this.enabledTools = this.resolveEnabledTools(options);
     this.basePath = normalizeMountPath(options?.basePath);
-    this.agentUrl = options?.agentUrl;
+    this.agentUrl = normalizeAgentUrl(options?.agentUrl);
 
     // Use injected forestServerClient or create default
     this.forestServerClient = options?.forestServerClient ?? this.createDefaultForestServerClient();

--- a/packages/mcp-server/src/tool-context.ts
+++ b/packages/mcp-server/src/tool-context.ts
@@ -1,0 +1,11 @@
+import type { ForestServerClient } from './http-client';
+import type { InProcessAgentDispatcher } from './in-process-agent-dispatcher';
+import type { Logger } from './server';
+
+export interface ToolContext {
+  forestServerClient: ForestServerClient;
+  logger: Logger;
+  collectionNames?: string[];
+  // Present only when the MCP server is mounted in an agent — tool calls then dispatch in-process.
+  agentDispatcher?: InProcessAgentDispatcher;
+}

--- a/packages/mcp-server/src/tool-context.ts
+++ b/packages/mcp-server/src/tool-context.ts
@@ -6,6 +6,5 @@ export interface ToolContext {
   forestServerClient: ForestServerClient;
   logger: Logger;
   collectionNames: string[];
-  // Present only when the MCP server is mounted in an agent — tool calls then dispatch in-process.
   agentDispatcher?: InProcessAgentDispatcher;
 }

--- a/packages/mcp-server/src/tool-context.ts
+++ b/packages/mcp-server/src/tool-context.ts
@@ -5,7 +5,7 @@ import type { Logger } from './server';
 export interface ToolContext {
   forestServerClient: ForestServerClient;
   logger: Logger;
-  collectionNames?: string[];
+  collectionNames: string[];
   // Present only when the MCP server is mounted in an agent — tool calls then dispatch in-process.
   agentDispatcher?: InProcessAgentDispatcher;
 }

--- a/packages/mcp-server/src/tools/associate.ts
+++ b/packages/mcp-server/src/tools/associate.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -29,12 +28,8 @@ function createAssociateArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareAssociateTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareAssociateTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createAssociateArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -47,7 +42,7 @@ export default function declareAssociateTool(
       inputSchema: argumentShape,
     },
     async (options: AssociateArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       return withActivityLog({
         forestServerClient,

--- a/packages/mcp-server/src/tools/associate.ts
+++ b/packages/mcp-server/src/tools/associate.ts
@@ -29,7 +29,7 @@ function createAssociateArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareAssociateTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createAssociateArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -34,7 +34,7 @@ function createArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareCreateTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/create.ts
+++ b/packages/mcp-server/src/tools/create.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -34,12 +33,8 @@ function createArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareCreateTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareCreateTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -51,7 +46,7 @@ export default function declareCreateTool(
       inputSchema: argumentShape,
     },
     async (options: CreateArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       return withActivityLog({
         forestServerClient,

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -23,7 +23,7 @@ function createArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareDeleteTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/delete.ts
+++ b/packages/mcp-server/src/tools/delete.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -23,12 +22,8 @@ function createArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareDeleteTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareDeleteTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -40,7 +35,7 @@ export default function declareDeleteTool(
       inputSchema: argumentShape,
     },
     async (options: DeleteArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       // Cast to satisfy the type system - the API accepts both string[] and number[]
       const recordIds = options.recordIds as string[] | number[];

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -1,5 +1,5 @@
-import type { ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -80,10 +80,9 @@ function mapRelationType(relationship: string | undefined): string {
 
 export default function declareDescribeCollectionTool(
   mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
+  ctx: ToolContext,
 ): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createDescribeCollectionArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -105,7 +104,7 @@ Check \`_meta\` for data availability context.`,
       inputSchema: argumentShape,
     },
     async (options: DescribeCollectionArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       return withActivityLog({
         forestServerClient,

--- a/packages/mcp-server/src/tools/describe-collection.ts
+++ b/packages/mcp-server/src/tools/describe-collection.ts
@@ -82,7 +82,7 @@ export default function declareDescribeCollectionTool(
   mcpServer: McpServer,
   ctx: ToolContext,
 ): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createDescribeCollectionArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/dissociate.ts
+++ b/packages/mcp-server/src/tools/dissociate.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -29,12 +28,8 @@ function createDissociateArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareDissociateTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareDissociateTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createDissociateArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -47,7 +42,7 @@ export default function declareDissociateTool(
       inputSchema: argumentShape,
     },
     async (options: DissociateArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       return withActivityLog({
         forestServerClient,

--- a/packages/mcp-server/src/tools/dissociate.ts
+++ b/packages/mcp-server/src/tools/dissociate.ts
@@ -29,7 +29,7 @@ function createDissociateArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareDissociateTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createDissociateArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -17,12 +16,8 @@ interface ExecuteActionArgument {
   reasoning?: string;
 }
 
-export default function declareExecuteActionTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareExecuteActionTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = {
     ...createActionArgumentShape(collectionNames),
     reasoning: z
@@ -50,7 +45,11 @@ If you call executeAction with missing required fields, it will return an error 
       inputSchema: argumentShape,
     },
     async (options: ExecuteActionArgument, extra) => {
-      const { rpcClient } = await buildClientWithActions(extra, forestServerClient);
+      const { rpcClient } = await buildClientWithActions(
+        extra,
+        forestServerClient,
+        ctx.agentDispatcher,
+      );
 
       // Cast to satisfy the type system - the API accepts both string[] and number[]
       const recordIds = (options.recordIds ?? []) as string[] | number[];

--- a/packages/mcp-server/src/tools/execute-action.ts
+++ b/packages/mcp-server/src/tools/execute-action.ts
@@ -17,7 +17,7 @@ interface ExecuteActionArgument {
 }
 
 export default function declareExecuteActionTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = {
     ...createActionArgumentShape(collectionNames),
     reasoning: z

--- a/packages/mcp-server/src/tools/get-action-form.ts
+++ b/packages/mcp-server/src/tools/get-action-form.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { createActionArgumentShape } from '../utils/action-helpers';
@@ -13,12 +12,8 @@ interface GetActionFormArgument {
   values?: Record<string, unknown>;
 }
 
-export default function declareGetActionFormTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareGetActionFormTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createActionArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -44,7 +39,11 @@ The response includes:
       inputSchema: argumentShape,
     },
     async (options: GetActionFormArgument, extra) => {
-      const { rpcClient } = await buildClientWithActions(extra, forestServerClient);
+      const { rpcClient } = await buildClientWithActions(
+        extra,
+        forestServerClient,
+        ctx.agentDispatcher,
+      );
 
       // TODO: Enhance when more methods are available in the agent client helper
       // https://github.com/ForestAdmin/forestadmin-experimental/pull/140

--- a/packages/mcp-server/src/tools/get-action-form.ts
+++ b/packages/mcp-server/src/tools/get-action-form.ts
@@ -13,7 +13,7 @@ interface GetActionFormArgument {
 }
 
 export default function declareGetActionFormTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createActionArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/list-related.ts
+++ b/packages/mcp-server/src/tools/list-related.ts
@@ -72,7 +72,7 @@ function createErrorEnhancer(
 }
 
 export default function declareListRelatedTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const listArgumentShape = createHasManyArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/list-related.ts
+++ b/packages/mcp-server/src/tools/list-related.ts
@@ -1,6 +1,7 @@
 import type { ListArgument } from './list';
 import type { ForestServerClient } from '../http-client';
 import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { SelectOptions } from '@forestadmin/agent-client';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -70,12 +71,8 @@ function createErrorEnhancer(
   };
 }
 
-export default function declareListRelatedTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareListRelatedTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const listArgumentShape = createHasManyArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -88,7 +85,7 @@ export default function declareListRelatedTool(
       inputSchema: listArgumentShape,
     },
     async (options: HasManyArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       const labelParts = [];
 

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -75,7 +75,7 @@ export function createListArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareListTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const listArgumentShape = createListArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/list.ts
+++ b/packages/mcp-server/src/tools/list.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { SelectOptions } from '@forestadmin/agent-client';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -75,12 +74,8 @@ export function createListArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareListTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareListTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const listArgumentShape = createListArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -93,7 +88,7 @@ export default function declareListTool(
       inputSchema: listArgumentShape,
     },
     async (options: ListArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       let actionType: 'index' | 'search' | 'filter' = 'index';
 

--- a/packages/mcp-server/src/tools/update.ts
+++ b/packages/mcp-server/src/tools/update.ts
@@ -36,7 +36,7 @@ function createArgumentShape(collectionNames: string[]) {
 }
 
 export default function declareUpdateTool(mcpServer: McpServer, ctx: ToolContext): string {
-  const { forestServerClient, logger, collectionNames = [] } = ctx;
+  const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(

--- a/packages/mcp-server/src/tools/update.ts
+++ b/packages/mcp-server/src/tools/update.ts
@@ -1,5 +1,4 @@
-import type { ForestServerClient } from '../http-client';
-import type { Logger } from '../server';
+import type { ToolContext } from '../tool-context';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { z } from 'zod';
@@ -36,12 +35,8 @@ function createArgumentShape(collectionNames: string[]) {
   };
 }
 
-export default function declareUpdateTool(
-  mcpServer: McpServer,
-  forestServerClient: ForestServerClient,
-  logger: Logger,
-  collectionNames: string[] = [],
-): string {
+export default function declareUpdateTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger, collectionNames = [] } = ctx;
   const argumentShape = createArgumentShape(collectionNames);
 
   return registerToolWithLogging(
@@ -53,7 +48,7 @@ export default function declareUpdateTool(
       inputSchema: argumentShape,
     },
     async (options: UpdateArgument, extra) => {
-      const { rpcClient } = buildClient(extra);
+      const { rpcClient } = buildClient(extra, ctx.agentDispatcher);
 
       return withActivityLog({
         forestServerClient,

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -1,16 +1,19 @@
 import type { ActionEndpoints } from './schema-fetcher';
 import type { ForestServerClient } from '../http-client';
+import type { InProcessAgentDispatcher } from '../in-process-agent-dispatcher';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 
 import { createRemoteAgentClient } from '@forestadmin/agent-client';
 
+import InProcessHttpRequester from '../in-process-http-requester';
 import { fetchForestSchema, getActionEndpoints } from './schema-fetcher';
 
 interface BuildClientOptions {
   request: RequestHandlerExtra<ServerRequest, ServerNotification>;
   actionEndpoints?: ActionEndpoints;
   forestServerUrl?: string;
+  agentDispatcher?: InProcessAgentDispatcher;
 }
 
 export type AuthData = {
@@ -23,7 +26,7 @@ export type AuthData = {
 };
 
 function createClient(options: BuildClientOptions) {
-  const { request, actionEndpoints = {}, forestServerUrl } = options;
+  const { request, actionEndpoints = {}, forestServerUrl, agentDispatcher } = options;
   const token = request.authInfo?.token;
   const url = request.authInfo?.extra?.environmentApiEndpoint;
   const { forestServerToken, renderingId } = (request.authInfo?.extra ?? {}) as AuthData;
@@ -32,7 +35,12 @@ function createClient(options: BuildClientOptions) {
     throw new Error('Authentication token is missing');
   }
 
-  if (!url || typeof url !== 'string') {
+  // Mounted in an agent: reach it in-process. Standalone: reach the public api_endpoint over HTTP.
+  const httpRequester = agentDispatcher
+    ? new InProcessHttpRequester(token, agentDispatcher)
+    : undefined;
+
+  if (!httpRequester && (!url || typeof url !== 'string')) {
     throw new Error('Environment API endpoint is missing or invalid');
   }
 
@@ -43,9 +51,10 @@ function createClient(options: BuildClientOptions) {
 
   const rpcClient = createRemoteAgentClient({
     token,
-    url,
+    url: (url as string) ?? '',
     actionEndpoints,
     forestServer,
+    httpRequester,
   });
 
   return {
@@ -56,8 +65,9 @@ function createClient(options: BuildClientOptions) {
 
 export default function buildClient(
   request: RequestHandlerExtra<ServerRequest, ServerNotification>,
+  agentDispatcher?: InProcessAgentDispatcher,
 ) {
-  return createClient({ request });
+  return createClient({ request, agentDispatcher });
 }
 
 /**
@@ -67,6 +77,7 @@ export default function buildClient(
 export async function buildClientWithActions(
   request: RequestHandlerExtra<ServerRequest, ServerNotification>,
   forestServerClient: ForestServerClient,
+  agentDispatcher?: InProcessAgentDispatcher,
 ) {
   const schema = await fetchForestSchema(forestServerClient);
   const actionEndpoints = getActionEndpoints(schema);
@@ -75,5 +86,6 @@ export async function buildClientWithActions(
     request,
     actionEndpoints,
     forestServerUrl: forestServerClient.forestServerUrl,
+    agentDispatcher,
   });
 }

--- a/packages/mcp-server/src/utils/agent-caller.ts
+++ b/packages/mcp-server/src/utils/agent-caller.ts
@@ -35,7 +35,6 @@ function createClient(options: BuildClientOptions) {
     throw new Error('Authentication token is missing');
   }
 
-  // Mounted in an agent: reach it in-process. Standalone: reach the public api_endpoint over HTTP.
   const httpRequester = agentDispatcher
     ? new InProcessHttpRequester(token, agentDispatcher)
     : undefined;

--- a/packages/mcp-server/src/utils/normalize-agent-url.ts
+++ b/packages/mcp-server/src/utils/normalize-agent-url.ts
@@ -1,0 +1,25 @@
+// agent-client concatenates the request path directly onto this URL, so a query string or fragment
+// would swallow it — reject them, and return the parsed, trailing-slash-free form.
+export default function normalizeAgentUrl(agentUrl?: string): string | undefined {
+  if (!agentUrl) return undefined;
+
+  let parsed: URL;
+
+  try {
+    parsed = new URL(agentUrl);
+  } catch {
+    throw new Error(`Invalid agentUrl "${agentUrl}": it must be an absolute http(s) URL.`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid agentUrl "${agentUrl}": only http and https are supported.`);
+  }
+
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      `Invalid agentUrl "${agentUrl}": it must not contain a query string or fragment.`,
+    );
+  }
+
+  return parsed.href.replace(/\/+$/, '');
+}

--- a/packages/mcp-server/test/forest-oauth-provider.test.ts
+++ b/packages/mcp-server/test/forest-oauth-provider.test.ts
@@ -868,6 +868,30 @@ describe('ForestOAuthProvider', () => {
       );
     });
 
+    it('falls back to the environment api_endpoint when no agentUrl is set', async () => {
+      mockServer.get('/liana/environment', {
+        data: { id: '1', attributes: { api_endpoint: 'https://public.example.com' } },
+      });
+      global.fetch = mockServer.fetch;
+
+      (jsonwebtoken.verify as jest.Mock).mockReturnValue({
+        id: 1,
+        email: 'user@example.com',
+        renderingId: 2,
+        serverToken: 'forest-server-token',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+      });
+
+      const provider = createProvider();
+      await provider.initialize();
+      const result = await provider.verifyAccessToken('valid-access-token');
+
+      expect((result.extra as { environmentApiEndpoint: string }).environmentApiEndpoint).toBe(
+        'https://public.example.com',
+      );
+    });
+
     it('strips a trailing slash from agentUrl', async () => {
       (jsonwebtoken.verify as jest.Mock).mockReturnValue({
         id: 1,

--- a/packages/mcp-server/test/forest-oauth-provider.test.ts
+++ b/packages/mcp-server/test/forest-oauth-provider.test.ts
@@ -74,8 +74,13 @@ describe('ForestOAuthProvider', () => {
       expect(customProvider).toBeDefined();
     });
 
-    it('throws for an invalid agentUrl', () => {
-      expect(() => createProvider('https://api.forestadmin.com', 'not-a-url')).toThrow(
+    it.each([
+      'not-a-url',
+      'ftp://internal:3310',
+      'http://internal:3310?x=1',
+      'http://internal:3310/#frag',
+    ])('throws for an invalid agentUrl %p', agentUrl => {
+      expect(() => createProvider('https://api.forestadmin.com', agentUrl)).toThrow(
         /Invalid agentUrl/,
       );
     });

--- a/packages/mcp-server/test/forest-oauth-provider.test.ts
+++ b/packages/mcp-server/test/forest-oauth-provider.test.ts
@@ -20,13 +20,14 @@ const TEST_ENV_SECRET = 'test-env-secret';
 const TEST_AUTH_SECRET = 'test-auth-secret';
 const TEST_FOREST_APP_URL = 'https://app.forestadmin.com';
 
-function createProvider(forestServerUrl = 'https://api.forestadmin.com') {
+function createProvider(forestServerUrl = 'https://api.forestadmin.com', agentUrl?: string) {
   return new ForestOAuthProvider({
     forestServerUrl,
     forestAppUrl: TEST_FOREST_APP_URL,
     envSecret: TEST_ENV_SECRET,
     authSecret: TEST_AUTH_SECRET,
     logger: console.info,
+    agentUrl,
   });
 }
 
@@ -71,6 +72,12 @@ describe('ForestOAuthProvider', () => {
       });
 
       expect(customProvider).toBeDefined();
+    });
+
+    it('throws for an invalid agentUrl', () => {
+      expect(() => createProvider('https://api.forestadmin.com', 'not-a-url')).toThrow(
+        /Invalid agentUrl/,
+      );
     });
   });
 
@@ -833,6 +840,45 @@ describe('ForestOAuthProvider', () => {
         environmentApiEndpoint: undefined,
         forestServerToken: 'forest-server-token',
       });
+    });
+
+    it('uses agentUrl as the tool callback endpoint when configured', async () => {
+      (jsonwebtoken.verify as jest.Mock).mockReturnValue({
+        id: 1,
+        email: 'user@example.com',
+        renderingId: 2,
+        serverToken: 'forest-server-token',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+      });
+
+      const provider = createProvider(
+        'https://api.forestadmin.com',
+        'http://forest-agent.internal:3310',
+      );
+      const result = await provider.verifyAccessToken('valid-access-token');
+
+      expect((result.extra as { environmentApiEndpoint: string }).environmentApiEndpoint).toBe(
+        'http://forest-agent.internal:3310',
+      );
+    });
+
+    it('strips a trailing slash from agentUrl', async () => {
+      (jsonwebtoken.verify as jest.Mock).mockReturnValue({
+        id: 1,
+        email: 'user@example.com',
+        renderingId: 2,
+        serverToken: 'forest-server-token',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+      });
+
+      const provider = createProvider('https://api.forestadmin.com', 'http://internal:3310/');
+      const result = await provider.verifyAccessToken('valid-access-token');
+
+      expect((result.extra as { environmentApiEndpoint: string }).environmentApiEndpoint).toBe(
+        'http://internal:3310',
+      );
     });
 
     it('should throw error for expired access token', async () => {

--- a/packages/mcp-server/test/forest-oauth-provider.test.ts
+++ b/packages/mcp-server/test/forest-oauth-provider.test.ts
@@ -73,17 +73,6 @@ describe('ForestOAuthProvider', () => {
 
       expect(customProvider).toBeDefined();
     });
-
-    it.each([
-      'not-a-url',
-      'ftp://internal:3310',
-      'http://internal:3310?x=1',
-      'http://internal:3310/#frag',
-    ])('throws for an invalid agentUrl %p', agentUrl => {
-      expect(() => createProvider('https://api.forestadmin.com', agentUrl)).toThrow(
-        /Invalid agentUrl/,
-      );
-    });
   });
 
   describe('initialize', () => {
@@ -889,24 +878,6 @@ describe('ForestOAuthProvider', () => {
 
       expect((result.extra as { environmentApiEndpoint: string }).environmentApiEndpoint).toBe(
         'https://public.example.com',
-      );
-    });
-
-    it('strips a trailing slash from agentUrl', async () => {
-      (jsonwebtoken.verify as jest.Mock).mockReturnValue({
-        id: 1,
-        email: 'user@example.com',
-        renderingId: 2,
-        serverToken: 'forest-server-token',
-        exp: Math.floor(Date.now() / 1000) + 3600,
-        iat: Math.floor(Date.now() / 1000),
-      });
-
-      const provider = createProvider('https://api.forestadmin.com', 'http://internal:3310/');
-      const result = await provider.verifyAccessToken('valid-access-token');
-
-      expect((result.extra as { environmentApiEndpoint: string }).environmentApiEndpoint).toBe(
-        'http://internal:3310',
       );
     });
 

--- a/packages/mcp-server/test/in-process-http-requester.test.ts
+++ b/packages/mcp-server/test/in-process-http-requester.test.ts
@@ -85,4 +85,12 @@ describe('InProcessHttpRequester', () => {
 
     expect(request).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2000 }));
   });
+
+  it('throws on stream() instead of hitting the sentinel host (CSV unsupported in-process)', async () => {
+    const { requester } = setup({ status: 200, body: {}, text: '{}' });
+
+    await expect(requester.stream()).rejects.toThrow(
+      'CSV streaming is not supported over the in-process MCP transport',
+    );
+  });
 });

--- a/packages/mcp-server/test/in-process-http-requester.test.ts
+++ b/packages/mcp-server/test/in-process-http-requester.test.ts
@@ -85,10 +85,4 @@ describe('InProcessHttpRequester', () => {
 
     expect(request).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2000 }));
   });
-
-  it('does not support CSV export in-process', async () => {
-    const { requester } = setup({ status: 200, body: null, text: '' });
-
-    await expect(requester.stream()).rejects.toThrow('CSV export is not supported');
-  });
 });

--- a/packages/mcp-server/test/in-process-http-requester.test.ts
+++ b/packages/mcp-server/test/in-process-http-requester.test.ts
@@ -1,0 +1,65 @@
+import type { InProcessAgentDispatcher } from '../src/in-process-agent-dispatcher';
+
+import { AgentHttpError } from '@forestadmin/agent-client';
+
+import InProcessHttpRequester from '../src/in-process-http-requester';
+
+describe('InProcessHttpRequester', () => {
+  function setup(response: { status: number; body: unknown; text: string }) {
+    const request = jest.fn().mockResolvedValue(response);
+    const dispatcher: InProcessAgentDispatcher = { request };
+    const requester = new InProcessHttpRequester('bearer-token', dispatcher);
+
+    return { request, requester };
+  }
+
+  it('dispatches the request in-process with auth, content-type and timezone', async () => {
+    const { request, requester } = setup({ status: 200, body: { records: [] }, text: '' });
+
+    await requester.query({
+      method: 'post',
+      path: '/forest/books',
+      body: { name: 'x' },
+      query: { search: 'foo' },
+      skipDeserialization: true,
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      method: 'post',
+      path: '/forest/books',
+      headers: {
+        Authorization: 'Bearer bearer-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      query: { timezone: 'Europe/Paris', search: 'foo' },
+      payload: { name: 'x' },
+    });
+  });
+
+  it('returns the raw body when skipDeserialization is set', async () => {
+    const { requester } = setup({ status: 200, body: { id: 1 }, text: '' });
+
+    const result = await requester.query({
+      method: 'get',
+      path: '/forest/books/1',
+      skipDeserialization: true,
+    });
+
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('throws an AgentHttpError carrying the status when the agent responds >= 400', async () => {
+    const { requester } = setup({ status: 403, body: { error: 'forbidden' }, text: 'forbidden' });
+
+    await expect(
+      requester.query({ method: 'post', path: '/forest/books/1/actions/x' }),
+    ).rejects.toMatchObject({ constructor: AgentHttpError, status: 403 });
+  });
+
+  it('does not support CSV export in-process', async () => {
+    const { requester } = setup({ status: 200, body: null, text: '' });
+
+    await expect(requester.stream()).rejects.toThrow('CSV export is not supported');
+  });
+});

--- a/packages/mcp-server/test/in-process-http-requester.test.ts
+++ b/packages/mcp-server/test/in-process-http-requester.test.ts
@@ -57,6 +57,35 @@ describe('InProcessHttpRequester', () => {
     ).rejects.toMatchObject({ constructor: AgentHttpError, status: 403 });
   });
 
+  it('preserves the approval-gate error shape (403 + CustomActionRequiresApprovalError)', async () => {
+    const approvalBody = { errors: [{ name: 'CustomActionRequiresApprovalError' }] };
+    const approvalText = JSON.stringify(approvalBody);
+    const { requester } = setup({ status: 403, body: approvalBody, text: approvalText });
+
+    const error = (await requester
+      .query({ method: 'post', path: '/forest/books/1/actions/x' })
+      .catch(e => e)) as AgentHttpError;
+
+    // domains/action.ts routes on both of these to raise ActionRequiresApprovalError.
+    expect(error).toBeInstanceOf(AgentHttpError);
+    expect(error.status).toBe(403);
+    expect(error.body).toEqual(approvalBody);
+    expect(error.responseText).toContain('CustomActionRequiresApprovalError');
+  });
+
+  it('forwards maxTimeAllowed to the dispatcher as timeoutMs', async () => {
+    const { request, requester } = setup({ status: 200, body: {}, text: '{}' });
+
+    await requester.query({
+      method: 'get',
+      path: '/forest/books',
+      maxTimeAllowed: 2000,
+      skipDeserialization: true,
+    });
+
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2000 }));
+  });
+
   it('does not support CSV export in-process', async () => {
     const { requester } = setup({ status: 200, body: null, text: '' });
 

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2704,6 +2704,39 @@ describe('basePath prefix', () => {
   });
 });
 
+describe('agentUrl option', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not affect the advertised OAuth metadata URLs', async () => {
+    const mockFetchServer = new MockServer();
+    mockFetchServer
+      .get('/liana/environment', {
+        data: { id: '1', attributes: { api_endpoint: 'https://api.example.com' } },
+      })
+      .get(/\/oauth\/register\//, { error: 'Client not found' }, 404);
+    global.fetch = mockFetchServer.fetch;
+
+    const server = new ForestMCPServer({
+      envSecret: 'ENV_SECRET',
+      authSecret: 'AUTH_SECRET',
+      forestServerClient: createMockForestServerClient(),
+      agentUrl: 'http://forest-agent.internal:3310',
+    });
+    const app = await server.buildExpressApp(new URL('http://localhost:3000'));
+
+    const response = await request(app).get('/.well-known/oauth-authorization-server');
+
+    expect(response.status).toBe(200);
+    expect(response.body.issuer).toBe('http://localhost:3000/');
+    expect(response.body.authorization_endpoint).toBe('http://localhost:3000/oauth/authorize');
+    expect(response.body.token_endpoint).toBe('http://localhost:3000/oauth/token');
+  });
+});
+
 describe('handleMcpRequest cleanup', () => {
   const originalFetch = global.fetch;
   let cleanupServer: ForestMCPServer;

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -2735,6 +2735,94 @@ describe('agentUrl option', () => {
     expect(response.body.authorization_endpoint).toBe('http://localhost:3000/oauth/authorize');
     expect(response.body.token_endpoint).toBe('http://localhost:3000/oauth/token');
   });
+
+  it('routes tool calls to agentUrl instead of the public api_endpoint', async () => {
+    clearSchemaCache();
+    process.env.FOREST_ENV_SECRET = 'test-env-secret';
+    process.env.FOREST_AUTH_SECRET = 'test-auth-secret';
+    process.env.MCP_SERVER_PORT = (await getAvailablePort()).toString();
+
+    let capturedForestUrl: string | undefined;
+    const mockServer = new MockServer();
+    mockServer
+      // Public endpoint Forest has on file — the tool must NOT use this one.
+      .get('/liana/environment', {
+        data: { id: '1', attributes: { api_endpoint: 'https://public.example.com' } },
+      })
+      .get('/liana/forest-schema', {
+        data: [
+          {
+            id: 'users',
+            type: 'collections',
+            attributes: {
+              name: 'users',
+              fields: [{ field: 'id', type: 'Number', isSortable: true }],
+            },
+          },
+        ],
+        meta: { liana: 'forest-express-sequelize', liana_version: '9.0.0', liana_features: null },
+      })
+      .post('/api/activity-logs-requests', {
+        data: { id: 'log-1', attributes: { index: 'logs' } },
+      })
+      .get(/\/forest\/\w+/, url => {
+        capturedForestUrl = url;
+
+        return { data: [] };
+      });
+    global.fetch = mockServer.fetch;
+    mockServer.setupSuperagentMock();
+
+    const server = new ForestMCPServer({
+      envSecret: 'test-env-secret',
+      authSecret: 'test-auth-secret',
+      forestServerUrl: 'https://test.forestadmin.com',
+      forestServerClient: createMockForestServerClient({
+        fetchSchema: jest
+          .fn()
+          .mockResolvedValue([
+            { name: 'users', fields: [{ field: 'id', type: 'Number', isSortable: true }] },
+          ]),
+      }),
+      agentUrl: 'http://internal-agent:9999',
+    });
+    server.run();
+    await new Promise(resolve => {
+      setTimeout(resolve, 500);
+    });
+
+    try {
+      const token = jsonwebtoken.sign(
+        {
+          id: 123,
+          email: 'user@example.com',
+          renderingId: 456,
+          serverToken: 'forest-server-token',
+        },
+        'test-auth-secret',
+        { expiresIn: '1h' },
+      );
+
+      const response = await request(server.httpServer as http.Server)
+        .post('/mcp')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          id: 1,
+          params: { name: 'list', arguments: { collectionName: 'users' } },
+        });
+
+      expect(response.status).toBe(200);
+      expect(capturedForestUrl).toContain('http://internal-agent:9999/forest/');
+      expect(capturedForestUrl).not.toContain('public.example.com');
+    } finally {
+      mockServer.restoreSuperagent();
+      await shutDownHttpServer(server.httpServer as http.Server);
+    }
+  });
 });
 
 describe('handleMcpRequest cleanup', () => {

--- a/packages/mcp-server/test/tools/associate.test.ts
+++ b/packages/mcp-server/test/tools/associate.test.ts
@@ -45,6 +45,7 @@ describe('declareAssociateTool', () => {
       declareAssociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -58,6 +59,7 @@ describe('declareAssociateTool', () => {
       declareAssociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Associate records in a relation');
@@ -70,6 +72,7 @@ describe('declareAssociateTool', () => {
       declareAssociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -79,6 +82,7 @@ describe('declareAssociateTool', () => {
       declareAssociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -117,6 +121,7 @@ describe('declareAssociateTool', () => {
       declareAssociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/associate.test.ts
+++ b/packages/mcp-server/test/tools/associate.test.ts
@@ -42,7 +42,10 @@ describe('declareAssociateTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "associate"', () => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'associate',
@@ -52,7 +55,10 @@ describe('declareAssociateTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Associate records in a relation');
       expect(registeredToolConfig.description).toBe(
@@ -61,13 +67,19 @@ describe('declareAssociateTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
@@ -76,7 +88,11 @@ describe('declareAssociateTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'posts']);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'posts'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -98,7 +114,10 @@ describe('declareAssociateTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareAssociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareAssociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call associate on the relation', async () => {

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -42,7 +42,10 @@ describe('declareCreateTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "create"', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'create',
@@ -52,7 +55,10 @@ describe('declareCreateTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Create a record');
       expect(registeredToolConfig.description).toBe(
@@ -61,20 +67,29 @@ describe('declareCreateTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('attributes');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -85,7 +100,11 @@ describe('declareCreateTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -109,7 +128,10 @@ describe('declareCreateTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareCreateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareCreateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -125,7 +147,7 @@ describe('declareCreateTool', () => {
         mockExtra,
       );
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/create.test.ts
+++ b/packages/mcp-server/test/tools/create.test.ts
@@ -45,6 +45,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -58,6 +59,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Create a record');
@@ -70,6 +72,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -79,6 +82,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -89,6 +93,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -131,6 +136,7 @@ describe('declareCreateTool', () => {
       declareCreateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -45,6 +45,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -58,6 +59,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Delete records');
@@ -70,6 +72,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -79,6 +82,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -89,6 +93,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -119,6 +124,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -146,6 +152,7 @@ describe('declareDeleteTool', () => {
       declareDeleteTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/delete.test.ts
+++ b/packages/mcp-server/test/tools/delete.test.ts
@@ -42,7 +42,10 @@ describe('declareDeleteTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "delete"', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'delete',
@@ -52,7 +55,10 @@ describe('declareDeleteTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Delete records');
       expect(registeredToolConfig.description).toBe(
@@ -61,20 +67,29 @@ describe('declareDeleteTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('recordIds');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -85,7 +100,11 @@ describe('declareDeleteTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -97,7 +116,10 @@ describe('declareDeleteTool', () => {
     });
 
     it('should accept array of strings or numbers for recordIds', () => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -121,7 +143,10 @@ describe('declareDeleteTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareDeleteTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDeleteTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -134,7 +159,7 @@ describe('declareDeleteTool', () => {
 
       await registeredToolHandler({ collectionName: 'users', recordIds: [1, 2] }, mockExtra);
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -57,7 +57,10 @@ describe('declareDescribeCollectionTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "describeCollection"', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'describeCollection',
@@ -67,7 +70,10 @@ describe('declareDescribeCollectionTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Describe a collection');
       expect(registeredToolConfig.description).toContain(
@@ -78,19 +84,28 @@ describe('declareDescribeCollectionTool', () => {
     });
 
     it('should be annotated as read-only', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -103,11 +118,11 @@ describe('declareDescribeCollectionTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger, [
-        'users',
-        'products',
-        'orders',
-      ]);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products', 'orders'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -135,7 +150,10 @@ describe('declareDescribeCollectionTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareDescribeCollectionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDescribeCollectionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -151,7 +169,7 @@ describe('declareDescribeCollectionTool', () => {
 
       await registeredToolHandler({ collectionName: 'users' }, mockExtra);
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should fetch forest schema', async () => {

--- a/packages/mcp-server/test/tools/describe-collection.test.ts
+++ b/packages/mcp-server/test/tools/describe-collection.test.ts
@@ -60,6 +60,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -73,6 +74,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Describe a collection');
@@ -87,6 +89,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
@@ -96,6 +99,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -105,6 +109,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -153,6 +158,7 @@ describe('declareDescribeCollectionTool', () => {
       declareDescribeCollectionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/dissociate.test.ts
+++ b/packages/mcp-server/test/tools/dissociate.test.ts
@@ -42,7 +42,10 @@ describe('declareDissociateTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "dissociate"', () => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'dissociate',
@@ -52,7 +55,10 @@ describe('declareDissociateTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Dissociate records from a relation');
       expect(registeredToolConfig.description).toBe(
@@ -61,13 +67,19 @@ describe('declareDissociateTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
@@ -76,7 +88,11 @@ describe('declareDissociateTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'posts']);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'posts'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -98,7 +114,10 @@ describe('declareDissociateTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareDissociateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareDissociateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call dissociate on the relation', async () => {

--- a/packages/mcp-server/test/tools/dissociate.test.ts
+++ b/packages/mcp-server/test/tools/dissociate.test.ts
@@ -45,6 +45,7 @@ describe('declareDissociateTool', () => {
       declareDissociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -58,6 +59,7 @@ describe('declareDissociateTool', () => {
       declareDissociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Dissociate records from a relation');
@@ -70,6 +72,7 @@ describe('declareDissociateTool', () => {
       declareDissociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -79,6 +82,7 @@ describe('declareDissociateTool', () => {
       declareDissociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -117,6 +121,7 @@ describe('declareDissociateTool', () => {
       declareDissociateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -47,7 +47,10 @@ describe('declareExecuteActionTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "executeAction"', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'executeAction',
@@ -57,7 +60,10 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Execute an action');
       expect(registeredToolConfig.description).toContain(
@@ -67,13 +73,19 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('actionName');
@@ -82,7 +94,10 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -93,10 +108,11 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger, [
-        'users',
-        'products',
-      ]);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -108,7 +124,10 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should accept array of strings or numbers for recordIds', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -120,7 +139,10 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should accept null for recordIds (global actions)', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -130,7 +152,10 @@ describe('declareExecuteActionTool', () => {
     });
 
     it('should accept optional values parameter', () => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -153,7 +178,10 @@ describe('declareExecuteActionTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareExecuteActionTool(mcpServer, mockForestServerClient, mockLogger);
+      declareExecuteActionTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClientWithActions with the extra parameter and forestServerUrl', async () => {
@@ -174,7 +202,11 @@ describe('declareExecuteActionTool', () => {
         mockExtra,
       );
 
-      expect(mockBuildClientWithActions).toHaveBeenCalledWith(mockExtra, mockForestServerClient);
+      expect(mockBuildClientWithActions).toHaveBeenCalledWith(
+        mockExtra,
+        mockForestServerClient,
+        undefined,
+      );
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -50,6 +50,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -63,6 +64,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Execute an action');
@@ -76,6 +78,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -85,6 +88,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -97,6 +101,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -127,6 +132,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -142,6 +148,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -155,6 +162,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -181,6 +189,7 @@ describe('declareExecuteActionTool', () => {
       declareExecuteActionTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -41,7 +41,10 @@ describe('declareGetActionFormTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "getActionForm"', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'getActionForm',
@@ -51,7 +54,10 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Retrieve action form');
       expect(registeredToolConfig.description).toContain(
@@ -61,13 +67,19 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should be annotated as read-only', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('actionName');
@@ -76,7 +88,10 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -87,10 +102,11 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger, [
-        'users',
-        'products',
-      ]);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -102,7 +118,10 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should accept array of strings or numbers for recordIds', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -114,7 +133,10 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should accept null for recordIds (global actions)', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -124,7 +146,10 @@ describe('declareGetActionFormTool', () => {
     });
 
     it('should accept optional values parameter', () => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -147,7 +172,10 @@ describe('declareGetActionFormTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareGetActionFormTool(mcpServer, mockForestServerClient, mockLogger);
+      declareGetActionFormTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClientWithActions with the extra parameter and forestServerUrl', async () => {
@@ -168,7 +196,11 @@ describe('declareGetActionFormTool', () => {
         mockExtra,
       );
 
-      expect(mockBuildClientWithActions).toHaveBeenCalledWith(mockExtra, mockForestServerClient);
+      expect(mockBuildClientWithActions).toHaveBeenCalledWith(
+        mockExtra,
+        mockForestServerClient,
+        undefined,
+      );
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -44,6 +44,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -57,6 +58,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Retrieve action form');
@@ -70,6 +72,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
@@ -79,6 +82,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -91,6 +95,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -121,6 +126,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -136,6 +142,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -149,6 +156,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -175,6 +183,7 @@ describe('declareGetActionFormTool', () => {
       declareGetActionFormTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -81,7 +81,10 @@ describe('declareListRelatedTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "listRelated"', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'listRelated',
@@ -91,7 +94,10 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('List records from a relation');
       expect(registeredToolConfig.description).toBe(
@@ -100,13 +106,19 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should be annotated as read-only', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('relationName');
@@ -117,7 +129,10 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -130,7 +145,11 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should use string type for collectionName when empty array provided', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger, []);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -143,11 +162,11 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger, [
-        'users',
-        'products',
-        'orders',
-      ]);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products', 'orders'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -163,7 +182,10 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should accept string parentRecordId', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -173,7 +195,10 @@ describe('declareListRelatedTool', () => {
     });
 
     it('should accept number parentRecordId', () => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -195,7 +220,10 @@ describe('declareListRelatedTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareListRelatedTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListRelatedTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -212,7 +240,7 @@ describe('declareListRelatedTool', () => {
         mockExtra,
       );
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/list-related.test.ts
+++ b/packages/mcp-server/test/tools/list-related.test.ts
@@ -84,6 +84,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -97,6 +98,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('List records from a relation');
@@ -109,6 +111,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
@@ -118,6 +121,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -132,6 +136,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -185,6 +190,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -198,6 +204,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -223,6 +230,7 @@ describe('declareListRelatedTool', () => {
       declareListRelatedTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -79,7 +79,10 @@ describe('declareListTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "list"', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'list',
@@ -89,7 +92,10 @@ describe('declareListTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('List records from a collection');
       expect(registeredToolConfig.description).toBe(
@@ -98,13 +104,19 @@ describe('declareListTool', () => {
     });
 
     it('should be annotated as read-only', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
     });
 
     it('should define correct input schema', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('search');
@@ -116,7 +128,10 @@ describe('declareListTool', () => {
     });
 
     it('should have fields schema with description mentioning @@@ separator for relations', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const schema = registeredToolConfig.inputSchema as any;
@@ -129,7 +144,10 @@ describe('declareListTool', () => {
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -142,7 +160,10 @@ describe('declareListTool', () => {
     });
 
     it('should use string type for collectionName when empty array provided', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -155,11 +176,11 @@ describe('declareListTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger, [
-        'users',
-        'products',
-        'orders',
-      ]);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products', 'orders'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -175,7 +196,10 @@ describe('declareListTool', () => {
     });
 
     it('should make ascending optional in sort schema with default value true', () => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -199,7 +223,10 @@ describe('declareListTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareListTool(mcpServer, mockForestServerClient, mockLogger);
+      declareListTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -212,7 +239,7 @@ describe('declareListTool', () => {
 
       await registeredToolHandler({ collectionName: 'users' }, mockExtra);
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/list.test.ts
+++ b/packages/mcp-server/test/tools/list.test.ts
@@ -82,6 +82,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -95,6 +96,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('List records from a collection');
@@ -107,6 +109,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations).toEqual({ readOnlyHint: true });
@@ -116,6 +119,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -131,6 +135,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -147,6 +152,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -163,6 +169,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -199,6 +206,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -226,6 +234,7 @@ describe('declareListTool', () => {
       declareListTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -42,7 +42,10 @@ describe('declareUpdateTool', () => {
 
   describe('tool registration', () => {
     it('should register a tool named "update"', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
         'update',
@@ -52,7 +55,10 @@ describe('declareUpdateTool', () => {
     });
 
     it('should register tool with correct title and description', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.title).toBe('Update a record');
       expect(registeredToolConfig.description).toBe(
@@ -61,13 +67,19 @@ describe('declareUpdateTool', () => {
     });
 
     it('should not be annotated as read-only', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
     });
 
     it('should define correct input schema', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
       expect(registeredToolConfig.inputSchema).toHaveProperty('recordId');
@@ -75,7 +87,10 @@ describe('declareUpdateTool', () => {
     });
 
     it('should use string type for collectionName when no collection names provided', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -86,7 +101,11 @@ describe('declareUpdateTool', () => {
     });
 
     it('should use enum type for collectionName when collection names provided', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger, ['users', 'products']);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: ['users', 'products'],
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -98,7 +117,10 @@ describe('declareUpdateTool', () => {
     });
 
     it('should accept both string and number for recordId', () => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
 
       const schema = registeredToolConfig.inputSchema as Record<
         string,
@@ -121,7 +143,10 @@ describe('declareUpdateTool', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     beforeEach(() => {
-      declareUpdateTool(mcpServer, mockForestServerClient, mockLogger);
+      declareUpdateTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+      });
     });
 
     it('should call buildClient with the extra parameter', async () => {
@@ -137,7 +162,7 @@ describe('declareUpdateTool', () => {
         mockExtra,
       );
 
-      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra);
+      expect(mockBuildClient).toHaveBeenCalledWith(mockExtra, undefined);
     });
 
     it('should call rpcClient.collection with the collection name', async () => {

--- a/packages/mcp-server/test/tools/update.test.ts
+++ b/packages/mcp-server/test/tools/update.test.ts
@@ -45,6 +45,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(mcpServer.registerTool).toHaveBeenCalledWith(
@@ -58,6 +59,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.title).toBe('Update a record');
@@ -70,6 +72,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
@@ -79,6 +82,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       expect(registeredToolConfig.inputSchema).toHaveProperty('collectionName');
@@ -90,6 +94,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -120,6 +125,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
 
       const schema = registeredToolConfig.inputSchema as Record<
@@ -146,6 +152,7 @@ describe('declareUpdateTool', () => {
       declareUpdateTool(mcpServer, {
         forestServerClient: mockForestServerClient,
         logger: mockLogger,
+        collectionNames: [],
       });
     });
 

--- a/packages/mcp-server/test/utils/agent-caller.test.ts
+++ b/packages/mcp-server/test/utils/agent-caller.test.ts
@@ -4,6 +4,7 @@ import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sd
 
 import { createRemoteAgentClient } from '@forestadmin/agent-client';
 
+import InProcessHttpRequester from '../../src/in-process-http-requester';
 import buildClient, { buildClientWithActions } from '../../src/utils/agent-caller';
 import { fetchForestSchema, getActionEndpoints } from '../../src/utils/schema-fetcher';
 import createMockForestServerClient from '../helpers/forest-server-client';
@@ -128,6 +129,45 @@ describe('buildClient', () => {
     } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
     expect(() => buildClient(request)).toThrow('Environment API endpoint is missing or invalid');
+  });
+
+  describe('when an agentDispatcher is provided', () => {
+    const agentDispatcher = { request: jest.fn() };
+
+    beforeEach(() => mockCreateRemoteAgentClient.mockClear());
+
+    it('builds an in-process httpRequester instead of reaching a url', () => {
+      const request = {
+        authInfo: { token: 'test-token', extra: { environmentApiEndpoint: 'http://public:3310' } },
+      } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+      buildClient(request, agentDispatcher);
+
+      expect(mockCreateRemoteAgentClient).toHaveBeenCalledWith(
+        expect.objectContaining({ httpRequester: expect.any(InProcessHttpRequester) }),
+      );
+    });
+
+    it('does not require environmentApiEndpoint', () => {
+      const request = {
+        authInfo: { token: 'test-token', extra: {} },
+      } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+      expect(() => buildClient(request, agentDispatcher)).not.toThrow();
+    });
+  });
+
+  it('does not build an httpRequester when no agentDispatcher is provided', () => {
+    mockCreateRemoteAgentClient.mockClear();
+    const request = {
+      authInfo: { token: 'test-token', extra: { environmentApiEndpoint: 'http://localhost:3310' } },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    buildClient(request);
+
+    expect(mockCreateRemoteAgentClient).toHaveBeenCalledWith(
+      expect.objectContaining({ httpRequester: undefined }),
+    );
   });
 });
 

--- a/packages/mcp-server/test/utils/agent-caller.test.ts
+++ b/packages/mcp-server/test/utils/agent-caller.test.ts
@@ -148,12 +148,16 @@ describe('buildClient', () => {
       );
     });
 
-    it('does not require environmentApiEndpoint', () => {
+    it('wires the in-process requester with an empty url when environmentApiEndpoint is absent', () => {
       const request = {
         authInfo: { token: 'test-token', extra: {} },
       } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
 
-      expect(() => buildClient(request, agentDispatcher)).not.toThrow();
+      buildClient(request, agentDispatcher);
+
+      expect(mockCreateRemoteAgentClient).toHaveBeenCalledWith(
+        expect.objectContaining({ httpRequester: expect.any(InProcessHttpRequester), url: '' }),
+      );
     });
   });
 

--- a/packages/mcp-server/test/utils/agent-caller.test.ts
+++ b/packages/mcp-server/test/utils/agent-caller.test.ts
@@ -370,4 +370,20 @@ describe('buildClientWithActions', () => {
       expect.objectContaining({ forestServer: undefined }),
     );
   });
+
+  it('builds an in-process httpRequester when an agentDispatcher is provided', async () => {
+    mockFetchForestSchema.mockResolvedValue({ collections: [] } as never);
+    mockGetActionEndpoints.mockReturnValue({});
+    const agentDispatcher = { request: jest.fn() };
+
+    const request = {
+      authInfo: { token: 'test-token', extra: { environmentApiEndpoint: 'http://public:3310' } },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    await buildClientWithActions(request, mockForestServerClient, agentDispatcher);
+
+    expect(mockCreateRemoteAgentClient).toHaveBeenLastCalledWith(
+      expect.objectContaining({ httpRequester: expect.any(InProcessHttpRequester) }),
+    );
+  });
 });

--- a/packages/mcp-server/test/utils/normalize-agent-url.test.ts
+++ b/packages/mcp-server/test/utils/normalize-agent-url.test.ts
@@ -1,0 +1,27 @@
+import normalizeAgentUrl from '../../src/utils/normalize-agent-url';
+
+describe('normalizeAgentUrl', () => {
+  it.each([undefined, ''])('returns undefined for %p', input => {
+    expect(normalizeAgentUrl(input)).toBeUndefined();
+  });
+
+  it.each([
+    ['http://forest-agent.internal:3310', 'http://forest-agent.internal:3310'],
+    ['https://forest-agent.internal', 'https://forest-agent.internal'],
+  ])('accepts %p and returns it unchanged', (input, expected) => {
+    expect(normalizeAgentUrl(input)).toBe(expected);
+  });
+
+  it('preserves a base path and strips a trailing slash', () => {
+    expect(normalizeAgentUrl('http://internal:3310/backend/')).toBe('http://internal:3310/backend');
+  });
+
+  it.each([
+    'not-a-url',
+    'ftp://internal:3310',
+    'http://internal:3310?x=1',
+    'http://internal:3310/#frag',
+  ])('throws for %p', input => {
+    expect(() => normalizeAgentUrl(input)).toThrow(/Invalid agentUrl/);
+  });
+});


### PR DESCRIPTION
> ⚠️ Stacked on #1740 — base is `feat/mcp-server-internal-agent-url`, not `main`. Review/merge #1740 first, then this diff collapses to the in-process work only.

## What

When the MCP server is **mounted in an agent** (`agent.mountAiMcpServer()`), tool calls now reach the agent's data layer **in-process** — dispatched into the agent's own Koa stack via `light-my-request` (in-memory, no socket) — instead of calling back over the public `api_endpoint`.

This removes the need for `agentUrl` in mounted mode (the feedback that motivated #1740). `agentUrl` stays for the **standalone** server (`FOREST_AGENT_URL`), where there is no agent process to dispatch into.

## Why

Self-hosted setups (Swaive) observed every mounted tool call leaving over the public internet and coming back, even though the MCP server and the agent run in the same process. In-process dispatch keeps that hop internal by construction — nothing to configure.

## How

- **agent-client**: extracted shared response parsing (`buildAgentHttpError`, `deserializeAgentBody`) and let `createRemoteAgentClient` accept an injected `httpRequester`.
- **agent**: `InProcessDispatcher` injects a request into the agent's real router (auth / permissions / serializer all run); `getInProcessDispatcher()` re-registers the handler on every remount so a captured reference never goes stale.
- **mcp-server**: tools now receive a single `ToolContext`; when a dispatcher is present, `buildClient` builds an `InProcessHttpRequester` that reuses the agent-client parse helpers — so the deserialized result and `AgentHttpError` shape are **byte-identical to the HTTP path**, keeping approval-gate detection and error handling unchanged. CSV export (`stream`) is not supported in-process and throws explicitly.

## Tests

- `mcp-server`: `InProcessHttpRequester` unit tests + `agent-caller` wiring (requester built only when a dispatcher is present) — 624 passing.
- `agent`: constructor-spy that `mountAiMcpServer` passes an `agentDispatcher`; and a full-stack guard that a real OAuth-authed `tools/call` reaches the agent through the `InProcessDispatcher` across **all 8 host frameworks** — 982 passing.
- The existing `should retrieve users via MCP tools/call` integration test now runs through the in-process path and still returns the seeded records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dispatch MCP server tool calls to the agent in-process instead of over HTTP
> - Introduces `InProcessDispatcher` in the agent and `InProcessHttpRequester` in the MCP server so that tool calls bypass the network and go directly into the agent's Koa stack via `light-my-request`.
> - Adds `agentDispatcher` to `ForestMCPServerOptions` and a shared `ToolContext`; all `declare*Tool` functions are refactored to accept this context so they can route calls in-process when a dispatcher is available.
> - Adds `agentUrl` support (`FOREST_AGENT_URL` env var) for standalone mode, normalised via a new `normalizeAgentUrl` utility, and plumbed through `ForestOAuthProvider` so `extra.environmentApiEndpoint` reflects the agent URL.
> - Extracts `buildAgentHttpError` and `deserializeAgentBody` helpers from `agent-client` and extends `createRemoteAgentClient` to accept an injected `HttpRequester`, enabling the in-process path to share the same error shapes and deserialization logic.
> - Risk: in-process tool calls bypass any middleware mounted in front of the agent; only the agent's own auth and permission checks apply.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1743 opened
>
> - Updated documentation for `agent.Agent.mountAiMcpServer` method to clarify middleware and authentication behavior [929a1c8]
> - Centralized type definitions for in-process agent dispatching by moving `InProcessDispatchRequest` and `InProcessDispatchResponse` types from `@forestadmin/agent` to `@forestadmin/mcp-server` [9db0616]
> - Removed descriptive comments from `ToolContext` interface, `createClient` function in `agent-caller` module, and updated comment on `DEFAULT_TIMEOUT_MS` constant to reference `HttpRequester.query` [9db0616]
> - Refactored `buildAgentHttpError` and `deserializeAgentBody` utility functions into protected methods within `HttpRequester` class [9a1a1c5]
> - Added `InProcessHttpRequester.stream()` method that throws an error indicating CSV streaming is not supported over the in-process MCP transport [ac2d6bb]
> - Added test coverage for `InProcessHttpRequester.stream()` error behavior and updated agent caller test to expect `InProcessHttpRequester` wiring when `environmentApiEndpoint` is absent [ac2d6bb]
> - Modified `InProcessDispatcher.parseBody` to reject with an `Error` for successful HTTP responses (status < 400) containing non-JSON payloads and to log a warning while returning `undefined` for error responses (status >= 400) with non-JSON payloads [c801d5b]
> - Fixed unhandled rejection issue in `InProcessDispatcher.injectWithTimeout` by capturing the injection promise separately and attaching a catch handler to log warnings when the handler rejects after the timeout has fired [c801d5b]
> - Added test coverage in `mcp-in-process-dispatcher.rejection.test.ts` to verify that late injection rejections after timeout are logged as warnings without causing unhandled rejections [c801d5b]
> - Updated test expectations in `mcp-in-process-dispatcher.test.ts` to validate that non-JSON 2xx responses throw errors and non-JSON 4xx/5xx responses log warnings while returning `undefined` body [c801d5b]
> - Updated documentation for `FrameworkMounter.getInProcessDispatcher` method and `InProcessDispatcher` class to clarify that the handler is rebuilt on every mount operation and captured references never become stale, removing previous references to a fixed '/forest' prefix [6636d46]
> - Updated `DEFAULT_TIMEOUT_MS` constant comment in `mcp-in-process-dispatcher` to reference the HTTP path's 10 second timeout bound instead of `superagent` implementation specifics [6636d46]
> - Revised documentation for `InProcessHttpRequester` class and its methods to emphasize reuse of `HttpRequester` parse helpers, identical result and error shapes to the HTTP path, sentinel host behavior, and error throwing behavior for unsupported `stream` method [6636d46]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8abefd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->