### PR TITLE
feat(agent-bff): expose the action form endpoint

### DIFF
--- a/packages/agent-bff/src/action/action-form-mapper.ts
+++ b/packages/agent-bff/src/action/action-form-mapper.ts
@@ -1,0 +1,57 @@
+import type { ActionForm } from './agent-action-client';
+import type { ForestServerActionFormLayoutElement } from '@forestadmin/forestadmin-client';
+
+const ENUM_TYPE = 'Enum';
+
+export interface ActionFormFieldResponse {
+  name: string;
+  type: string;
+  value: unknown;
+  isRequired: boolean;
+  enumValues?: string[] | null;
+}
+
+export interface ActionFormResponse {
+  fields: ActionFormFieldResponse[];
+  canExecute: boolean;
+  requiredFields: string[];
+  skippedFields: string[];
+  layout: ForestServerActionFormLayoutElement[];
+}
+
+// Mirrors the MCP getActionForm tool, adding `layout`. A required field is "missing a value" only
+// when its resolved value is null/undefined; an explicit empty string or 0 counts as present.
+export function mapActionForm(
+  action: ActionForm,
+  skippedFields: string[],
+  layout: ForestServerActionFormLayoutElement[],
+): ActionFormResponse {
+  const fields = action.getFields();
+
+  const requiredFields = fields
+    .filter(field => field.isRequired())
+    .filter(field => field.getValue() === undefined || field.getValue() === null)
+    .map(field => field.getName());
+
+  return {
+    fields: fields.map(field => {
+      const base: ActionFormFieldResponse = {
+        name: field.getName(),
+        type: field.getType(),
+        value: field.getValue(),
+        isRequired: field.isRequired() ?? false,
+      };
+
+      // enumValues is emitted only for Enum fields, matching the MCP tool.
+      if (field.getType() === ENUM_TYPE) {
+        return { ...base, enumValues: action.getEnumField(field.getName()).getOptions() ?? null };
+      }
+
+      return base;
+    }),
+    canExecute: requiredFields.length === 0,
+    requiredFields,
+    skippedFields,
+    layout,
+  };
+}

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -20,15 +20,17 @@ interface ActionFormRequestBody {
   values?: unknown;
 }
 
