### PR TITLE
feat(workflow-executor): deterministic source record for Get Data steps (PRD-775)

### DIFF
--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -66,6 +66,7 @@ export interface ServerWorkflowTaskGuideline extends ServerWorkflowTaskBase {
 interface ServerWorkflowTaskGetData extends ServerWorkflowTaskBase {
   taskType: ServerTaskTypeEnum.GetData;
   executionType: ServerStepExecutionTypeEnum.FullyAutomated;
+  preRecordedArgs?: { selectedRecordStepId?: string };
 }
 
 interface ServerWorkflowTaskUpdateData extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -66,7 +66,7 @@ export interface ServerWorkflowTaskGuideline extends ServerWorkflowTaskBase {
 interface ServerWorkflowTaskGetData extends ServerWorkflowTaskBase {
   taskType: ServerTaskTypeEnum.GetData;
   executionType: ServerStepExecutionTypeEnum.FullyAutomated;
-  preRecordedArgs?: { selectedRecordStepId?: string };
+  preRecordedArgs?: { selectedRecordStepId?: string; fieldNames?: string[] };
 }
 
 interface ServerWorkflowTaskUpdateData extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -34,7 +34,11 @@ function mapTask(task: ServerWorkflowTask): StepDefinition {
     case ServerTaskTypeEnum.Guideline:
       return GuidanceStepDefinitionSchema.parse({ ...base, type: StepType.Guidance });
     case ServerTaskTypeEnum.GetData:
-      return ReadRecordStepDefinitionSchema.parse({ ...base, type: StepType.ReadRecord });
+      return ReadRecordStepDefinitionSchema.parse({
+        ...base,
+        type: StepType.ReadRecord,
+        preRecordedArgs: task.preRecordedArgs,
+      });
     case ServerTaskTypeEnum.UpdateData:
       return UpdateRecordStepDefinitionSchema.parse({ ...base, type: StepType.UpdateRecord });
     case ServerTaskTypeEnum.TriggerAction:

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -30,8 +30,9 @@ export default class ReadRecordStepExecutor extends RecordStepExecutor<ReadRecor
           preRecordedArgs?.selectedRecordStepIndex,
         );
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
-    const fieldNames =
-      preRecordedArgs?.fieldNames ?? (await this.selectFields(schema, step.prompt));
+    const fieldNames = preRecordedArgs?.fieldNames?.length
+      ? preRecordedArgs.fieldNames
+      : await this.selectFields(schema, step.prompt);
     const selectedFields = fieldNames.map(requested => ({
       requested,
       field: this.findFieldByTechnicalName(schema, requested),

--- a/packages/workflow-executor/src/executors/read-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/read-record-step-executor.ts
@@ -21,13 +21,14 @@ export default class ReadRecordStepExecutor extends RecordStepExecutor<ReadRecor
   protected async doExecute(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const { preRecordedArgs } = step;
-    const records = await this.getAvailableRecordRefs();
 
-    const selectedRecordRef = await this.resolveRecordRef(
-      records,
-      step.prompt,
-      preRecordedArgs?.selectedRecordStepIndex,
-    );
+    const selectedRecordRef = preRecordedArgs?.selectedRecordStepId
+      ? await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepId)
+      : await this.resolveRecordRef(
+          await this.getAvailableRecordRefs(),
+          step.prompt,
+          preRecordedArgs?.selectedRecordStepIndex,
+        );
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
     const fieldNames =
       preRecordedArgs?.fieldNames ?? (await this.selectFields(schema, step.prompt));

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -46,6 +46,13 @@ export const ReadRecordStepDefinitionSchema = z.object({
   executionType: z.literal(FullyAutomated).default(FullyAutomated).catch(FullyAutomated),
   preRecordedArgs: z
     .object({
+      /**
+       * "On record" — the source record to read from, referenced by the stable BPMN step id of the
+       * previous Load Related Record step that loaded it, or WORKFLOW_START_STEP_ID for the trigger
+       * record. Stable across revisions, unlike the runtime stepIndex.
+       */
+      selectedRecordStepId: z.string().optional(),
+      // Legacy runtime index; superseded by selectedRecordStepId. Kept for back-compat.
       selectedRecordStepIndex: z.number().int().optional(),
       /** Technical names of the fields to read */
       fieldNames: z.array(z.string()).optional(),

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -65,6 +65,19 @@ describe('toStepDefinition', () => {
       });
     });
 
+    it('should forward preRecordedArgs.selectedRecordStepId on a get-data task', () => {
+      const task = makeTask({
+        taskType: ServerTaskTypeEnum.GetData,
+        prompt: 'read it',
+        preRecordedArgs: { selectedRecordStepId: 'load-1' },
+      } as Partial<ServerWorkflowTask>);
+
+      expect(toStepDefinition(task)).toMatchObject({
+        type: StepType.ReadRecord,
+        preRecordedArgs: { selectedRecordStepId: 'load-1' },
+      });
+    });
+
     it('should map task with update-data taskType to update-record', () => {
       const task = makeTask({ taskType: ServerTaskTypeEnum.UpdateData, prompt: 'update it' });
 

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -13,7 +13,11 @@ import AgentWithLog from '../../src/executors/agent-with-log';
 import ReadRecordStepExecutor from '../../src/executors/read-record-step-executor';
 import SchemaCache from '../../src/schema-cache';
 import SchemaResolver from '../../src/schema-resolver';
-import { StepExecutionMode, StepType } from '../../src/types/validated/step-definition';
+import {
+  StepExecutionMode,
+  StepType,
+  WORKFLOW_START_STEP_ID,
+} from '../../src/types/validated/step-definition';
 
 function makeStep(overrides: Partial<ReadRecordStepDefinition> = {}): ReadRecordStepDefinition {
   return {
@@ -1140,6 +1144,82 @@ describe('ReadRecordStepExecutor', () => {
       await executor.execute();
 
       expect(mockModel.bindTools).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves the source record deterministically from selectedRecordStepId (no select-record AI)', async () => {
+      const relatedRef = makeRecordRef({ collectionName: 'orders', recordId: [99], stepIndex: 1 });
+      const mockModel = makeMockModel({ fieldNames: ['Email'] });
+      const agentPort = makeMockAgentPort({ orders: { values: { email: 'ord@example.com' } } });
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 1,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: relatedRef,
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        runStore,
+        agentPort,
+        previousSteps: [makeLoadRelatedPreviousStep(1)],
+        stepDefinition: makeStep({ preRecordedArgs: { selectedRecordStepId: 'load-1' } }),
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema(),
+          orders: makeCollectionSchema({
+            collectionName: 'orders',
+            collectionDisplayName: 'Orders',
+          }),
+        }),
+      });
+      const executor = new ReadRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // Only selectFields ran (1 AI call); no select-record round.
+      expect(mockModel.bindTools).toHaveBeenCalledTimes(1);
+      expect(agentPort.getRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'orders', id: [99] }),
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+
+    it('resolves WORKFLOW_START_STEP_ID to the base record', async () => {
+      const mockModel = makeMockModel({ fieldNames: ['email'] });
+      const agentPort = makeMockAgentPort();
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          preRecordedArgs: { selectedRecordStepId: WORKFLOW_START_STEP_ID },
+        }),
+      });
+      const executor = new ReadRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.getRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'customers', id: [42] }),
+        expect.objectContaining({ id: 1 }),
+      );
+    });
+
+    it('returns error when selectedRecordStepId matches no source step', async () => {
+      const context = makeContext({
+        stepDefinition: makeStep({ preRecordedArgs: { selectedRecordStepId: 'nope' } }),
+      });
+      const executor = new ReadRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
     });
   });
 

