### PR TITLE
test(ai-proxy): retry transient provider errors in LLM integration test

### DIFF
--- a/packages/ai-proxy/test/llm.integration.test.ts
+++ b/packages/ai-proxy/test/llm.integration.test.ts
@@ -26,6 +26,23 @@ const { OPENAI_API_KEY, ANTHROPIC_API_KEY } = process.env;
 const describeWithOpenAI = OPENAI_API_KEY ? describe : describe.skip;
 const describeWithAnthropic = ANTHROPIC_API_KEY ? describe : describe.skip;
 
+const HARD_INFRA_ERROR_PATTERN = /401|403|Authentication|invalid x-api-key|ECONNREFUSED|getaddrinfo/i;
+const TRANSIENT_ERROR_PATTERN =
+  /429|500|502|503|504|529|rate limit|overloaded|ETIMEDOUT|ECONNRESET|ECONNABORTED|socket hang up/i;
+const MAX_MODEL_QUERY_ATTEMPTS = 3;
+
+function classifyProviderError(message: string): 'hard' | 'transient' | 'capability' {
+  if (HARD_INFRA_ERROR_PATTERN.test(message)) return 'hard';
+  if (TRANSIENT_ERROR_PATTERN.test(message)) return 'transient';
+
+  return 'capability';
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+
 async function fetchChatModelsFromOpenAI(): Promise<string[]> {
   const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
@@ -410,18 +427,16 @@ providers.forEach(
           console.log(`Testing ${modelsToTest.length} ${label} models:`, modelsToTest);
         });
 
-        it('all models should support tool calls', async () => {
-          const results: { model: string; success: boolean; error?: string }[] = [];
+        const queryModelToolSupport = async (model: string): Promise<ChatCompletionResponse> => {
+          const modelRouter = new Router({
+            aiConfigurations: [
+              { name: 'test', provider: aiConfig.provider, model, apiKey: aiConfig.apiKey },
+            ],
+          });
 
-          for (const model of modelsToTest) {
-            const modelRouter = new Router({
-              aiConfigurations: [
-                { name: 'test', provider: aiConfig.provider, model, apiKey: aiConfig.apiKey },
-              ],
-            });
-
+          for (let attempt = 1; ; attempt += 1) {
             try {
-              const response = (await modelRouter.route({
+              return (await modelRouter.route({
                 route: 'ai-query',
                 body: {
                   messages: [{ role: 'user', content: 'What is 2+2?' }],
@@ -442,6 +457,23 @@ providers.forEach(
                   parallel_tool_calls: false,
                 },
               })) as ChatCompletionResponse;
+            } catch (error) {
+              const isTransient = classifyProviderError(String(error)) === 'transient';
+
+              if (!isTransient || attempt >= MAX_MODEL_QUERY_ATTEMPTS) throw error;
+
+              await sleep(2000 * attempt);
+            }
+          }
+        };
+
+        it('all models should support tool calls', async () => {
+          const results: { model: string; success: boolean; error?: string }[] = [];
+          const skipped: { model: string; error: string }[] = [];
+
+          for (const model of modelsToTest) {
+            try {
+              const response = await queryModelToolSupport(model);
 
               const success =
                 response.choices[0].finish_reason === 'tool_calls' &&
@@ -451,21 +483,25 @@ providers.forEach(
             } catch (error) {
               const errorMessage = String(error);
 
-              const isInfrastructureError =
-                errorMessage.includes('rate limit') ||
-                errorMessage.includes('429') ||
-                errorMessage.includes('401') ||
-                errorMessage.includes('Authentication') ||
-                errorMessage.includes('ECONNREFUSED') ||
-                errorMessage.includes('ETIMEDOUT') ||
-                errorMessage.includes('getaddrinfo');
-
-              if (isInfrastructureError) {
-                throw new Error(`Infrastructure error testing model ${model}: ${errorMessage}`);
+              switch (classifyProviderError(errorMessage)) {
+                case 'hard':
+                  throw new Error(`Infrastructure error testing model ${model}: ${errorMessage}`);
+                case 'transient':
+                  skipped.push({ model, error: errorMessage });
+                  break;
+                default:
+                  results.push({ model, success: false, error: errorMessage });
               }
-
-              results.push({ model, success: false, error: errorMessage });
             }
+          }
+
+          if (skipped.length > 0) {
+            const skippedModelNames = skipped.map(s => s.model).join(', ');
+            // eslint-disable-next-line no-console
+            console.warn(
+              `\n⚠️ ${skipped.length} ${label} model(s) skipped after transient provider errors: ${skippedModelNames}\n`,
+              skipped,
+            );
           }
 
           const failures = results.filter(r => !r.success);


### PR DESCRIPTION
## Problem

The `LLM Integration Tests (ai-proxy)` job on `main` goes red whenever a provider returns a transient error. The `all models should support tool calls` test treated an Anthropic `HTTP 529 overloaded_error` as a model **capability** failure:

```
AIProviderUnavailableError: Anthropic server error (HTTP 529): ... "type":"overloaded_error" ... model: claude-opus-4-5
```

The dispatcher is built with `maxRetries: 0` by design (passthrough proxy), so nothing absorbs the blip, and `expect(failures).toEqual([])` fails on a purely transient provider availability issue that says nothing about the model.

## Fix

- Retry transient errors (`429` / `5xx` / `529` / `overloaded` / network timeouts) with a small backoff (up to 3 attempts).
- If a model still errors transiently after retries, **skip** it (logged) instead of counting it as a failure — a provider blip is not a capability signal.
- Genuine capability failures still fail the test.
- Hard infra errors (`401`/`403`/auth/DNS) still fail loudly — those mean the test setup is broken.

This job already has `continue-on-error: true` and is not in the release `needs`, so it never blocked publishing; this just stops the noise and makes the signal meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient provider errors in LLM integration tool-call test
> - Adds `queryModelToolSupport`, a helper that issues an `ai-query` with a function tool and retries up to 3 times (`MAX_MODEL_QUERY_ATTEMPTS`) with incremental backoff on transient errors.
> - Classifies provider errors into `hard` (auth/infra), `transient` (rate-limit/5xx/network), or `capability` using two new regex patterns; hard errors fail immediately, transient errors are retried then skipped with a warning, and capability errors fail the test.
> - Updates the `'all models should support tool calls'` test in [llm.integration.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1758/files#diff-48feb2f9ecfdc5a8e078463454a6034c45dbf8a77706e9f83d551696eaaac759) to collect skipped and failed models separately, so intermittent provider outages no longer cause false test failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc6648.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->