-// recordIds are opaque BFF ids passed through unchanged; only presence and array-ness are checked.
-// An empty array is allowed on purpose (global/bulk actions have no selected records); the spec AC
-// only covers a missing recordIds, so `[]` is an explicit BFF choice, not a spec requirement.
-function parseRecordIds(raw: unknown): (string | number)[] {
+// recordIds are opaque BFF ids; only presence and array-ness are checked. An empty array is allowed
+// on purpose (global/bulk actions have no selected records); the spec AC only covers a missing
+// recordIds, so `[]` is an explicit BFF choice, not a spec requirement.
+// Ids are coerced to strings so a valid `0` (numeric primary key) survives agent-client's downstream
+// `.filter(Boolean)`, which would otherwise drop it and load the form as if no record were selected.
+function parseRecordIds(raw: unknown): string[] {
   if (!Array.isArray(raw)) {
     throw invalidRequest('recordIds is required and must be an array');
   }
 
-  return raw as (string | number)[];
+  return raw.map(id => String(id));
 }
 
 function parseValues(raw: unknown): Record<string, unknown> {

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -1,0 +1,102 @@
+import type { AgentActionClient, AgentActionClientOptions } from './agent-action-client';
+import type { Logger } from '../ports/logger-port';
+import type ReadModelStore from '../read-model/read-model-store';
+import type { Middleware } from 'koa';
+
+import { mapActionForm } from './action-form-mapper';
+import defaultCreateAgentActionClient, { extractRawLayout } from './agent-action-client';
+import {
+  callAgent,
+  decodeSegment,
+  requireAgentToken,
+  resolveReadModel,
+} from '../http/agent-route-helpers';
+import { invalidRequest, unknownAction } from '../http/bff-local-errors';
+
+const ACTION_FORM_ROUTE = /^\/agent\/v1\/([^/]+)\/actions\/([^/]+)\/form$/;
+
+interface ActionFormRequestBody {
+  recordIds?: unknown;
+  values?: unknown;
+}
+
+// recordIds are opaque BFF ids passed through unchanged; only presence and array-ness are checked.
+// An empty array is allowed on purpose (global/bulk actions have no selected records); the spec AC
+// only covers a missing recordIds, so `[]` is an explicit BFF choice, not a spec requirement.
+function parseRecordIds(raw: unknown): (string | number)[] {
+  if (!Array.isArray(raw)) {
+    throw invalidRequest('recordIds is required and must be an array');
+  }
+
+  return raw as (string | number)[];
+}
+
+function parseValues(raw: unknown): Record<string, unknown> {
+  if (raw === undefined) return {};
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw invalidRequest('values must be an object');
+  }
+
+  return raw as Record<string, unknown>;
+}
+
+export interface ActionRoutesMiddlewareOptions {
+  store: ReadModelStore;
+  agentUrl: string;
+  logger: Logger;
+  createClient?: (options: AgentActionClientOptions) => AgentActionClient;
+}
+
+export default function createActionRoutesMiddleware({
+  store,
+  agentUrl,
+  logger,
+  createClient = defaultCreateAgentActionClient,
+}: ActionRoutesMiddlewareOptions): Middleware {
+  return async function actionRoutesMiddleware(ctx, next) {
+    const match = ACTION_FORM_ROUTE.exec(ctx.path);
+
+    if (!match || ctx.method !== 'POST') {
+      await next();
+
+      return;
+    }
+
+    const collection = decodeSegment(match[1], 'collection name');
+    const actionName = decodeSegment(match[2], 'action name');
+    const token = requireAgentToken(ctx);
+    const readModel = await resolveReadModel(store);
+
+    // The read-model's action map IS the allow-list, so an absent action cannot be told from a
+    // known-but-disallowed one — every non-exposed action maps to 404 here; `action_not_allowed`
+    // (403) has no local trigger, mirroring `collection_not_allowed`/`relation_not_allowed`. The
+    // URL identity is resolved before the body, so a bad action 404s before its payload is read.
+    // TODO(PRD-673): distinguish disallowed from unknown when a separate exposure source exists.
+    if (!readModel.isActionAllowed(collection, actionName)) {
+      throw unknownAction(`Unknown action: ${collection}.${actionName}`);
+    }
+
+    const body = (ctx.request.body ?? {}) as ActionFormRequestBody;
+    const recordIds = parseRecordIds(body.recordIds);
+    const values = parseValues(body.values);
+
+    const client = createClient({
+      agentUrl,
+      token,
+      actionEndpoints: readModel.getActionEndpoints(),
+    });
+
+    // Each agent-hitting call is wrapped on its own; getFields/extractRawLayout/mapping stay outside
+    // callAgent so a local BFF bug surfaces as a 500, not a mislabelled agent error. Fields and
+    // layout are read AFTER tryToSetFields because a change hook rebuilds them in place.
+    const action = await callAgent(
+      () => client.loadActionForm(collection, actionName, recordIds),
+      logger,
+    );
+    const skippedFields = await callAgent(() => action.tryToSetFields(values), logger);
+
+    ctx.status = 200;
+    ctx.body = mapActionForm(action, skippedFields, extractRawLayout(action));
+  };
+}

--- a/packages/agent-bff/src/action/agent-action-client.ts
+++ b/packages/agent-bff/src/action/agent-action-client.ts
@@ -1,0 +1,62 @@
+import type { ActionEndpointsByCollection } from '@forestadmin/agent-client';
+import type { ForestServerActionFormLayoutElement } from '@forestadmin/forestadmin-client';
+
+import { createRemoteAgentClient } from '@forestadmin/agent-client';
+
+export interface ActionFormField {
+  getName(): string;
+  getType(): string;
+  getValue(): unknown;
+  isRequired(): boolean | undefined;
+}
+
+// Structural subset of agent-client's `Action` the form endpoint consumes. Kept local so the BFF
+// does not depend on agent-client exporting the concrete `Action` type (see extractRawLayout).
+export interface ActionForm {
+  tryToSetFields(values: Record<string, unknown>): Promise<string[]>;
+  getFields(): ActionFormField[];
+  getEnumField(name: string): { getOptions(): string[] | undefined };
+  getLayout(): unknown;
+}
+
+export interface AgentActionClient {
+  loadActionForm(
+    collection: string,
+    action: string,
+    recordIds: (string | number)[],
+  ): Promise<ActionForm>;
+}
+
+export interface AgentActionClientOptions {
+  agentUrl: string;
+  token: string;
+  actionEndpoints: ActionEndpointsByCollection;
+}
+
+// The raw layout must be read AFTER tryToSetFields: a change hook rebuilds fields+layout in place.
+// agent-client's `Action.getLayout()` only returns an `ActionLayoutRoot` wrapper whose element array
+// lives in a protected field. The rollback contract forbids agent-client changes, so we read it
+// through a cast rather than adding a public accessor. A layout-shape test guards against drift.
+export function extractRawLayout(action: ActionForm): ForestServerActionFormLayoutElement[] {
+  const root = action.getLayout() as { layout?: ForestServerActionFormLayoutElement[] };
+
+  return root.layout ?? [];
+}
+
+/**
+ * Thin action-form client bound to a request's agent token. Reuses agent-client's stateful form
+ * loading (`/hooks/load` + `/hooks/change`, Ruby 404 fallback, dependent-field re-evaluation) rather
+ * than reimplementing it. The endpoint map from the read-model is the action allow-list.
+ */
+export default function createAgentActionClient({
+  agentUrl,
+  token,
+  actionEndpoints,
+}: AgentActionClientOptions): AgentActionClient {
+  const client = createRemoteAgentClient({ url: agentUrl, token, actionEndpoints });
+
+  return {
+    loadActionForm: (collection, action, recordIds) =>
+      client.collection(collection).action(action, { recordIds }),
+  };
+}

--- a/packages/agent-bff/src/action/agent-action-client.ts
+++ b/packages/agent-bff/src/action/agent-action-client.ts
@@ -32,7 +32,8 @@ export interface AgentActionClientOptions {
 // The raw layout must be read AFTER tryToSetFields: a change hook rebuilds fields+layout in place.
 // agent-client's `Action.getLayout()` only returns an `ActionLayoutRoot` wrapper whose element array
 // lives in a protected field. The rollback contract forbids agent-client changes, so we read it
-// through a cast rather than adding a public accessor. A layout-shape test guards against drift.
+// through a cast rather than adding a public accessor. `extract-raw-layout.test.ts` builds a real
+// `ActionLayoutRoot` and asserts this unwraps it, so a rename of that field fails a test.
 export function extractRawLayout(action: ActionForm): ForestServerActionFormLayoutElement[] {
   const root = action.getLayout() as { layout?: ForestServerActionFormLayoutElement[] };
 

--- a/packages/agent-bff/src/action/agent-action-client.ts
+++ b/packages/agent-bff/src/action/agent-action-client.ts
@@ -20,11 +20,7 @@ export interface ActionForm {
 }
 
 export interface AgentActionClient {
-  loadActionForm(
-    collection: string,
-    action: string,
-    recordIds: (string | number)[],
-  ): Promise<ActionForm>;
+  loadActionForm(collection: string, action: string, recordIds: string[]): Promise<ActionForm>;
 }
 
 export interface AgentActionClientOptions {

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -4,6 +4,7 @@ import type { Middleware } from 'koa';
 
 import { bodyParser } from '@koa/bodyparser';
 
+import createActionRoutesMiddleware from './action/action-routes-middleware';
 import createConsoleLogger from './adapters/console-logger';
 import createAgentStubMiddleware from './agent/agent-stub';
 import createApiKeyAuthenticator from './api-key/api-key-authenticator';
@@ -154,13 +155,15 @@ function buildApiKeyMiddleware(config: BFFConfig, logger: Logger): Middleware | 
   return createApiKeyMiddleware({ authenticator, logger });
 }
 
-function buildDataRoutesMiddleware(config: BFFConfig, logger: Logger): Middleware {
+// Data and action routes share one read-model store (a single cache, a single schema fetch). The
+// data middleware falls through to the action middleware on a non-data path.
+function buildAgentRouteMiddlewares(config: BFFConfig, logger: Logger): Middleware[] {
   const apiKeyConfig = resolveApiKeyConfig(config);
 
   if (!apiKeyConfig || !config.agentUrl) {
     logger('Warn', 'Data endpoints disabled: AGENT_URL or read-model configuration is missing');
 
-    return createAgentStubMiddleware();
+    return [createAgentStubMiddleware()];
   }
 
   const { store } = createReadModel({
@@ -168,8 +171,12 @@ function buildDataRoutesMiddleware(config: BFFConfig, logger: Logger): Middlewar
     envSecret: apiKeyConfig.forestEnvSecret,
     logger,
   });
+  const { agentUrl } = config;
 
-  return createDataRoutesMiddleware({ store, agentUrl: config.agentUrl, logger });
+  return [
+    createDataRoutesMiddleware({ store, agentUrl, logger }),
+    createActionRoutesMiddleware({ store, agentUrl, logger }),
+  ];
 }
 
 function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] {
@@ -188,7 +195,7 @@ function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] 
     apiKeyStep,
     createPerKeyOriginMiddleware(),
     createTimezoneMiddleware({ defaultTimezone }),
-    buildDataRoutesMiddleware(config, logger),
+    ...buildAgentRouteMiddlewares(config, logger),
   ];
 
   return chain.map(agentScoped);

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -23,15 +23,13 @@ import {
   parseRelationListRequest,
 } from './agent-query';
 import { mapCountResponse, mapListResponse } from './response-mappers';
-import { mapAgentError } from '../http/agent-error-mapper';
-import { unauthorized } from '../http/bff-http-error';
 import {
-  invalidRequest,
-  schemaUnavailable,
-  unknownCollection,
-  unknownRelation,
-} from '../http/bff-local-errors';
-import SchemaUnavailableError from '../read-model/errors';
+  callAgent,
+  decodeSegment,
+  requireAgentToken,
+  resolveReadModel,
+} from '../http/agent-route-helpers';
+import { unknownCollection, unknownRelation } from '../http/bff-local-errors';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
@@ -61,33 +59,6 @@ interface RequestHandlerDeps {
 }
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
-
-function decodeSegment(raw: string, label: string): string {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    throw invalidRequest(`Malformed ${label} in path`);
-  }
-}
-
-async function resolveReadModel(store: ReadModelStore): Promise<ReadModel> {
-  try {
-    return await store.getReadModel();
-  } catch (error) {
-    if (error instanceof SchemaUnavailableError) throw schemaUnavailable();
-    throw error;
-  }
-}
-
-// Only the agent call is wrapped: guard, query-building and mapping errors are BFF-origin and must
-// keep their own type, not be recategorized as agent errors.
-async function callAgent<T>(fn: () => Promise<T>, logger: Logger): Promise<T> {
-  try {
-    return await fn();
-  } catch (error) {
-    throw mapAgentError(error, { logger });
-  }
-}
 
 async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandlerDeps) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
