### PR TITLE
fix(workflow-executor): Full AI load-related — reference field + empty-list skip (PRD-751)

### DIFF
--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -337,6 +337,12 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     });
   }
 
+  private followableRelationFields(sourceSchema: CollectionSchema): RelationRef[] {
+    return sourceSchema.fields
+      .filter(isFollowableRelation)
+      .map(f => ({ name: f.fieldName, displayName: f.displayName }));
+  }
+
   private async persistAwaitInput(
     target: RelationTarget,
     sourceSchema: CollectionSchema,
@@ -348,15 +354,11 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   ): Promise<StepExecutionResult> {
     const { selectedRecordRef, name, displayName } = target;
 
-    const availableFields: RelationRef[] = sourceSchema.fields
-      .filter(isFollowableRelation)
-      .map(f => ({ name: f.fieldName, displayName: f.displayName }));
-
     await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'load-related-record',
       stepIndex: this.context.stepIndex,
       pendingData: {
-        availableFields,
+        availableFields: this.followableRelationFields(sourceSchema),
         suggestedField: { name, displayName },
         availableRecordIds: pending.availableRecordIds,
         suggestedRecord: pending.suggestedRecord,
@@ -450,7 +452,21 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       stepIndex: this.context.stepIndex,
     };
 
-    return this.persistAndReturn(record, target, undefined);
+    // Persist the candidates as pendingData on the completed step so the front's record dropdown keeps
+    // each candidate's referenceFieldValue label; without it Full AI's auto-load falls back to the
+    // raw recordId (AI-assisted already carries this through its await-then-confirm execution).
+    const sourceSchema = await this.getCollectionSchema(target.selectedRecordRef.collectionName);
+
+    return this.persistAndReturn(record, target, {
+      type: 'load-related-record',
+      stepIndex: this.context.stepIndex,
+      pendingData: {
+        availableFields: this.followableRelationFields(sourceSchema),
+        suggestedField: { name: target.name, displayName: target.displayName },
+        availableRecordIds,
+        suggestedRecord,
+      },
+    });
   }
 
   private async fetchXToOneCandidate(

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -630,11 +630,16 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
     });
   }
 
