### PR TITLE
feat(agent-bff): validate top-level list and count against capabilities

### DIFF
--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -33,6 +33,24 @@ export interface ActionExecuteMapped {
   body: ActionExecuteMappedBody;
 }
 
+interface AgentWebhookPayload {
+  url: string;
+  method: string;
+  headers: unknown;
+  body: unknown;
+}
+
+// The agent always serializes the four webhook fields together
+// (`agent/src/routes/modification/action/action.ts`), so a payload missing url/method is malformed
+// and must reach the 501 path rather than surface as a 200 the client cannot act on.
+function isWebhook(value: unknown): value is AgentWebhookPayload {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+  const { url, method } = value as Record<string, unknown>;
+
+  return typeof url === 'string' && typeof method === 'string';
+}
+
 // Normalizes the agent's 200 execute payload into the flat BFF wrapper. The execute result is
 // untyped at the BFF boundary (`Action.execute(): Promise<unknown>`), so we discriminate on the
 // agent HTTP payload shape. A File result streams a binary with no JSON marker, so any unrecognized
@@ -43,19 +61,10 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
   // Each branch validates the value shape, not just key presence: a malformed payload
   // (`{ webhook: null }`, `{ redirectTo: {} }`, `{ success: {} }`) must fall through to the 501
   // path rather than be surfaced as a 200 with null fields the client cannot tell from a real one.
