### PR TITLE
fix(workflow-executor): accept null title/prompt/aiConfigName in step definitions

### DIFF
--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -121,13 +121,13 @@ export interface ServerWorkflowEnd extends ServerWorkflowStepBase {
 export interface ServerWorkflowCondition extends ServerWorkflowStepBase {
   type: ServerStepTypeEnum.Condition;
   executionType: ServerStepExecutionTypeEnum.Manual | ServerStepExecutionTypeEnum.FullyAutomated;
-  prompt: string;
+  prompt: string | null;
   automaticCompletion: false;
 }
 
 export interface ServerWorkflowEscalation extends ServerWorkflowStepBase {
   type: ServerStepTypeEnum.Escalation;
-  prompt: string;
+  prompt: string | null;
   outgoing: [ServerWorkflowTransition];
   inboxId: string | null;
 }

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -39,8 +39,9 @@ export enum ServerStepExecutionTypeEnum {
 
 interface ServerWorkflowStepBase {
   type: ServerStepTypeEnum;
-  title: string;
-  prompt?: string;
+  // The orchestrator serializes missing BPMN attributes as null (DOM getAttribute), never omits.
+  title: string | null;
+  prompt?: string | null;
   executionType: ServerStepExecutionTypeEnum;
   automaticCompletion: boolean;
   outgoing: ServerWorkflowTransition[];
@@ -50,7 +51,7 @@ export interface ServerWorkflowTaskBase extends ServerWorkflowStepBase {
   type: ServerStepTypeEnum.Task;
   taskType: ServerTaskTypeEnum;
   isSubTask?: boolean;
-  prompt: string;
+  prompt: string | null;
   outgoing: [ServerWorkflowTransition];
 }
 

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -23,10 +23,17 @@ export enum StepExecutionMode {
 // Shared fields across all step types. executionType is intentionally excluded —
 // each schema declares its own valid modes (most with .default().catch() for normalization;
 // guidance deliberately omits .catch to fail loud on an unknown mode).
+// The orchestrator serializes missing BPMN attributes as JSON null (DOM getAttribute), not as
+// absent keys — accept both and normalize to undefined.
+const optionalString = z
+  .string()
+  .nullish()
+  .transform(value => value ?? undefined);
+
 const sharedFields = {
-  prompt: z.string().optional(),
-  aiConfigName: z.string().optional(),
-  title: z.string().optional(),
+  prompt: optionalString,
+  aiConfigName: optionalString,
+  title: optionalString,
 };
 
 // Use z.enum(EnumObject), not z.nativeEnum — the latter is deprecated in zod 4.

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -309,6 +309,38 @@ describe('toStepDefinition', () => {
         options: ['Valid', 'AlsoValid'],
       });
     });
+
+    it('accepts a condition whose title and prompt are null (unnamed BPMN gateway)', () => {
+      const condition = makeCondition(
+        [
+          { stepId: 's1', buttonText: 'Option A' },
+          { stepId: 's2', buttonText: 'Option B' },
+        ],
+        { title: null, prompt: null },
+      );
+
+      expect(toStepDefinition(condition)).toMatchObject({
+        type: 'condition',
+        title: undefined,
+        prompt: undefined,
+        options: ['Option A', 'Option B'],
+      });
+    });
+  });
+
+  describe('null shared fields', () => {
+    it('accepts a task whose title and prompt are null (serialized missing BPMN attributes)', () => {
+      const task = makeTask({
+        title: null,
+        prompt: null,
+      });
+
+      expect(toStepDefinition(task)).toMatchObject({
+        type: 'read-record',
+        title: undefined,
+        prompt: undefined,
+      });
+    });
   });
 
   describe('unsupported step types', () => {


### PR DESCRIPTION
## Why

A customer running migrated browser-engine workflows on the orchestrator hit `Internal validation error occurred while preparing the step` (`DomainValidationError`). The orchestrator serializes missing BPMN attributes as JSON `null` (DOM `getAttribute` semantics — see `bpmn-parser.ts` `getPrompt()` returning `null` explicitly), while the executor's shared step-definition fields used `z.string().optional()`, which accepts `undefined` but **rejects `null`**.

## What

- `title` / `prompt` / `aiConfigName` now accept `null` and normalize it to `undefined` (`.nullish().transform()`), keeping the inferred output type `string | undefined` for all consumers.
- The wire types (`ServerWorkflowStepBase`) now tell the truth: `title: string | null`, `prompt?: string | null`.
- Tests: a task and a condition with `title: null` / `prompt: null` map successfully.

Companion server-side fix: unnamed **manual** gateways no longer hard-fail BPMN parsing (browser-engine parity) — ForestAdmin/forestadmin-server `fix/workflow-unnamed-manual-gateways`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept null `title`, `prompt`, and `aiConfigName` in workflow step definitions
> The BPMN orchestrator serializes missing attributes as `null`, which previously caused validation failures. A new `optionalString` zod helper in [step-definition.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1753/files#diff-66dcc667cb1ebecf3964eecfb28391b1cb81e16c853ad79d4f9017172521aea3) accepts `null` or `undefined` and normalizes both to `undefined`. The `title`, `prompt`, and `aiConfigName` fields in `sharedFields` now use this helper, and the server-type interfaces are updated to reflect nullable values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95975b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->