--- a/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/read-record-step-executor.test.ts
@@ -1220,6 +1220,76 @@ describe('ReadRecordStepExecutor', () => {
       const result = await executor.execute();
 
       expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe('The pre-configured step parameters are invalid');
+    });
+
+    it('returns SourceRecordMissingError when the pinned source step loaded no record', async () => {
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest
+          .fn()
+          .mockResolvedValue([
+            { type: 'load-related-record', stepIndex: 1, executionResult: undefined },
+          ]),
+      });
+      const context = makeContext({
+        runStore,
+        previousSteps: [makeLoadRelatedPreviousStep(1)],
+        stepDefinition: makeStep({ preRecordedArgs: { selectedRecordStepId: 'load-1' } }),
+      });
+      const executor = new ReadRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        "This step uses its source step as its source, but that step didn't load any record.",
+      );
+    });
+
+    it('runs zero AI rounds when both selectedRecordStepId and fieldNames are pre-recorded', async () => {
+      const relatedRef = makeRecordRef({ collectionName: 'orders', recordId: [99], stepIndex: 1 });
+      const mockModel = makeMockModel({ fieldNames: [] });
+      const agentPort = makeMockAgentPort({ orders: { values: { total: 100 } } });
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 1,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: relatedRef,
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        runStore,
+        agentPort,
+        previousSteps: [makeLoadRelatedPreviousStep(1)],
+        stepDefinition: makeStep({
+          preRecordedArgs: { selectedRecordStepId: 'load-1', fieldNames: ['total'] },
+        }),
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema(),
+          orders: makeCollectionSchema({
+            collectionName: 'orders',
+            collectionDisplayName: 'Orders',
+            fields: [{ fieldName: 'total', displayName: 'Total', isRelationship: false }],
+          }),
+        }),
+      });
+      const executor = new ReadRecordStepExecutor(context);
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(mockModel.bindTools).toHaveBeenCalledTimes(0);
+      expect(agentPort.getRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'orders', id: [99], fields: ['total'] }),
+        expect.objectContaining({ id: 1 }),
+      );
     });
   });
 