@@ -213,13 +184,7 @@ export default function createDataRoutesMiddleware({
     }
 
     const collection = decodeSegment(match[1], 'collection name');
-
-    // The agent token is minted only on the API-key path; the OAuth path sets a principal but no
-    // agent token yet. Fail closed instead of calling the agent with `Bearer undefined`.
-    // TODO(PRD-637): mint an agent token from the OAuth principal so data routes work in OAuth mode.
-    const token = ctx.state.agentToken as string | undefined;
-    if (!token) throw unauthorized('No agent credentials for this request');
-
+    const token = requireAgentToken(ctx);
     const readModel = await resolveReadModel(store);
 
     if (!readModel.isCollectionAllowed(collection)) {

--- a/packages/agent-bff/src/http/agent-route-helpers.ts
+++ b/packages/agent-bff/src/http/agent-route-helpers.ts
@@ -1,0 +1,46 @@
+import type { Logger } from '../ports/logger-port';
+import type ReadModel from '../read-model/read-model';
+import type ReadModelStore from '../read-model/read-model-store';
+import type { Context } from 'koa';
+
+import { mapAgentError } from './agent-error-mapper';
+import { unauthorized } from './bff-http-error';
+import { invalidRequest, schemaUnavailable } from './bff-local-errors';
+import SchemaUnavailableError from '../read-model/errors';
+
+export function decodeSegment(raw: string, label: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw invalidRequest(`Malformed ${label} in path`);
+  }
+}
+
+export async function resolveReadModel(store: ReadModelStore): Promise<ReadModel> {
+  try {
+    return await store.getReadModel();
+  } catch (error) {
+    if (error instanceof SchemaUnavailableError) throw schemaUnavailable();
+    throw error;
+  }
+}
+
+// The agent token is minted only on the API-key path; the OAuth path sets a principal but no agent
+// token yet. Fail closed instead of calling the agent with `Bearer undefined`.
+// TODO(PRD-637): mint an agent token from the OAuth principal so agent routes work in OAuth mode.
+export function requireAgentToken(ctx: Context): string {
+  const token = ctx.state.agentToken as string | undefined;
+  if (!token) throw unauthorized('No agent credentials for this request');
+
+  return token;
+}
+
+// Only the agent call is wrapped: guard, query-building and mapping errors are BFF-origin and must
+// keep their own type, not be recategorized as agent errors.
+export async function callAgent<T>(fn: () => Promise<T>, logger: Logger): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    throw mapAgentError(error, { logger });
+  }
+}

