### PR TITLE
fix(agent-client): only fire change hook for fields that declare one

### DIFF
--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -69,7 +69,11 @@ export default class FieldFormStates {
 
     field.getPlainField().value = value;
 
-    if (!this.hooks || this.hooks.change.length > 0) {
+    // Only fields that declare a change hook trigger a /hooks/change request. This mirrors the
+    // admin UI, which never fires a change for a hookless field. Firing it for every field breaks
+    // agents that resolve the change hook by the changed field's own hook name: forest_liana does
+    // `hooks[:change][field.hook].call` and raises `undefined method 'call' for nil` when nil.
+    if (field.getPlainField().hook) {
       await this.loadChanges(name);
     }
   }
@@ -122,6 +126,7 @@ export default class FieldFormStates {
               isRequired: f.isRequired ?? false,
               isReadOnly: false,
               value: f.defaultValue,
+              hook: f.hook,
             })),
           );
         }

--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -69,11 +69,10 @@ export default class FieldFormStates {
 
     field.getPlainField().value = value;
 
-    // Only fields that declare a change hook trigger a /hooks/change request. This mirrors the
-    // admin UI, which never fires a change for a hookless field. Firing it for every field breaks
-    // agents that resolve the change hook by the changed field's own hook name: forest_liana does
-    // `hooks[:change][field.hook].call` and raises `undefined method 'call' for nil` when nil.
-    if (field.getPlainField().hook) {
+    const fieldHasHook = field.getPlainField().hook;
+
+    // Only fields that declare a change hook trigger a /hooks/change request.
+    if (fieldHasHook) {
       await this.loadChanges(name);
     }
   }

--- a/packages/agent-client/src/action-fields/types.ts
+++ b/packages/agent-client/src/action-fields/types.ts
@@ -17,6 +17,7 @@ export type PlainField = {
   value?: unknown;
   isRequired: boolean;
   isReadOnly: boolean;
+  hook?: string;
   widgetEdit?: {
     parameters: {
       static: {

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -213,7 +213,14 @@ describe('FieldFormStates', () => {
     beforeEach(async () => {
       httpRequester.query.mockResolvedValue({
         fields: [
-          { field: 'name', type: 'String', isRequired: false, isReadOnly: false, value: 'initial' },
+          {
+            field: 'name',
+            type: 'String',
+            isRequired: false,
+            isReadOnly: false,
+            value: 'initial',
+            hook: 'changeHook',
+          },
         ],
         layout: [],
       });
@@ -400,19 +407,26 @@ describe('FieldFormStates', () => {
       expect(httpRequester.query).not.toHaveBeenCalled();
     });
 
-    it('should call change hook when hooks.change is non-empty', async () => {
+    it('should call change hook when the changed field has a hook', async () => {
       const formStates = new FieldFormStates(
         'testAction',
         '/forest/actions/test-action',
         'users',
         httpRequester,
         ['1'],
-        { load: true, change: ['name'] },
+        { load: true, change: ['changeHook'] },
       );
 
       httpRequester.query.mockResolvedValue({
         fields: [
-          { field: 'name', type: 'String', isRequired: false, isReadOnly: false, value: 'initial' },
+          {
+            field: 'name',
+            type: 'String',
+            isRequired: false,
+            isReadOnly: false,
+            value: 'initial',
+            hook: 'changeHook',
+          },
         ],
         layout: [],
       });
@@ -431,6 +445,38 @@ describe('FieldFormStates', () => {
       expect(httpRequester.query).toHaveBeenCalledWith(
         expect.objectContaining({ path: '/forest/actions/test-action/hooks/change' }),
       );
+    });
+
+    it('should skip change hook when the changed field has no hook, even with change hooks', async () => {
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+        { load: true, change: ['changeHook'] },
+      );
+
+      httpRequester.query.mockResolvedValue({
+        fields: [
+          { field: 'code', type: 'String', isRequired: false, isReadOnly: false, value: null },
+          {
+            field: 'voucher_type',
+            type: 'Enum',
+            isRequired: true,
+            isReadOnly: false,
+            value: null,
+            hook: 'changeHook',
+          },
+        ],
+        layout: [],
+      });
+      await formStates.loadInitialState();
+
+      httpRequester.query.mockClear();
+      await formStates.setFieldValue('code', 'ABC');
+
+      expect(httpRequester.query).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -198,6 +198,7 @@ export interface ForestSchemaAction {
     isRequired?: boolean;
     defaultValue?: unknown;
     label?: string;
+    hook?: string;
   }[];
   hooks: {
     load: boolean;


### PR DESCRIPTION
## Problem
Running a smart action through the workflow executor (trigger-record-action, AI-assisted or Full AI) crashes against Ruby (`forest_liana`) agents: `getActionForm failed: Agent responded with HTTP 500`, the agent raising `NoMethodError: undefined method 'call' for nil:NilClass`. Manual form fill in the Ember UI works; Node agents tolerate it.

## Root cause
`FieldFormStates.setFieldValue` posted to `/hooks/change` for any field as soon as the action declared at least one change hook, without checking the changed field had its own `hook`. `tryToSetFields` iterates every AI-filled field, so setting a hookless field (e.g. `code`) sent `changed_field` for it; forest_liana then evaluated `action.hooks[:change][nil].call` and raised. The Ember UI only fires a change for fields that declare a `hook`.

## Fix
- Gate `loadChanges` on the **changed field's own `hook`**, matching the admin UI.
- Thread the per-field `hook` through `PlainField`, `ForestSchemaAction.fields`, and the `loadInitialState` fallback mapping so it is reliably available (Node sets `changeHook` only on watched fields; Ruby sets the hook name).

## Tests
`field-form-states` suite green (20/20), incl. a new regression test: a hookless field does not trigger a change even when the action has change hooks.

Fixes PRD-778

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `setFieldValue` to only fire change hook for fields that declare one
> Previously, `FieldFormStates.setFieldValue` triggered a POST to `/hooks/change` based on whether `hooks.change` had entries, regardless of whether the specific changed field declared a hook. Now it checks `field.getPlainField().hook` and skips the request for fields without a hook.
>
> - Adds an optional `hook?: string` property to `PlainField` in [types.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1762/files#diff-b1918f0b9646c4d029b86c3fa358f3acfe31cab7292b6b68cd6211a514337d07) and `ForestSchemaAction` fields in [forestadmin-client types.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1762/files#diff-0dc84b87009ba37728449d24dedc0bbb46e9ad3e54c785c08554a3fea20d2181).
> - Updates `loadInitialState` to forward the `hook` property when mapping fallback fields, so hook-based change behavior works correctly for those fields too.
> - Behavioral Change: fields without a declared `hook` no longer trigger change hook requests even if the action has `hooks.change` defined.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a243be3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->