### PR TITLE
feat(agent-bff): expose the action execute endpoint with result normalization

### DIFF
--- a/packages/agent-bff/package.json
+++ b/packages/agent-bff/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@forestadmin/agent-client": "1.12.2",
+    "@forestadmin/datasource-toolkit": "1.54.0",
     "@forestadmin/forestadmin-client": "1.41.3",
     "@koa/bodyparser": "^6.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -33,10 +33,10 @@ export interface ActionExecuteMapped {
   body: ActionExecuteMappedBody;
 }
 
-// Normalizes the agent's 200 execute payload into the flat BFF wrapper. The native ActionResult
-// union never reaches the BFF (agent-client `execute()` is typed `{ success, html? }`), so we
-// discriminate on the agent HTTP payload shape. A File result streams a binary with no JSON marker,
-// so any unrecognized 200 body falls through to a structured 501 rather than being mislabelled.
+// Normalizes the agent's 200 execute payload into the flat BFF wrapper. The execute result is
+// untyped at the BFF boundary (`Action.execute(): Promise<unknown>`), so we discriminate on the
+// agent HTTP payload shape. A File result streams a binary with no JSON marker, so any unrecognized
+// 200 body falls through to a structured 501 rather than being mislabelled.
 export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
   const body = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
 

--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -40,10 +40,11 @@ export interface ActionExecuteMapped {
 export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
   const body = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
 
-  if ('webhook' in body) {
-    const hook = (
-      typeof body.webhook === 'object' && body.webhook !== null ? body.webhook : {}
-    ) as Record<string, unknown>;
+  // Each branch validates the value shape, not just key presence: a malformed payload
+  // (`{ webhook: null }`, `{ redirectTo: {} }`, `{ success: {} }`) must fall through to the 501
+  // path rather than be surfaced as a 200 with null fields the client cannot tell from a real one.
+  if (typeof body.webhook === 'object' && body.webhook !== null) {
+    const hook = body.webhook as Record<string, unknown>;
 
     return {
       status: 200,
@@ -57,21 +58,23 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
     };
   }
 
-  if ('redirectTo' in body) {
+  if (typeof body.redirectTo === 'string') {
     return { status: 200, body: { type: 'redirect', path: body.redirectTo } };
   }
 
-  if ('success' in body || 'refresh' in body) {
-    const refresh = (
-      typeof body.refresh === 'object' && body.refresh !== null ? body.refresh : {}
-    ) as { relationships?: unknown };
+  const refresh = typeof body.refresh === 'object' && body.refresh !== null ? body.refresh : null;
+
+  // A Success carries a string message and/or a refresh object; the agent always sends the refresh,
+  // so a bare refresh (message absent) still normalizes to a success with a null message.
+  if (typeof body.success === 'string' || refresh !== null) {
+    const relationships = (refresh as { relationships?: unknown } | null)?.relationships;
 
     return {
       status: 200,
       body: {
         type: 'success',
         message: typeof body.success === 'string' ? body.success : null,
-        invalidated: Array.isArray(refresh.relationships) ? (refresh.relationships as string[]) : [],
+        invalidated: Array.isArray(relationships) ? (relationships as string[]) : [],
         html: typeof body.html === 'string' ? body.html : null,
       },
     };

--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -1,0 +1,81 @@
+export interface ActionExecuteSuccessBody {
+  type: 'success';
+  message: string | null;
+  invalidated: string[];
+  html: string | null;
+}
+
+export interface ActionExecuteWebhookBody {
+  type: 'webhook';
+  url: unknown;
+  method: unknown;
+  headers: unknown;
+  body: unknown;
+}
+
+export interface ActionExecuteRedirectBody {
+  type: 'redirect';
+  path: unknown;
+}
+
+export interface ActionExecuteUnsupportedBody {
+  error: { type: 'unsupported_action_result'; status: 501 };
+}
+
+export type ActionExecuteMappedBody =
+  | ActionExecuteSuccessBody
+  | ActionExecuteWebhookBody
+  | ActionExecuteRedirectBody
+  | ActionExecuteUnsupportedBody;
+
+export interface ActionExecuteMapped {
+  status: number;
+  body: ActionExecuteMappedBody;
+}
+
+// Normalizes the agent's 200 execute payload into the flat BFF wrapper. The native ActionResult
+// union never reaches the BFF (agent-client `execute()` is typed `{ success, html? }`), so we
+// discriminate on the agent HTTP payload shape. A File result streams a binary with no JSON marker,
+// so any unrecognized 200 body falls through to a structured 501 rather than being mislabelled.
+export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
+  const body = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+
+  if ('webhook' in body) {
+    const hook = (
+      typeof body.webhook === 'object' && body.webhook !== null ? body.webhook : {}
+    ) as Record<string, unknown>;
+
+    return {
+      status: 200,
+      body: {
+        type: 'webhook',
+        url: hook.url,
+        method: hook.method,
+        headers: hook.headers,
+        body: hook.body,
+      },
+    };
+  }
+
+  if ('redirectTo' in body) {
+    return { status: 200, body: { type: 'redirect', path: body.redirectTo } };
+  }
+
+  if ('success' in body || 'refresh' in body) {
+    const refresh = (
+      typeof body.refresh === 'object' && body.refresh !== null ? body.refresh : {}
+    ) as { relationships?: unknown };
+
+    return {
+      status: 200,
+      body: {
+        type: 'success',
+        message: typeof body.success === 'string' ? body.success : null,
+        invalidated: Array.isArray(refresh.relationships) ? (refresh.relationships as string[]) : [],
+        html: typeof body.html === 'string' ? body.html : null,
+      },
+    };
+  }
+
+  return { status: 501, body: { error: { type: 'unsupported_action_result', status: 501 } } };
+}

--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -51,6 +51,14 @@ function isWebhook(value: unknown): value is AgentWebhookPayload {
   return typeof url === 'string' && typeof method === 'string';
 }
 
+// The agent serializes a Success refresh as `{ relationships: [...] }`, so anything else (an array,
+// a bare object without relationships) is malformed and must not act as the Success discriminator.
+function isRefresh(value: unknown): value is { relationships: unknown[] } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  return Array.isArray((value as { relationships?: unknown }).relationships);
+}
+
 // Normalizes the agent's 200 execute payload into the flat BFF wrapper. The execute result is
 // untyped at the BFF boundary (`Action.execute(): Promise<unknown>`), so we discriminate on the
 // agent HTTP payload shape. A File result streams a binary with no JSON marker, so any unrecognized
@@ -71,21 +79,17 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
     return { status: 200, body: { type: 'redirect', path: body.redirectTo } };
   }
 
-  const refresh = typeof body.refresh === 'object' && body.refresh !== null ? body.refresh : null;
-
-  // A Success carries a string message and/or a refresh object; the agent always sends the refresh,
-  // so a bare refresh (message absent) still normalizes to a success with a null message.
-  if (typeof body.success === 'string' || refresh !== null) {
-    const relationships = (refresh as { relationships?: unknown } | null)?.relationships;
+  // A Success carries a string message and/or a well-formed refresh; the agent always sends the
+  // refresh, so a bare refresh (message absent) still normalizes to a success with a null message.
+  if (typeof body.success === 'string' || isRefresh(body.refresh)) {
+    const relationships = isRefresh(body.refresh) ? body.refresh.relationships : [];
 
     return {
       status: 200,
       body: {
         type: 'success',
         message: typeof body.success === 'string' ? body.success : null,
-        invalidated: Array.isArray(relationships)
-          ? relationships.filter((name): name is string => typeof name === 'string')
-          : [],
+        invalidated: relationships.filter((name): name is string => typeof name === 'string'),
         html: typeof body.html === 'string' ? body.html : null,
       },
     };

--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -33,6 +33,24 @@ export interface ActionExecuteMapped {
   body: ActionExecuteMappedBody;
 }
 
+interface AgentWebhookPayload {
+  url: string;
+  method: string;
+  headers: unknown;
+  body: unknown;
+}
+
+// The agent always serializes the four webhook fields together
+// (`agent/src/routes/modification/action/action.ts`), so a payload missing url/method is malformed
+// and must reach the 501 path rather than surface as a 200 the client cannot act on.
+function isWebhook(value: unknown): value is AgentWebhookPayload {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const { url, method } = value as Record<string, unknown>;
+
+  return typeof url === 'string' && typeof method === 'string';
+}
+
 // Normalizes the agent's 200 execute payload into the flat BFF wrapper. The execute result is
 // untyped at the BFF boundary (`Action.execute(): Promise<unknown>`), so we discriminate on the
 // agent HTTP payload shape. A File result streams a binary with no JSON marker, so any unrecognized
@@ -43,19 +61,10 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
   // Each branch validates the value shape, not just key presence: a malformed payload
   // (`{ webhook: null }`, `{ redirectTo: {} }`, `{ success: {} }`) must fall through to the 501
   // path rather than be surfaced as a 200 with null fields the client cannot tell from a real one.
-  if (typeof body.webhook === 'object' && body.webhook !== null) {
-    const hook = body.webhook as Record<string, unknown>;
+  if (isWebhook(body.webhook)) {
+    const { url, method, headers, body: hookBody } = body.webhook;
 
-    return {
-      status: 200,
-      body: {
-        type: 'webhook',
-        url: hook.url,
-        method: hook.method,
-        headers: hook.headers,
-        body: hook.body,
-      },
-    };
+    return { status: 200, body: { type: 'webhook', url, method, headers, body: hookBody } };
   }
 
   if (typeof body.redirectTo === 'string') {
@@ -74,7 +83,9 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
       body: {
         type: 'success',
         message: typeof body.success === 'string' ? body.success : null,
-        invalidated: Array.isArray(relationships) ? (relationships as string[]) : [],
+        invalidated: Array.isArray(relationships)
+          ? relationships.filter((name): name is string => typeof name === 'string')
+          : [],
         html: typeof body.html === 'string' ? body.html : null,
       },
     };

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -70,7 +70,10 @@ async function handleForm(
   // Each agent-hitting call is wrapped on its own; getFields/extractRawLayout/mapping stay outside
   // callAgent so a local BFF bug surfaces as a 500, not a mislabelled agent error. Fields and
   // layout are read AFTER tryToSetFields because a change hook rebuilds them in place.
-  const action = await callAgent(() => client.loadAction(collection, actionName, recordIds), logger);
+  const action = await callAgent(
+    () => client.loadAction(collection, actionName, recordIds),
+    logger,
+  );
   const skippedFields = await callAgent(() => action.tryToSetFields(values), logger);
 
   ctx.status = 200;
@@ -86,7 +89,10 @@ async function handleExecute(
   values: Record<string, unknown>,
   logger: Logger,
 ): Promise<void> {
-  const action = await callAgent(() => client.loadAction(collection, actionName, recordIds), logger);
+  const action = await callAgent(
+    () => client.loadAction(collection, actionName, recordIds),
+    logger,
+  );
 
   // setFields is strict: an unknown submitted field is a client error (400), not a 500. A transport
   // failure from the change-hook it triggers is a genuine agent error, so it goes to the mapper.

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -1,21 +1,29 @@
 import type { AgentActionClient, AgentActionClientOptions } from './agent-action-client';
 import type { Logger } from '../ports/logger-port';
 import type ReadModelStore from '../read-model/read-model-store';
-import type { Middleware } from 'koa';
+import type { Context, Middleware } from 'koa';
 
+import {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  UnknownActionFieldError,
+} from '@forestadmin/agent-client';
+
+import { mapActionExecuteResult } from './action-execute-mapper';
 import { mapActionForm } from './action-form-mapper';
 import defaultCreateAgentActionClient, { extractRawLayout } from './agent-action-client';
+import { mapAgentError } from '../http/agent-error-mapper';
 import {
   callAgent,
   decodeSegment,
   requireAgentToken,
   resolveReadModel,
 } from '../http/agent-route-helpers';
-import { invalidRequest, unknownAction } from '../http/bff-local-errors';
+import { actionRequiresApproval, invalidRequest, unknownAction } from '../http/bff-local-errors';
 
-const ACTION_FORM_ROUTE = /^\/agent\/v1\/([^/]+)\/actions\/([^/]+)\/form$/;
+const ACTION_ROUTE = /^\/agent\/v1\/([^/]+)\/actions\/([^/]+)\/(form|execute)$/;
 
-interface ActionFormRequestBody {
+interface ActionRequestBody {
   recordIds?: unknown;
   values?: unknown;
 }
@@ -50,6 +58,77 @@ export interface ActionRoutesMiddlewareOptions {
   createClient?: (options: AgentActionClientOptions) => AgentActionClient;
 }
 
+async function handleForm(
+  ctx: Context,
+  client: AgentActionClient,
+  collection: string,
+  actionName: string,
+  recordIds: string[],
+  values: Record<string, unknown>,
+  logger: Logger,
+): Promise<void> {
+  // Each agent-hitting call is wrapped on its own; getFields/extractRawLayout/mapping stay outside
+  // callAgent so a local BFF bug surfaces as a 500, not a mislabelled agent error. Fields and
+  // layout are read AFTER tryToSetFields because a change hook rebuilds them in place.
+  const action = await callAgent(() => client.loadAction(collection, actionName, recordIds), logger);
+  const skippedFields = await callAgent(() => action.tryToSetFields(values), logger);
+
+  ctx.status = 200;
+  ctx.body = mapActionForm(action, skippedFields, extractRawLayout(action));
+}
+
+async function handleExecute(
+  ctx: Context,
+  client: AgentActionClient,
+  collection: string,
+  actionName: string,
+  recordIds: string[],
+  values: Record<string, unknown>,
+  logger: Logger,
+): Promise<void> {
+  const action = await callAgent(() => client.loadAction(collection, actionName, recordIds), logger);
+
+  // setFields is strict: an unknown submitted field is a client error (400), not a 500. A transport
+  // failure from the change-hook it triggers is a genuine agent error, so it goes to the mapper.
+  try {
+    await action.setFields(values);
+  } catch (error) {
+    if (error instanceof UnknownActionFieldError) throw invalidRequest(error.message);
+    throw mapAgentError(error, { logger });
+  }
+
+  // execute() cannot go through the generic callAgent: agent-client turns the native action Error
+  // (HTTP 400) into ActionFormValidationError, a non-AgentHttpError the mapper would mislabel as a
+  // transport 502. So the semantic outcomes are caught here, everything else falls to the mapper.
+  let raw: unknown;
+
+  try {
+    raw = await action.execute();
+  } catch (error) {
+    if (error instanceof ActionRequiresApprovalError) {
+      throw actionRequiresApproval(
+        error.message,
+        error.roleIdsAllowedToApprove
+          ? { roleIdsAllowedToApprove: error.roleIdsAllowedToApprove }
+          : undefined,
+      );
+    }
+
+    if (error instanceof ActionFormValidationError) {
+      ctx.status = 400;
+      ctx.body = { type: 'error', status: 400, message: error.message, html: error.html ?? null };
+
+      return;
+    }
+
+    throw mapAgentError(error, { logger });
+  }
+
+  const { status, body } = mapActionExecuteResult(raw);
+  ctx.status = status;
+  ctx.body = body;
+}
+
 export default function createActionRoutesMiddleware({
   store,
   agentUrl,
@@ -57,7 +136,7 @@ export default function createActionRoutesMiddleware({
   createClient = defaultCreateAgentActionClient,
 }: ActionRoutesMiddlewareOptions): Middleware {
   return async function actionRoutesMiddleware(ctx, next) {
-    const match = ACTION_FORM_ROUTE.exec(ctx.path);
+    const match = ACTION_ROUTE.exec(ctx.path);
 
     if (!match || ctx.method !== 'POST') {
       await next();
@@ -67,6 +146,7 @@ export default function createActionRoutesMiddleware({
 
     const collection = decodeSegment(match[1], 'collection name');
     const actionName = decodeSegment(match[2], 'action name');
+    const verb = match[3];
     const token = requireAgentToken(ctx);
     const readModel = await resolveReadModel(store);
 
@@ -79,7 +159,7 @@ export default function createActionRoutesMiddleware({
       throw unknownAction(`Unknown action: ${collection}.${actionName}`);
     }
 
-    const body = (ctx.request.body ?? {}) as ActionFormRequestBody;
+    const body = (ctx.request.body ?? {}) as ActionRequestBody;
     const recordIds = parseRecordIds(body.recordIds);
     const values = parseValues(body.values);
 
@@ -89,16 +169,10 @@ export default function createActionRoutesMiddleware({
       actionEndpoints: readModel.getActionEndpoints(),
     });
 
-    // Each agent-hitting call is wrapped on its own; getFields/extractRawLayout/mapping stay outside
-    // callAgent so a local BFF bug surfaces as a 500, not a mislabelled agent error. Fields and
-    // layout are read AFTER tryToSetFields because a change hook rebuilds them in place.
-    const action = await callAgent(
-      () => client.loadActionForm(collection, actionName, recordIds),
-      logger,
-    );
-    const skippedFields = await callAgent(() => action.tryToSetFields(values), logger);
-
-    ctx.status = 200;
-    ctx.body = mapActionForm(action, skippedFields, extractRawLayout(action));
+    if (verb === 'execute') {
+      await handleExecute(ctx, client, collection, actionName, recordIds, values, logger);
+    } else {
+      await handleForm(ctx, client, collection, actionName, recordIds, values, logger);
+    }
   };
 }

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -131,6 +131,15 @@ async function handleExecute(
   }
 
   const { status, body } = mapActionExecuteResult(raw);
+
+  // An unrecognized payload (a File stream, or a new agent result type) maps to a generic 501 with
+  // no trace of what it was; log the payload keys so the case can be diagnosed without the body.
+  if (status === 501) {
+    logger('Warn', 'Unrecognized action execute result mapped to 501', {
+      keys: typeof raw === 'object' && raw !== null ? Object.keys(raw) : typeof raw,
+    });
+  }
+
   ctx.status = status;
   ctx.body = body;
 }

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -108,7 +108,7 @@ async function handleExecute(
     if (error instanceof ActionRequiresApprovalError) {
       throw actionRequiresApproval(
         error.message,
-        error.roleIdsAllowedToApprove
+        error.roleIdsAllowedToApprove !== undefined
           ? { roleIdsAllowedToApprove: error.roleIdsAllowedToApprove }
           : undefined,
       );

--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -51,6 +51,19 @@ function parseValues(raw: unknown): Record<string, unknown> {
   return raw as Record<string, unknown>;
 }
 
+// Only plain objects are enumerated: a File result arrives as a Buffer/stream whose every byte
+// index is an enumerable key, so `Object.keys` on it would build a multi-million entry log.
+function describePayloadShape(raw: unknown): string {
+  if (raw === null) return 'null';
+  if (typeof raw !== 'object') return typeof raw;
+  if (Buffer.isBuffer(raw)) return `Buffer(${raw.length})`;
+  if (ArrayBuffer.isView(raw)) return `${raw.constructor.name}(${raw.byteLength})`;
+  if (Array.isArray(raw)) return `array(${raw.length})`;
+  if (Object.getPrototypeOf(raw) !== Object.prototype) return raw.constructor?.name ?? 'object';
+
+  return `object{${Object.keys(raw).join(',')}}`;
+}
+
 export interface ActionRoutesMiddlewareOptions {
   store: ReadModelStore;
   agentUrl: string;
@@ -133,10 +146,10 @@ async function handleExecute(
   const { status, body } = mapActionExecuteResult(raw);
 
   // An unrecognized payload (a File stream, or a new agent result type) maps to a generic 501 with
-  // no trace of what it was; log the payload keys so the case can be diagnosed without the body.
+  // no trace of what it was; log a short shape hint so the case can be diagnosed without the body.
   if (status === 501) {
     logger('Warn', 'Unrecognized action execute result mapped to 501', {
-      keys: typeof raw === 'object' && raw !== null ? Object.keys(raw) : typeof raw,
+      shape: describePayloadShape(raw),
     });
   }
 

--- a/packages/agent-bff/src/action/agent-action-client.ts
+++ b/packages/agent-bff/src/action/agent-action-client.ts
@@ -19,8 +19,15 @@ export interface ActionForm {
   getLayout(): unknown;
 }
 
+// The form and execute endpoints load the same agent-client `Action` object; execute adds the
+// strict setFields + execute members on top of the form ones.
+export interface Action extends ActionForm {
+  setFields(values: Record<string, unknown>): Promise<void>;
+  execute(): Promise<unknown>;
+}
+
 export interface AgentActionClient {
-  loadActionForm(collection: string, action: string, recordIds: string[]): Promise<ActionForm>;
+  loadAction(collection: string, action: string, recordIds: string[]): Promise<Action>;
 }
 
 export interface AgentActionClientOptions {
@@ -53,7 +60,7 @@ export default function createAgentActionClient({
   const client = createRemoteAgentClient({ url: agentUrl, token, actionEndpoints });
 
   return {
-    loadActionForm: (collection, action, recordIds) =>
+    loadAction: (collection, action, recordIds) =>
       client.collection(collection).action(action, { recordIds }),
   };
 }

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -69,6 +69,14 @@ interface RequestHandlerDeps {
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
+// The route's allow-list check ran against the read-model captured before this request awaited the
+// capabilities; a refresh in that window can drop the collection, so it is re-checked against the
+// generation the capabilities belong to. The agent stays the authority (it asserts canBrowse itself)
+// — this keeps the BFF from serving a collection its own current schema no longer exposes.
+function assertCollectionStillAllowed(readModel: ReadModel, collection: string): void {
+  if (!readModel.isCollectionAllowed(collection)) throw unknownCollection();
+}
+
 function resolveCapabilities(
   deps: RequestHandlerDeps,
 ): Promise<{ capabilities: CapabilitiesResult; readModel: ReadModel }> {
@@ -92,11 +100,13 @@ async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandler
   };
 
   // The store hands back the read-model the capabilities belong to; using it keeps the primary keys
-  // serialized below from a different schema generation than the fields just validated.
+  // serialized below from a different schema generation than the fields just validated, and re-checks
+  // the allow-list in case that generation dropped the collection.
   let { primaryKeys } = deps;
 
   if (hasCapabilityConstrainedInput(validationInput)) {
     const { capabilities, readModel } = await resolveCapabilities(deps);
+    assertCollectionStillAllowed(readModel, deps.collection);
     assertValidAgainstCapabilities(validationInput, capabilities);
     primaryKeys = readModel.getPrimaryKeys(deps.collection);
   }
@@ -113,7 +123,8 @@ async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHa
 
   // Count carries only a filter (no sort/projection), so that is all there is to validate.
   if (body.filter !== undefined) {
-    const { capabilities } = await resolveCapabilities(deps);
+    const { capabilities, readModel } = await resolveCapabilities(deps);
+    assertCollectionStillAllowed(readModel, deps.collection);
     assertValidAgainstCapabilities({ filter: body.filter }, capabilities);
   }
 

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -6,6 +6,7 @@ import type {
   RelationListRequestBody,
 } from './agent-query';
 import type { Logger } from '../ports/logger-port';
+import type { CapabilitiesResult } from '../read-model/capabilities-cache';
 import type ReadModel from '../read-model/read-model';
 import type { PrimaryKeyField, RelationTarget } from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
@@ -30,6 +31,11 @@ import {
   resolveReadModel,
 } from '../http/agent-route-helpers';
 import { unknownCollection, unknownRelation } from '../http/bff-local-errors';
+import createAgentCapabilitiesFetcher from '../read-model/agent-capabilities-fetcher';
+import {
+  assertValidAgainstCapabilities,
+  hasCapabilityConstrainedInput,
+} from '../validation/capabilities-validator';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
@@ -54,14 +60,38 @@ export interface DataRoutesMiddlewareOptions {
 interface RequestHandlerDeps {
   collection: string;
   client: AgentDataClient;
+  store: ReadModelStore;
+  agentUrl: string;
+  token: string;
   timezone: string;
   logger: Logger;
 }
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
+function resolveCapabilities(deps: RequestHandlerDeps): Promise<CapabilitiesResult> {
+  return callAgent(
+    () =>
+      deps.store.getCapabilities(
+        deps.collection,
+        createAgentCapabilitiesFetcher({ agentUrl: deps.agentUrl, token: deps.token }),
+      ),
+    deps.logger,
+  );
+}
+
 async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandlerDeps) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
+
+  const validationInput = {
+    filter: body.filter,
+    sortFields: body.sort?.map(clause => clause.field),
+    projectionFields: body.projection,
+  };
+
+  if (hasCapabilityConstrainedInput(validationInput)) {
+    assertValidAgainstCapabilities(validationInput, await resolveCapabilities(deps));
+  }
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
@@ -72,6 +102,11 @@ async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandler
 
 async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerDeps) {
   assertNoRelationFieldPaths(collectCountFieldPaths(body));
+
+  // Count carries only a filter (no sort/projection), so that is all there is to validate.
+  if (body.filter !== undefined) {
+    assertValidAgainstCapabilities({ filter: body.filter }, await resolveCapabilities(deps));
+  }
 
   const query = buildCountAgentQuery(deps.timezone, body);
   const raw = await callAgent(() => deps.client.countRaw(deps.collection, query), deps.logger);
@@ -198,6 +233,9 @@ export default function createDataRoutesMiddleware({
     const deps: RequestHandlerDeps = {
       collection,
       client: createClient({ agentUrl, token }),
+      store,
+      agentUrl,
+      token,
       timezone: ctx.state.timezone as string,
       logger,
     };

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -69,7 +69,9 @@ interface RequestHandlerDeps {
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
-function resolveCapabilities(deps: RequestHandlerDeps): Promise<CapabilitiesResult> {
+function resolveCapabilities(
+  deps: RequestHandlerDeps,
+): Promise<{ capabilities: CapabilitiesResult; readModel: ReadModel }> {
   return callAgent(
     () =>
       deps.store.getCapabilities(
@@ -89,15 +91,21 @@ async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandler
     projectionFields: body.projection,
   };
 
+  // The store hands back the read-model the capabilities belong to; using it keeps the primary keys
+  // serialized below from a different schema generation than the fields just validated.
+  let { primaryKeys } = deps;
+
   if (hasCapabilityConstrainedInput(validationInput)) {
-    assertValidAgainstCapabilities(validationInput, await resolveCapabilities(deps));
+    const { capabilities, readModel } = await resolveCapabilities(deps);
+    assertValidAgainstCapabilities(validationInput, capabilities);
+    primaryKeys = readModel.getPrimaryKeys(deps.collection);
   }
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
 
   ctx.status = 200;
-  ctx.body = mapListResponse(deps.collection, records, deps.primaryKeys);
+  ctx.body = mapListResponse(deps.collection, records, primaryKeys);
 }
 
 async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerDeps) {
@@ -105,7 +113,8 @@ async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHa
 
   // Count carries only a filter (no sort/projection), so that is all there is to validate.
   if (body.filter !== undefined) {
-    assertValidAgainstCapabilities({ filter: body.filter }, await resolveCapabilities(deps));
+    const { capabilities } = await resolveCapabilities(deps);
+    assertValidAgainstCapabilities({ filter: body.filter }, capabilities);
   }
 
   const query = buildCountAgentQuery(deps.timezone, body);

--- a/packages/agent-bff/src/http/bff-local-errors.ts
+++ b/packages/agent-bff/src/http/bff-local-errors.ts
@@ -39,3 +39,10 @@ export function schemaUnavailable(message = 'The agent schema is unavailable'): 
 export function unsupportedActionResult(message = 'Unsupported action result'): BffHttpError {
   return new BffHttpError(501, 'unsupported_action_result', message);
 }
+
+export function actionRequiresApproval(
+  message = 'This action requires an approval before it can run',
+  details?: unknown,
+): BffHttpError {
+  return new BffHttpError(403, 'action_requires_approval', message, details);
+}

--- a/packages/agent-bff/src/read-model/capabilities-cache.ts
+++ b/packages/agent-bff/src/read-model/capabilities-cache.ts
@@ -1,7 +1,7 @@
 import { ONE_DAY_MS } from './schema-cache';
 
 export interface CapabilitiesResult {
-  fields: { name: string; type: string; operators: string[] }[];
+  fields: { name: string; type: string; operators?: string[] }[];
 }
 
 export type CapabilitiesFetcher = (collection: string) => Promise<CapabilitiesResult>;

--- a/packages/agent-bff/src/read-model/read-model-store.ts
+++ b/packages/agent-bff/src/read-model/read-model-store.ts
@@ -40,11 +40,14 @@ export default class ReadModelStore {
     // Ensure any pending schema refresh (and its capabilities invalidation) runs first.
     await this.getReadModel();
 
-    // TODO(wiring): possible TOCTOU once this is called from request handling. A concurrent schema
-    // refresh can clear capabilities while this fetch is in flight, so the caller could receive
-    // capabilities from the previous schema generation alongside the new allow-list. When wiring
-    // the data endpoints, re-check `schemaCache.revision` after the fetch resolves and retry on a
-    // mismatch so capabilities and schema stay atomically coupled.
+    // TODO(wiring): known TOCTOU, deferred. Two snapshots can straddle a schema generation:
+    //   1. the data middleware captures the read-model (allow-list) once, then calls this later;
+    //   2. this capabilities fetch can be in flight when a concurrent schema refresh clear()s it.
+    // Either gap lets the caller validate against capabilities from one generation while the
+    // allow-list came from another. A full fix couples both reads to a single generation (return
+    // read-model + capabilities together, or re-check `schemaCache.revision` across both and retry);
+    // a retry here alone only closes gap 2. Low risk: the trigger is a 24h-TTL refresh landing exactly
+    // during a request, and the agent stays the final validator.
     return this.capabilitiesCache.get(collection, fetcher);
   }
 

--- a/packages/agent-bff/src/read-model/read-model-store.ts
+++ b/packages/agent-bff/src/read-model/read-model-store.ts
@@ -33,22 +33,26 @@ export default class ReadModelStore {
     return this.readModel;
   }
 
+  /**
+   * Returns the capabilities together with the read-model they belong to, so a caller cannot mix a
+   * read-model captured earlier (allow-list, primary keys) with capabilities from a newer schema
+   * generation. Callers must use the returned `readModel`, not the one they held before this call.
+   */
   async getCapabilities(
     collection: string,
     fetcher: CapabilitiesFetcher,
-  ): Promise<CapabilitiesResult> {
+  ): Promise<{ capabilities: CapabilitiesResult; readModel: ReadModel }> {
     // Ensure any pending schema refresh (and its capabilities invalidation) runs first.
-    await this.getReadModel();
+    const readModel = await this.getReadModel();
+    const capabilities = await this.capabilitiesCache.get(collection, fetcher);
 
-    // TODO(wiring): known TOCTOU, deferred. Two snapshots can straddle a schema generation:
-    //   1. the data middleware captures the read-model (allow-list) once, then calls this later;
-    //   2. this capabilities fetch can be in flight when a concurrent schema refresh clear()s it.
-    // Either gap lets the caller validate against capabilities from one generation while the
-    // allow-list came from another. A full fix couples both reads to a single generation (return
-    // read-model + capabilities together, or re-check `schemaCache.revision` across both and retry);
-    // a retry here alone only closes gap 2. Low risk: the trigger is a 24h-TTL refresh landing exactly
-    // during a request, and the agent stays the final validator.
-    return this.capabilitiesCache.get(collection, fetcher);
+    // A refresh can land while the fetch is in flight; the cache already drops such a write, but the
+    // read-model must be re-read so the pair returned here always comes from one generation.
+    if (this.readModel !== readModel) {
+      return { capabilities, readModel: await this.getReadModel() };
+    }
+
+    return { capabilities, readModel };
   }
 
   ageSeconds(): number | undefined {

--- a/packages/agent-bff/src/read-model/read-model-store.ts
+++ b/packages/agent-bff/src/read-model/read-model-store.ts
@@ -4,6 +4,8 @@ import type SchemaCache from './schema-cache';
 
 import ReadModel from './read-model';
 
+const MAX_GENERATION_RETRIES = 3;
+
 /**
  * Single owner of the coupled schema + capabilities lifecycle. A successful schema refresh (a bump
  * of the cache `revision`) rebuilds the read-model and clears capabilities atomically, so the
@@ -41,15 +43,23 @@ export default class ReadModelStore {
   async getCapabilities(
     collection: string,
     fetcher: CapabilitiesFetcher,
+    attemptsLeft = MAX_GENERATION_RETRIES,
   ): Promise<{ capabilities: CapabilitiesResult; readModel: ReadModel }> {
+    if (attemptsLeft <= 0) {
+      throw new Error(
+        `Schema generation kept changing while reading capabilities for "${collection}"`,
+      );
+    }
+
     // Ensure any pending schema refresh (and its capabilities invalidation) runs first.
     const readModel = await this.getReadModel();
     const capabilities = await this.capabilitiesCache.get(collection, fetcher);
 
-    // A refresh can land while the fetch is in flight; the cache already drops such a write, but the
-    // read-model must be re-read so the pair returned here always comes from one generation.
+    // A refresh can land while the fetch is in flight: the cache drops the stale write but still
+    // resolves with it, so both reads are retried until they observe one generation. Bounded because
+    // a refresh is driven by the 24h schema TTL, not by request volume.
     if (this.readModel !== readModel) {
-      return { capabilities, readModel: await this.getReadModel() };
+      return this.getCapabilities(collection, fetcher, attemptsLeft - 1);
     }
 
     return { capabilities, readModel };

--- a/packages/agent-bff/src/read-model/read-model-store.ts
+++ b/packages/agent-bff/src/read-model/read-model-store.ts
@@ -53,12 +53,16 @@ export default class ReadModelStore {
 
     // Ensure any pending schema refresh (and its capabilities invalidation) runs first.
     const readModel = await this.getReadModel();
+    const { revision } = this.schemaCache;
     const capabilities = await this.capabilitiesCache.get(collection, fetcher);
 
     // A refresh can land while the fetch is in flight: the cache drops the stale write but still
-    // resolves with it, so both reads are retried until they observe one generation. Bounded because
-    // a refresh is driven by the 24h schema TTL, not by request volume.
-    if (this.readModel !== readModel) {
+    // resolves with it, so both reads are retried until they observe one generation. The revision is
+    // the discriminator, not the read-model identity — `SchemaCache` bumps the revision inside its
+    // refresh, before an awaiting `getReadModel` caller resumes and installs the new model, so an
+    // identity comparison still sees the old object in that window. Bounded because a refresh is
+    // driven by the 24h schema TTL, not by request volume.
+    if (this.schemaCache.revision !== revision) {
       return this.getCapabilities(collection, fetcher, attemptsLeft - 1);
     }
 

--- a/packages/agent-bff/src/validation/capabilities-validator.ts
+++ b/packages/agent-bff/src/validation/capabilities-validator.ts
@@ -1,0 +1,157 @@
+import type { BffHttpError } from '../http/bff-http-error';
+import type { CapabilitiesResult } from '../read-model/capabilities-cache';
+
+import { normalizeOperator } from './operator-normalizer';
+import {
+  fieldNotFilterable,
+  filterTooDeep,
+  invalidFilterOperator,
+  unknownField,
+} from './validation-errors';
+import { mappingError } from '../http/bff-local-errors';
+
+export interface ValidateParams {
+  filter?: unknown;
+  sortFields?: string[];
+  projectionFields?: string[];
+}
+
+interface FilterLeaf {
+  field: string;
+  operator?: string;
+}
+
+function isBranch(node: unknown): node is { conditions: unknown[] } {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    Array.isArray((node as { conditions?: unknown }).conditions)
+  );
+}
+
+function isLeaf(node: unknown): node is FilterLeaf {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    typeof (node as { field?: unknown }).field === 'string'
+  );
+}
+
+export const MAX_FILTER_DEPTH = 100;
+
+function collectLeaves(node: unknown, acc: FilterLeaf[], depth = 0): void {
+  if (depth > MAX_FILTER_DEPTH) throw filterTooDeep(MAX_FILTER_DEPTH);
+
+  if (isBranch(node)) {
+    node.conditions.forEach(condition => collectLeaves(condition, acc, depth + 1));
+  } else if (isLeaf(node)) {
+    const { operator } = node as { operator?: unknown };
+    acc.push({ field: node.field, operator: typeof operator === 'string' ? operator : undefined });
+  }
+}
+
+function indexOperators(capabilities: CapabilitiesResult): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  capabilities.fields.forEach(field => index.set(field.name, field.operators ?? []));
+
+  return index;
+}
+
+function normalizeFieldOperators(field: string, operators: string[]): string[] {
+  return operators.map(operator => {
+    const normalized = normalizeOperator(operator);
+
+    if (!normalized) {
+      throw mappingError(
+        `Capabilities operator "${operator}" on field "${field}" has no canonical mapping`,
+      );
+    }
+
+    return normalized;
+  });
+}
+
+function validateFilter(filter: unknown, index: Map<string, string[]>): BffHttpError[] {
+  const leaves: FilterLeaf[] = [];
+  collectLeaves(filter, leaves);
+
+  const errors: BffHttpError[] = [];
+
+  for (const leaf of leaves) {
+    const operators = index.get(leaf.field);
+
+    if (operators === undefined) {
+      errors.push(unknownField(leaf.field));
+    } else if (operators.length === 0) {
+      errors.push(fieldNotFilterable(leaf.field));
+    } else {
+      const normalized = normalizeFieldOperators(leaf.field, operators);
+
+      if (leaf.operator === undefined || !normalized.includes(leaf.operator)) {
+        errors.push(invalidFilterOperator(leaf.field, normalized));
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateExistence(fields: string[], index: Map<string, string[]>): BffHttpError[] {
+  return fields.filter(field => !index.has(field)).map(unknownField);
+}
+
+function dedupe(errors: BffHttpError[]): BffHttpError[] {
+  const seen = new Set<string>();
+  const result: BffHttpError[] = [];
+
+  for (const error of errors) {
+    const key = `${error.type}:${(error.details as { field?: string }).field}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(error);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * True when the request carries something capabilities can invalidate. Callers use it to skip the
+ * capabilities fetch entirely, so a plain list/count still succeeds while that fetch is unavailable.
+ */
+export function hasCapabilityConstrainedInput(params: ValidateParams): boolean {
+  return (
+    params.filter !== undefined ||
+    (params.sortFields?.length ?? 0) > 0 ||
+    (params.projectionFields?.length ?? 0) > 0
+  );
+}
+
+/**
+ * Validates a request's filter, sort, and projection fields against the target collection's
+ * capabilities. Returns every offending field as a structured error (empty = valid); the caller
+ * surfaces the whole list or just the first. Throws a 500 mapping_error when a capabilities
+ * operator has no canonical mapping (a version skew between agent and BFF).
+ */
+export function validateAgainstCapabilities(
+  params: ValidateParams,
+  capabilities: CapabilitiesResult,
+): BffHttpError[] {
+  const index = indexOperators(capabilities);
+
+  return dedupe([
+    ...validateFilter(params.filter, index),
+    ...validateExistence(params.sortFields ?? [], index),
+    ...validateExistence(params.projectionFields ?? [], index),
+  ]);
+}
+
+export function assertValidAgainstCapabilities(
+  params: ValidateParams,
+  capabilities: CapabilitiesResult,
+): void {
+  const [first] = validateAgainstCapabilities(params, capabilities);
+
+  if (first) throw first;
+}

--- a/packages/agent-bff/src/validation/operator-normalizer.ts
+++ b/packages/agent-bff/src/validation/operator-normalizer.ts
@@ -1,0 +1,28 @@
+import type { Operator } from '@forestadmin/datasource-toolkit';
+
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
+/**
+ * Mirrors the agent's capabilities serialization (`packages/agent/src/routes/capabilities.ts`),
+ * which converts each PascalCase operator to snake_case before returning it. Kept identical so the
+ * inverse map below round-trips every operator the agent can emit.
+ */
+export function toSnakeCaseOperator(operator: string): string {
+  return operator
+    .split(/\.?(?=[A-Z])/)
+    .join('_')
+    .toLowerCase();
+}
+
+const SNAKE_TO_PASCAL = new Map<string, Operator>(
+  allOperators.map(operator => [toSnakeCaseOperator(operator), operator]),
+);
+
+/**
+ * Maps an agent snake_case capabilities operator to the canonical PascalCase operator from
+ * datasource-toolkit `allOperators`. Returns undefined when no canonical operator matches, which
+ * only happens when the agent runs a newer operator set than this package (a version skew).
+ */
+export function normalizeOperator(snakeCaseOperator: string): Operator | undefined {
+  return SNAKE_TO_PASCAL.get(snakeCaseOperator);
+}

--- a/packages/agent-bff/src/validation/validation-errors.ts
+++ b/packages/agent-bff/src/validation/validation-errors.ts
@@ -1,0 +1,29 @@
+import { BffHttpError } from '../http/bff-http-error';
+
+export function unknownField(field: string): BffHttpError {
+  return new BffHttpError(422, 'unknown_field', `Unknown field: ${field}`, { field });
+}
+
+export function fieldNotFilterable(field: string): BffHttpError {
+  return new BffHttpError(422, 'field_not_filterable', `Field is not filterable: ${field}`, {
+    field,
+  });
+}
+
+export function filterTooDeep(maxDepth: number): BffHttpError {
+  return new BffHttpError(
+    400,
+    'filter_too_deep',
+    `Filter nesting exceeds the maximum depth of ${maxDepth}`,
+    { maxDepth },
+  );
+}
+
+export function invalidFilterOperator(field: string, validOperators: string[]): BffHttpError {
+  return new BffHttpError(
+    400,
+    'invalid_filter_operator',
+    `Unsupported operator for field: ${field}`,
+    { field, validOperators },
+  );
+}

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -15,7 +15,7 @@ describe('mapActionExecuteResult', () => {
   });
 
   it('defaults message and html to null and invalidated to [] when absent', () => {
-    expect(mapActionExecuteResult({ success: undefined })).toEqual({
+    expect(mapActionExecuteResult({ success: undefined, refresh: { relationships: [] } })).toEqual({
       status: 200,
       body: { type: 'success', message: null, invalidated: [], html: null },
     });
@@ -61,6 +61,17 @@ describe('mapActionExecuteResult', () => {
 
   it('falls through to 501 for a non-object payload', () => {
     expect(mapActionExecuteResult(null)).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+
+  it.each([
+    ['a null webhook', { webhook: null }],
+    ['a non-string redirectTo', { redirectTo: {} }],
+    ['a non-string success with no refresh', { success: {} }],
+  ])('falls through to 501 for a malformed payload: %s', (_label, payload) => {
+    expect(mapActionExecuteResult(payload)).toEqual({
       status: 501,
       body: { error: { type: 'unsupported_action_result', status: 501 } },
     });

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -33,6 +33,16 @@ describe('mapActionExecuteResult', () => {
     });
   });
 
+  it.each([
+    ['relationships absent', { success: 'ok', refresh: {} }],
+    ['relationships not an array', { success: 'ok', refresh: { relationships: 'x' } }],
+  ])('falls back invalidated to [] when %s', (_label, payload) => {
+    expect(mapActionExecuteResult(payload)).toEqual({
+      status: 200,
+      body: { type: 'success', message: 'ok', invalidated: [], html: null },
+    });
+  });
+
   it('maps a Webhook payload verbatim', () => {
     expect(
       mapActionExecuteResult({

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -10,7 +10,12 @@ describe('mapActionExecuteResult', () => {
       }),
     ).toEqual({
       status: 200,
-      body: { type: 'success', message: 'Done', invalidated: ['orders', 'items'], html: '<b>ok</b>' },
+      body: {
+        type: 'success',
+        message: 'Done',
+        invalidated: ['orders', 'items'],
+        html: '<b>ok</b>',
+      },
     });
   });
 

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -1,0 +1,68 @@
+import { mapActionExecuteResult } from '../../src/action/action-execute-mapper';
+
+describe('mapActionExecuteResult', () => {
+  it('maps a Success payload, serializing refresh.relationships into invalidated', () => {
+    expect(
+      mapActionExecuteResult({
+        success: 'Done',
+        html: '<b>ok</b>',
+        refresh: { relationships: ['orders', 'items'] },
+      }),
+    ).toEqual({
+      status: 200,
+      body: { type: 'success', message: 'Done', invalidated: ['orders', 'items'], html: '<b>ok</b>' },
+    });
+  });
+
+  it('defaults message and html to null and invalidated to [] when absent', () => {
+    expect(mapActionExecuteResult({ success: undefined })).toEqual({
+      status: 200,
+      body: { type: 'success', message: null, invalidated: [], html: null },
+    });
+  });
+
+  it('treats a bare refresh payload as a Success', () => {
+    expect(mapActionExecuteResult({ refresh: { relationships: ['orders'] } })).toEqual({
+      status: 200,
+      body: { type: 'success', message: null, invalidated: ['orders'], html: null },
+    });
+  });
+
+  it('maps a Webhook payload verbatim', () => {
+    expect(
+      mapActionExecuteResult({
+        webhook: { url: 'https://x.test', method: 'POST', headers: { a: '1' }, body: { b: 2 } },
+      }),
+    ).toEqual({
+      status: 200,
+      body: {
+        type: 'webhook',
+        url: 'https://x.test',
+        method: 'POST',
+        headers: { a: '1' },
+        body: { b: 2 },
+      },
+    });
+  });
+
+  it('maps a Redirect payload to the path', () => {
+    expect(mapActionExecuteResult({ redirectTo: '/orders/1' })).toEqual({
+      status: 200,
+      body: { type: 'redirect', path: '/orders/1' },
+    });
+  });
+
+  it('falls through to 501 for an unrecognized (File) payload', () => {
+    expect(mapActionExecuteResult({})).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+
+  it('falls through to 501 for a non-object payload', () => {
+    expect(mapActionExecuteResult(null)).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+});

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -73,6 +73,17 @@ describe('mapActionExecuteResult', () => {
     });
   });
 
+  it.each([
+    ['an array', { refresh: [] }],
+    ['an object without relationships', { refresh: {} }],
+    ['relationships not an array', { refresh: { relationships: 'x' } }],
+  ])('falls through to 501 when the only marker is a refresh that is %s', (_label, payload) => {
+    expect(mapActionExecuteResult(payload)).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+
   it('drops non-string entries from invalidated', () => {
     expect(
       mapActionExecuteResult({ success: 'ok', refresh: { relationships: ['orders', 42, null] } }),

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -60,6 +60,28 @@ describe('mapActionExecuteResult', () => {
     });
   });
 
+  it.each([
+    ['an empty object', { webhook: {} }],
+    ['an array', { webhook: [] }],
+    ['url missing', { webhook: { method: 'POST' } }],
+    ['method missing', { webhook: { url: 'https://x.test' } }],
+    ['url not a string', { webhook: { url: 42, method: 'POST' } }],
+  ])('falls through to 501 when the webhook payload is %s', (_label, payload) => {
+    expect(mapActionExecuteResult(payload)).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+
+  it('drops non-string entries from invalidated', () => {
+    expect(
+      mapActionExecuteResult({ success: 'ok', refresh: { relationships: ['orders', 42, null] } }),
+    ).toEqual({
+      status: 200,
+      body: { type: 'success', message: 'ok', invalidated: ['orders'], html: null },
+    });
+  });
+
   it('maps a Redirect payload to the path', () => {
     expect(mapActionExecuteResult({ redirectTo: '/orders/1' })).toEqual({
       status: 200,

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -515,7 +515,12 @@ describe('action execute', () => {
       .send({ recordIds: ['42'] });
 
     expect(response.status).toBe(400);
-    expect(response.body).toEqual({ type: 'error', status: 400, message: 'Refund failed', html: null });
+    expect(response.body).toEqual({
+      type: 'error',
+      status: 400,
+      message: 'Refund failed',
+      html: null,
+    });
   });
 
   it('rejects an unknown submitted field as 400 invalid_request', async () => {

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -503,6 +503,21 @@ describe('action execute', () => {
     });
   });
 
+  it('defaults html to null on the error body when the action Error carries none', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new ActionFormValidationError('Refund failed');
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ type: 'error', status: 400, message: 'Refund failed', html: null });
+  });
+
   it('rejects an unknown submitted field as 400 invalid_request', async () => {
     const setFields = jest.fn(async () => {
       throw new UnknownActionFieldError('ghost');
@@ -516,6 +531,22 @@ describe('action execute', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('maps a non-unknown-field setFields rejection through the agent error contract', async () => {
+    const setFields = jest.fn(async () => {
+      throw new AgentHttpError(422, { errors: [{ status: 422, name: 'UnprocessableError' }] });
+    });
+    const execute = jest.fn();
+    const form = makeAction({ setFields, execute });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'], values: { reason: 'x' } });
+
+    expect(response.status).toBe(422);
+    expect(response.body.error).toMatchObject({ type: 'unprocessable_entity', status: 422 });
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -551,6 +582,22 @@ describe('action execute', () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error.details).toEqual({ roleIdsAllowedToApprove: [] });
+  });
+
+  it('omits details when the approval error carries no roleIdsAllowedToApprove', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new ActionRequiresApprovalError('Needs approval');
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({ type: 'action_requires_approval', status: 403 });
+    expect(response.body.error.details).toBeUndefined();
   });
 
   it('maps a transport 5xx to agent_unavailable, distinct from the action-Error 400', async () => {

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -1,8 +1,13 @@
-import type { ActionForm, AgentActionClient } from '../../src/action/agent-action-client';
+import type { Action, AgentActionClient } from '../../src/action/agent-action-client';
 import type { Logger } from '../../src/ports/logger-port';
 import type ReadModelStore from '../../src/read-model/read-model-store';
 
-import { AgentHttpError } from '@forestadmin/agent-client';
+import {
+  ActionFormValidationError,
+  ActionRequiresApprovalError,
+  AgentHttpError,
+  UnknownActionFieldError,
+} from '@forestadmin/agent-client';
 import { bodyParser } from '@koa/bodyparser';
 import Koa from 'koa';
 import request from 'supertest';
@@ -41,12 +46,14 @@ function makeAction({
   skipped = [],
   postChange,
   execute = jest.fn(),
+  setFields = jest.fn(async () => {}),
 }: {
   fields?: FakeField[];
   layout?: unknown[];
   skipped?: string[];
   postChange?: { fields?: FakeField[]; layout?: unknown[] };
   execute?: jest.Mock;
+  setFields?: jest.Mock;
 } = {}) {
   const state = { fields: [...fields], layout: [...layout] };
   const tryToSetFields = jest.fn(async () => {
@@ -58,8 +65,9 @@ function makeAction({
     return skipped;
   });
 
-  const form: ActionForm & { tryToSetFields: jest.Mock; execute: jest.Mock } = {
+  const form: Action & { tryToSetFields: jest.Mock; execute: jest.Mock; setFields: jest.Mock } = {
     execute,
+    setFields,
     tryToSetFields,
     getFields: () =>
       state.fields.map(f => ({
@@ -78,10 +86,10 @@ function makeAction({
 }
 
 function clientOf(
-  form: ActionForm,
-  loadActionForm: jest.Mock = jest.fn(async () => form),
-): AgentActionClient & { loadActionForm: jest.Mock } {
-  return { loadActionForm };
+  form: Action,
+  loadAction: jest.Mock = jest.fn(async () => form),
+): AgentActionClient & { loadAction: jest.Mock } {
+  return { loadAction };
 }
 
 function buildApp(
@@ -224,44 +232,44 @@ describe('action routes middleware', () => {
 
   it('passes an opaque composite recordId through unchanged', async () => {
     const form = makeAction();
-    const loadActionForm = jest.fn(async () => form);
-    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+    const loadAction = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadAction));
 
     await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: ['1|2'] });
 
-    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', ['1|2']);
+    expect(loadAction).toHaveBeenCalledWith('users', 'approve', ['1|2']);
   });
 
   it('coerces a numeric zero recordId to a string so it survives the downstream filter', async () => {
     const form = makeAction();
-    const loadActionForm = jest.fn(async () => form);
-    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+    const loadAction = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadAction));
 
     await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: [0] });
 
-    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', ['0']);
+    expect(loadAction).toHaveBeenCalledWith('users', 'approve', ['0']);
   });
 
   it('accepts an empty recordIds array for a global action', async () => {
     const form = makeAction();
-    const loadActionForm = jest.fn(async () => form);
-    const app = buildApp(storeOf(readModel), clientOf(form, loadActionForm));
+    const loadAction = jest.fn(async () => form);
+    const app = buildApp(storeOf(readModel), clientOf(form, loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: [] });
 
     expect(response.status).toBe(200);
-    expect(loadActionForm).toHaveBeenCalledWith('users', 'approve', []);
+    expect(loadAction).toHaveBeenCalledWith('users', 'approve', []);
   });
 
   it('returns 400 invalid_request with no agent call when recordIds is missing', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
@@ -269,36 +277,36 @@ describe('action routes middleware', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('returns 400 invalid_request when recordIds is not an array', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: '42' });
 
     expect(response.status).toBe(400);
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('returns 400 invalid_request when values is not an object', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: ['42'], values: 'nope' });
 
     expect(response.status).toBe(400);
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('returns 404 unknown_action for an action that is not exposed', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/ghost/form')
@@ -306,18 +314,18 @@ describe('action routes middleware', () => {
 
     expect(response.status).toBe(404);
     expect(response.body.error).toMatchObject({ type: 'unknown_action', status: 404 });
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('maps an agent failure on form load through the error contract', async () => {
-    const loadActionForm = jest.fn(async () => {
+    const loadAction = jest.fn(async () => {
       throw new AgentHttpError(
         403,
         { errors: [{ status: 403, name: 'ForbiddenError' }] },
         undefined,
       );
     });
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm));
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
@@ -343,8 +351,8 @@ describe('action routes middleware', () => {
   });
 
   it('returns 401 when no agent token is available', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadActionForm), {
+    const loadAction = jest.fn();
+    const app = buildApp(storeOf(readModel), clientOf(makeAction(), loadAction), {
       agentToken: null,
     });
 
@@ -353,27 +361,27 @@ describe('action routes middleware', () => {
       .send({ recordIds: ['42'] });
 
     expect(response.status).toBe(401);
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('falls through to the next middleware for a non-POST request on the form path', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildAppWithTerminal(clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildAppWithTerminal(clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback()).get('/agent/v1/users/actions/approve/form');
 
     expect(response.status).toBe(204);
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('falls through to the next middleware for a path that is not an action form route', async () => {
-    const loadActionForm = jest.fn();
-    const app = buildAppWithTerminal(clientOf(makeAction(), loadActionForm));
+    const loadAction = jest.fn();
+    const app = buildAppWithTerminal(clientOf(makeAction(), loadAction));
 
     const response = await request(app.callback()).post('/agent/v1/users/list').send({});
 
     expect(response.status).toBe(204);
-    expect(loadActionForm).not.toHaveBeenCalled();
+    expect(loadAction).not.toHaveBeenCalled();
   });
 
   it('returns 503 schema_unavailable when the schema cannot be loaded', async () => {
@@ -385,5 +393,189 @@ describe('action routes middleware', () => {
 
     expect(response.status).toBe(503);
     expect(response.body.error).toMatchObject({ type: 'schema_unavailable', status: 503 });
+  });
+});
+
+describe('action execute', () => {
+  function execApp(client: AgentActionClient) {
+    return buildApp(storeOf(readModel), client);
+  }
+
+  it('sets the submitted values then executes the action', async () => {
+    const setFields = jest.fn(async () => {});
+    const execute = jest.fn(async () => ({ success: 'Done' }));
+    const form = makeAction({ setFields, execute });
+    const loadAction = jest.fn(async () => form);
+
+    await request(execApp(clientOf(form, loadAction)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'], values: { reason: 'x' } });
+
+    expect(loadAction).toHaveBeenCalledWith('users', 'approve', ['42']);
+    expect(setFields).toHaveBeenCalledWith({ reason: 'x' });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes a Success result to 200 with invalidated as an array', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => ({
+        success: 'Refunded',
+        html: '<b>ok</b>',
+        refresh: { relationships: ['orders'] },
+      })),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      type: 'success',
+      message: 'Refunded',
+      invalidated: ['orders'],
+      html: '<b>ok</b>',
+    });
+  });
+
+  it('normalizes a Webhook result to 200 passing its fields through verbatim', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => ({
+        webhook: { url: 'https://x.test', method: 'POST', headers: { a: '1' }, body: { b: 2 } },
+      })),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      type: 'webhook',
+      url: 'https://x.test',
+      method: 'POST',
+      headers: { a: '1' },
+      body: { b: 2 },
+    });
+  });
+
+  it('normalizes a Redirect result to 200 with the path', async () => {
+    const form = makeAction({ execute: jest.fn(async () => ({ redirectTo: '/orders/1' })) });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ type: 'redirect', path: '/orders/1' });
+  });
+
+  it('returns 501 unsupported_action_result for an unrecognized (File) result', async () => {
+    const form = makeAction({ execute: jest.fn(async () => ({})) });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(501);
+    expect(response.body).toEqual({
+      error: { type: 'unsupported_action_result', status: 501 },
+    });
+  });
+
+  it('renders a native action Error as HTTP 400 with the forwarded html', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new ActionFormValidationError('Refund failed', '<strong>Nope</strong>');
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      type: 'error',
+      status: 400,
+      message: 'Refund failed',
+      html: '<strong>Nope</strong>',
+    });
+  });
+
+  it('rejects an unknown submitted field as 400 invalid_request', async () => {
+    const setFields = jest.fn(async () => {
+      throw new UnknownActionFieldError('ghost');
+    });
+    const execute = jest.fn();
+    const form = makeAction({ setFields, execute });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'], values: { ghost: 1 } });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('maps an approval-gated action to 403 action_requires_approval with the allowed roles', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new ActionRequiresApprovalError('Needs approval', [7, 9]);
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({
+      type: 'action_requires_approval',
+      status: 403,
+      details: { roleIdsAllowedToApprove: [7, 9] },
+    });
+  });
+
+  it('maps a transport 5xx to agent_unavailable, distinct from the action-Error 400', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new AgentHttpError(502, null);
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(503);
+    expect(response.body.error).toMatchObject({ type: 'agent_unavailable', status: 503 });
+  });
+
+  it('returns 400 invalid_request with no agent call when recordIds is missing', async () => {
+    const loadAction = jest.fn();
+    const form = makeAction();
+
+    const response = await request(execApp(clientOf(form, loadAction)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ values: {} });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatchObject({ type: 'invalid_request', status: 400 });
+    expect(loadAction).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 unknown_action for an action that is not exposed', async () => {
+    const loadAction = jest.fn();
+    const form = makeAction();
+
+    const response = await request(execApp(clientOf(form, loadAction)).callback())
+      .post('/agent/v1/users/actions/ghost/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toMatchObject({ type: 'unknown_action', status: 404 });
+    expect(loadAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -538,6 +538,21 @@ describe('action execute', () => {
     });
   });
 
+  it('keeps an empty roleIdsAllowedToApprove array in the 403 details', async () => {
+    const form = makeAction({
+      execute: jest.fn(async () => {
+        throw new ActionRequiresApprovalError('Needs approval', []);
+      }),
+    });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.details).toEqual({ roleIdsAllowedToApprove: [] });
+  });
+
   it('maps a transport 5xx to agent_unavailable, distinct from the action-Error 400', async () => {
     const form = makeAction({
       execute: jest.fn(async () => {

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -417,6 +417,9 @@ describe('action execute', () => {
     expect(loadAction).toHaveBeenCalledWith('users', 'approve', ['42']);
     expect(setFields).toHaveBeenCalledWith({ reason: 'x' });
     expect(execute).toHaveBeenCalledTimes(1);
+    // Order is the behaviour named by this test: executing before the values are applied would run
+    // the action on an empty form.
+    expect(setFields.mock.invocationCallOrder[0]).toBeLessThan(execute.mock.invocationCallOrder[0]);
   });
 
   it('normalizes a Success result to 200 with invalidated as an array', async () => {
@@ -473,8 +476,13 @@ describe('action execute', () => {
     expect(response.body).toEqual({ type: 'redirect', path: '/orders/1' });
   });
 
-  it('returns 501 unsupported_action_result for an unrecognized (File) result', async () => {
-    const form = makeAction({ execute: jest.fn(async () => ({})) });
+  // The agent streams a File result with no JSON marker, so it reaches the BFF as a binary body,
+  // not as an object carrying a recognizable key.
+  it.each([
+    ['an unrecognized object payload', {} as unknown],
+    ['a File result streamed as a binary body', Buffer.from('%PDF-1.4 invoice')],
+  ])('returns 501 unsupported_action_result for %s', async (_label, payload) => {
+    const form = makeAction({ execute: jest.fn(async () => payload) });
 
     const response = await request(execApp(clientOf(form)).callback())
       .post('/agent/v1/users/actions/approve/execute')

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -95,7 +95,10 @@ function clientOf(
 function buildApp(
   store: ReadModelStore,
   client: AgentActionClient,
-  { agentToken = 'agent-jwt' }: { agentToken?: string | null } = {},
+  {
+    agentToken = 'agent-jwt',
+    logger = noopLogger,
+  }: { agentToken?: string | null; logger?: Logger } = {},
 ) {
   const app = new Koa();
   app.silent = true;
@@ -110,7 +113,7 @@ function buildApp(
     createActionRoutesMiddleware({
       store,
       agentUrl: 'https://agent.example.com',
-      logger: noopLogger,
+      logger,
       createClient: () => client,
     }),
   );
@@ -397,8 +400,8 @@ describe('action routes middleware', () => {
 });
 
 describe('action execute', () => {
-  function execApp(client: AgentActionClient) {
-    return buildApp(storeOf(readModel), client);
+  function execApp(client: AgentActionClient, logger?: Logger) {
+    return buildApp(storeOf(readModel), client, logger ? { logger } : {});
   }
 
   it('sets the submitted values then executes the action', async () => {
@@ -481,6 +484,37 @@ describe('action execute', () => {
     expect(response.body).toEqual({
       error: { type: 'unsupported_action_result', status: 501 },
     });
+  });
+
+  it('logs a bounded shape hint instead of enumerating a binary payload byte by byte', async () => {
+    const logger = jest.fn();
+    const form = makeAction({ execute: jest.fn(async () => Buffer.alloc(4096, 1)) });
+
+    const response = await request(execApp(clientOf(form), logger).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(501);
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      'Unrecognized action execute result mapped to 501',
+      { shape: 'Buffer(4096)' },
+    );
+  });
+
+  it('logs the key names for an unrecognized plain-object payload', async () => {
+    const logger = jest.fn();
+    const form = makeAction({ execute: jest.fn(async () => ({ mystery: 1, other: 2 })) });
+
+    await request(execApp(clientOf(form), logger).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(logger).toHaveBeenCalledWith(
+      'Warn',
+      'Unrecognized action execute result mapped to 501',
+      { shape: 'object{mystery,other}' },
+    );
   });
 
   it('renders a native action Error as HTTP 400 with the forwarded html', async () => {

--- a/packages/agent-bff/test/action/agent-action-client.test.ts
+++ b/packages/agent-bff/test/action/agent-action-client.test.ts
@@ -7,7 +7,7 @@ jest.mock('@forestadmin/agent-client', () => ({ createRemoteAgentClient: jest.fn
 const createRemoteAgentClientMock = createRemoteAgentClient as jest.Mock;
 
 describe('createAgentActionClient', () => {
-  it('loads the form via createRemoteAgentClient().collection(name).action(name, { recordIds })', async () => {
+  it('loads the action via createRemoteAgentClient().collection(name).action(name, { recordIds })', async () => {
     const loadedAction = { tag: 'action' };
     const actionFn = jest.fn(async () => loadedAction);
     const collectionFn = jest.fn(() => ({ action: actionFn }));
@@ -19,7 +19,7 @@ describe('createAgentActionClient', () => {
       token: 'agent-jwt',
       actionEndpoints,
     });
-    const result = await client.loadActionForm('users', 'approve', ['1', '2']);
+    const result = await client.loadAction('users', 'approve', ['1', '2']);
 
     expect(createRemoteAgentClientMock).toHaveBeenCalledWith({
       url: 'https://agent.example.com',

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -388,6 +388,34 @@ describe('data routes middleware', () => {
       expect(list).not.toHaveBeenCalled();
     });
 
+    it.each([['list'], ['count']])(
+      'should return 404 on %s when a refresh during the capabilities read drops the collection',
+      async operation => {
+        const client = {
+          list: jest.fn(async () => []),
+          countRaw: jest.fn(async () => ({ count: 0 })),
+        };
+        // The store hands back a read-model from the newer generation, which no longer exposes users.
+        const refreshedStore = {
+          getReadModel: async () => usersReadModel,
+          getCapabilities: async () => ({
+            capabilities: { fields: [{ name: 'id', type: 'Number', operators: ['equal'] }] },
+            readModel: new ReadModel([collection('orders', [column('id')])]),
+          }),
+        } as unknown as ReadModelStore;
+        const app = buildApp(refreshedStore, client);
+
+        const response = await request(app.callback())
+          .post(`/agent/v1/users/${operation}`)
+          .send({ filter: { field: 'id', operator: 'Equal', value: 1 } });
+
+        expect(response.status).toBe(404);
+        expect(response.body.error).toMatchObject({ type: 'unknown_collection', status: 404 });
+        expect(client.list).not.toHaveBeenCalled();
+        expect(client.countRaw).not.toHaveBeenCalled();
+      },
+    );
+
     it('should map a capabilities fetch failure to agent_unavailable instead of internal_error', async () => {
       const list = jest.fn(async () => []);
       const getCapabilities = jest.fn(async () => {

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -44,7 +44,10 @@ function storeOf(
 
       return readModel;
     },
-    getCapabilities: (collectionName: string) => getCapabilities(collectionName),
+    getCapabilities: async (collectionName: string) => ({
+      capabilities: await getCapabilities(collectionName),
+      readModel,
+    }),
   } as unknown as ReadModelStore;
 }
 

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -1,5 +1,6 @@
 import type { AgentDataClient } from '../../src/data/agent-data-client';
 import type { Logger } from '../../src/ports/logger-port';
+import type { CapabilitiesResult } from '../../src/read-model/capabilities-cache';
 import type ReadModelStore from '../../src/read-model/read-model-store';
 
 import { AgentHttpError } from '@forestadmin/agent-client';
@@ -17,13 +18,33 @@ const TIMEZONE = 'Europe/Paris';
 
 const noopLogger: Logger = () => {};
 
-function storeOf(readModel: ReadModel | Error): ReadModelStore {
+type CapabilitiesStub = (collection: string) => Promise<CapabilitiesResult>;
+
+const BROAD_SNAKE_OPERATORS = ['present', 'blank', 'equal', 'not_equal', 'in', 'like'];
+
+const defaultCapabilities: CapabilitiesStub = async () => ({
+  fields: ['id', 'email', 'title', 'name', 'value', 'slug', 'label'].map(name => ({
+    name,
+    type: 'String',
+    operators: BROAD_SNAKE_OPERATORS,
+  })),
+});
+
+function capabilitiesOf(fields: CapabilitiesResult['fields']): CapabilitiesStub {
+  return async () => ({ fields });
+}
+
+function storeOf(
+  readModel: ReadModel | Error,
+  getCapabilities: CapabilitiesStub = defaultCapabilities,
+): ReadModelStore {
   return {
     getReadModel: async () => {
       if (readModel instanceof Error) throw readModel;
 
       return readModel;
     },
+    getCapabilities: (collectionName: string) => getCapabilities(collectionName),
   } as unknown as ReadModelStore;
 }
 
@@ -272,6 +293,253 @@ describe('data routes middleware', () => {
       expect(response.body.data[0]).toMatchObject({
         __forest: { collection: 'metrics', primaryKey: { id: 42 } },
       });
+    });
+  });
+
+  describe('capabilities validation', () => {
+    it('should reject a list filter operator unsupported by capabilities before calling the agent', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'email', type: 'String', operators: ['present'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ filter: { field: 'email', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'email', validOperators: ['Present'] },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should reject a list projection field absent from capabilities with 422 unknown_field', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['id', 'ghost'] });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should reject a list sort field absent from capabilities with 422 unknown_field', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ sort: [{ field: 'ghost', direction: 'asc' }] });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should read capabilities before the agent call and skip the agent on a validation failure', async () => {
+      const calls: string[] = [];
+      const list = jest.fn(async () => {
+        calls.push('agent');
+
+        return [];
+      });
+      const getCapabilities = jest.fn(async () => {
+        calls.push('capabilities');
+
+        return {
+          fields: [{ name: 'id', type: 'String', operators: ['equal'] }],
+        } as CapabilitiesResult;
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['ghost'] });
+
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(calls).toEqual(['capabilities']);
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should map a capabilities fetch failure to agent_unavailable instead of internal_error', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['id'] });
+
+      expect(response.status).toBe(503);
+      expect(response.body.error).toEqual(
+        expect.objectContaining({ type: 'agent_unavailable', status: 503 }),
+      );
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should skip the capabilities fetch when the list carries nothing to validate', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).not.toHaveBeenCalled();
+      expect(list).toHaveBeenCalled();
+    });
+
+    it('should skip the capabilities fetch when the count carries no filter', async () => {
+      const countRaw = jest.fn(async () => ({ count: 3 }));
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).not.toHaveBeenCalled();
+      expect(countRaw).toHaveBeenCalled();
+    });
+
+    it('should proceed to the agent when the list filter, sort, and projection are all valid', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(defaultCapabilities);
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({
+          projection: ['id', 'email'],
+          filter: { field: 'email', operator: 'Present' },
+          sort: [{ field: 'id', direction: 'asc' }],
+        });
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(list).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject a count filter operator unsupported by capabilities before calling the agent', async () => {
+      const countRaw = jest.fn(async () => ({ count: 0 }));
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'email', type: 'String', operators: ['present'] }]),
+      );
+      const app = buildApp(store, { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'email', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'email', validOperators: ['Present'] },
+      });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should reject a count filter field absent from capabilities with 422 unknown_field', async () => {
+      const countRaw = jest.fn(async () => ({ count: 0 }));
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'ghost', operator: 'Equal' } });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should read capabilities before the agent call on the count path', async () => {
+      const calls: string[] = [];
+      const countRaw = jest.fn(async () => {
+        calls.push('agent');
+
+        return { count: 0 };
+      });
+      const getCapabilities = jest.fn(async () => {
+        calls.push('capabilities');
+
+        return {
+          fields: [{ name: 'id', type: 'String', operators: ['equal'] }],
+        } as CapabilitiesResult;
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { countRaw });
+
+      await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'ghost', operator: 'Equal' } });
+
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(calls).toEqual(['capabilities']);
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Zendesk stripeEmail operator regression', () => {
+    it('should reject Equal on stripeEmail with 400 and its normalized supported operators, no agent call', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        new ReadModel([collection('tickets', [column('id'), column('stripeEmail')])]),
+        capabilitiesOf([
+          { name: 'id', type: 'String', operators: ['equal'] },
+          { name: 'stripeEmail', type: 'String', operators: ['present', 'blank'] },
+        ]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/tickets/list')
+        .send({ filter: { field: 'stripeEmail', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'stripeEmail', validOperators: ['Present', 'Blank'] },
+      });
+      expect(list).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent-bff/test/read-model/read-model-store.test.ts
+++ b/packages/agent-bff/test/read-model/read-model-store.test.ts
@@ -86,6 +86,51 @@ describe('ReadModelStore', () => {
       expect(capsFetcher).toHaveBeenCalledTimes(2);
     });
 
+    // SchemaCache bumps `revision` inside its own refresh, before an awaiting getReadModel caller
+    // resumes and installs the rebuilt model. Detecting the refresh by read-model identity misses
+    // that window, so the retry must key on the revision instead.
+    it('should retry when the revision moves while the read-model instance is not yet replaced', async () => {
+      let releaseSchema: () => void = () => {};
+
+      const blocked = new Promise<void>(resolve => {
+        releaseSchema = resolve;
+      });
+      const fetchSchema = jest
+        .fn()
+        .mockResolvedValueOnce(makeSchema('users'))
+        .mockImplementationOnce(async () => {
+          await blocked;
+
+          return makeSchema('orders');
+        })
+        .mockResolvedValue(makeSchema('orders'));
+      const store = build(fetchSchema);
+      await store.getReadModel();
+
+      let disturbed = false;
+      const capsFetcher = jest.fn(async () => {
+        if (!disturbed) {
+          disturbed = true;
+          clock += ONE_DAY_MS;
+          // Kick off the refresh and let SchemaCache bump its revision, but deliberately do NOT
+          // await the rebuild: on return the revision has moved while the store still holds the
+          // previous read-model instance. An identity check cannot see that; the revision can.
+          void store.getReadModel();
+          releaseSchema();
+          await Promise.resolve();
+        }
+
+        return { fields: [{ name: 'tagged', type: 'String', operators: [] }] };
+      });
+
+      const { capabilities, readModel } = await store.getCapabilities('orders', capsFetcher);
+
+      expect(readModel.isCollectionAllowed('orders')).toBe(true);
+      expect(readModel.isCollectionAllowed('users')).toBe(false);
+      expect(capsFetcher.mock.calls.length).toBeGreaterThan(1);
+      expect(capabilities.fields[0].name).toBe('tagged');
+    });
+
     it('should pair capabilities and read-model from one generation when a refresh lands mid-fetch', async () => {
       const fetchSchema = jest
         .fn()

--- a/packages/agent-bff/test/read-model/read-model-store.test.ts
+++ b/packages/agent-bff/test/read-model/read-model-store.test.ts
@@ -86,6 +86,29 @@ describe('ReadModelStore', () => {
       expect(capsFetcher).toHaveBeenCalledTimes(2);
     });
 
+    it('should return the read-model rebuilt by a refresh that lands during the capabilities fetch', async () => {
+      const fetchSchema = jest
+        .fn()
+        .mockResolvedValueOnce(makeSchema('users'))
+        .mockResolvedValueOnce(makeSchema('orders'));
+      const store = build(fetchSchema);
+      const stale = await store.getReadModel();
+
+      // The refresh lands while the fetch is in flight — the window the re-read exists to close.
+      const capsFetcher = jest.fn(async () => {
+        clock += ONE_DAY_MS;
+        await store.getReadModel();
+
+        return { fields: [] };
+      });
+
+      const { readModel } = await store.getCapabilities('orders', capsFetcher);
+
+      expect(readModel).not.toBe(stale);
+      expect(readModel.isCollectionAllowed('orders')).toBe(true);
+      expect(readModel.isCollectionAllowed('users')).toBe(false);
+    });
+
     it('should not rebuild the read-model or clear capabilities when a refresh fails', async () => {
       const fetchSchema = jest
         .fn()

--- a/packages/agent-bff/test/read-model/read-model-store.test.ts
+++ b/packages/agent-bff/test/read-model/read-model-store.test.ts
@@ -86,27 +86,35 @@ describe('ReadModelStore', () => {
       expect(capsFetcher).toHaveBeenCalledTimes(2);
     });
 
-    it('should return the read-model rebuilt by a refresh that lands during the capabilities fetch', async () => {
+    it('should pair capabilities and read-model from one generation when a refresh lands mid-fetch', async () => {
       const fetchSchema = jest
         .fn()
         .mockResolvedValueOnce(makeSchema('users'))
-        .mockResolvedValueOnce(makeSchema('orders'));
+        .mockResolvedValueOnce(makeSchema('orders'))
+        .mockResolvedValue(makeSchema('orders'));
       const store = build(fetchSchema);
       const stale = await store.getReadModel();
 
-      // The refresh lands while the fetch is in flight — the window the re-read exists to close.
+      // Each fetch is tagged with the collection the current schema exposes, so a stale capabilities
+      // result stays distinguishable from one belonging to the rebuilt read-model.
+      let refreshed = false;
       const capsFetcher = jest.fn(async () => {
-        clock += ONE_DAY_MS;
-        await store.getReadModel();
+        if (!refreshed) {
+          refreshed = true;
+          clock += ONE_DAY_MS;
+          await store.getReadModel();
 
-        return { fields: [] };
+          return { fields: [{ name: 'from-users-generation', type: 'String', operators: [] }] };
+        }
+
+        return { fields: [{ name: 'from-orders-generation', type: 'String', operators: [] }] };
       });
 
-      const { readModel } = await store.getCapabilities('orders', capsFetcher);
+      const { capabilities, readModel } = await store.getCapabilities('orders', capsFetcher);
 
       expect(readModel).not.toBe(stale);
       expect(readModel.isCollectionAllowed('orders')).toBe(true);
-      expect(readModel.isCollectionAllowed('users')).toBe(false);
+      expect(capabilities.fields[0].name).toBe('from-orders-generation');
     });
 
     it('should not rebuild the read-model or clear capabilities when a refresh fails', async () => {

--- a/packages/agent-bff/test/validation/capabilities-validator.test.ts
+++ b/packages/agent-bff/test/validation/capabilities-validator.test.ts
@@ -1,0 +1,285 @@
+import type { CapabilitiesResult } from '../../src/read-model/capabilities-cache';
+
+import { toErrorBody } from '../../src/http/bff-http-error';
+import {
+  MAX_FILTER_DEPTH,
+  assertValidAgainstCapabilities,
+  validateAgainstCapabilities,
+} from '../../src/validation/capabilities-validator';
+
+const capabilities: CapabilitiesResult = {
+  fields: [
+    { name: 'id', type: 'Number', operators: ['equal', 'in', 'greater_than'] },
+    { name: 'title', type: 'String', operators: ['equal', 'contains', 'i_contains'] },
+    { name: 'internalCode', type: 'String', operators: [] },
+    { name: 'author', type: 'ManyToOne' },
+  ],
+};
+
+function nestFilter(depth: number): unknown {
+  let node: unknown = { field: 'title', operator: 'Equal', value: 'x' };
+
+  for (let i = 0; i < depth; i += 1) node = { aggregator: 'And', conditions: [node] };
+
+  return node;
+}
+
+function captureError(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error('expected to throw');
+}
+
+describe('validateAgainstCapabilities', () => {
+  describe('filter', () => {
+    it('rejects a leaf on a field absent from capabilities', () => {
+      const errors = validateAgainstCapabilities(
+        { filter: { field: 'missing', operator: 'Equal', value: 1 } },
+        capabilities,
+      );
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'unknown_field',
+          status: 422,
+          details: { field: 'missing' },
+        }),
+      );
+    });
+
+    it('rejects a leaf nested under an And/Or group', () => {
+      const errors = validateAgainstCapabilities(
+        {
+          filter: {
+            aggregator: 'And',
+            conditions: [
+              { field: 'id', operator: 'Equal', value: 1 },
+              { aggregator: 'Or', conditions: [{ field: 'missing', operator: 'Equal', value: 2 }] },
+            ],
+          },
+        },
+        capabilities,
+      );
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({ type: 'unknown_field', details: { field: 'missing' } }),
+      );
+    });
+
+    it('rejects a leaf on a field present with an empty operators array', () => {
+      const errors = validateAgainstCapabilities(
+        { filter: { field: 'internalCode', operator: 'Equal', value: 'x' } },
+        capabilities,
+      );
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'field_not_filterable',
+          status: 422,
+          details: { field: 'internalCode' },
+        }),
+      );
+    });
+
+    it('treats a relation field with no operators key as not filterable', () => {
+      const errors = validateAgainstCapabilities(
+        { filter: { field: 'author', operator: 'Equal', value: 1 } },
+        capabilities,
+      );
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({ type: 'field_not_filterable', details: { field: 'author' } }),
+      );
+    });
+
+    it('rejects an operator not in the field normalized operators, listing validOperators', () => {
+      const errors = validateAgainstCapabilities(
+        { filter: { field: 'title', operator: 'StartsWith', value: 'a' } },
+        capabilities,
+      );
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'invalid_filter_operator',
+          status: 400,
+          details: { field: 'title', validOperators: ['Equal', 'Contains', 'IContains'] },
+        }),
+      );
+    });
+
+    it('rejects a filterable-field leaf that carries no operator', () => {
+      const errors = validateAgainstCapabilities({ filter: { field: 'title' } }, capabilities);
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'invalid_filter_operator',
+          status: 400,
+          details: { field: 'title', validOperators: ['Equal', 'Contains', 'IContains'] },
+        }),
+      );
+    });
+
+    it('rejects a leaf whose operator is not a string', () => {
+      const errors = validateAgainstCapabilities(
+        { filter: { field: 'title', operator: 1, value: 'a' } },
+        capabilities,
+      );
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'invalid_filter_operator',
+          details: { field: 'title', validOperators: ['Equal', 'Contains', 'IContains'] },
+        }),
+      );
+    });
+
+    it('accepts an operator supported by the field', () => {
+      expect(
+        validateAgainstCapabilities(
+          { filter: { field: 'title', operator: 'IContains', value: 'a' } },
+          capabilities,
+        ),
+      ).toEqual([]);
+    });
+
+    it('throws a 500 mapping_error when a capabilities operator does not normalize', () => {
+      const error = captureError(() =>
+        validateAgainstCapabilities(
+          { filter: { field: 'weird', operator: 'Equal', value: 1 } },
+          { fields: [{ name: 'weird', type: 'String', operators: ['made_up_operator'] }] },
+        ),
+      );
+
+      expect(error).toEqual(expect.objectContaining({ type: 'mapping_error', status: 500 }));
+    });
+
+    it('accepts a filter nested up to the maximum depth', () => {
+      expect(
+        validateAgainstCapabilities({ filter: nestFilter(MAX_FILTER_DEPTH) }, capabilities),
+      ).toEqual([]);
+    });
+
+    it('rejects a filter nested beyond the maximum depth with a 400 instead of overflowing', () => {
+      const error = captureError(() =>
+        validateAgainstCapabilities({ filter: nestFilter(MAX_FILTER_DEPTH + 1) }, capabilities),
+      );
+
+      expect(error).toEqual(
+        expect.objectContaining({
+          type: 'filter_too_deep',
+          status: 400,
+          details: { maxDepth: MAX_FILTER_DEPTH },
+        }),
+      );
+    });
+
+    it('rejects a filter deep enough to blow the call stack without the guard', () => {
+      const error = captureError(() =>
+        validateAgainstCapabilities({ filter: nestFilter(20000) }, capabilities),
+      );
+
+      expect(error).toEqual(expect.objectContaining({ type: 'filter_too_deep', status: 400 }));
+    });
+  });
+
+  describe('sort and projection', () => {
+    it('rejects an unknown sort field', () => {
+      const errors = validateAgainstCapabilities({ sortFields: ['ghost'] }, capabilities);
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'unknown_field',
+          status: 422,
+          details: { field: 'ghost' },
+        }),
+      );
+    });
+
+    it('rejects an unknown projection field', () => {
+      const errors = validateAgainstCapabilities({ projectionFields: ['ghost'] }, capabilities);
+
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          type: 'unknown_field',
+          status: 422,
+          details: { field: 'ghost' },
+        }),
+      );
+    });
+
+    it('accepts a non-filterable field for sort and projection existence checks', () => {
+      expect(
+        validateAgainstCapabilities(
+          { sortFields: ['internalCode'], projectionFields: ['author'] },
+          capabilities,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  it('passes a fully valid filter, sort, and projection', () => {
+    expect(
+      validateAgainstCapabilities(
+        {
+          filter: { field: 'id', operator: 'GreaterThan', value: 1 },
+          sortFields: ['title'],
+          projectionFields: ['id', 'title'],
+        },
+        capabilities,
+      ),
+    ).toEqual([]);
+  });
+
+  it('rejects a projection field absent from capabilities, consulting no type table', () => {
+    const errors = validateAgainstCapabilities({ projectionFields: ['description'] }, capabilities);
+
+    expect(errors[0]).toEqual(
+      expect.objectContaining({ type: 'unknown_field', details: { field: 'description' } }),
+    );
+  });
+
+  it('reports every offending field in order and dedupes a field seen twice', () => {
+    const errors = validateAgainstCapabilities(
+      {
+        filter: { field: 'foo', operator: 'Equal', value: 1 },
+        sortFields: ['bar'],
+        projectionFields: ['bar', 'baz'],
+      },
+      capabilities,
+    );
+
+    expect(errors.map(e => (e.details as { field: string }).field)).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('serializes an error to the wire envelope', () => {
+    const [error] = validateAgainstCapabilities({ sortFields: ['ghost'] }, capabilities);
+
+    expect(toErrorBody(error)).toEqual({
+      error: {
+        type: 'unknown_field',
+        status: 422,
+        message: 'Unknown field: ghost',
+        details: { field: 'ghost' },
+      },
+    });
+  });
+});
+
+describe('assertValidAgainstCapabilities', () => {
+  it('throws the first error', () => {
+    expect(() => assertValidAgainstCapabilities({ sortFields: ['ghost'] }, capabilities)).toThrow(
+      expect.objectContaining({ type: 'unknown_field', details: { field: 'ghost' } }),
+    );
+  });
+
+  it('does not throw for a valid request', () => {
+    expect(() =>
+      assertValidAgainstCapabilities({ projectionFields: ['id'] }, capabilities),
+    ).not.toThrow();
+  });
+});

--- a/packages/agent-bff/test/validation/operator-normalizer.test.ts
+++ b/packages/agent-bff/test/validation/operator-normalizer.test.ts
@@ -1,0 +1,43 @@
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
+import { normalizeOperator, toSnakeCaseOperator } from '../../src/validation/operator-normalizer';
+
+describe('operator-normalizer', () => {
+  describe('normalizeOperator', () => {
+    it('maps a snake_case operator back to its PascalCase form', () => {
+      expect(normalizeOperator('less_than_or_equal')).toBe('LessThanOrEqual');
+    });
+
+    it('maps a single-word operator', () => {
+      expect(normalizeOperator('blank')).toBe('Blank');
+    });
+
+    it('maps a leading-initialism operator', () => {
+      expect(normalizeOperator('i_contains')).toBe('IContains');
+      expect(normalizeOperator('not_i_contains')).toBe('NotIContains');
+      expect(normalizeOperator('i_like')).toBe('ILike');
+    });
+
+    it('maps an operator that embeds a single letter and a word', () => {
+      expect(normalizeOperator('after_x_hours_ago')).toBe('AfterXHoursAgo');
+      expect(normalizeOperator('previous_x_days_to_date')).toBe('PreviousXDaysToDate');
+    });
+
+    it('round-trips every canonical operator through snake_case', () => {
+      allOperators.forEach(operator => {
+        expect(normalizeOperator(toSnakeCaseOperator(operator))).toBe(operator);
+      });
+    });
+
+    it('returns undefined for an operator absent from the canonical set', () => {
+      expect(normalizeOperator('made_up_operator')).toBeUndefined();
+    });
+
+    it.each(['constructor', 'toString', '__proto__', 'valueOf', 'hasOwnProperty'])(
+      'returns undefined for the inherited object key %s',
+      key => {
+        expect(normalizeOperator(key)).toBeUndefined();
+      },
+    );
+  });
+});

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -74,7 +74,10 @@ function toActionError(error: unknown): unknown {
   }
 
   if (error.status === 400 || error.status === 422) {
-    return new ActionFormValidationError(detail ?? 'The action form values were rejected.', body.html);
+    return new ActionFormValidationError(
+      detail ?? 'The action form values were rejected.',
+      body.html,
+    );
   }
 
   return error;

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -22,6 +22,7 @@ import AgentHttpError, {
   ActionFormValidationError,
   ActionRequiresApprovalError,
   ApprovalRequestCreationError,
+  UnknownActionFieldError,
 } from '../errors';
 
 // JSON:API error body the agent returns on a rejected action.
@@ -35,6 +36,7 @@ type ActionErrorBody = {
   }[];
   error?: string;
   message?: string;
+  html?: string;
   data?: { roleIdsAllowedToApprove?: number[] };
 };
 
@@ -72,7 +74,7 @@ function toActionError(error: unknown): unknown {
   }
 
   if (error.status === 400 || error.status === 422) {
-    return new ActionFormValidationError(detail ?? 'The action form values were rejected.');
+    return new ActionFormValidationError(detail ?? 'The action form values were rejected.', body.html);
   }
 
   return error;
@@ -187,7 +189,7 @@ export default class Action {
   async setFields(fields: Record<string, unknown>): Promise<void> {
     for (const [fieldName, value] of Object.entries(fields)) {
       if (!this.doesFieldExist(fieldName)) {
-        throw new Error(`Field "${fieldName}" does not exist in this form`);
+        throw new UnknownActionFieldError(fieldName);
       }
 
       // eslint-disable-next-line no-await-in-loop

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -19,9 +19,19 @@ export class ActionRequiresApprovalError extends Error {
 }
 
 export class ActionFormValidationError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly html?: string,
+  ) {
     super(message);
     this.name = 'ActionFormValidationError';
+  }
+}
+
+export class UnknownActionFieldError extends Error {
+  constructor(readonly fieldName: string) {
+    super(`Field "${fieldName}" does not exist in this form`);
+    this.name = 'UnknownActionFieldError';
   }
 }
 

--- a/packages/agent-client/src/errors.ts
+++ b/packages/agent-client/src/errors.ts
@@ -19,10 +19,7 @@ export class ActionRequiresApprovalError extends Error {
 }
 
 export class ActionFormValidationError extends Error {
-  constructor(
-    message: string,
-    readonly html?: string,
-  ) {
+  constructor(message: string, readonly html?: string) {
     super(message);
     this.name = 'ActionFormValidationError';
   }

--- a/packages/agent-client/src/index.ts
+++ b/packages/agent-client/src/index.ts
@@ -13,6 +13,7 @@ import AgentHttpError, {
   ActionFormValidationError,
   ActionRequiresApprovalError,
   ApprovalRequestCreationError,
+  UnknownActionFieldError,
 } from './errors';
 import HttpRequester from './http-requester';
 
@@ -26,6 +27,7 @@ export {
   ActionRequiresApprovalError,
   ActionFormValidationError,
   ApprovalRequestCreationError,
+  UnknownActionFieldError,
 };
 export type {
   ActionEndpointsByCollection,

--- a/packages/agent-client/test/domains/action.test.ts
+++ b/packages/agent-client/test/domains/action.test.ts
@@ -303,6 +303,18 @@ describe('Action', () => {
       });
     });
 
+    it('forwards the html from a native action Error result', async () => {
+      httpRequester.query.mockRejectedValue(
+        new AgentHttpError(400, { error: 'Refund failed', html: '<strong>Nope</strong>' }),
+      );
+
+      await expect(action.execute()).rejects.toMatchObject({
+        name: 'ActionFormValidationError',
+        message: 'Refund failed',
+        html: '<strong>Nope</strong>',
+      });
+    });
+
     it('should propagate other HTTP errors unchanged', async () => {
       const error = new AgentHttpError(500, null);
       httpRequester.query.mockRejectedValue(error);
@@ -338,14 +350,18 @@ describe('Action', () => {
       expect(callOrder).toEqual(['first', 'second', 'third']);
     });
 
-    it('should throw when field does not exist', async () => {
+    it('should throw a typed UnknownActionFieldError when field does not exist', async () => {
       fieldsFormStates.getField.mockReturnValue(null);
 
       await expect(
         action.setFields({
           nonexistent: 'value',
         }),
-      ).rejects.toThrow('Field "nonexistent" does not exist in this form');
+      ).rejects.toMatchObject({
+        name: 'UnknownActionFieldError',
+        fieldName: 'nonexistent',
+        message: 'Field "nonexistent" does not exist in this form',
+      });
     });
   });
 


### PR DESCRIPTION
## What

Exposes `POST /v1/:collection/actions/:action/execute` on the BFF, stacked on the action-form PR (#1748). It rejects unknown submitted fields, runs the Smart Action, and normalizes the agent result into one flat wrapper — success / error / webhook / redirect — returning a structured 501 for File results, which are unimplemented in v1.

Fixes PRD-674

> Base branch is `feature/prd-673-expose-the-action-form-endpoint` (stacked). Review after #1748 merges; rebase onto `main` at that point.

## How

**`agent-client`** (2 additive, backward-compatible changes — a version bump ships with this, so rollback is no longer "redeploy agent-bff alone"):
- `ActionFormValidationError` now carries `html`; `toActionError` forwards it from the native action `Error` payload (`{ error, html }`). Without this the html is dropped before reaching the BFF.
- `setFields` throws a typed `UnknownActionFieldError` (same message as before) so callers route an unknown field to a client error instead of a generic 500. Existing consumers (mcp-server, workflow-executor) catch generically and are unaffected.

**`agent-bff`**:
- `action-execute-mapper.ts` — pure mapper: the agent 200 payload is discriminated positively (webhook / redirect / success); any unrecognized body (a streamed File) falls through to a `501 unsupported_action_result`. `HttpRequester` does not expose response headers, so `Content-Disposition` cannot be read — the fall-through is the only viable File detection.
- `agent-action-client.ts` — a single `loadAction` method (form and execute load the same agent-client `Action` object); `Action extends ActionForm`.
- `action-routes-middleware.ts` — one middleware matching both `/form` and `/execute` with shared body parsing and action resolution. `execute()` gets its own try/catch (it cannot use the generic `callAgent`, which would mislabel the action-Error 400 as a transport 502): `UnknownActionFieldError` → 400 `invalid_request`, `ActionFormValidationError` → 400 `{ type: "error", ..., html }`, `ActionRequiresApprovalError` → 403 `action_requires_approval`, transport 5xx → `agent_unavailable`.
- `bff-local-errors.ts` — new `actionRequiresApproval` (403).

## Result shapes

| Agent result | HTTP | BFF body |
|---|---|---|
| Success | 200 | `{ type: "success", message, invalidated: [...], html }` |
| Error (native) | 400 | `{ type: "error", status: 400, message, html }` |
| Webhook | 200 | `{ type: "webhook", url, method, headers, body }` |
| Redirect | 200 | `{ type: "redirect", path }` |
| File | 501 | `{ error: { type: "unsupported_action_result", status: 501 } }` |

## Out of scope / follow-ups

- **Approval-gated actions** are not wired (no `createApprovalRequest`); they surface as `403 action_requires_approval` (with `roleIdsAllowedToApprove`). Full wiring depends on the auth foundation (PRD-637) providing a per-mode Forest-server token + rendering context, and would add an `approvalRequested` wrapper shape. To confirm with the spec author.
- `action_not_allowed` (403) still has no local trigger — every non-exposed action maps to 404, mirroring the collection/relation routes (existing TODO).

## Tests

- `agent-client`: html carry on the error path, typed `UnknownActionFieldError` from `setFields`.
- `agent-bff`: pure execute mapper (all shapes + 501), the `/execute` route (missing recordIds, unknown field, action Error + html, approval, File, unknown action, transport 5xx vs action-Error 400, success/webhook/redirect), and the shared `loadAction`.
- No regression in `setFields` consumers: mcp-server (24) and workflow-executor adapter (63) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose action execute endpoint in agent-bff with result normalization and capability validation
> - Adds a new `/execute` route to [`action-routes-middleware.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1752/files#diff-1507f08ca51ccc3a715be158e30f8c80ccfb52881e3853b72775f1e677981d4d) that loads the action, applies field validation, executes it, and returns a normalized response.
> - Introduces [`action-execute-mapper.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1752/files#diff-adf19282557435797abff69c50303936dd52dc28025a4ebaded3bf3159c81f77) to normalize raw agent execute results into structured success/webhook/redirect bodies, returning 501 for unrecognized payloads.
> - Renames `loadActionForm` to `loadAction` on `AgentActionClient` and extends the returned `Action` interface with `setFields` and `execute` methods.
> - Adds typed `UnknownActionFieldError` to `agent-client` so the execute handler can return a 400 when a field is missing, and extends `ActionFormValidationError` with an optional `html` payload.
> - Adds capabilities validation to list and count routes in [`data-routes-middleware.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1752/files#diff-f72d9e0085f04fbc09b3ee055760d1ab06989a7f7609ff77350b0c92ec43be20), rejecting requests with invalid fields or operators before querying the agent.
> - `ReadModelStore.getCapabilities` now returns capabilities paired with their read-model and retries on schema-generation races.
> - Behavioral Change: `AgentActionClient.loadActionForm` is replaced by `loadAction`; any callers relying on the old method name will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d9392a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->