--- a/packages/agent-bff/test/action/action-form-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-form-mapper.test.ts
@@ -1,0 +1,98 @@
+import type { ActionForm, ActionFormField } from '../../src/action/agent-action-client';
+
+import { mapActionForm } from '../../src/action/action-form-mapper';
+
+interface FakeField {
+  name: string;
+  type: string;
+  value: unknown;
+  isRequired: boolean;
+  enumValues?: string[];
+}
+
+function fieldStub(f: FakeField): ActionFormField {
+  return {
+    getName: () => f.name,
+    getType: () => f.type,
+    getValue: () => f.value,
+    isRequired: () => f.isRequired,
+  };
+}
+
+function actionWith(fields: FakeField[]): ActionForm {
+  return {
+    tryToSetFields: async () => [],
+    getFields: () => fields.map(fieldStub),
+    getEnumField: (name: string) => ({
+      getOptions: () => fields.find(f => f.name === name)?.enumValues,
+    }),
+    getLayout: () => ({ layout: [] }),
+  };
+}
+
+describe('mapActionForm', () => {
+  it('maps each field to name, type, value and isRequired', () => {
+    const action = actionWith([{ name: 'reason', type: 'String', value: 'x', isRequired: true }]);
+
+    const result = mapActionForm(action, [], []);
+
+    expect(result.fields).toEqual([
+      { name: 'reason', type: 'String', value: 'x', isRequired: true },
+    ]);
+  });
+
+  it('emits enumValues only for Enum fields', () => {
+    const action = actionWith([
+      { name: 'reason', type: 'String', value: null, isRequired: false },
+      { name: 'status', type: 'Enum', value: null, isRequired: false, enumValues: ['a', 'b'] },
+    ]);
+
+    const result = mapActionForm(action, [], []);
+
+    expect(result.fields[0]).not.toHaveProperty('enumValues');
+    expect(result.fields[1]).toMatchObject({ name: 'status', enumValues: ['a', 'b'] });
+  });
+
+  it('sets enumValues to null when an Enum field has no options', () => {
+    const action = actionWith([{ name: 'status', type: 'Enum', value: null, isRequired: false }]);
+
+    const result = mapActionForm(action, [], []);
+
+    expect(result.fields[0].enumValues).toBeNull();
+  });
+
+  it('lists required fields whose resolved value is null or undefined and sets canExecute false', () => {
+    const action = actionWith([
+      { name: 'a', type: 'String', value: null, isRequired: true },
+      { name: 'b', type: 'String', value: undefined, isRequired: true },
+      { name: 'c', type: 'String', value: 'set', isRequired: true },
+    ]);
+
+    const result = mapActionForm(action, [], []);
+
+    expect(result.requiredFields).toEqual(['a', 'b']);
+    expect(result.canExecute).toBe(false);
+  });
+
+  it('treats an explicit empty string or 0 as present so canExecute is true', () => {
+    const action = actionWith([
+      { name: 'a', type: 'String', value: '', isRequired: true },
+      { name: 'b', type: 'Number', value: 0, isRequired: true },
+    ]);
+
+    const result = mapActionForm(action, [], []);
+
+    expect(result.requiredFields).toEqual([]);
+    expect(result.canExecute).toBe(true);
+  });
+
+  it('passes skippedFields and layout through unchanged', () => {
+    const layout = [{ component: 'page', elements: [] }] as never;
+    const action = actionWith([]);
+
+    const result = mapActionForm(action, ['ghost'], layout);
+
+    expect(result.skippedFields).toEqual(['ghost']);
+    expect(result.layout).toBe(layout);
+  });
+});

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -114,6 +114,31 @@ const readModel = new ReadModel([
   collection('users', [column('id')], [action('approve', '/forest/_actions/users/0/approve')]),
 ]);
 
