### PR TITLE
feat(agent-bff): expose relation list and count with foreign-collection validation

### DIFF
--- a/packages/agent-bff/src/data/agent-data-client.ts
+++ b/packages/agent-bff/src/data/agent-data-client.ts
@@ -8,6 +8,18 @@ export interface AgentDataClientOptions {
 export interface AgentDataClient {
   list(collection: string, query: Record<string, unknown>): Promise<Record<string, unknown>[]>;
   countRaw(collection: string, query: Record<string, unknown>): Promise<unknown>;
+  listRelation(
+    collection: string,
+    parentId: string,
+    relation: string,
+    query: Record<string, unknown>,
+  ): Promise<Record<string, unknown>[]>;
+  countRelationRaw(
+    collection: string,
+    parentId: string,
+    relation: string,
+    query: Record<string, unknown>,
+  ): Promise<unknown>;
 }
 
 /**
@@ -21,6 +33,10 @@ export default function createAgentDataClient({
 }: AgentDataClientOptions): AgentDataClient {
   const requester = new HttpRequester(token, { url: agentUrl });
 
+  const relationPath = (collection: string, parentId: string, relation: string) =>
+    `/forest/${encodeURIComponent(collection)}/${encodeURIComponent(parentId)}` +
+    `/relationships/${encodeURIComponent(relation)}`;
+
   return {
     list: (collection, query) =>
       requester.query({ method: 'get', path: `/forest/${collection}`, query }),
@@ -28,6 +44,15 @@ export default function createAgentDataClient({
       requester.query({
         method: 'get',
         path: `/forest/${collection}/count`,
+        query,
+        skipDeserialization: true,
+      }),
+    listRelation: (collection, parentId, relation, query) =>
+      requester.query({ method: 'get', path: relationPath(collection, parentId, relation), query }),
+    countRelationRaw: (collection, parentId, relation, query) =>
+      requester.query({
+        method: 'get',
+        path: `${relationPath(collection, parentId, relation)}/count`,
         query,
         skipDeserialization: true,
       }),

--- a/packages/agent-bff/src/data/agent-data-client.ts
+++ b/packages/agent-bff/src/data/agent-data-client.ts
@@ -33,9 +33,10 @@ export default function createAgentDataClient({
 }: AgentDataClientOptions): AgentDataClient {
   const requester = new HttpRequester(token, { url: agentUrl });
 
+  // Segments are passed raw: HttpRequester.buildUrl already runs the whole path through
+  // escapeUrlSlug/encodeURI, so pre-encoding here would double-encode (`|` -> `%257C`).
   const relationPath = (collection: string, parentId: string, relation: string) =>
-    `/forest/${encodeURIComponent(collection)}/${encodeURIComponent(parentId)}` +
-    `/relationships/${encodeURIComponent(relation)}`;
+    `/forest/${collection}/${parentId}/relationships/${relation}`;
 
   return {
     list: (collection, query) =>

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -21,6 +21,10 @@ export interface CountRequestBody {
   filter?: unknown;
 }
 
+export type RelationListRequestBody = ListRequestBody & { parentId?: unknown };
+
+export type RelationCountRequestBody = CountRequestBody & { parentId?: unknown };
+
 export type AgentQuery = Record<string, unknown> & { timezone: string };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -164,6 +168,23 @@ export function collectListFieldPaths(body: ListRequestBody): string[] {
   (body.sort ?? []).forEach(({ field }) => paths.push(field));
 
   return paths;
+}
+
+// The parent record id is opaque: a packed/composite id must survive unchanged, so its content is
+// never inspected — only presence and primitive type. A finite number (single numeric pk) is
+// coerced to string; anything else is a BFF-local 400 with no agent call.
+export function parseParentId(parentId: unknown): string {
+  if (typeof parentId === 'string') {
+    if (parentId.trim() === '') throw invalidRequest('parentId must not be empty');
+
+    return parentId;
+  }
+
+  if (typeof parentId === 'number' && Number.isFinite(parentId)) {
+    return String(parentId);
+  }
+
+  throw invalidRequest('parentId is required and must be a non-empty string or a number');
 }
 
 export function collectCountFieldPaths(body: CountRequestBody): string[] {

--- a/packages/agent-bff/src/data/agent-query.ts
+++ b/packages/agent-bff/src/data/agent-query.ts
@@ -21,9 +21,9 @@ export interface CountRequestBody {
   filter?: unknown;
 }
 
-export type RelationListRequestBody = ListRequestBody & { parentId?: unknown };
+export type RelationListRequestBody = ListRequestBody & { parentId: string };
 
-export type RelationCountRequestBody = CountRequestBody & { parentId?: unknown };
+export type RelationCountRequestBody = CountRequestBody & { parentId: string };
 
 export type AgentQuery = Record<string, unknown> & { timezone: string };
 
@@ -185,6 +185,18 @@ export function parseParentId(parentId: unknown): string {
   }
 
   throw invalidRequest('parentId is required and must be a non-empty string or a number');
+}
+
+export function parseRelationListRequest(body: unknown): RelationListRequestBody {
+  const parentId = parseParentId((body as { parentId?: unknown } | null)?.parentId);
+
+  return { ...parseListRequest(body), parentId };
+}
+
+export function parseRelationCountRequest(body: unknown): RelationCountRequestBody {
+  const parentId = parseParentId((body as { parentId?: unknown } | null)?.parentId);
+
+  return { ...parseCountRequest(body), parentId };
 }
 
 export function collectCountFieldPaths(body: CountRequestBody): string[] {

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -170,6 +170,12 @@ async function handleRelation(
     throw unknownRelation(`Unknown relation: ${deps.collection}.${relation}`);
   }
 
+  // The agent's count-related authorizes only the parent, so an unguarded foreign collection would
+  // leak a hidden collection's rows/count. Guard it here, mirroring the parent allow-list check.
+  if (!readModel.isCollectionAllowed(foreignCollection)) {
+    throw unknownCollection(`Unknown collection: ${foreignCollection}`);
+  }
+
   const parentId = parseParentId((rawBody as { parentId?: unknown }).parentId);
   const relationDeps: RelationHandlerDeps = { ...deps, relation, parentId, foreignCollection };
 

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -180,7 +180,7 @@ async function handleRelation(
   // The agent's count-related authorizes only the parent, so an unguarded foreign collection would
   // leak a hidden collection's rows/count. Guard it here, mirroring the parent allow-list check.
   if (!readModel.isCollectionAllowed(foreignCollection)) {
-    throw unknownCollection(`Unknown collection: ${foreignCollection}`);
+    throw unknownCollection();
   }
 
   const relationDeps: RelationHandlerDeps = { ...deps, relation, foreignCollection };

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -19,7 +19,8 @@ import {
   collectListFieldPaths,
   parseCountRequest,
   parseListRequest,
-  parseParentId,
+  parseRelationCountRequest,
+  parseRelationListRequest,
 } from './agent-query';
 import { mapCountResponse, mapListResponse } from './response-mappers';
 import { mapAgentError } from '../http/agent-error-mapper';
@@ -112,7 +113,6 @@ async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHa
 // foreign collection, so the agent query is built and the response mapped against the foreign side.
 interface RelationHandlerDeps extends RequestHandlerDeps {
   relation: string;
-  parentId: string;
   foreignCollection: string;
 }
 
@@ -123,9 +123,14 @@ async function handleRelationList(
   body: RelationListRequestBody,
   deps: RelationListHandlerDeps,
 ) {
+  // The nested-relation guard IS wired here: the agent's list-related asserts browse only on the
+  // immediate foreign collection, so a nested `:`-path would traverse to a third collection whose
+  // browse is never checked. Plain foreign fields (no `:`) are unaffected.
+  assertNoRelationFieldPaths(collectListFieldPaths(body));
+
   const query = buildListAgentQuery(deps.foreignCollection, deps.timezone, body);
   const records = await callAgent(
-    () => deps.client.listRelation(deps.collection, deps.parentId, deps.relation, query),
+    () => deps.client.listRelation(deps.collection, body.parentId, deps.relation, query),
     deps.logger,
   );
 
@@ -138,9 +143,11 @@ async function handleRelationCount(
   body: RelationCountRequestBody,
   deps: RelationHandlerDeps,
 ) {
+  assertNoRelationFieldPaths(collectCountFieldPaths(body));
+
   const query = buildCountAgentQuery(deps.timezone, body);
   const raw = await callAgent(
-    () => deps.client.countRelationRaw(deps.collection, deps.parentId, deps.relation, query),
+    () => deps.client.countRelationRaw(deps.collection, body.parentId, deps.relation, query),
     deps.logger,
   );
 
@@ -157,7 +164,7 @@ async function handleRelation(
   const relation = decodeSegment(match[2], 'relation name');
   const operation = match[3] as 'list' | 'count';
 
-  // The URL identity (does this listable relation exist?) is resolved before the body's parentId,
+  // The URL identity (does this listable relation exist?) is resolved before the body,
   // so a bad path 404s before its payload is inspected.
   const foreignCollection = resolveForeignCollection(
     readModel.getRelationTarget(deps.collection, relation),
@@ -176,16 +183,15 @@ async function handleRelation(
     throw unknownCollection(`Unknown collection: ${foreignCollection}`);
   }
 
-  const parentId = parseParentId((rawBody as { parentId?: unknown }).parentId);
-  const relationDeps: RelationHandlerDeps = { ...deps, relation, parentId, foreignCollection };
+  const relationDeps: RelationHandlerDeps = { ...deps, relation, foreignCollection };
 
   if (operation === 'list') {
-    await handleRelationList(ctx, parseListRequest(rawBody), {
+    await handleRelationList(ctx, parseRelationListRequest(rawBody), {
       ...relationDeps,
       primaryKeys: readModel.getPrimaryKeys(foreignCollection),
     });
   } else {
-    await handleRelationCount(ctx, parseCountRequest(rawBody), relationDeps);
+    await handleRelationCount(ctx, parseRelationCountRequest(rawBody), relationDeps);
   }
 }
 

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -1,8 +1,13 @@
 import type { AgentDataClient, AgentDataClientOptions } from './agent-data-client';
-import type { CountRequestBody, ListRequestBody } from './agent-query';
+import type {
+  CountRequestBody,
+  ListRequestBody,
+  RelationCountRequestBody,
+  RelationListRequestBody,
+} from './agent-query';
 import type { Logger } from '../ports/logger-port';
 import type ReadModel from '../read-model/read-model';
-import type { PrimaryKeyField } from '../read-model/read-model';
+import type { PrimaryKeyField, RelationTarget } from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
 import type { Context, Middleware } from 'koa';
 
@@ -14,15 +19,31 @@ import {
   collectListFieldPaths,
   parseCountRequest,
   parseListRequest,
+  parseParentId,
 } from './agent-query';
 import { mapCountResponse, mapListResponse } from './response-mappers';
 import { mapAgentError } from '../http/agent-error-mapper';
 import { unauthorized } from '../http/bff-http-error';
-import { invalidRequest, schemaUnavailable, unknownCollection } from '../http/bff-local-errors';
+import {
+  invalidRequest,
+  schemaUnavailable,
+  unknownCollection,
+  unknownRelation,
+} from '../http/bff-local-errors';
 import SchemaUnavailableError from '../read-model/errors';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
+const RELATION_ROUTE = /^\/agent\/v1\/([^/]+)\/relations\/([^/]+)\/(list|count)$/;
+
+// Only to-many relations expose list/count on the agent; to-one relations get update-relation only.
+// A polymorphic relation carrying multiple targets is always the to-one (PolymorphicManyToOne) side.
+function resolveForeignCollection(target: RelationTarget | undefined): string | null {
+  if (!target || !('target' in target)) return null;
+  if (target.type !== 'HasMany' && target.type !== 'BelongsToMany') return null;
+
+  return target.target;
+}
 
 export interface DataRoutesMiddlewareOptions {
   store: ReadModelStore;
@@ -40,11 +61,11 @@ interface RequestHandlerDeps {
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
-function decodeCollection(raw: string): string {
+function decodeSegment(raw: string, label: string): string {
   try {
     return decodeURIComponent(raw);
   } catch {
-    throw invalidRequest('Malformed collection name in path');
+    throw invalidRequest(`Malformed ${label} in path`);
   }
 }
 
@@ -87,6 +108,81 @@ async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHa
   ctx.body = mapCountResponse(raw);
 }
 
+// The parent drives ONLY route resolution (path + parentId); projection/filter/sort/count run on the
+// foreign collection, so the agent query is built and the response mapped against the foreign side.
+interface RelationHandlerDeps extends RequestHandlerDeps {
+  relation: string;
+  parentId: string;
+  foreignCollection: string;
+}
+
+type RelationListHandlerDeps = RelationHandlerDeps & { primaryKeys: PrimaryKeyField[] };
+
+async function handleRelationList(
+  ctx: Context,
+  body: RelationListRequestBody,
+  deps: RelationListHandlerDeps,
+) {
+  const query = buildListAgentQuery(deps.foreignCollection, deps.timezone, body);
+  const records = await callAgent(
+    () => deps.client.listRelation(deps.collection, deps.parentId, deps.relation, query),
+    deps.logger,
+  );
+
+  ctx.status = 200;
+  ctx.body = mapListResponse(deps.foreignCollection, records, deps.primaryKeys);
+}
+
+async function handleRelationCount(
+  ctx: Context,
+  body: RelationCountRequestBody,
+  deps: RelationHandlerDeps,
+) {
+  const query = buildCountAgentQuery(deps.timezone, body);
+  const raw = await callAgent(
+    () => deps.client.countRelationRaw(deps.collection, deps.parentId, deps.relation, query),
+    deps.logger,
+  );
+
+  ctx.status = 200;
+  ctx.body = mapCountResponse(raw);
+}
+
+async function handleRelation(
+  ctx: Context,
+  rawBody: unknown,
+  match: RegExpExecArray,
+  { deps, readModel }: { deps: RequestHandlerDeps; readModel: ReadModel },
+) {
+  const relation = decodeSegment(match[2], 'relation name');
+  const operation = match[3] as 'list' | 'count';
+
+  // The URL identity (does this listable relation exist?) is resolved before the body's parentId,
+  // so a bad path 404s before its payload is inspected.
+  const foreignCollection = resolveForeignCollection(
+    readModel.getRelationTarget(deps.collection, relation),
+  );
+
+  // TODO(PRD-672): the read-model's relation map is the allow-list, so an absent/to-one/polymorphic
+  // relation cannot be told from a disallowed one — every non-listable relation maps to 404 here;
+  // `relation_not_allowed` (403) has no local trigger, mirroring `collection_not_allowed`.
+  if (!foreignCollection) {
+    throw unknownRelation(`Unknown relation: ${deps.collection}.${relation}`);
+  }
+
+  const parentId = parseParentId((rawBody as { parentId?: unknown }).parentId);
+  const relationDeps: RelationHandlerDeps = { ...deps, relation, parentId, foreignCollection };
+
+  if (operation === 'list') {
+    await handleRelationList(ctx, parseListRequest(rawBody), {
+      ...relationDeps,
+      primaryKeys: readModel.getPrimaryKeys(foreignCollection),
+    });
+  } else {
+    await handleRelationCount(ctx, parseCountRequest(rawBody), relationDeps);
+  }
+}
+
 export default function createDataRoutesMiddleware({
   store,
   agentUrl,
@@ -94,7 +190,9 @@ export default function createDataRoutesMiddleware({
   createClient = defaultCreateAgentDataClient,
 }: DataRoutesMiddlewareOptions): Middleware {
   return async function dataRoutesMiddleware(ctx, next) {
-    const match = DATA_ROUTE.exec(ctx.path);
+    const dataMatch = DATA_ROUTE.exec(ctx.path);
+    const relationMatch = dataMatch ? null : RELATION_ROUTE.exec(ctx.path);
+    const match = dataMatch ?? relationMatch;
 
     if (!match || ctx.method !== 'POST') {
       await next();
@@ -102,8 +200,7 @@ export default function createDataRoutesMiddleware({
       return;
     }
 
-    const collection = decodeCollection(match[1]);
-    const operation = match[2] as 'list' | 'count';
+    const collection = decodeSegment(match[1], 'collection name');
 
     // The agent token is minted only on the API-key path; the OAuth path sets a principal but no
     // agent token yet. Fail closed instead of calling the agent with `Bearer undefined`.
@@ -128,6 +225,14 @@ export default function createDataRoutesMiddleware({
       logger,
     };
     const rawBody = ctx.request.body ?? {};
+
+    if (relationMatch) {
+      await handleRelation(ctx, rawBody, relationMatch, { deps, readModel });
+
+      return;
+    }
+
+    const operation = match[2] as 'list' | 'count';
 
     if (operation === 'list') {
       const body = parseListRequest(rawBody);

--- a/packages/agent-bff/test/data/agent-data-client.test.ts
+++ b/packages/agent-bff/test/data/agent-data-client.test.ts
@@ -11,6 +11,7 @@ describe('createAgentDataClient', () => {
 
   beforeEach(() => {
     query.mockReset();
+    query.mockResolvedValue([]);
     mockedHttpRequester.mockReset();
     mockedHttpRequester.mockImplementation(() => ({ query } as unknown as HttpRequester));
   });
@@ -48,5 +49,30 @@ describe('createAgentDataClient', () => {
       skipDeserialization: true,
     });
     expect(result).toEqual({ meta: { count: 'deactivated' } });
+  });
+
+  it('should request the relation list path without pre-encoding the segments', async () => {
+    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+
+    await client.listRelation('users', 'tenant-1|42', 'posts', { timezone: 'Europe/Paris' });
+
+    expect(query).toHaveBeenCalledWith({
+      method: 'get',
+      path: '/forest/users/tenant-1|42/relationships/posts',
+      query: { timezone: 'Europe/Paris' },
+    });
+  });
+
+  it('should request the relation count path with skipDeserialization and no pre-encoding', async () => {
+    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+
+    await client.countRelationRaw('users', 'tenant-1|42', 'posts', { timezone: 'Europe/Paris' });
+
+    expect(query).toHaveBeenCalledWith({
+      method: 'get',
+      path: '/forest/users/tenant-1|42/relationships/posts/count',
+      query: { timezone: 'Europe/Paris' },
+      skipDeserialization: true,
+    });
   });
 });

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -5,6 +5,7 @@ import {
   collectListFieldPaths,
   parseCountRequest,
   parseListRequest,
+  parseParentId,
 } from '../../src/data/agent-query';
 
 describe('buildListAgentQuery', () => {
@@ -124,6 +125,35 @@ describe('parseCountRequest', () => {
     ['an array', []],
   ])('should reject a non-object body (%s) with 400 invalid_request', (_label, body) => {
     expect(() => parseCountRequest(body)).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
+});
+
+describe('parseParentId', () => {
+  it('should return a non-empty string unchanged, including a composite packed id', () => {
+    expect(parseParentId('a|b')).toBe('a|b');
+    expect(parseParentId('550e8400-e29b-41d4-a716-446655440000')).toBe(
+      '550e8400-e29b-41d4-a716-446655440000',
+    );
+  });
+
+  it('should coerce a finite number to a string', () => {
+    expect(parseParentId(42)).toBe('42');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['whitespace', '   '],
+    ['object', {}],
+    ['array', []],
+    ['boolean', true],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+  ])('should reject %s with invalid_request', (_label, value) => {
+    expect(() => parseParentId(value)).toThrow(
       expect.objectContaining({ type: 'invalid_request', status: 400 }),
     );
   });

--- a/packages/agent-bff/test/data/agent-query.test.ts
+++ b/packages/agent-bff/test/data/agent-query.test.ts
@@ -6,6 +6,8 @@ import {
   parseCountRequest,
   parseListRequest,
   parseParentId,
+  parseRelationCountRequest,
+  parseRelationListRequest,
 } from '../../src/data/agent-query';
 
 describe('buildListAgentQuery', () => {
@@ -154,6 +156,41 @@ describe('parseParentId', () => {
     ['Infinity', Infinity],
   ])('should reject %s with invalid_request', (_label, value) => {
     expect(() => parseParentId(value)).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
+});
+
+describe('parseRelationListRequest', () => {
+  it('should return the validated list body with the parsed parentId', () => {
+    expect(parseRelationListRequest({ parentId: 'a|b', projection: ['id'] })).toEqual({
+      parentId: 'a|b',
+      projection: ['id'],
+    });
+  });
+
+  it('should reject a missing parentId with 400 invalid_request', () => {
+    expect(() => parseRelationListRequest({ projection: ['id'] })).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
+
+  it('should reject an invalid list body with 400 invalid_request', () => {
+    expect(() => parseRelationListRequest({ parentId: '7', projection: 'id' })).toThrow(
+      expect.objectContaining({ type: 'invalid_request', status: 400 }),
+    );
+  });
+});
+
+describe('parseRelationCountRequest', () => {
+  it('should return the validated count body with the parsed parentId', () => {
+    expect(
+      parseRelationCountRequest({ parentId: '7', filter: { field: 'a', operator: 'present' } }),
+    ).toEqual({ parentId: '7', filter: { field: 'a', operator: 'present' } });
+  });
+
+  it('should reject a missing parentId with 400 invalid_request', () => {
+    expect(() => parseRelationCountRequest({})).toThrow(
       expect.objectContaining({ type: 'invalid_request', status: 400 }),
     );
   });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -73,11 +73,13 @@ const relationReadModel = new ReadModel([
     column('id'),
     column('email'),
     relation('posts', 'HasMany', 'posts.id'),
+    relation('tags', 'BelongsToMany', 'tags.slug'),
     relation('company', 'BelongsTo', 'companies.id'),
     relation('secrets', 'HasMany', 'secrets.id'),
     polymorphic('avatar', ['images', 'files']),
   ]),
   collection('posts', [column('id'), column('title')]),
+  collection('tags', [{ ...column('slug'), isPrimaryKey: true }, column('label')]),
   collection('companies', [column('id')]),
 ]);
 
@@ -462,16 +464,48 @@ describe('data routes middleware', () => {
       expect(listRelation).toHaveBeenCalledWith('users', 'tenant-1|42', 'posts', expect.anything());
     });
 
-    it('should not wire the nested-relation guard on relation routes', async () => {
+    it('should accept a plain foreign field but reject a nested foreign path with 422', async () => {
       const listRelation = jest.fn(async () => []);
       const app = buildApp(storeOf(relationReadModel), { listRelation });
 
-      const response = await request(app.callback())
+      const ok = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({ parentId: '7', projection: ['id', 'title'] });
+
+      expect(ok.status).toBe(200);
+
+      const rejected = await request(app.callback())
         .post('/agent/v1/users/relations/posts/list')
         .send({ parentId: '7', filter: { field: 'author:name', operator: 'present' } });
 
+      expect(rejected.status).toBe(422);
+      expect(rejected.body.error).toMatchObject({
+        type: 'relation_field_not_supported',
+        status: 422,
+        details: { fields: ['author:name'] },
+      });
+    });
+
+    it('should list a BelongsToMany relation and use the foreign primary key in __forest', async () => {
+      const listRelation = jest.fn(async () => [{ id: 'ts', label: 'TypeScript' }]);
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/tags/list')
+        .send({ parentId: '7', projection: ['slug', 'label'] });
+
       expect(response.status).toBe(200);
-      expect(listRelation).toHaveBeenCalled();
+      expect(listRelation).toHaveBeenCalledWith(
+        'users',
+        '7',
+        'tags',
+        expect.objectContaining({ 'fields[tags]': 'slug,label' }),
+      );
+      expect(response.body.data[0]).toEqual({
+        id: 'ts',
+        label: 'TypeScript',
+        __forest: { collection: 'tags', primaryKey: { slug: 'ts' } },
+      });
     });
 
     it.each([
@@ -577,6 +611,42 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({ count: null, countStatus: 'deactivated' });
+    });
+
+    it.each([
+      ['unknown relation', 'users', 'ghosts', 'unknown_relation'],
+      ['to-one relation', 'users', 'company', 'unknown_relation'],
+      ['disallowed foreign collection', 'users', 'secrets', 'unknown_collection'],
+    ])(
+      'should return 404 for a %s on the count path without calling the agent',
+      async (_label, parent, relationName, type) => {
+        const countRelationRaw = jest.fn();
+        const app = buildApp(storeOf(relationReadModel), { countRelationRaw });
+
+        const response = await request(app.callback())
+          .post(`/agent/v1/${parent}/relations/${relationName}/count`)
+          .send({ parentId: '7' });
+
+        expect(response.status).toBe(404);
+        expect(response.body.error).toMatchObject({ type, status: 404 });
+        expect(countRelationRaw).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should reject a nested foreign path in the count filter with 422', async () => {
+      const countRelationRaw = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { countRelationRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/count')
+        .send({ parentId: '7', filter: { field: 'author:name', operator: 'present' } });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'relation_field_not_supported',
+        status: 422,
+      });
+      expect(countRelationRaw).not.toHaveBeenCalled();
     });
 
     it('should return 400 for a malformed parentId without calling the agent', async () => {

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -11,7 +11,7 @@ import createDataRoutesMiddleware from '../../src/data/data-routes-middleware';
 import createErrorMiddleware from '../../src/http/error-middleware';
 import SchemaUnavailableError from '../../src/read-model/errors';
 import ReadModel from '../../src/read-model/read-model';
-import { collection, column } from '../read-model/fixtures';
+import { collection, column, polymorphic, relation } from '../read-model/fixtures';
 
 const TIMEZONE = 'Europe/Paris';
 
@@ -67,6 +67,18 @@ function buildApp(
 }
 
 const usersReadModel = new ReadModel([collection('users', [column('id'), column('email')])]);
+
+const relationReadModel = new ReadModel([
+  collection('users', [
+    column('id'),
+    column('email'),
+    relation('posts', 'HasMany', 'posts.id'),
+    relation('company', 'BelongsTo', 'companies.id'),
+    polymorphic('avatar', ['images', 'files']),
+  ]),
+  collection('posts', [column('id'), column('title')]),
+  collection('companies', [column('id')]),
+]);
 
 describe('data routes middleware', () => {
   describe('routing', () => {
@@ -386,6 +398,184 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    });
+  });
+
+  describe('relation list', () => {
+    it('should return flat foreign records with __forest and meta.countStatus not_requested', async () => {
+      const listRelation = jest.fn(async () => [{ id: '99', title: 'Hello' }]);
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({ parentId: '7', projection: ['id', 'title'] });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        data: [
+          {
+            id: '99',
+            title: 'Hello',
+            __forest: { collection: 'posts', primaryKey: { id: '99' } },
+          },
+        ],
+        meta: { countStatus: 'not_requested' },
+      });
+    });
+
+    it('should resolve the parent from the path but project/filter/sort on the foreign collection', async () => {
+      const listRelation = jest.fn(async () => []);
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({
+          parentId: '7',
+          projection: ['id', 'title'],
+          filter: { field: 'title', operator: 'present' },
+          sort: [{ field: 'title', direction: 'desc' }],
+        });
+
+      expect(listRelation).toHaveBeenCalledWith(
+        'users',
+        '7',
+        'posts',
+        expect.objectContaining({
+          'fields[posts]': 'id,title',
+          filters: JSON.stringify({ field: 'title', operator: 'present' }),
+          sort: '-title',
+        }),
+      );
+      const query = (listRelation.mock.calls[0] as unknown[])[3];
+      expect(query).not.toHaveProperty('fields[users]');
+    });
+
+    it('should forward a composite parentId unchanged to the relation query', async () => {
+      const listRelation = jest.fn(async () => []);
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({ parentId: 'tenant-1|42' });
+
+      expect(listRelation).toHaveBeenCalledWith('users', 'tenant-1|42', 'posts', expect.anything());
+    });
+
+    it('should not wire the nested-relation guard on relation routes', async () => {
+      const listRelation = jest.fn(async () => []);
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({ parentId: '7', filter: { field: 'author:name', operator: 'present' } });
+
+      expect(response.status).toBe(200);
+      expect(listRelation).toHaveBeenCalled();
+    });
+
+    it.each([
+      ['unknown', 'ghosts'],
+      ['to-one', 'company'],
+      ['polymorphic', 'avatar'],
+    ])('should return 404 unknown_relation for a %s relation', async (_label, relationName) => {
+      const listRelation = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post(`/agent/v1/users/relations/${relationName}/list`)
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'unknown_relation', status: 404 });
+      expect(listRelation).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 unknown_collection for an unknown parent collection', async () => {
+      const listRelation = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/ghosts/relations/posts/list')
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'unknown_collection', status: 404 });
+      expect(listRelation).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['missing', {}],
+      ['empty', { parentId: '' }],
+      ['malformed', { parentId: { composite: true } }],
+    ])('should return 400 for a %s parentId without calling the agent', async (_label, body) => {
+      const listRelation = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send(body);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+      expect(listRelation).not.toHaveBeenCalled();
+    });
+
+    it('should map an agent failure through the error contract', async () => {
+      const listRelation = jest.fn(async () => {
+        throw new AgentHttpError(
+          404,
+          { errors: [{ status: 404, name: 'NotFoundError' }] },
+          undefined,
+        );
+      });
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/list')
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'not_found', status: 404 });
+    });
+  });
+
+  describe('relation count', () => {
+    it('should count on the foreign collection and return available', async () => {
+      const countRelationRaw = jest.fn(async () => ({ count: 3 }));
+      const app = buildApp(storeOf(relationReadModel), { countRelationRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/count')
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ count: 3, countStatus: 'available' });
+      expect(countRelationRaw).toHaveBeenCalledWith('users', '7', 'posts', expect.anything());
+    });
+
+    it('should return deactivated from the raw agent payload', async () => {
+      const countRelationRaw = jest.fn(async () => ({ meta: { count: 'deactivated' } }));
+      const app = buildApp(storeOf(relationReadModel), { countRelationRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/count')
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ count: null, countStatus: 'deactivated' });
+    });
+
+    it('should return 400 for a malformed parentId without calling the agent', async () => {
+      const countRelationRaw = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { countRelationRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/posts/count')
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+      expect(countRelationRaw).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -74,6 +74,7 @@ const relationReadModel = new ReadModel([
     column('email'),
     relation('posts', 'HasMany', 'posts.id'),
     relation('company', 'BelongsTo', 'companies.id'),
+    relation('secrets', 'HasMany', 'secrets.id'),
     polymorphic('avatar', ['images', 'files']),
   ]),
   collection('posts', [column('id'), column('title')]),
@@ -487,6 +488,19 @@ describe('data routes middleware', () => {
 
       expect(response.status).toBe(404);
       expect(response.body.error).toMatchObject({ type: 'unknown_relation', status: 404 });
+      expect(listRelation).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 unknown_collection when the relation targets a disallowed collection', async () => {
+      const listRelation = jest.fn();
+      const app = buildApp(storeOf(relationReadModel), { listRelation });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/relations/secrets/list')
+        .send({ parentId: '7' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toMatchObject({ type: 'unknown_collection', status: 404 });
       expect(listRelation).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## What
Exposes the relation read surface on the BFF: `POST /v1/:collection/relations/:relation/list` and `/count`. The relation route resolves authorization/allow-list on the **parent**, but projection, filter, sort, and count run against the **foreign** collection — the BFF owns the correct agent query shape so the agent's non-uniform relation precedent (parent-vs-foreign projection serialization) never leaks.

Builds on PRD-671's shared helpers (flat mapping, packed-id, count-deactivation).

## How
- **Route**: extends `data-routes-middleware` with a second regex `\/agent\/v1\/:collection\/relations\/:relation\/(list|count)`, reusing the existing token/read-model/error plumbing.
- **Relation resolution**: to-many only (`HasMany`\/`BelongsToMany`). To-one, polymorphic (multi-target), and absent relations map to `unknown_relation` (404). Verified against both the Node agent (per-type route generation) and the Ruby agent (only `PolymorphicManyToOne` carries multiple targets, and it is to-one).
- **Parent vs foreign**: the parent name + `parentId` + relation name go only into the agent path; `fields[FOREIGN]`, filters, sort, and count run on the foreign collection. A test proves the parent is used solely for route resolution.
- **parentId**: opaque parent record id (int\/UUID\/composite packed). Presence + primitive check only, forwarded unchanged (URL-encoded in the path). Missing\/empty\/malformed → `invalid_request` (400) with no agent call.
- **Mapping\/errors**: reuses `mapListResponse`\/`mapCountResponse` (foreign-side) and PRD-670 error mapping. The nested-relation guard is deliberately NOT wired (relation routes legitimately accept foreign fields).

No agent or agent-client package changes; all changes are agent-bff-local.

## Tests
- Relation list flat mapping (`data[]` + `__forest` foreign + `countStatus: not_requested`)
- Foreign-projection proof (`fields[posts]`, not `fields[users]`)
- Relation count available\/deactivated on the foreign collection
- 404 for unknown\/to-one\/polymorphic relation and unknown parent collection
- 400 for missing\/empty\/malformed `parentId` (agent not called)
- Composite `parentId` passthrough unchanged
- Agent failure → PRD-670 envelope
- `parseParentId` unit cases

`yarn workspace @forestadmin/agent-bff lint test build` all green (541 tests).

Fixes PRD-672

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add relation list and count endpoints to agent-bff data routes middleware
> - Adds `POST /agent/v1/:collection/relations/:relation/list` and `.../count` endpoints to [data-routes-middleware.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1746/files#diff-f72d9e0085f04fbc09b3ee055760d1ab06989a7f7609ff77350b0c92ec43be20), routing through a new `handleRelation` orchestrator that validates relation existence, allow-list status, and foreign collection before dispatching.
> - Adds `listRelation()` and `countRelationRaw()` to the `AgentDataClient` interface and factory in [agent-data-client.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1746/files#diff-18366e30ae76b06475553223d609a9a475fabf8865955f6eb9880ff19c41cb90); count requests bypass deserialization via `skipDeserialization: true`.
> - Adds `parseRelationListRequest` and `parseRelationCountRequest` in [agent-query.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1746/files#diff-f9e4f9c436e7f894464509bbcbe60f542338d97355ce39ad711d5c2990d80868) with a `parseParentId` validator that accepts strings and finite numbers, rejecting empty/whitespace/non-finite values with a 400 `invalid_request`.
> - Only to-many relations (`HasMany`, `BelongsToMany`) are listable; to-one and polymorphic relations return 404. Nested relation field paths are rejected with 400.
> - Risk: Relation routes share the existing collection allow-list check but add a second foreign-collection allow-list check; disallowed foreign collections return 404 `unknown_collection` rather than a data error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ab6908.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->