-  /** Persists the loaded record ref and returns a success outcome. */
-  /** Persists a "continue without a record" skip and returns a success outcome. */
   private async persistSkip(
     target: Pick<RelationTarget, 'selectedRecordRef' | 'name' | 'displayName'>,
   ): Promise<StepExecutionResult> {
+    // Full AI made this call on its own — log it so an unexpectedly empty relation is auditable.
+    this.context.logger(
+      'Info',
+      'load-related-record: no candidate to load, continuing without a record',
+      { ...this.logCtx, relation: target.name },
+    );
+
     await this.context.runStore.saveStepExecution(this.context.runId, {
       type: 'load-related-record',
       stepIndex: this.context.stepIndex,

--- a/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/load-related-record-step-executor.ts
@@ -434,8 +434,15 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
       true,
     );
 
-    // Full AI auto-loads only a confident single pick; otherwise it degrades to an AI-assisted
-    // confirmation — "No X to load" pre-checked when nothing fits, else its best guess pre-selected.
+    // Full AI with no candidate at all: a human couldn't pick one either, so continue without a
+    // record (skip) instead of handing off to AI-assisted (PRD-751 decision).
+    if (availableRecordIds.length === 0) {
+      return this.persistSkip(target);
+    }
+
+    // Otherwise Full AI auto-loads only a confident single pick; a non-empty list with no confident
+    // pick (ambiguous, or the AI judged none relevant) degrades to an AI-assisted confirmation
+    // ("No X to load" pre-checked when the AI found nothing relevant, else its best guess).
     if (!suggestedRecord || ambiguous) {
       const sourceSchema = await this.getCollectionSchema(target.selectedRecordRef.collectionName);
 
@@ -624,6 +631,21 @@ export default class LoadRelatedRecordStepExecutor extends RecordStepExecutor<Lo
   }
 
   /** Persists the loaded record ref and returns a success outcome. */
+  /** Persists a "continue without a record" skip and returns a success outcome. */
+  private async persistSkip(
+    target: Pick<RelationTarget, 'selectedRecordRef' | 'name' | 'displayName'>,
+  ): Promise<StepExecutionResult> {
+    await this.context.runStore.saveStepExecution(this.context.runId, {
+      type: 'load-related-record',
+      stepIndex: this.context.stepIndex,
+      executionParams: { name: target.name, displayName: target.displayName },
+      executionResult: { skipped: true },
+      selectedRecordRef: target.selectedRecordRef,
+    });
+
+    return this.buildOutcomeResult({ status: 'success' });
+  }
+
   private async persistAndReturn(
     record: RecordRef,
     target: Pick<RelationTarget, 'selectedRecordRef' | 'name' | 'displayName'>,

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -1062,8 +1062,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    // Empty list: Full AI hands off with "No X to load" pre-checked rather than auto-skipping.
-    it('falls back to awaiting-input (No X to load) when getRelatedData returns an empty array (Branch B)', async () => {
+    // Empty list: Full AI has nothing to load and nothing a human could pick either, so it continues
+    // without a record (skip) instead of handing off to AI-assisted (PRD-751).
+    it('continues without a record (skip) when getRelatedData returns an empty array (Branch B)', async () => {
       const belongsToManySchema = makeCollectionSchema({
         fields: [
           {
@@ -1089,11 +1090,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       const result = await executor.execute();
 
-      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(result.stepOutcome.status).toBe('success');
       const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
-      expect(saved.pendingData.availableRecordIds).toEqual([]);
-      expect(saved.pendingData.suggestedRecord).toBeUndefined();
-      expect(saved.pendingData.suggestNoRecord).toBe(true);
+      expect(saved.executionResult).toEqual({ skipped: true });
     });
   });
 
@@ -3364,8 +3363,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
     });
   });
 
-  describe('empty candidate list → awaiting-input (No X to load)', () => {
-    it('falls back to awaiting-input when BelongsTo has no linked record (Branch B)', async () => {
+  describe('empty candidate list → skip (Full AI continues without a record)', () => {
+    it('skips when BelongsTo has no linked record (Branch B)', async () => {
       const agentPort = makeMockAgentPort([]);
       const mockModel = makeMockModel({
         relation: relationOption({
@@ -3386,13 +3385,12 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       const result = await executor.execute();
 
-      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(result.stepOutcome.status).toBe('success');
       const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
-      expect(saved.pendingData.availableRecordIds).toEqual([]);
-      expect(saved.pendingData.suggestNoRecord).toBe(true);
+      expect(saved.executionResult).toEqual({ skipped: true });
     });
 
-    it('falls back to awaiting-input when HasMany returns an empty array (Branch B)', async () => {
+    it('skips when HasMany returns an empty array (Branch B)', async () => {
       const hasManySchema = makeCollectionSchema({
         fields: [
           {
@@ -3418,10 +3416,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
 
       const result = await executor.execute();
 
-      expect(result.stepOutcome.status).toBe('awaiting-input');
+      expect(result.stepOutcome.status).toBe('success');
       const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
-      expect(saved.pendingData.availableRecordIds).toEqual([]);
-      expect(saved.pendingData.suggestNoRecord).toBe(true);
+      expect(saved.executionResult).toEqual({ skipped: true });
     });
   });
 

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -510,6 +510,7 @@ describe('LoadRelatedRecordStepExecutor', () => {
       const addressSchema = makeCollectionSchema({
         collectionName: 'addresses',
         collectionDisplayName: 'Addresses',
+        referenceField: 'city',
         fields: [
           { fieldName: 'city', displayName: 'City', isRelationship: false },
           { fieldName: 'zip', displayName: 'Zip', isRelationship: false },
@@ -577,8 +578,8 @@ describe('LoadRelatedRecordStepExecutor', () => {
           // one's referenceFieldValue label instead of falling back to the raw recordId (PRD-751).
           pendingData: expect.objectContaining({
             availableRecordIds: expect.arrayContaining([
-              expect.objectContaining({ recordId: [1] }),
-              expect.objectContaining({ recordId: [2] }),
+              expect.objectContaining({ recordId: [1], referenceFieldValue: 'Paris' }),
+              expect.objectContaining({ recordId: [2], referenceFieldValue: 'Lyon' }),
             ]),
           }),
         }),
@@ -1093,6 +1094,11 @@ describe('LoadRelatedRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       const saved = (runStore.saveStepExecution as jest.Mock).mock.calls.at(-1)?.[1];
       expect(saved.executionResult).toEqual({ skipped: true });
+      // The skip still records the relation and the source record for downstream steps.
+      expect(saved.executionParams).toEqual({ name: 'tags', displayName: 'Tags' });
+      expect(saved.selectedRecordRef).toEqual(
+        expect.objectContaining({ collectionName: 'customers', recordId: [42] }),
+      );
     });
   });
 

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -573,6 +573,14 @@ describe('LoadRelatedRecordStepExecutor', () => {
           executionResult: expect.objectContaining({
             record: expect.objectContaining({ collectionName: 'addresses', recordId: [2] }),
           }),
+          // The candidates are persisted as pendingData so the front's record dropdown can show each
+          // one's referenceFieldValue label instead of falling back to the raw recordId (PRD-751).
+          pendingData: expect.objectContaining({
+            availableRecordIds: expect.arrayContaining([
+              expect.objectContaining({ recordId: [1] }),
+              expect.objectContaining({ recordId: [2] }),
+            ]),
+          }),
         }),
       );
     });


### PR DESCRIPTION
## Summary

Two PRD-751 fixes to the **Full AI** Load Related Record path in the executor (both in `load-related-record-step-executor.ts`).

### 1. Keep the reference field on loaded records

In Full AI, the run's record dropdown showed the raw `recordId` instead of the record's **reference field** label (Full-AI-only — AI-assisted already carried the candidates through its await-then-confirm flow). The auto-load path called `persistAndReturn` with no `pendingData`, so the completed step had no `availableRecordIds` for the front to read. Now the candidates' `pendingData` (with `referenceFieldValue`) is persisted on the auto-load path too.

### 2. Auto-skip when the candidate list is empty

Per the sync with Brice (documented on PRD-751): in Full AI, an **empty candidate list** (no related record at all) now **continues without a record (skip)** instead of handing off to AI-assisted — a human couldn't pick one either. Unchanged: a non-empty list with no confident pick (ambiguous, or the AI judged none relevant) still degrades to the AI-assisted confirmation.

## Testing

- Extended/updated the executor tests: Full AI persists `pendingData.availableRecordIds` on auto-load; empty-list (BelongsTo / HasMany / BelongsToMany) now skips (`executionResult: { skipped: true }`, success); AI-assisted empty-list and "AI judged none relevant" cases still await input. 102 tests green.
- Manual E2E: a Full AI Load Related step (account → store) shows the store's reference field ("Bradtke - Donnelly") in the record dropdown.

fixes PRD-751

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix empty-list skip and reference field handling in `LoadRelatedRecordStepExecutor` for full AI mode
> - When no candidate related records are found in fully automated execution, the step now persists a skip (`executionResult.skipped=true`) via a new `persistSkip` method and returns success instead of awaiting input.
> - When a confident record is auto-loaded, the saved step execution now includes `pendingData` (candidate list, suggested field, available fields via the new `followableRelationFields` helper) so candidate labels are preserved.
> - Extracts a `followableRelationFields` helper to avoid duplicate inline computation across `persistAwaitInput` and `resolveAndLoadAutomatic`.
> - Behavioral Change: fully automated workflows with empty related-record lists no longer stall awaiting input — they skip the step and continue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ca5a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->