+function buildAppWithTerminal(client: AgentActionClient) {
+  const app = new Koa();
+  app.silent = true;
+  app.use(createErrorMiddleware({ logger: noopLogger }));
+  app.use(bodyParser());
+  app.use(async (ctx, next) => {
+    ctx.state.timezone = TIMEZONE;
+    ctx.state.agentToken = 'agent-jwt';
+    await next();
+  });
+  app.use(
+    createActionRoutesMiddleware({
+      store: storeOf(readModel),
+      agentUrl: 'https://agent.example.com',
+      logger: noopLogger,
+      createClient: () => client,
+    }),
+  );
+  app.use(async ctx => {
+    ctx.status = 204;
+  });
+
+  return app;
+}
+
 describe('action routes middleware', () => {
   it('returns the full form shape with fields, canExecute, requiredFields, skippedFields and layout', async () => {
     const form = makeAction({
@@ -328,6 +353,26 @@ describe('action routes middleware', () => {
       .send({ recordIds: ['42'] });
 
     expect(response.status).toBe(401);
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the next middleware for a non-POST request on the form path', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildAppWithTerminal(clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback()).get('/agent/v1/users/actions/approve/form');
+
+    expect(response.status).toBe(204);
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the next middleware for a path that is not an action form route', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildAppWithTerminal(clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+    expect(response.status).toBe(204);
     expect(loadActionForm).not.toHaveBeenCalled();
   });
 

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -209,6 +209,18 @@ describe('action routes middleware', () => {
     expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', ['1|2']);
   });
 
+  it('coerces a numeric zero recordId to a string so it survives the downstream filter', async () => {
+    const form = makeAction();
+    const loadActionForm = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+
+    await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: [0] });
+
+    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', ['0']);
+  });
+
   it('accepts an empty recordIds array for a global action', async () => {
     const form = makeAction();
     const loadActionForm = jest.fn(async () => form);

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -1,0 +1,332 @@
+import type { ActionForm, AgentActionClient } from '../../src/action/agent-action-client';
+import type { Logger } from '../../src/ports/logger-port';
+import type ReadModelStore from '../../src/read-model/read-model-store';
+
+import { AgentHttpError } from '@forestadmin/agent-client';
+import { bodyParser } from '@koa/bodyparser';
+import Koa from 'koa';
+import request from 'supertest';
+
+import createActionRoutesMiddleware from '../../src/action/action-routes-middleware';
+import createErrorMiddleware from '../../src/http/error-middleware';
+import SchemaUnavailableError from '../../src/read-model/errors';
+import ReadModel from '../../src/read-model/read-model';
+import { action, collection, column } from '../read-model/fixtures';
+
+const TIMEZONE = 'Europe/Paris';
+
+const noopLogger: Logger = () => {};
+
+function storeOf(readModel: ReadModel | Error): ReadModelStore {
+  return {
+    getReadModel: async () => {
+      if (readModel instanceof Error) throw readModel;
+
+      return readModel;
+    },
+  } as unknown as ReadModelStore;
+}
+
+interface FakeField {
+  name: string;
+  type: string;
+  value: unknown;
+  isRequired: boolean;
+  enumValues?: string[];
+}
+
+function makeAction({
+  fields = [],
+  layout = [],
+  skipped = [],
+  postChange,
+  execute = jest.fn(),
+}: {
+  fields?: FakeField[];
+  layout?: unknown[];
+  skipped?: string[];
+  postChange?: { fields?: FakeField[]; layout?: unknown[] };
+  execute?: jest.Mock;
+} = {}) {
+  const state = { fields: [...fields], layout: [...layout] };
+  const tryToSetFields = jest.fn(async () => {
+    if (postChange) {
+      state.fields = postChange.fields ?? state.fields;
+      state.layout = postChange.layout ?? state.layout;
+    }
+
+    return skipped;
+  });
+
+  const form: ActionForm & { tryToSetFields: jest.Mock; execute: jest.Mock } = {
+    execute,
+    tryToSetFields,
+    getFields: () =>
+      state.fields.map(f => ({
+        getName: () => f.name,
+        getType: () => f.type,
+        getValue: () => f.value,
+        isRequired: () => f.isRequired,
+      })),
+    getEnumField: (name: string) => ({
+      getOptions: () => state.fields.find(f => f.name === name)?.enumValues,
+    }),
+    getLayout: () => ({ layout: state.layout }),
+  };
+
+  return form;
+}
+
+function clientOf(
+  form: ActionForm,
+  loadActionForm: jest.Mock = jest.fn(async () => form),
+): AgentActionClient & { loadActionForm: jest.Mock } {
+  return { loadActionForm };
+}
+
+function buildApp(
+  store: ReadModelStore,
+  client: AgentActionClient,
+  { agentToken = 'agent-jwt' }: { agentToken?: string | null } = {},
+) {
+  const app = new Koa();
+  app.silent = true;
+  app.use(createErrorMiddleware({ logger: noopLogger }));
+  app.use(bodyParser());
+  app.use(async (ctx, next) => {
+    ctx.state.timezone = TIMEZONE;
+    if (agentToken !== null) ctx.state.agentToken = agentToken;
+    await next();
+  });
+  app.use(
+    createActionRoutesMiddleware({
+      store,
+      agentUrl: 'https://agent.example.com',
+      logger: noopLogger,
+      createClient: () => client,
+    }),
+  );
+
+  return app;
+}
+
+const readModel = new ReadModel([
+  collection('users', [column('id')], [action('approve', '/forest/_actions/users/0/approve')]),
+]);
+
+describe('action routes middleware', () => {
+  it('returns the full form shape with fields, canExecute, requiredFields, skippedFields and layout', async () => {
+    const form = makeAction({
+      fields: [{ name: 'reason', type: 'String', value: null, isRequired: true }],
+      layout: [{ component: 'input', fieldId: 'reason' }],
+      skipped: [],
+    });
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'], values: {} });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      fields: [{ name: 'reason', type: 'String', value: null, isRequired: true }],
+      canExecute: false,
+      requiredFields: ['reason'],
+      skippedFields: [],
+      layout: [{ component: 'input', fieldId: 'reason' }],
+    });
+  });
+
+  it('lists unknown submitted values in skippedFields', async () => {
+    const form = makeAction({
+      fields: [{ name: 'reason', type: 'String', value: 'x', isRequired: false }],
+      skipped: ['ghost'],
+    });
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'], values: { ghost: 1 } });
+
+    expect(form.tryToSetFields).toHaveBeenCalledWith({ ghost: 1 });
+    expect(response.body.skippedFields).toEqual(['ghost']);
+  });
+
+  it('reports canExecute true when every required field has a value', async () => {
+    const form = makeAction({
+      fields: [{ name: 'reason', type: 'String', value: 'ok', isRequired: true }],
+    });
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'] });
+
+    expect(response.body).toMatchObject({ canExecute: true, requiredFields: [] });
+  });
+
+  it('reads fields and layout after tryToSetFields when a change hook rebuilds the form', async () => {
+    const form = makeAction({
+      fields: [{ name: 'reason', type: 'String', value: null, isRequired: true }],
+      layout: [{ component: 'input', fieldId: 'reason' }],
+      postChange: {
+        fields: [{ name: 'comment', type: 'String', value: 'added', isRequired: false }],
+        layout: [{ component: 'input', fieldId: 'comment' }],
+      },
+    });
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'], values: { reason: 'x' } });
+
+    expect(response.body.fields).toEqual([
+      { name: 'comment', type: 'String', value: 'added', isRequired: false },
+    ]);
+    expect(response.body.layout).toEqual([{ component: 'input', fieldId: 'comment' }]);
+  });
+
+  it('never executes the action while loading its form', async () => {
+    const form = makeAction();
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'] });
+
+    expect(form.execute).not.toHaveBeenCalled();
+  });
+
+  it('passes an opaque composite recordId through unchanged', async () => {
+    const form = makeAction();
+    const loadActionForm = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+
+    await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['1|2'] });
+
+    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', ['1|2']);
+  });
+
+  it('accepts an empty recordIds array for a global action', async () => {
+    const form = makeAction();
+    const loadActionForm = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: [] });
+
+    expect(response.status).toBe(200);
+    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', []);
+  });
+
+  it('returns 400 invalid_request with no agent call when recordIds is missing', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ values: {} });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 invalid_request when recordIds is not an array', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: '42' });
+
+    expect(response.status).toBe(400);
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 invalid_request when values is not an object', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'], values: 'nope' });
+
+    expect(response.status).toBe(400);
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 unknown_action for an action that is not exposed', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/ghost/form')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toMatchObject({ type: 'unknown_action', status: 404 });
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('maps an agent failure on form load through the error contract', async () => {
+    const loadActionForm = jest.fn(async () => {
+      throw new AgentHttpError(
+        403,
+        { errors: [{ status: 403, name: 'ForbiddenError' }] },
+        undefined,
+      );
+    });
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({ type: 'forbidden', status: 403 });
+  });
+
+  it('maps an agent failure on tryToSetFields through the error contract', async () => {
+    const form = makeAction();
+    form.tryToSetFields.mockRejectedValueOnce(
+      new AgentHttpError(422, { errors: [{ status: 422, name: 'UnprocessableError' }] }, undefined),
+    );
+    const app = buildApp(storeOf(readModel), clientOf(form));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'], values: { reason: 'x' } });
+
+    expect(response.status).toBe(422);
+    expect(response.body.error).toMatchObject({ type: 'unprocessable_entity', status: 422 });
+  });
+
+  it('returns 401 when no agent token is available', async () => {
+    const loadActionForm = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm), {
+      agentToken: null,
+    });
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(401);
+    expect(loadActionForm).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 schema_unavailable when the schema cannot be loaded', async () => {
+    const app = buildApp(storeOf(new SchemaUnavailableError()), clientOf(makeAction()));
+
+    const response = await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+  });
+});

