### PR TITLE
fix(agent): exempt direct loopback callers from the IP whitelist

### DIFF
--- a/packages/agent/src/routes/security/ip-whitelist.ts
+++ b/packages/agent/src/routes/security/ip-whitelist.ts
@@ -7,6 +7,8 @@ import IpUtil from 'forest-ip-utils';
 import { HttpCode, RouteType } from '../../types';
 import BaseRoute from '../base-route';
 
+const LOOPBACK_IPS = ['127.0.0.1', '::1', '::ffff:127.0.0.1'];
+
 export default class IpWhitelist extends BaseRoute {
   type = RouteType.Authentication;
 
@@ -23,6 +25,12 @@ export default class IpWhitelist extends BaseRoute {
 
   async checkIp(context: Context, next: Next): Promise<boolean> {
     if (this.configuration.isFeatureEnabled) {
+      if (this.isTrustedInternalCaller(context)) {
+        this.options.logger('Debug', 'IP whitelist: exempting trusted internal caller');
+
+        return next();
+      }
+
       const { ipRules } = this.configuration;
       const currentIp = context.request.headers['x-forwarded-for'] ?? context.request.ip;
       const allowed = ipRules.some(ipRule => IpUtil.isIpMatchesRule(currentIp, ipRule));
@@ -33,5 +41,15 @@ export default class IpWhitelist extends BaseRoute {
     }
 
     return next();
+  }
+
+  // A caller reaching us directly over a loopback socket with no proxy hop (no x-forwarded-for) is
+  // on this host and already JWT-authenticated (koa-jwt runs before this) — e.g. the embedded
+  // executor's loopback call. Keys off the socket peer (req.socket.remoteAddress), never
+  // request.ip / x-forwarded-for, which follow the spoofable header once the host app sets app.proxy.
+  private isTrustedInternalCaller(context: Context): boolean {
+    const socketIp = context.req?.socket?.remoteAddress ?? '';
+
+    return LOOPBACK_IPS.includes(socketIp) && !context.request.headers['x-forwarded-for'];
   }
 }

--- a/packages/agent/test/routes/security/ip-whitelist.test.ts
+++ b/packages/agent/test/routes/security/ip-whitelist.test.ts
@@ -154,5 +154,91 @@ describe('IpWhitelist', () => {
         });
       });
     });
+
+    describe('when the caller is a trusted internal caller (feature enabled, restrictive rules)', () => {
+      const restrictiveRules = {
+        isFeatureEnabled: true,
+        ipRules: [{ type: 0, ip: '10.20.15.10' }],
+      };
+
+      // socketIp = the true socket peer (req.socket.remoteAddress); xff is the proxy hop marker.
+      const forgeContext = (opts: { socketIp: string; xff?: string | null }): Context =>
+        ({
+          req: { socket: { remoteAddress: opts.socketIp } },
+          request: {
+            ip: opts.socketIp,
+            headers: { 'x-forwarded-for': opts.xff ?? null },
+          },
+          throw: jest.fn(),
+        } as unknown as Context);
+
+      test.each(['127.0.0.1', '::1', '::ffff:127.0.0.1'])(
+        'exempts a direct loopback caller with no proxy hop from socket %s',
+        async socketIp => {
+          const service = await setupIpWhitelistService(restrictiveRules);
+          const context = forgeContext({ socketIp });
+          const next = jest.fn() as Next;
+
+          await service.checkIp(context, next);
+
+          expect(next).toHaveBeenCalled();
+          expect(context.throw).not.toHaveBeenCalled();
+        },
+      );
+
+      test('does NOT exempt a non-loopback socket', async () => {
+        const service = await setupIpWhitelistService(restrictiveRules);
+        const context = forgeContext({ socketIp: '203.0.113.5' });
+        const next = jest.fn() as Next;
+
+        await service.checkIp(context, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(context.throw).toHaveBeenCalledWith(HttpCode.Forbidden, expect.any(String));
+      });
+
+      // A proxied user's socket peer is the same-host proxy (loopback), but the proxy sets
+      // x-forwarded-for → the exemption must NOT fire, so the real IP is checked normally.
+      test('does NOT exempt a loopback socket that carries x-forwarded-for (proxy hop)', async () => {
+        const service = await setupIpWhitelistService(restrictiveRules);
+        const context = forgeContext({ socketIp: '127.0.0.1', xff: '203.0.113.5' });
+        const next = jest.fn() as Next;
+
+        await service.checkIp(context, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(context.throw).toHaveBeenCalledWith(
+          HttpCode.Forbidden,
+          `IP address rejected (203.0.113.5)`,
+        );
+      });
+
+      // Anti-spoof: an external socket carrying x-forwarded-for: 127.0.0.1 must NOT be exempted
+      // (exemption reads the socket, not the header) and the header IP is what gets rejected.
+      test('ignores a spoofed x-forwarded-for loopback (socket is external)', async () => {
+        const service = await setupIpWhitelistService(restrictiveRules);
+        const context = forgeContext({ socketIp: '203.0.113.5', xff: '127.0.0.1' });
+        const next = jest.fn() as Next;
+
+        await service.checkIp(context, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(context.throw).toHaveBeenCalledWith(
+          HttpCode.Forbidden,
+          `IP address rejected (127.0.0.1)`,
+        );
+      });
+
+      test('a proxied user from a whitelisted IP still passes the normal check', async () => {
+        const service = await setupIpWhitelistService(restrictiveRules);
+        const context = forgeContext({ socketIp: '127.0.0.1', xff: '10.20.15.10' });
+        const next = jest.fn() as Next;
+
+        await service.checkIp(context, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(context.throw).not.toHaveBeenCalled();
+      });
+    });
   });
 });


