### PR TITLE
fix(workflow-executor): tolerate non-primitive field types in collection schema

### DIFF
--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -52,7 +52,10 @@ export const FieldSchemaSchema = z.object({
   // Polymorphic relations: discriminator column + candidate target collections, resolved per record.
   polymorphicTypeField: z.string().optional(),
   polymorphicReferencedModels: z.array(z.string()).optional(),
-  type: ColumnTypeSchema.nullable().optional(),
+  // forest-rails apimaps carry field types this contract can't model — hand-authored smart-field
+  // type strings, and `[null]` from array columns the liana fails to map. They must not fail the
+  // whole collection schema; an unparseable type normalizes to null (consumers already guard on it).
+  type: ColumnTypeSchema.nullable().optional().catch(null),
   enumValues: z.array(z.string()).min(1).optional(),
 });
 export type FieldSchema = z.infer<typeof FieldSchemaSchema>;

--- a/packages/workflow-executor/test/types/collection.test.ts
+++ b/packages/workflow-executor/test/types/collection.test.ts
@@ -1,0 +1,49 @@
+import { CollectionSchemaSchema, FieldSchemaSchema } from '../../src/types/validated/collection';
+
+describe('FieldSchemaSchema type tolerance', () => {
+  const base = {
+    fieldName: 'col',
+    displayName: 'Col',
+    isRelationship: false,
+  };
+
+  it('parses a primitive type', () => {
+    expect(FieldSchemaSchema.parse({ ...base, type: 'String' }).type).toBe('String');
+  });
+
+  it('normalizes a non-primitive smart-field type string to null', () => {
+    expect(FieldSchemaSchema.parse({ ...base, type: 'DateTime' }).type).toBeNull();
+  });
+
+  it('normalizes a [null] array-column type to null', () => {
+    expect(FieldSchemaSchema.parse({ ...base, type: [null] }).type).toBeNull();
+  });
+
+  it('keeps an explicit null type as null', () => {
+    expect(FieldSchemaSchema.parse({ ...base, type: null }).type).toBeNull();
+  });
+
+  it('keeps a missing type as undefined', () => {
+    expect(FieldSchemaSchema.parse(base).type).toBeUndefined();
+  });
+});
+
+describe('CollectionSchemaSchema field type tolerance', () => {
+  const collection = {
+    collectionName: 'orders',
+    collectionId: 'orders',
+    collectionDisplayName: 'Orders',
+    primaryKeyFields: ['id'],
+    fields: [
+      { fieldName: 'id', displayName: 'Id', isRelationship: false, type: 'Number' },
+      { fieldName: 'computed', displayName: 'Computed', isRelationship: false, type: 'DateTime' },
+      { fieldName: 'tags', displayName: 'Tags', isRelationship: false, type: [null] },
+    ],
+  };
+
+  it('parses the collection instead of rejecting it, dropping unparseable types to null', () => {
+    const parsed = CollectionSchemaSchema.parse(collection);
+
+    expect(parsed.fields.map(f => f.type)).toEqual(['Number', null, null]);
+  });
+});


### PR DESCRIPTION
## Why

A customer running migrated workflows hit **`Internal validation error occurred while preparing the step`** (`DomainValidationError`) on their **Get Data** step. This message is `DomainValidationError`'s user-facing text, thrown when `CollectionSchemaSchema.parse()` fails inside `getCollectionSchema` (`forest-server-workflow-port.ts:197,209`).

The executor's `ColumnTypeSchema` only accepts primitive/tuple/record/composite types. Two shapes in a **forest-rails** apimap fail it:
- **Hand-authored smart-field type strings** not in `PRIMITIVE_TYPES` (e.g. `DateTime`) — rejected by `z.enum(PRIMITIVE_TYPES)`.
- **`[null]` array-column types** (columns the liana can't map) — the field's top-level `type` is already `.nullable()`, but the tuple branch `z.tuple([ColumnTypeSchema])` has a non-nullable inner element, so `[null]` fails.

A single unmodelable field type failed the **entire** collection schema and blocked the run.

> Note: this is a **different** bug from #1753 (which fixes null `title`/`prompt`/`aiConfigName` on *step* definitions). The customer's reported symptom traces to *collection*-schema validation, not step validation.

## What

- Add `.catch(null)` on `FieldSchemaSchema.type` so an unparseable type **normalizes to `null`** instead of throwing — the whole collection schema keeps parsing.
- This is safe and consistent with the schema's documented "resilient to orchestrator drift" design (it already strips unknown keys). Consumers already guard on a null type — e.g. `update-record-step-executor.ts:315` filters `f.type != null`.
- Tests: non-primitive type string and `[null]` normalize to `null`; primitive/`null`/absent types are unchanged; a mixed collection parses instead of being rejected.

## Test plan

- `yarn workspace @forestadmin/workflow-executor test -- test/types/collection.test.ts` — 6/6 pass
- Re-ran collection-schema consumers (`forest-server-workflow-port`, `schema-resolver`, `schema-cache`, `update-record-step-executor`) — 155/155 pass
- Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate non-primitive field types in `FieldSchemaSchema` collection parsing
> Adds `.catch(null)` to the `type` field in `FieldSchemaSchema` so unparseable `ColumnTypeSchema` values (e.g. smart-field type strings or array-column `[null]`) resolve to `null` instead of failing validation. Explicit `null` stays `null` and missing `type` stays `undefined`. New Jest tests in [collection.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1756/files#diff-760e94b0792e47a257349c9050eec4474671cad77a2a6dc7652c349ed03f8d0d) cover all these cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a2705.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->