--- a/packages/agent-bff/test/action/agent-action-client.test.ts
+++ b/packages/agent-bff/test/action/agent-action-client.test.ts
@@ -1,0 +1,33 @@
+import { createRemoteAgentClient } from '@forestadmin/agent-client';
+
+import createAgentActionClient from '../../src/action/agent-action-client';
+
+jest.mock('@forestadmin/agent-client', () => ({ createRemoteAgentClient: jest.fn() }));
+
+const createRemoteAgentClientMock = createRemoteAgentClient as jest.Mock;
+
+describe('createAgentActionClient', () => {
+  it('loads the form via createRemoteAgentClient().collection(name).action(name, { recordIds })', async () => {
+    const loadedAction = { tag: 'action' };
+    const actionFn = jest.fn(async () => loadedAction);
+    const collectionFn = jest.fn(() => ({ action: actionFn }));
+    createRemoteAgentClientMock.mockReturnValue({ collection: collectionFn });
+
+    const actionEndpoints = { users: { approve: {} } } as never;
+    const client = createAgentActionClient({
+      agentUrl: 'https://agent.example.com',
+      token: 'agent-jwt',
+      actionEndpoints,
+    });
+    const result = await client.loadActionForm('users', 'approve', ['1', '2']);
+
+    expect(createRemoteAgentClientMock).toHaveBeenCalledWith({
+      url: 'https://agent.example.com',
+      token: 'agent-jwt',
+      actionEndpoints,
+    });
+    expect(collectionFn).toHaveBeenCalledWith('users');
+    expect(actionFn).toHaveBeenCalledWith('approve', { recordIds: ['1', '2'] });
+    expect(result).toBe(loadedAction);
+  });
+});

