### PR TITLE
ci: unbreak main test suite

### DIFF
--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -46,6 +46,10 @@ const OPENAI_UNSUPPORTED_PATTERNS = [
 
 const OPENAI_UNSUPPORTED_MODELS = [
   'us-40-51r-vm-ev3', // Not a chat model (v1/completions only)
+  // Reject reasoning_effort with function tools on v1/chat/completions (v1/responses only)
+  'gpt-5.6-luna',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
 ];
 
 const OPENAI_SUPPORTED_OVERRIDES = ['gpt-4-turbo', 'gpt-4o', 'gpt-4.1'];

--- a/packages/ai-proxy/test/supported-models.test.ts
+++ b/packages/ai-proxy/test/supported-models.test.ts
@@ -13,6 +13,13 @@ describe('isModelSupportingTools', () => {
     expect(isModelSupportingTools('gpt-4')).toBe(false);
   });
 
+  it.each(['gpt-5.6-luna', 'gpt-5.6-sol', 'gpt-5.6-terra'])(
+    'should return false for %s (v1/responses only)',
+    model => {
+      expect(isModelSupportingTools(model)).toBe(false);
+    },
+  );
+
   it('should return false for claude-fable-5 (always-on thinking incompatible with proxy)', () => {
     expect(isModelSupportingTools('claude-fable-5', 'anthropic')).toBe(false);
   });

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -3177,7 +3177,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       await new LoadRelatedRecordStepExecutor(context).execute();
 
-      expect(selectRecordPrompt(invoke)).not.toContain('-1');
+      expect(selectRecordPrompt(invoke)).not.toContain('return -1');
     });
 
     // The AI sees only the budgeted prefix, but its index maps back into the FULL list — so a


### PR DESCRIPTION
## Why

The `Lint, Build, Test and Doc` workflow has been red on `main` since 2026-07-09 due to two independent, non-code-regression failures.

## Fixes

### 1. workflow-executor — date-dependent test

`load-related-record-step-executor.test.ts` asserted the whole select-record prompt `not.toContain('-1')` to verify the `-1` "none" option is withheld when the candidate list is truncated. The prompt embeds the current date (`Current date and time: 2026-07-10...`), and any date containing the substring `-1` (day 10-19, or months 10-12) matched, failing the assertion. Passed on 2026-07-08 (last green run), broke on 2026-07-10.

Fix: assert against the actual none-option text (`return -1`) rather than the raw `-1` substring across the full prompt.

### 2. ai-proxy — unsupported OpenAI models

`gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra` reject function tools combined with `reasoning_effort` on `v1/chat/completions` (they only support `v1/responses`), failing the `llm.integration` tool-support test. Added them to `OPENAI_UNSUPPORTED_MODELS`, per the maintained allow/deny-list convention, plus a unit test.

## Test

- `workflow-executor`: 102/102 pass
- `ai-proxy` supported-models: 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI test suite by blocking gpt-5.6-luna, gpt-5.6-sol, and gpt-5.6-terra from tool support
> - Adds `'gpt-5.6-luna'`, `'gpt-5.6-sol'`, and `'gpt-5.6-terra'` to `OPENAI_UNSUPPORTED_MODELS` in [supported-models.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1750/files#diff-c8703b3b65d1492f147178cbdc7ea897138fe0c4fe9c842993d4141d7a8a6cd3); these models reject `reasoning_effort` with function tools on `v1/chat/completions`.
> - Updates a test assertion in [load-related-record-step-executor.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1750/files#diff-ac728230ca190f664862205507ae80cd2c51bc30da32dfa3e0ccbd36e13f3345) to check for absence of `'return -1'` rather than `'-1'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8cfea08. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->