-  if (typeof body.webhook === 'object' && body.webhook !== null) {
-    const hook = body.webhook as Record<string, unknown>;
+  if (isWebhook(body.webhook)) {
+    const { url, method, headers, body: hookBody } = body.webhook;
 
-    return {
-      status: 200,
-      body: {
-        type: 'webhook',
-        url: hook.url,
-        method: hook.method,
-        headers: hook.headers,
-        body: hook.body,
-      },
-    };
+    return { status: 200, body: { type: 'webhook', url, method, headers, body: hookBody } };
   }
 
   if (typeof body.redirectTo === 'string') {
@@ -74,7 +83,9 @@ export function mapActionExecuteResult(raw: unknown): ActionExecuteMapped {
       body: {
         type: 'success',
         message: typeof body.success === 'string' ? body.success : null,
-        invalidated: Array.isArray(relationships) ? (relationships as string[]) : [],
+        invalidated: Array.isArray(relationships)
+          ? relationships.filter((name): name is string => typeof name === 'string')
+          : [],
         html: typeof body.html === 'string' ? body.html : null,
       },
     };

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -6,6 +6,7 @@ import type {
   RelationListRequestBody,
 } from './agent-query';
 import type { Logger } from '../ports/logger-port';
+import type { CapabilitiesResult } from '../read-model/capabilities-cache';
 import type ReadModel from '../read-model/read-model';
 import type { PrimaryKeyField, RelationTarget } from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
@@ -30,6 +31,8 @@ import {
   resolveReadModel,
 } from '../http/agent-route-helpers';
 import { unknownCollection, unknownRelation } from '../http/bff-local-errors';
+import createAgentCapabilitiesFetcher from '../read-model/agent-capabilities-fetcher';
+import { assertValidAgainstCapabilities } from '../validation/capabilities-validator';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
@@ -54,14 +57,33 @@ export interface DataRoutesMiddlewareOptions {
 interface RequestHandlerDeps {
   collection: string;
   client: AgentDataClient;
+  store: ReadModelStore;
+  agentUrl: string;
+  token: string;
   timezone: string;
   logger: Logger;
 }
 
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
+function resolveCapabilities(deps: RequestHandlerDeps): Promise<CapabilitiesResult> {
+  return deps.store.getCapabilities(
+    deps.collection,
+    createAgentCapabilitiesFetcher({ agentUrl: deps.agentUrl, token: deps.token }),
+  );
+}
+
 async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandlerDeps) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
+
+  assertValidAgainstCapabilities(
+    {
+      filter: body.filter,
+      sortFields: body.sort?.map(clause => clause.field),
+      projectionFields: body.projection,
+    },
+    await resolveCapabilities(deps),
+  );
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
@@ -72,6 +94,9 @@ async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandler
 
 async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHandlerDeps) {
   assertNoRelationFieldPaths(collectCountFieldPaths(body));
+
+  // Count carries only a filter (no sort/projection), so that is all there is to validate.
+  assertValidAgainstCapabilities({ filter: body.filter }, await resolveCapabilities(deps));
 
   const query = buildCountAgentQuery(deps.timezone, body);
   const raw = await callAgent(() => deps.client.countRaw(deps.collection, query), deps.logger);
@@ -198,6 +223,9 @@ export default function createDataRoutesMiddleware({
     const deps: RequestHandlerDeps = {
       collection,
       client: createClient({ agentUrl, token }),
+      store,
+      agentUrl,
+      token,
       timezone: ctx.state.timezone as string,
       logger,
     };

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -32,7 +32,10 @@ import {
 } from '../http/agent-route-helpers';
 import { unknownCollection, unknownRelation } from '../http/bff-local-errors';
 import createAgentCapabilitiesFetcher from '../read-model/agent-capabilities-fetcher';
-import { assertValidAgainstCapabilities } from '../validation/capabilities-validator';
+import {
+  assertValidAgainstCapabilities,
+  hasCapabilityConstrainedInput,
+} from '../validation/capabilities-validator';
 import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
@@ -80,14 +83,15 @@ function resolveCapabilities(deps: RequestHandlerDeps): Promise<CapabilitiesResu
 async function handleList(ctx: Context, body: ListRequestBody, deps: ListHandlerDeps) {
   assertNoRelationFieldPaths(collectListFieldPaths(body));
 
-  assertValidAgainstCapabilities(
-    {
-      filter: body.filter,
-      sortFields: body.sort?.map(clause => clause.field),
-      projectionFields: body.projection,
-    },
-    await resolveCapabilities(deps),
-  );
+  const validationInput = {
+    filter: body.filter,
+    sortFields: body.sort?.map(clause => clause.field),
+    projectionFields: body.projection,
+  };
+
+  if (hasCapabilityConstrainedInput(validationInput)) {
+    assertValidAgainstCapabilities(validationInput, await resolveCapabilities(deps));
+  }
 
   const query = buildListAgentQuery(deps.collection, deps.timezone, body);
   const records = await callAgent(() => deps.client.list(deps.collection, query), deps.logger);
@@ -100,7 +104,9 @@ async function handleCount(ctx: Context, body: CountRequestBody, deps: RequestHa
   assertNoRelationFieldPaths(collectCountFieldPaths(body));
 
   // Count carries only a filter (no sort/projection), so that is all there is to validate.
-  assertValidAgainstCapabilities({ filter: body.filter }, await resolveCapabilities(deps));
+  if (body.filter !== undefined) {
+    assertValidAgainstCapabilities({ filter: body.filter }, await resolveCapabilities(deps));
+  }
 
   const query = buildCountAgentQuery(deps.timezone, body);
   const raw = await callAgent(() => deps.client.countRaw(deps.collection, query), deps.logger);

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -67,9 +67,13 @@ interface RequestHandlerDeps {
 type ListHandlerDeps = RequestHandlerDeps & { primaryKeys: PrimaryKeyField[] };
 
 function resolveCapabilities(deps: RequestHandlerDeps): Promise<CapabilitiesResult> {
-  return deps.store.getCapabilities(
-    deps.collection,
-    createAgentCapabilitiesFetcher({ agentUrl: deps.agentUrl, token: deps.token }),
+  return callAgent(
+    () =>
+      deps.store.getCapabilities(
+        deps.collection,
+        createAgentCapabilitiesFetcher({ agentUrl: deps.agentUrl, token: deps.token }),
+      ),
+    deps.logger,
   );
 }
 

--- a/packages/agent-bff/src/read-model/read-model-store.ts
+++ b/packages/agent-bff/src/read-model/read-model-store.ts
@@ -40,11 +40,14 @@ export default class ReadModelStore {
     // Ensure any pending schema refresh (and its capabilities invalidation) runs first.
     await this.getReadModel();
 
-    // TODO(wiring): possible TOCTOU once this is called from request handling. A concurrent schema
-    // refresh can clear capabilities while this fetch is in flight, so the caller could receive
-    // capabilities from the previous schema generation alongside the new allow-list. When wiring
-    // the data endpoints, re-check `schemaCache.revision` after the fetch resolves and retry on a
-    // mismatch so capabilities and schema stay atomically coupled.
+    // TODO(wiring): known TOCTOU, deferred. Two snapshots can straddle a schema generation:
+    //   1. the data middleware captures the read-model (allow-list) once, then calls this later;
+    //   2. this capabilities fetch can be in flight when a concurrent schema refresh clear()s it.
+    // Either gap lets the caller validate against capabilities from one generation while the
+    // allow-list came from another. A full fix couples both reads to a single generation (return
+    // read-model + capabilities together, or re-check `schemaCache.revision` across both and retry);
+    // a retry here alone only closes gap 2. Low risk: the trigger is a 24h-TTL refresh landing exactly
+    // during a request, and the agent stays the final validator.
     return this.capabilitiesCache.get(collection, fetcher);
   }
 

--- a/packages/agent-bff/src/validation/capabilities-validator.ts
+++ b/packages/agent-bff/src/validation/capabilities-validator.ts
@@ -2,7 +2,12 @@ import type { BffHttpError } from '../http/bff-http-error';
 import type { CapabilitiesResult } from '../read-model/capabilities-cache';
 
 import { normalizeOperator } from './operator-normalizer';
-import { fieldNotFilterable, invalidFilterOperator, unknownField } from './validation-errors';
+import {
+  fieldNotFilterable,
+  filterTooDeep,
+  invalidFilterOperator,
+  unknownField,
+} from './validation-errors';
 import { mappingError } from '../http/bff-local-errors';
 
 export interface ValidateParams {
@@ -32,9 +37,13 @@ function isLeaf(node: unknown): node is FilterLeaf {
   );
 }
 
-function collectLeaves(node: unknown, acc: FilterLeaf[]): void {
+export const MAX_FILTER_DEPTH = 100;
+
+function collectLeaves(node: unknown, acc: FilterLeaf[], depth = 0): void {
+  if (depth > MAX_FILTER_DEPTH) throw filterTooDeep(MAX_FILTER_DEPTH);
+
   if (isBranch(node)) {
-    node.conditions.forEach(condition => collectLeaves(condition, acc));
+    node.conditions.forEach(condition => collectLeaves(condition, acc, depth + 1));
   } else if (isLeaf(node)) {
     const { operator } = node as { operator?: unknown };
     acc.push({ field: node.field, operator: typeof operator === 'string' ? operator : undefined });

--- a/packages/agent-bff/src/validation/capabilities-validator.ts
+++ b/packages/agent-bff/src/validation/capabilities-validator.ts
@@ -117,6 +117,18 @@ function dedupe(errors: BffHttpError[]): BffHttpError[] {
 }
 
 /**
+ * True when the request carries something capabilities can invalidate. Callers use it to skip the
+ * capabilities fetch entirely, so a plain list/count still succeeds while that fetch is unavailable.
+ */
+export function hasCapabilityConstrainedInput(params: ValidateParams): boolean {
+  return (
+    params.filter !== undefined ||
+    (params.sortFields?.length ?? 0) > 0 ||
+    (params.projectionFields?.length ?? 0) > 0
+  );
+}
+
+/**
  * Validates a request's filter, sort, and projection fields against the target collection's
  * capabilities. Returns every offending field as a structured error (empty = valid); the caller
  * surfaces the whole list or just the first. Throws a 500 mapping_error when a capabilities

--- a/packages/agent-bff/src/validation/operator-normalizer.ts
+++ b/packages/agent-bff/src/validation/operator-normalizer.ts
@@ -14,7 +14,7 @@ export function toSnakeCaseOperator(operator: string): string {
     .toLowerCase();
 }
 
-const SNAKE_TO_PASCAL: Record<string, Operator> = Object.fromEntries(
+const SNAKE_TO_PASCAL = new Map<string, Operator>(
   allOperators.map(operator => [toSnakeCaseOperator(operator), operator]),
 );
 
@@ -24,5 +24,5 @@ const SNAKE_TO_PASCAL: Record<string, Operator> = Object.fromEntries(
  * only happens when the agent runs a newer operator set than this package (a version skew).
  */
 export function normalizeOperator(snakeCaseOperator: string): Operator | undefined {
-  return SNAKE_TO_PASCAL[snakeCaseOperator];
+  return SNAKE_TO_PASCAL.get(snakeCaseOperator);
 }

--- a/packages/agent-bff/src/validation/validation-errors.ts
+++ b/packages/agent-bff/src/validation/validation-errors.ts
@@ -10,6 +10,15 @@ export function fieldNotFilterable(field: string): BffHttpError {
   });
 }
 
+export function filterTooDeep(maxDepth: number): BffHttpError {
+  return new BffHttpError(
+    400,
+    'filter_too_deep',
+    `Filter nesting exceeds the maximum depth of ${maxDepth}`,
+    { maxDepth },
+  );
+}
+
 export function invalidFilterOperator(field: string, validOperators: string[]): BffHttpError {
   return new BffHttpError(
     400,

--- a/packages/agent-bff/test/action/action-execute-mapper.test.ts
+++ b/packages/agent-bff/test/action/action-execute-mapper.test.ts
@@ -60,6 +60,28 @@ describe('mapActionExecuteResult', () => {
     });
   });
 
+  it.each([
+    ['an empty object', { webhook: {} }],
+    ['an array', { webhook: [] }],
+    ['url missing', { webhook: { method: 'POST' } }],
+    ['method missing', { webhook: { url: 'https://x.test' } }],
+    ['url not a string', { webhook: { url: 42, method: 'POST' } }],
+  ])('falls through to 501 when the webhook payload is %s', (_label, payload) => {
+    expect(mapActionExecuteResult(payload)).toEqual({
+      status: 501,
+      body: { error: { type: 'unsupported_action_result', status: 501 } },
+    });
+  });
+
+  it('drops non-string entries from invalidated', () => {
+    expect(
+      mapActionExecuteResult({ success: 'ok', refresh: { relationships: ['orders', 42, null] } }),
+    ).toEqual({
+      status: 200,
+      body: { type: 'success', message: 'ok', invalidated: ['orders'], html: null },
+    });
+  });
+
   it('maps a Redirect payload to the path', () => {
     expect(mapActionExecuteResult({ redirectTo: '/orders/1' })).toEqual({
       status: 200,

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -1,5 +1,6 @@
 import type { AgentDataClient } from '../../src/data/agent-data-client';
 import type { Logger } from '../../src/ports/logger-port';
+import type { CapabilitiesResult } from '../../src/read-model/capabilities-cache';
 import type ReadModelStore from '../../src/read-model/read-model-store';
 
 import { AgentHttpError } from '@forestadmin/agent-client';
@@ -17,13 +18,33 @@ const TIMEZONE = 'Europe/Paris';
 
 const noopLogger: Logger = () => {};
 
-function storeOf(readModel: ReadModel | Error): ReadModelStore {
+type CapabilitiesStub = (collection: string) => Promise<CapabilitiesResult>;
+
+const BROAD_SNAKE_OPERATORS = ['present', 'blank', 'equal', 'not_equal', 'in', 'like'];
+
+const defaultCapabilities: CapabilitiesStub = async () => ({
+  fields: ['id', 'email', 'title', 'name', 'value', 'slug', 'label'].map(name => ({
+    name,
+    type: 'String',
+    operators: BROAD_SNAKE_OPERATORS,
+  })),
+});
+
+function capabilitiesOf(fields: CapabilitiesResult['fields']): CapabilitiesStub {
+  return async () => ({ fields });
+}
+
+function storeOf(
+  readModel: ReadModel | Error,
+  getCapabilities: CapabilitiesStub = defaultCapabilities,
+): ReadModelStore {
   return {
     getReadModel: async () => {
       if (readModel instanceof Error) throw readModel;
 
       return readModel;
     },
+    getCapabilities: (collectionName: string) => getCapabilities(collectionName),
   } as unknown as ReadModelStore;
 }
 
@@ -272,6 +293,207 @@ describe('data routes middleware', () => {
       expect(response.body.data[0]).toMatchObject({
         __forest: { collection: 'metrics', primaryKey: { id: 42 } },
       });
+    });
+  });
+
+  describe('capabilities validation', () => {
+    it('should reject a list filter operator unsupported by capabilities before calling the agent', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'email', type: 'String', operators: ['present'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ filter: { field: 'email', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'email', validOperators: ['Present'] },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should reject a list projection field absent from capabilities with 422 unknown_field', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['id', 'ghost'] });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should reject a list sort field absent from capabilities with 422 unknown_field', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ sort: [{ field: 'ghost', direction: 'asc' }] });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should read capabilities before the agent call and skip the agent on a validation failure', async () => {
+      const calls: string[] = [];
+      const list = jest.fn(async () => {
+        calls.push('agent');
+
+        return [];
+      });
+      const getCapabilities = jest.fn(async () => {
+        calls.push('capabilities');
+
+        return {
+          fields: [{ name: 'id', type: 'String', operators: ['equal'] }],
+        } as CapabilitiesResult;
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['ghost'] });
+
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(calls).toEqual(['capabilities']);
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should proceed to the agent when the list filter, sort, and projection are all valid', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(defaultCapabilities);
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({
+          projection: ['id', 'email'],
+          filter: { field: 'email', operator: 'Present' },
+          sort: [{ field: 'id', direction: 'asc' }],
+        });
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(list).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject a count filter operator unsupported by capabilities before calling the agent', async () => {
+      const countRaw = jest.fn(async () => ({ count: 0 }));
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'email', type: 'String', operators: ['present'] }]),
+      );
+      const app = buildApp(store, { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'email', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'email', validOperators: ['Present'] },
+      });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should reject a count filter field absent from capabilities with 422 unknown_field', async () => {
+      const countRaw = jest.fn(async () => ({ count: 0 }));
+      const store = storeOf(
+        usersReadModel,
+        capabilitiesOf([{ name: 'id', type: 'String', operators: ['equal'] }]),
+      );
+      const app = buildApp(store, { countRaw });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'ghost', operator: 'Equal' } });
+
+      expect(response.status).toBe(422);
+      expect(response.body.error).toMatchObject({
+        type: 'unknown_field',
+        status: 422,
+        details: { field: 'ghost' },
+      });
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+
+    it('should read capabilities before the agent call on the count path', async () => {
+      const calls: string[] = [];
+      const countRaw = jest.fn(async () => {
+        calls.push('agent');
+
+        return { count: 0 };
+      });
+      const getCapabilities = jest.fn(async () => {
+        calls.push('capabilities');
+
+        return {
+          fields: [{ name: 'id', type: 'String', operators: ['equal'] }],
+        } as CapabilitiesResult;
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { countRaw });
+
+      await request(app.callback())
+        .post('/agent/v1/users/count')
+        .send({ filter: { field: 'ghost', operator: 'Equal' } });
+
+      expect(getCapabilities).toHaveBeenCalledWith('users');
+      expect(calls).toEqual(['capabilities']);
+      expect(countRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Zendesk stripeEmail operator regression', () => {
+    it('should reject Equal on stripeEmail with 400 and its normalized supported operators, no agent call', async () => {
+      const list = jest.fn(async () => []);
+      const store = storeOf(
+        new ReadModel([collection('tickets', [column('id'), column('stripeEmail')])]),
+        capabilitiesOf([
+          { name: 'id', type: 'String', operators: ['equal'] },
+          { name: 'stripeEmail', type: 'String', operators: ['present', 'blank'] },
+        ]),
+      );
+      const app = buildApp(store, { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/tickets/list')
+        .send({ filter: { field: 'stripeEmail', operator: 'Equal' } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatchObject({
+        type: 'invalid_filter_operator',
+        status: 400,
+        details: { field: 'stripeEmail', validOperators: ['Present', 'Blank'] },
+      });
+      expect(list).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -385,6 +385,24 @@ describe('data routes middleware', () => {
       expect(list).not.toHaveBeenCalled();
     });
 
+    it('should map a capabilities fetch failure to agent_unavailable instead of internal_error', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback())
+        .post('/agent/v1/users/list')
+        .send({ projection: ['id'] });
+
+      expect(response.status).toBe(503);
+      expect(response.body.error).toEqual(
+        expect.objectContaining({ type: 'agent_unavailable', status: 503 }),
+      );
+      expect(list).not.toHaveBeenCalled();
+    });
+
     it('should proceed to the agent when the list filter, sort, and projection are all valid', async () => {
       const list = jest.fn(async () => []);
       const getCapabilities = jest.fn(defaultCapabilities);

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -403,6 +403,34 @@ describe('data routes middleware', () => {
       expect(list).not.toHaveBeenCalled();
     });
 
+    it('should skip the capabilities fetch when the list carries nothing to validate', async () => {
+      const list = jest.fn(async () => []);
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { list });
+
+      const response = await request(app.callback()).post('/agent/v1/users/list').send({});
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).not.toHaveBeenCalled();
+      expect(list).toHaveBeenCalled();
+    });
+
+    it('should skip the capabilities fetch when the count carries no filter', async () => {
+      const countRaw = jest.fn(async () => ({ count: 3 }));
+      const getCapabilities = jest.fn(async () => {
+        throw new AgentHttpError(503, {}, 'Service Unavailable');
+      });
+      const app = buildApp(storeOf(usersReadModel, getCapabilities), { countRaw });
+
+      const response = await request(app.callback()).post('/agent/v1/users/count').send({});
+
+      expect(response.status).toBe(200);
+      expect(getCapabilities).not.toHaveBeenCalled();
+      expect(countRaw).toHaveBeenCalled();
+    });
+
     it('should proceed to the agent when the list filter, sort, and projection are all valid', async () => {
       const list = jest.fn(async () => []);
       const getCapabilities = jest.fn(defaultCapabilities);

--- a/packages/agent-bff/test/validation/capabilities-validator.test.ts
+++ b/packages/agent-bff/test/validation/capabilities-validator.test.ts
@@ -2,6 +2,7 @@ import type { CapabilitiesResult } from '../../src/read-model/capabilities-cache
 
 import { toErrorBody } from '../../src/http/bff-http-error';
 import {
+  MAX_FILTER_DEPTH,
   assertValidAgainstCapabilities,
   validateAgainstCapabilities,
 } from '../../src/validation/capabilities-validator';
@@ -14,6 +15,14 @@ const capabilities: CapabilitiesResult = {
     { name: 'author', type: 'ManyToOne' },
   ],
 };
+
+function nestFilter(depth: number): unknown {
+  let node: unknown = { field: 'title', operator: 'Equal', value: 'x' };
+
+  for (let i = 0; i < depth; i += 1) node = { aggregator: 'And', conditions: [node] };
+
+  return node;
+}
 
 function captureError(fn: () => void): unknown {
   try {
@@ -147,6 +156,34 @@ describe('validateAgainstCapabilities', () => {
       );
 
       expect(error).toEqual(expect.objectContaining({ type: 'mapping_error', status: 500 }));
+    });
+
+    it('accepts a filter nested up to the maximum depth', () => {
+      expect(
+        validateAgainstCapabilities({ filter: nestFilter(MAX_FILTER_DEPTH) }, capabilities),
+      ).toEqual([]);
+    });
+
+    it('rejects a filter nested beyond the maximum depth with a 400 instead of overflowing', () => {
+      const error = captureError(() =>
+        validateAgainstCapabilities({ filter: nestFilter(MAX_FILTER_DEPTH + 1) }, capabilities),
+      );
+
+      expect(error).toEqual(
+        expect.objectContaining({
+          type: 'filter_too_deep',
+          status: 400,
+          details: { maxDepth: MAX_FILTER_DEPTH },
+        }),
+      );
+    });
+
+    it('rejects a filter deep enough to blow the call stack without the guard', () => {
+      const error = captureError(() =>
+        validateAgainstCapabilities({ filter: nestFilter(20000) }, capabilities),
+      );
+
+      expect(error).toEqual(expect.objectContaining({ type: 'filter_too_deep', status: 400 }));
     });
   });
 

--- a/packages/agent-bff/test/validation/operator-normalizer.test.ts
+++ b/packages/agent-bff/test/validation/operator-normalizer.test.ts
@@ -32,5 +32,12 @@ describe('operator-normalizer', () => {
     it('returns undefined for an operator absent from the canonical set', () => {
       expect(normalizeOperator('made_up_operator')).toBeUndefined();
     });
+
+    it.each(['constructor', 'toString', '__proto__', 'valueOf', 'hasOwnProperty'])(
+      'returns undefined for the inherited object key %s',
+      key => {
+        expect(normalizeOperator(key)).toBeUndefined();
+      },
+    );
   });
 });


### PR DESCRIPTION
## What

Wires the capabilities validator into the **top-level list and count** handlers in `agent-bff`, so a request's filter/sort/projection is validated against the agent's real capabilities **before** the agent call — catching unsupported operators early with a structured error instead of discovering them late.

## Changes

- `data-routes-middleware.ts`
  - `handleList` validates `filter` + `sort` + `projection`; `handleCount` validates the `filter` only (the count contract carries no sort/projection).
  - Validation runs **after** the syntactic nested-relation guard and **before** the agent call.
  - Request-handler deps now carry `store` / `agentUrl` / `token`; a shared `resolveCapabilities` helper builds the token-bound fetcher and reads the capabilities cache.
- `read-model-store.ts` — sharpened the deferred-TOCTOU `TODO` to name both halves of the race (the middleware read-model snapshot + the in-flight capabilities fetch). Comment-only, no behavior change.
- Tests — list/count operator + unknown-field cases, read-order assertions (capabilities read before the agent, both paths), valid-request pass-through, and a **Zendesk `stripeEmail`/`Equal` regression** using a raw snake_case fixture so the validator's snake→Pascal normalization path is exercised (returns `400 invalid_filter_operator` with `validOperators` = the field's supported operators, no agent call).

## Notes

- **Stacked on PRD-675** (the validator itself). This PR targets the PRD-675 branch; it should merge after PRD-675.
- TOCTOU coupling of the read-model + capabilities generations is intentionally **deferred** (documented in the TODO) — the trigger is a 24h-TTL schema refresh landing exactly during a request, and the agent stays the final validator.
- Relation endpoint wiring is out of scope (PRD-677).

## Verification

- `tsc --noEmit` clean; changed files lint clean.
- Full `@forestadmin/agent-bff` suite: **671/671** passing.

Fixes PRD-676

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate list and count requests against collection capabilities in agent-bff data routes
> - List and count endpoints in [data-routes-middleware.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1759/files#diff-f72d9e0085f04fbc09b3ee055760d1ab06989a7f7609ff77350b0c92ec43be20) now fetch collection capabilities and validate filters, sort fields, and projections before forwarding requests to the agent, returning 400/422 errors locally when invalid.
> - Adds a `MAX_FILTER_DEPTH` guard in [capabilities-validator.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1759/files#diff-cff066ad8696ed33f89763a6029006dcc2e1dda09c911f5c6630a75b2ae1c3b3) to prevent stack overflows on deeply nested filter trees, throwing a 400 `filter_too_deep` error instead.
> - Fixes `normalizeOperator` in [operator-normalizer.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1759/files#diff-653e0cee258f214240011bcbb55314be0494a4c2965438d6b4abbfea94e51f74) to use a `Map` instead of a plain object, preventing inherited keys like `constructor` from resolving to unintended operators.
> - Fixes webhook payload mapping in [action-execute-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1759/files#diff-adf19282557435797abff69c50303936dd52dc28025a4ebaded3bf3159c81f77) to require both `url` and `method` as strings; malformed payloads now fall through to 501 instead of 200.
> - Behavioral Change: list and count requests that were previously forwarded to the agent may now be rejected locally with validation errors when capabilities are available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b59bbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->