--- a/packages/agent-bff/test/action/extract-raw-layout.test.ts
+++ b/packages/agent-bff/test/action/extract-raw-layout.test.ts
@@ -1,0 +1,23 @@
+import type { ActionForm } from '../../src/action/agent-action-client';
+
+import ActionLayoutRoot from '@forestadmin/agent-client/dist/action-layout/action-layout-root';
+
+import { extractRawLayout } from '../../src/action/agent-action-client';
+
+function actionReturning(layout: unknown): ActionForm {
+  return { getLayout: () => layout } as unknown as ActionForm;
+}
+
+describe('extractRawLayout', () => {
+  it('unwraps the element array from a real agent-client ActionLayoutRoot', () => {
+    const elements = [{ component: 'input', fieldId: 'reason' }, { component: 'separator' }];
+
+    const result = extractRawLayout(actionReturning(new ActionLayoutRoot(elements as never)));
+
+    expect(result).toEqual(elements);
+  });
+
+  it('falls back to an empty array when the layout exposes no element array', () => {
+    expect(extractRawLayout(actionReturning({}))).toEqual([]);
+  });
+});

--- a/packages/agent-bff/test/http/agent-route-helpers.test.ts
+++ b/packages/agent-bff/test/http/agent-route-helpers.test.ts
@@ -1,0 +1,26 @@
+import type ReadModelStore from '../../src/read-model/read-model-store';
+
+import { resolveReadModel } from '../../src/http/agent-route-helpers';
+import SchemaUnavailableError from '../../src/read-model/errors';
+
+function storeThrowing(error: unknown): ReadModelStore {
+  return {
+    getReadModel: async () => {
+      throw error;
+    },
+  } as unknown as ReadModelStore;
+}
+
+describe('resolveReadModel', () => {
+  it('maps a SchemaUnavailableError to a 503 schema_unavailable error', async () => {
+    await expect(
+      resolveReadModel(storeThrowing(new SchemaUnavailableError())),
+    ).rejects.toMatchObject({ status: 503, type: 'schema_unavailable' });
+  });
+
+  it('rethrows a non-schema error unchanged', async () => {
+    const boom = new Error('boom');
+
+    await expect(resolveReadModel(storeThrowing(boom))).rejects.toBe(boom);
+  });
+});


