### PR TITLE
docs(workflow-executor): add nodemon caveat for in-memory executor

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -156,7 +156,7 @@ If you embed the executor with `agent.addWorkflowExecutor({ inMemory: true })` a
 
 In development the agent rewrites `.forestadmin-schema.json` on every boot. Without this ignore, nodemon sees the change and restarts the agent, and each restart clears the in-memory store — in-flight runs vanish and users are asked to reconnect their OAuth-protected MCP connectors.
 
-Projects scaffolded with forest-cli ≤ 5.17.0 ship a broken entry, `./forestadmin-schema.json`; the leading `./` never matches the real `.forestadmin-schema.json`, so the restarts happen even though an ignore was intended. Replace it with `.forestadmin-schema.json`.
+Projects scaffolded with forest-cli ship a broken entry, `./forestadmin-schema.json`; the leading `./` never matches the real `.forestadmin-schema.json`, so the restarts happen even though an ignore was intended. Replace it with `.forestadmin-schema.json`.
 
 ---
 

--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -142,6 +142,24 @@ When your workflows use OAuth-protected MCP connectors, the executor stores each
 
 ---
 
+## Embedded in-memory executor under nodemon
+
+If you embed the executor with `agent.addWorkflowExecutor({ inMemory: true })` and run your agent under nodemon in development, add `.forestadmin-schema.json` to `nodemonConfig.ignore` in your `package.json`:
+
+```json
+{
+  "nodemonConfig": {
+    "ignore": [".forestadmin-schema.json"]
+  }
+}
+```
+
+In development the agent rewrites `.forestadmin-schema.json` on every boot. Without this ignore, nodemon sees the change and restarts the agent, and each restart clears the in-memory store — in-flight runs vanish and users are asked to reconnect their OAuth-protected MCP connectors.
+
+Projects scaffolded with forest-cli ≤ 5.17.0 ship a broken entry, `./forestadmin-schema.json`; the leading `./` never matches the real `.forestadmin-schema.json`, so the restarts happen even though an ignore was intended. Replace it with `.forestadmin-schema.json`.
+
+---
+
 ## Testing only
 
 The following modes skip the database requirement but are **not suitable for production** — state is lost on restart.


### PR DESCRIPTION
## What

Adds an `## Embedded in-memory executor under nodemon` section to the workflow-executor README. It warns that embedding the executor with `agent.addWorkflowExecutor({ inMemory: true })` under nodemon loses run state and deposited OAuth-MCP credentials on every dev-boot schema rewrite, and shows the required `nodemonConfig.ignore` entry (`.forestadmin-schema.json`).

## Why

In development the agent rewrites `.forestadmin-schema.json` on every boot; under nodemon that restarts the process and clears the in-memory store (runs vanish, users are asked to reconnect their OAuth-protected MCP connectors). Projects scaffolded with forest-cli ≤ 5.17.0 ship a broken ignore entry (`./forestadmin-schema.json`, with a leading `./` that never matches), so the restart loop happens even though an ignore was intended.

Documentation only — no code changes, no tests. Placed under the encryption-key section (PR #1619 / PRD-367 PR4) as the nearest embedded-setup anchor.

fixes PRD-756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nodemon caveat for in-memory executor to workflow-executor README
> Documents a pitfall when embedding the workflow executor with `inMemory: true` under nodemon: the agent rewrites `.forestadmin-schema.json` on every boot, which triggers nodemon restarts that clear in-memory state and force OAuth reconnections. Adds a config snippet showing the correct `nodemonConfig.ignore` entry, and notes that projects scaffolded with `forest-cli` ≤ 5.17.0 may have an incorrect `'./forestadmin-schema.json'` entry that must be replaced with `'.forestadmin-schema.json'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c91c7ad. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->