### PR DESCRIPTION
Part of the deterministic Get Data step work.

fixes PRD-775

## What

The `read-record` (Get Data) step can now resolve its source record deterministically from a build-time-configured **stable BPMN step id** (`selectedRecordStepId`), mirroring how `trigger-action` and `load-related-record` already work — instead of always asking the AI to pick among the available records.

## Changes

- `ReadRecordStepDefinitionSchema.preRecordedArgs` gains `selectedRecordStepId` (legacy `selectedRecordStepIndex` kept for back-compat).
- `read-record-step-executor`: when `selectedRecordStepId` is set, resolve via `resolveSourceRecordRef` (revise-safe; `WORKFLOW_START_STEP_ID` → base record). Falls back to legacy index / AI selection when unset.
- Server contract (`ServerWorkflowTaskGetData`) + mapper forward `preRecordedArgs` for `get-data`.

The `fieldNames` pre-recorded path (build-time field selection) already existed and is unchanged.

## Tests

- Deterministic resolve skips the select-record AI round; `WORKFLOW_START_STEP_ID` → base record; unresolvable id → error.
- Mapper forwards `preRecordedArgs.selectedRecordStepId`.

Companion PRs: forestadmin-server (orchestrator), forestadmin (editor UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic source record resolution by step ID to `ReadRecordStepExecutor`
> - Adds an optional `selectedRecordStepId` field to `preRecordedArgs` in `ReadRecordStepDefinition` and the `ServerWorkflowTaskGetData` interface, alongside the legacy `selectedRecordStepIndex` for back-compat.
> - When `preRecordedArgs.selectedRecordStepId` is set, `ReadRecordStepExecutor.doExecute` calls `resolveSourceRecordRef(selectedRecordStepId)` and skips the interactive record selection flow entirely.
> - The `mapTask` mapper in [step-definition-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1760/files#diff-b7de2aee7747c46286af27c1dac9169be8f2469b8a2bebe327065e1cc51efe02) now forwards `preRecordedArgs` from `GetData` server tasks to the resulting `ReadRecord` step definition.
> - Behavioral Change: executions with `selectedRecordStepId` set will bypass record selection; an unmatched step ID results in an error rather than falling back to selection.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1760 opened
>
> - Modified field name resolution logic in `ReadRecordStepExecutor.doExecute` method to check both existence and non-zero length of `preRecordedArgs.fieldNames` before using pre-recorded values, falling back to `selectFields` call when `fieldNames` is undefined, null, or an empty array [1b73908]
> - Added test coverage for error handling when pinned source step returns no record and validation of deterministic execution path when both `selectedRecordStepId` and `fieldNames` are pre-recorded [1b73908]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1b73908. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->