### PR DESCRIPTION
Fixes PRD-673

## What

Adds `POST /v1/:collection/actions/:action/form` to `agent-bff`. It loads a Smart Action form without failing on unknown UI-supplied values and returns the fields a UI needs to render (including the layout). No activity log is written.

Response shape:
```
{ fields: [{ name, type, value, isRequired, enumValues? }], canExecute, requiredFields, skippedFields, layout }
```

## How

- **Action resolution** via the read-model action allow-list (`isActionAllowed`). Since the endpoint map *is* the allow-list, an absent action cannot be told from a known-but-disallowed one → every non-exposed action maps to `unknown_action` (404); `action_not_allowed` (403) has no local trigger, mirroring the `collection`/`relation` precedent.
- **Form load** reuses agent-client (`createRemoteAgentClient().collection().action()`), so the stateful `/hooks/load` + `/hooks/change` logic is not reimplemented. `tryToSetFields` skips unknown submitted values and returns them as `skippedFields`.
- **Error mapping** (PRD-670): each agent-hitting call (`loadActionForm`, `tryToSetFields`) is wrapped on its own; field/layout reads and mapping stay outside so a local bug surfaces as a 500. Fields and layout are read **after** `tryToSetFields` because a change hook rebuilds them.
- **Shared read-model store**: extracted `src/http/agent-route-helpers.ts` (token guard, read-model resolution, `callAgent`, `decodeSegment`) so the new action middleware and the existing data middleware share one cache.

## Decisions / deviations from the ticket

See the [planning-decisions comment on PRD-673](https://linear.app/forestadmin/issue/PRD-673) for the full list. Highlights:

- **`layout` = raw `ForestServerActionFormLayoutElement[]` array.** The spec is self-contradictory (prose says "`ActionLayoutRoot` serialized", example shows `{type,component,elements}`, actual `JSON.stringify` yields `{layout:[...]}`). We return the raw element array. ⚠️ **To confirm with Anthony** — trivial to change.
- **`enumValues` present only for `Enum` fields** (matches the MCP tool + AC `enumValues?`; the spec example shows `null` everywhere).
- **`recordIds: []` accepted** for global/bulk actions (spec AC only covers *missing* recordIds); non-array → `400 invalid_request` with no agent call.
- **Timezone limitation**: form hooks use agent-client’s hardcoded `Europe/Paris` (cannot forward the resolved timezone without an agent-client change, forbidden here). Tracked in **PRD-768**.
- **"No activity log" test is behavioral**: no activity-log writer exists in `agent-bff` yet (PRD-637); the test asserts the action is never executed / only form hooks are called.

## Tests

`test/action/action-routes-middleware.test.ts` + `test/action/action-form-mapper.test.ts`: full response shape incl. layout, skipped values, `canExecute` true/false, post-change-hook read ordering, `recordIds` missing/non-array/`[]`, `values` non-object, `unknown_action` 404, agent failures on load and `tryToSetFields` → PRD-670, 401/503.

Lint ✓ · build ✓ · 565/565 tests ✓.

> Stacked on the PRD-672 branch — merge #1746 first, then this rebases onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose POST action form endpoint in agent-bff
> - Adds a `POST /agent/v1/:collection/actions/:action/form` route in [action-routes-middleware.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1748/files#diff-1507f08ca51ccc3a715be158e30f8c80ccfb52881e3853b72775f1e677981d4d) that loads an action form from the agent, applies submitted values via `tryToSetFields`, and returns fields, `canExecute`, `requiredFields`, `skippedFields`, and layout.
> - Adds [action-form-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1748/files#diff-d92b29ebb0f7ffb07a8e4a66876f5501235d0d9f2b481cd048c0594267ae455c) to serialize `ActionForm` to a response object, including `enumValues` only for `Enum`-typed fields.
> - Adds [agent-action-client.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1748/files#diff-7e97dab793bf0ad68588e6be872c8f1e7a9fbc5e301f06152429397b0c6a1198) as a thin client that calls the remote agent to load action forms.
> - Extracts shared helpers (`decodeSegment`, `resolveReadModel`, `requireAgentToken`, `callAgent`) into [agent-route-helpers.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1748/files#diff-971699371a896d7fd29b364801eaae696000b5608f45d8230f125e08302101a8), replacing duplicated logic in the data routes middleware.
> - Updates [cli-core.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1748/files#diff-76c14e8251a9859dc672905a36febbeb3311acac1dd54a57a05f65282794f19c) to register both data and action route middlewares sharing a single read-model store.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae6772e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->