### PR TITLE
ci: pin release npm to ^11 to fix EBADENGINE blocking releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/*/package.json') }}
           fail-on-cache-miss: true
       - name: Install npm >= 11.15.0
-        run: npm install -g npm@latest
+        run: npm install -g 'npm@^11'
       - name: Restore build from cache
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
## Problem

The `Release packages` job on `main` fails before `multi-semantic-release` runs, so no packages have been published for the last several commits.

Root cause: the step `Install npm >= 11.15.0` runs `npm install -g npm@latest`. `npm@latest` is now `npm@12.0.0`, which requires node `^22.22.2 || ^24.15.0 || >=26.0.0`. The runner uses node `24.10` (`.nvmrc`), which does not satisfy `^24.15.0`, so the step fails with `EBADENGINE` and the release never runs:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"11.6.1","node":"v24.10.0"}
```

## Fix

Pin the release npm install to `npm@^11`, matching the step intent (>= 11.15.0) and staying compatible with the current node version.

Note: the separate `LLM Integration Tests (ai-proxy)` red is an unrelated flaky failure (Anthropic HTTP 529 overloaded) and does not block the release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin npm to `^11` in release workflow to fix `EBADENGINE` errors
> The [build.yml](.github/workflows/build.yml) release workflow was installing `npm@latest`, which caused `EBADENGINE` errors when a newer npm version dropped support for the Node version in use. Pinning to `npm@^11` keeps the install on the 11.x line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4c2bad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->