### PR DESCRIPTION
## What

The agent's IP whitelist evaluated `x-forwarded-for ?? request.ip` on **all** `/forest` routes. The embedded workflow-executor reaches `/forest` over a loopback socket with no real client IP, so once a customer enabled the whitelist the executor was rejected as `127.0.0.1` → **403 at its probe → the executor never started**.

## Fix

`IpWhitelist.checkIp` now exempts a **trusted internal caller** before the rule check: one reaching us **directly over a loopback socket with no proxy hop** (no `x-forwarded-for`).

- Keys on `req.socket.remoteAddress` (the true socket peer) — never `request.ip` / `x-forwarded-for`, which are spoofable once the host app sets `app.proxy`.
- **Feature-agnostic**: no coupling to any specific token/scope. A caller behind a same-host reverse proxy carries `x-forwarded-for`, so it is *not* exempted and its real IP is still checked normally.
- Safe: `checkIp` runs *after* koa-jwt, so an exempted request is already authenticated; a remote attacker can neither forge the socket peer nor pass koa-jwt without the `authSecret`.

## Scope (deliberately narrow)

Fixes **only the executor case**. Whether the MCP channel should be subject to the IP whitelist is a deferred product decision ([Slack thread](https://forestadmin.slack.com/archives/C09196KAJ4Q/p1783510364964809), **PRD-752**). Consequences, documented (**PRD-753**), not changed here:

- **Mounted MCP in-process + whitelist ON** -> tool calls remain `403` (known limitation, not silently exempted).
- **Standalone mcp-server + whitelist ON** -> the mcp-server's IP must be whitelisted on the agent (pre-existing).

## Tests

`packages/agent/test/routes/security/ip-whitelist.test.ts` — exemption for the 3 loopback socket forms with no proxy hop; **not** exempt for a non-loopback socket, nor for a loopback socket carrying `x-forwarded-for` (proxied user); anti-spoof (external socket + `x-forwarded-for: 127.0.0.1` -> 403 on the header IP); non-regression (proxied user from a whitelisted IP passes the normal check).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exempt direct loopback callers from IP whitelist checks in agent
> Requests originating from a loopback socket (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`) with no `x-forwarded-for` header now bypass IP whitelist validation in [`IpWhitelist.checkIp`](https://github.com/ForestAdmin/agent-nodejs/pull/1744/files#diff-07e381a9078fddc268a2abd2a817fbbc195162ee67046c7b1e82ef1daf0b13a5). A `Debug` log line is emitted for each exempted request. Loopback sockets that carry an `x-forwarded-for` header are still subject to normal IP rule checks using the header value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5306eaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->