### PR TITLE
feat(workflow-executor): deterministic source record for Update Data steps (PRD-777)

### DIFF
--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -73,6 +73,7 @@ interface ServerWorkflowTaskUpdateData extends ServerWorkflowTaskBase {
   executionType:
     | ServerStepExecutionTypeEnum.FullyAutomated
     | ServerStepExecutionTypeEnum.AutomatedWithConfirmation;
+  preRecordedArgs?: { selectedRecordStepId?: string; fieldName?: string; value?: unknown };
 }
 
 interface ServerWorkflowTaskTriggerAction extends ServerWorkflowTaskBase {

--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -36,7 +36,11 @@ function mapTask(task: ServerWorkflowTask): StepDefinition {
     case ServerTaskTypeEnum.GetData:
       return ReadRecordStepDefinitionSchema.parse({ ...base, type: StepType.ReadRecord });
     case ServerTaskTypeEnum.UpdateData:
-      return UpdateRecordStepDefinitionSchema.parse({ ...base, type: StepType.UpdateRecord });
+      return UpdateRecordStepDefinitionSchema.parse({
+        ...base,
+        type: StepType.UpdateRecord,
+        preRecordedArgs: task.preRecordedArgs,
+      });
     case ServerTaskTypeEnum.TriggerAction:
       return TriggerActionStepDefinitionSchema.parse({
         ...base,

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -186,13 +186,14 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
   private async handleFirstCall(): Promise<StepExecutionResult> {
     const { stepDefinition: step } = this.context;
     const { preRecordedArgs } = step;
-    const records = await this.getAvailableRecordRefs();
 
-    const selectedRecordRef = await this.resolveRecordRef(
-      records,
-      step.prompt,
-      preRecordedArgs?.selectedRecordStepIndex,
-    );
+    const selectedRecordRef = preRecordedArgs?.selectedRecordStepId
+      ? await this.resolveSourceRecordRef(preRecordedArgs.selectedRecordStepId)
+      : await this.resolveRecordRef(
+          await this.getAvailableRecordRefs(),
+          step.prompt,
+          preRecordedArgs?.selectedRecordStepIndex,
+        );
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
 
     if (preRecordedArgs?.fieldName !== undefined && preRecordedArgs?.value === undefined) {

--- a/packages/workflow-executor/src/executors/update-record-step-executor.ts
+++ b/packages/workflow-executor/src/executors/update-record-step-executor.ts
@@ -40,16 +40,27 @@ const jsonStringSchema = z
   )
   .describe('JSON content as a valid JSON string');
 
-function buildZodSchemaForPrimitive(type: string, enumValues?: string[]): z.ZodTypeAny {
+// `forAiTool` = the schema is bound into an AI tool (langchain converts it to JSON Schema). The
+// Boolean coercion uses `z.preprocess`, which langchain's cross-package transform-stripping misses
+// when the workspace resolves two zod copies (root vs nested) → "Transforms cannot be represented
+// in JSON Schema". For the AI tool we hand it a plain z.boolean(); coerceFieldValue (which builds
+// with forAiTool=false) still normalizes any stray "true"/"false" string afterwards.
+function buildZodSchemaForPrimitive(
+  type: string,
+  enumValues?: string[],
+  forAiTool = false,
+): z.ZodTypeAny {
   switch (type) {
     case 'Boolean':
-      return z.preprocess(val => {
-        if (typeof val !== 'string') return val;
-        if (val === 'true') return true;
-        if (val === 'false') return false;
+      return forAiTool
+        ? z.boolean()
+        : z.preprocess(val => {
+            if (typeof val !== 'string') return val;
+            if (val === 'true') return true;
+            if (val === 'false') return false;
 
-        return val;
-      }, z.boolean());
+            return val;
+          }, z.boolean());
     case 'Date':
       return z.iso.datetime().describe('ISO 8601 datetime, e.g. 2024-06-01T00:00:00Z');
     case 'Dateonly':
@@ -74,7 +85,11 @@ function buildZodSchemaForPrimitive(type: string, enumValues?: string[]): z.ZodT
   }
 }
 
-function buildZodSchemaForField(field: FieldSchema, collectionName: string): z.ZodTypeAny {
+function buildZodSchemaForField(
+  field: FieldSchema,
+  collectionName: string,
+  forAiTool = false,
+): z.ZodTypeAny {
   const { type, enumValues } = field;
 
   // A writable (non-relationship) field with no column type is a malformed schema for this update:
@@ -87,14 +102,14 @@ function buildZodSchemaForField(field: FieldSchema, collectionName: string): z.Z
     // Nested array (e.g. [['String']]) → treat as opaque JSON.
     if (Array.isArray(type[0])) return z.array(jsonStringSchema);
 
-    return z.array(buildZodSchemaForPrimitive(type[0] as string, enumValues));
+    return z.array(buildZodSchemaForPrimitive(type[0] as string, enumValues, forAiTool));
   }
 
   if (typeof type === 'object' && type !== null) {
     return jsonStringSchema;
   }
 
-  return buildZodSchemaForPrimitive(type as string, enumValues);
+  return buildZodSchemaForPrimitive(type as string, enumValues, forAiTool);
 }
 
 // Coerce a user-overridden value to the field's native type before updating the record.
@@ -196,23 +211,31 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
         );
     const schema = await this.getCollectionSchema(selectedRecordRef.collectionName);
 
-    if (preRecordedArgs?.fieldName !== undefined && preRecordedArgs?.value === undefined) {
-      throw new InvalidPreRecordedArgsError(
-        'fieldName and value must both be provided or both omitted',
-      );
-    }
-
+    // A value without a field is meaningless (nothing to write it to).
     if (preRecordedArgs?.value !== undefined && preRecordedArgs?.fieldName === undefined) {
-      throw new InvalidPreRecordedArgsError(
-        'fieldName and value must both be provided or both omitted',
-      );
+      throw new InvalidPreRecordedArgsError('value was provided without a fieldName');
     }
 
+    // Three build-time configurations, in order of determinism:
+    // - fieldName + value → fully deterministic, no AI.
+    // - fieldName only     → field is pinned; the AI resolves just the value from the prompt.
+    // - neither            → the AI picks both field and value.
     const recordedField = preRecordedArgs?.fieldName;
-    const { fieldName, value } =
-      recordedField !== undefined
-        ? { fieldName: recordedField, value: preRecordedArgs?.value }
-        : await this.selectFieldAndValue(schema, step.prompt);
+    let fieldName: string;
+    let value: unknown;
+
+    if (recordedField !== undefined && preRecordedArgs?.value !== undefined) {
+      fieldName = recordedField;
+      value = preRecordedArgs.value;
+    } else if (recordedField !== undefined) {
+      const field = this.findFieldByTechnicalName(schema, recordedField);
+      if (!field) throw new FieldNotFoundError(recordedField, schema.collectionName);
+      fieldName = recordedField;
+      value = await this.selectValueForField(schema, field, step.prompt);
+    } else {
+      ({ fieldName, value } = await this.selectFieldAndValue(schema, step.prompt));
+    }
+
     const field = this.findFieldByTechnicalName(schema, fieldName);
 
     if (!field) {
@@ -303,10 +326,56 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
       input: { fieldName: string; value: unknown; reasoning: string };
     }>(messages, tool);
 
+    const fieldName = this.resolveAiFieldName(schema, input.fieldName);
+
+    // The AI tool schema is JSON-Schema-safe (plain z.boolean() for Boolean), so it does not coerce
+    // a stray string — normalize to the field's native type, matching the pinned-field path.
     return {
-      fieldName: this.resolveAiFieldName(schema, input.fieldName),
-      value: input.value,
+      fieldName,
+      value: coerceFieldValue(
+        this.findFieldByTechnicalName(schema, fieldName),
+        input.value,
+        schema.collectionName,
+      ),
     };
+  }
+
+  // Field is pinned at build time; only the value is AI-resolved from the prompt/workflow context.
+  private async selectValueForField(
+    schema: CollectionSchema,
+    field: FieldSchema,
+    prompt: string | undefined,
+  ): Promise<unknown> {
+    if (field.type == null) {
+      throw new FieldTypeMissingError(field.fieldName, schema.collectionName);
+    }
+
+    const tool = new DynamicStructuredTool({
+      name: 'set-record-field-value',
+      description: `Provide the new value for the "${field.displayName}" field.`,
+      schema: z.object({
+        reasoning: z.string().describe('Why this value was chosen'),
+        value: buildZodSchemaForField(field, schema.collectionName, true).nullable(),
+      }),
+      func: undefined,
+    });
+
+    const messages = [
+      this.buildContextMessage(),
+      ...(await this.buildPreviousStepsMessages()),
+      new SystemMessage(UPDATE_RECORD_SYSTEM_PROMPT),
+      new SystemMessage(
+        `The selected record belongs to the "${schema.collectionDisplayName}" collection. ` +
+          `Set the value of the "${field.displayName}" field.`,
+      ),
+      new HumanMessage(`**Request**: ${prompt ?? `Set the "${field.displayName}" field.`}`),
+    ];
+
+    const { value } = await this.invokeWithTool<{ value: unknown }>(messages, tool);
+
+    // The AI tool schema is JSON-Schema-safe (plain z.boolean() for Boolean), so it does not coerce
+    // a stray "true"/"42" string — coerceFieldValue normalizes the value to the field's native type.
+    return coerceFieldValue(field, value, schema.collectionName);
   }
 
   private buildUpdateFieldTool(schema: CollectionSchema): DynamicStructuredTool {
@@ -328,7 +397,7 @@ export default class UpdateRecordStepExecutor extends RecordStepExecutor<UpdateR
     const fieldObjects = nonRelationFields.map(f =>
       z.object({
         fieldName: z.literal(f.displayName),
-        value: buildZodSchemaForField(f, schema.collectionName).nullable(),
+        value: buildZodSchemaForField(f, schema.collectionName, true).nullable(),
         reasoning: z.string().describe('Why this field and value were chosen'),
       }),
     ) as FieldObject[];

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -63,6 +63,13 @@ export const UpdateRecordStepDefinitionSchema = z.object({
     .catch(AutomatedWithConfirmation),
   preRecordedArgs: z
     .object({
+      /**
+       * "From record" — the source record to update, referenced by the stable BPMN step id of the
+       * previous Load Related Record step that loaded it, or WORKFLOW_START_STEP_ID for the trigger
+       * record. Stable across revisions, unlike the runtime stepIndex.
+       */
+      selectedRecordStepId: z.string().optional(),
+      // Legacy runtime index; superseded by selectedRecordStepId. Kept for back-compat.
       selectedRecordStepIndex: z.number().int().optional(),
       /** Technical name of the field to update */
       fieldName: z.string().optional(),

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -76,6 +76,19 @@ describe('toStepDefinition', () => {
       });
     });
 
+    it('should forward preRecordedArgs on an update-data task', () => {
+      const task = makeTask({
+        taskType: ServerTaskTypeEnum.UpdateData,
+        prompt: 'update it',
+        preRecordedArgs: { selectedRecordStepId: 'load-1', fieldName: 'status', value: 'active' },
+      } as Partial<ServerWorkflowTask>);
+
+      expect(toStepDefinition(task)).toMatchObject({
+        type: StepType.UpdateRecord,
+        preRecordedArgs: { selectedRecordStepId: 'load-1', fieldName: 'status', value: 'active' },
+      });
+    });
+
     it('should map task with trigger-action taskType to trigger-action', () => {
       const task = makeTask({ taskType: ServerTaskTypeEnum.TriggerAction, prompt: 'trigger it' });
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1567,18 +1567,138 @@ describe('UpdateRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('error');
     });
 
-    it('returns error when fieldName is provided without value', async () => {
+    it('keeps the pre-recorded field and AI-resolves only the value when value is omitted', async () => {
+      // AI is asked for the value only, via the field-scoped tool.
+      const mockModel = makeMockModel({ value: 'active', reasoning: 'r' }, 'set-record-field-value');
+      const agentPort = makeMockAgentPort({ status: 'active' });
+      const runStore = makeMockRunStore();
       const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore,
         stepDefinition: makeStep({
           executionType: StepExecutionMode.FullyAutomated,
           preRecordedArgs: { fieldName: 'status' },
         }),
       });
-      const executor = new UpdateRecordStepExecutor(context);
 
-      const result = await executor.execute();
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // The value tool was offered (field pinned, value AI-chosen), not the field+value picker.
+      const tool = mockModel.bindTools.mock.calls[0][0][0] as { name: string };
+      expect(tool.name).toBe('set-record-field-value');
+      // The pinned technical field name is written with the AI value.
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ values: { status: 'active' } }),
+        context.user,
+      );
+    });
+
+    // The pinned-field value tool offers the field's exact type to the AI (here: a Number → the
+    // schema's value slot parses 5 but rejects a bare word).
+    it('offers the pinned field’s exact type to the AI (Number accepts a number, rejects text)', async () => {
+      const mockModel = makeMockModel({ value: 5, reasoning: 'r' }, 'set-record-field-value');
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort: makeMockAgentPort({ count: 5 }),
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            fields: [
+              { fieldName: 'count', displayName: 'Count', isRelationship: false, type: 'Number' },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { fieldName: 'count' },
+        }),
+      });
+
+      await new UpdateRecordStepExecutor(context).execute();
+
+      const tool = mockModel.bindTools.mock.calls[0][0][0] as {
+        schema: { shape: { value: unknown } };
+      };
+      const valueSchema = tool.schema.shape.value as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      expect(valueSchema.safeParse(5).success).toBe(true);
+      expect(valueSchema.safeParse(null).success).toBe(true);
+      expect(valueSchema.safeParse('not a number').success).toBe(false);
+    });
+
+    it('coerces a stringified AI value to the field type before writing (Number from "42")', async () => {
+      // Safety net: real LLMs sometimes return "42" even when asked for a number. coerceFieldValue
+      // (not the tool schema, which the mock bypasses) normalizes it before the datasource write.
+      const mockModel = makeMockModel({ value: '42', reasoning: 'r' }, 'set-record-field-value');
+      const agentPort = makeMockAgentPort({ count: 42 });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            fields: [
+              { fieldName: 'count', displayName: 'Count', isRelationship: false, type: 'Number' },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { fieldName: 'count' },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ values: { count: 42 } }),
+        context.user,
+      );
+    });
+
+    it('returns error when a pre-recorded (value-less) fieldName does not resolve', async () => {
+      const context = makeContext({
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { fieldName: 'does_not_exist' },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
 
       expect(result.stepOutcome.status).toBe('error');
+    });
+
+    // Regression: a Boolean field's coercion schema (z.preprocess) crashed langchain's real
+    // tool→JSON-Schema conversion ("Transforms cannot be represented in JSON Schema") for the
+    // pinned-field tool. Convert the actual bound tool schema through langchain's converter — the
+    // exact operation that ran at bind time — to prove it no longer throws.
+    it('binds a Boolean pinned-field tool that langchain can convert to JSON Schema', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      const { toJsonSchema } = require('@langchain/core/utils/json_schema');
+      const mockModel = makeMockModel({ value: true, reasoning: 'r' }, 'set-record-field-value');
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort: makeMockAgentPort({ active: true }),
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            fields: [
+              { fieldName: 'active', displayName: 'Active', isRelationship: false, type: 'Boolean' },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { fieldName: 'active' },
+        }),
+      });
+
+      await new UpdateRecordStepExecutor(context).execute();
+
+      const boundTool = mockModel.bindTools.mock.calls[0][0][0] as { schema: unknown };
+      expect(() => toJsonSchema(boundTool.schema)).not.toThrow();
     });
 
     it('returns error when value is provided without fieldName', async () => {
@@ -1685,7 +1805,9 @@ describe('UpdateRecordStepExecutor', () => {
       return lastCall[0][0].schema;
     }
 
-    it('Boolean: accepts true/false and coerces string "true"/"false"', async () => {
+    it('Boolean: accepts native true/false, rejects strings (AI tool uses a JSON-Schema-safe schema)', async () => {
+      // The AI tool schema is plain z.boolean() (no z.preprocess) so langchain can serialize it to
+      // JSON Schema across dual zod copies. String→boolean coercion happens later in coerceFieldValue.
       const schema = await getToolSchema([
         { fieldName: 'active', displayName: 'Active', isRelationship: false, type: 'Boolean' },
       ]);
@@ -1694,13 +1816,10 @@ describe('UpdateRecordStepExecutor', () => {
         schema.parse({ input: { fieldName: 'Active', value: true, reasoning: 'r' } }).input.value,
       ).toBe(true);
       expect(
-        schema.parse({ input: { fieldName: 'Active', value: 'true', reasoning: 'r' } }).input.value,
-      ).toBe(true);
-      expect(
         schema.parse({ input: { fieldName: 'Active', value: false, reasoning: 'r' } }).input.value,
       ).toBe(false);
       expect(() =>
-        schema.parse({ input: { fieldName: 'Active', value: 'maybe', reasoning: 'r' } }),
+        schema.parse({ input: { fieldName: 'Active', value: 'true', reasoning: 'r' } }),
       ).toThrow();
     });
 

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -19,7 +19,11 @@ import AgentWithLog from '../../src/executors/agent-with-log';
 import UpdateRecordStepExecutor from '../../src/executors/update-record-step-executor';
 import SchemaCache from '../../src/schema-cache';
 import SchemaResolver from '../../src/schema-resolver';
-import { StepExecutionMode, StepType } from '../../src/types/validated/step-definition';
+import {
+  StepExecutionMode,
+  StepType,
+  WORKFLOW_START_STEP_ID,
+} from '../../src/types/validated/step-definition';
 
 function makeStep(overrides: Partial<UpdateRecordStepDefinition> = {}): UpdateRecordStepDefinition {
   return {
@@ -1464,6 +1468,103 @@ describe('UpdateRecordStepExecutor', () => {
       await executor.execute();
 
       expect(mockModel.bindTools).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves the source record deterministically from selectedRecordStepId (no select-record AI)', async () => {
+      const relatedRecord = makeRecordRef({
+        stepIndex: 2,
+        recordId: [99],
+        collectionName: 'orders',
+      });
+      const ordersSchema = makeCollectionSchema({
+        collectionName: 'orders',
+        collectionId: 'col-orders',
+        collectionDisplayName: 'Orders',
+        fields: [
+          { fieldName: 'total', displayName: 'Total', isRelationship: false, type: 'Number' },
+        ],
+      });
+      const mockModel = makeMockModel();
+      const agentPort = makeMockAgentPort({ total: 150 });
+      const runStore = makeMockRunStore({
+        getStepExecutions: jest.fn().mockResolvedValue([
+          {
+            type: 'load-related-record',
+            stepIndex: 2,
+            executionResult: {
+              relation: { name: 'order', displayName: 'Order' },
+              record: relatedRecord,
+            },
+            selectedRecordRef: makeRecordRef(),
+          },
+        ]),
+      });
+      const context = makeContext({
+        model: mockModel.model,
+        runStore,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema(),
+          orders: ordersSchema,
+        }),
+        previousSteps: [makeLoadRelatedPreviousStep(2)],
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepId: 'load-2', fieldName: 'total', value: 150 },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      // No AI at all: source came from selectedRecordStepId, field/value pre-recorded.
+      expect(mockModel.bindTools).not.toHaveBeenCalled();
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: 'orders', id: [99], values: { total: 150 } }),
+        context.user,
+      );
+    });
+
+    it('resolves WORKFLOW_START_STEP_ID to the base record', async () => {
+      const mockModel = makeMockModel();
+      const agentPort = makeMockAgentPort({ status: 'active' });
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: WORKFLOW_START_STEP_ID,
+            fieldName: 'status',
+            value: 'active',
+          },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(agentPort.updateRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: 'customers',
+          id: [42],
+          values: { status: 'active' },
+        }),
+        context.user,
+      );
+    });
+
+    it('returns error when selectedRecordStepId matches no source step', async () => {
+      const context = makeContext({
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { selectedRecordStepId: 'nope', fieldName: 'status', value: 'x' },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('error');
     });
 
     it('returns error when fieldName is provided without value', async () => {

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1569,7 +1569,10 @@ describe('UpdateRecordStepExecutor', () => {
 
     it('keeps the pre-recorded field and AI-resolves only the value when value is omitted', async () => {
       // AI is asked for the value only, via the field-scoped tool.
-      const mockModel = makeMockModel({ value: 'active', reasoning: 'r' }, 'set-record-field-value');
+      const mockModel = makeMockModel(
+        { value: 'active', reasoning: 'r' },
+        'set-record-field-value',
+      );
       const agentPort = makeMockAgentPort({ status: 'active' });
       const runStore = makeMockRunStore();
       const context = makeContext({
@@ -1676,7 +1679,7 @@ describe('UpdateRecordStepExecutor', () => {
     // pinned-field tool. Convert the actual bound tool schema through langchain's converter — the
     // exact operation that ran at bind time — to prove it no longer throws.
     it('binds a Boolean pinned-field tool that langchain can convert to JSON Schema', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-extraneous-dependencies
       const { toJsonSchema } = require('@langchain/core/utils/json_schema');
       const mockModel = makeMockModel({ value: true, reasoning: 'r' }, 'set-record-field-value');
       const context = makeContext({
@@ -1685,7 +1688,12 @@ describe('UpdateRecordStepExecutor', () => {
         workflowPort: makeMockWorkflowPort({
           customers: makeCollectionSchema({
             fields: [
-              { fieldName: 'active', displayName: 'Active', isRelationship: false, type: 'Boolean' },
+              {
+                fieldName: 'active',
+                displayName: 'Active',
+                isRelationship: false,
+                type: 'Boolean',
+              },
             ],
           }),
         }),

--- a/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/update-record-step-executor.test.ts
@@ -1661,6 +1661,30 @@ describe('UpdateRecordStepExecutor', () => {
       );
     });
 
+    it('fails the step when the pinned (value-less) field has no type', async () => {
+      const context = makeContext({
+        model: makeMockModel({ value: 'x', reasoning: 'r' }, 'set-record-field-value').model,
+        agentPort: makeMockAgentPort(),
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            fields: [{ fieldName: 'age', displayName: 'Age', isRelationship: false }],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { fieldName: 'age' },
+        }),
+      });
+
+      const result = await new UpdateRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        "This field can't be updated because its type is missing from the schema. " +
+          'Contact your administrator if the problem persists.',
+      );
+    });
+
     it('returns error when a pre-recorded (value-less) fieldName does not resolve', async () => {
       const context = makeContext({
         stepDefinition: makeStep({
@@ -2429,6 +2453,21 @@ describe('UpdateRecordStepExecutor', () => {
         { collection: 'customers', id: [42], values: { orders: opaque } },
         expect.objectContaining({ id: 1 }),
       );
+    });
+
+    it('fails on a non-boolean string override to a Boolean field (preprocess passes it through, z.boolean rejects)', async () => {
+      const { executor, agentPort } = makeCoercionContext(booleanField, null, {
+        userConfirmed: true,
+        value: 'yes',
+      });
+
+      const result = await executor.execute();
+
+      expect(result.stepOutcome.status).toBe('error');
+      expect(result.stepOutcome.error).toBe(
+        'An unexpected error occurred while processing this step.',
+      );
+      expect(agentPort.updateRecord).not.toHaveBeenCalled();
     });
 
     it('fails the step when overriding a non-relationship field that has no type', async () => {


### PR DESCRIPTION
Part of the deterministic Update Data step work.

fixes PRD-777

## What

The `update-record` (Update Data) step can now resolve its source record deterministically from a build-time-configured **stable BPMN step id** (`selectedRecordStepId`), mirroring `read-record` (Get Data) and `trigger-action` — instead of always asking the AI to pick among the available records.

## Changes

- `UpdateRecordStepDefinitionSchema.preRecordedArgs` gains `selectedRecordStepId` (legacy `selectedRecordStepIndex` kept for back-compat; `fieldName`/`value` unchanged).
- `update-record-step-executor` (`handleFirstCall`): when `selectedRecordStepId` is set, resolve via `resolveSourceRecordRef` (revise-safe; `WORKFLOW_START_STEP_ID` → base record). Falls back to legacy index / AI selection when unset.
- Server contract (`ServerWorkflowTaskUpdateData`) + mapper forward `preRecordedArgs` for `update-data`.

## Tests

- Deterministic resolve skips the select-record AI round; `WORKFLOW_START_STEP_ID` → base record; unresolvable id → error.
- Mapper forwards `preRecordedArgs` (selectedRecordStepId + fieldName + value).

Companion PRs: forestadmin-server (orchestrator), forestadmin (editor UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic source record resolution and preRecordedArgs support to Update Data workflow steps
> - Adds `selectedRecordStepId` to `preRecordedArgs` in [UpdateRecordStepDefinitionSchema](https://github.com/ForestAdmin/agent-nodejs/pull/1761/files#diff-66dcc667cb1ebecf3964eecfb28391b1cb81e16c853ad79d4f9017172521aea3) and the server task interface, allowing callers to pin the source record by BPMN step ID instead of index.
> - Updates `UpdateRecordStepExecutor.handleFirstCall` to support three tiers: (1) `fieldName`+`value` uses both as-is, (2) `fieldName` alone pins the field and asks the AI for the value via the new `selectValueForField` method, (3) neither defers fully to the AI.
> - Adds `selectValueForField`, a new method that builds a value-only AI tool (`set-record-field-value`) for pinned-field flows and coerces the returned value to the field's native type.
> - Fixes Boolean fields in AI tool schemas by adding a `forAiTool` flag to `buildZodSchemaForPrimitive`, using plain `z.boolean()` instead of a `z.preprocess` transform to avoid JSON Schema conversion errors.
> - Risk: `value` provided without `fieldName` in `preRecordedArgs` now throws an error; previously this combination was not validated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c2eb74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->