### PR TITLE
feat(datasource mongoose): handle nested enums

### DIFF
--- a/packages/agent/src/utils/forest-schema/generator-fields.ts
+++ b/packages/agent/src/utils/forest-schema/generator-fields.ts
@@ -95,13 +95,9 @@ export default class SchemaGeneratorFields {
       return [this.convertColumnType(type[0])];
     }
 
-    // Defensive: a nested enum is only expected inside a sub-document (handled below), never as a
-    // top-level column type. Keep it from falling into the sub-document branch just in case.
-    if (TypeGetter.isEnumColumnType(type)) return 'Enum';
-
     return {
       fields: Object.entries(type).map(([key, subType]) =>
-        TypeGetter.isEnumColumnType(subType)
+        TypeGetter.isEnumField(subType)
           ? { field: key, type: 'Enum', enums: subType.enumValues }
           : { field: key, type: this.convertColumnType(subType) },
       ),

--- a/packages/agent/src/utils/forest-schema/generator-fields.ts
+++ b/packages/agent/src/utils/forest-schema/generator-fields.ts
@@ -98,7 +98,7 @@ export default class SchemaGeneratorFields {
     return {
       fields: Object.entries(type).map(([key, subType]) =>
         TypeGetter.isEnumField(subType)
-          ? { field: key, type: 'Enum', enums: subType.enumValues }
+          ? { field: key, type: 'Enum', enums: [...subType.enumValues].sort() }
           : { field: key, type: this.convertColumnType(subType) },
       ),
     };

--- a/packages/agent/src/utils/forest-schema/generator-fields.ts
+++ b/packages/agent/src/utils/forest-schema/generator-fields.ts
@@ -11,7 +11,12 @@ import type {
 } from '@forestadmin/datasource-toolkit';
 import type { ForestServerColumnType, ForestServerField } from '@forestadmin/forestadmin-client';
 
-import { CollectionUtils, SchemaUtils, ValidationError } from '@forestadmin/datasource-toolkit';
+import {
+  CollectionUtils,
+  SchemaUtils,
+  TypeGetter,
+  ValidationError,
+} from '@forestadmin/datasource-toolkit';
 
 import ColumnSchemaValidator from './column-schema-validator';
 import FrontendFilterableUtils from './filterable';
@@ -90,11 +95,16 @@ export default class SchemaGeneratorFields {
       return [this.convertColumnType(type[0])];
     }
 
+    // Defensive: a nested enum is only expected inside a sub-document (handled below), never as a
+    // top-level column type. Keep it from falling into the sub-document branch just in case.
+    if (TypeGetter.isEnumColumnType(type)) return 'Enum';
+
     return {
-      fields: Object.entries(type).map(([key, subType]) => ({
-        field: key,
-        type: this.convertColumnType(subType),
-      })),
+      fields: Object.entries(type).map(([key, subType]) =>
+        TypeGetter.isEnumColumnType(subType)
+          ? { field: key, type: 'Enum', enums: subType.enumValues }
+          : { field: key, type: this.convertColumnType(subType) },
+      ),
     };
   }
 

--- a/packages/agent/test/utils/forest-schema/generator-fields_column.test.ts
+++ b/packages/agent/test/utils/forest-schema/generator-fields_column.test.ts
@@ -81,6 +81,9 @@ describe('SchemaGeneratorFields > Column', () => {
           arrayOfComposite: factories.columnSchema.build({
             columnType: [{ firstname: 'String', lastname: 'String' }],
           }),
+          compositeWithEnum: factories.columnSchema.build({
+            columnType: { name: 'String', kind: { type: 'Enum', enumValues: ['A', 'B'] } },
+          }),
         },
       }),
     });
@@ -123,6 +126,19 @@ describe('SchemaGeneratorFields > Column', () => {
           fields: [
             { field: 'firstname', type: 'String' },
             { field: 'lastname', type: 'String' },
+          ],
+        },
+      });
+    });
+
+    test('is should carry enum values for nested enum sub-fields', () => {
+      const schema = SchemaGeneratorFields.buildSchema(collection, 'compositeWithEnum');
+
+      expect(schema).toMatchObject({
+        type: {
+          fields: [
+            { field: 'name', type: 'String' },
+            { field: 'kind', type: 'Enum', enums: ['A', 'B'] },
           ],
         },
       });

--- a/packages/agent/test/utils/forest-schema/generator-fields_column.test.ts
+++ b/packages/agent/test/utils/forest-schema/generator-fields_column.test.ts
@@ -82,7 +82,7 @@ describe('SchemaGeneratorFields > Column', () => {
             columnType: [{ firstname: 'String', lastname: 'String' }],
           }),
           compositeWithEnum: factories.columnSchema.build({
-            columnType: { name: 'String', kind: { type: 'Enum', enumValues: ['A', 'B'] } },
+            columnType: { name: 'String', kind: { type: 'Enum', enumValues: ['B', 'A'] } },
           }),
         },
       }),
@@ -131,7 +131,7 @@ describe('SchemaGeneratorFields > Column', () => {
       });
     });
 
-    test('is should carry enum values for nested enum sub-fields', () => {
+    test('is should carry sorted enum values for nested enum sub-fields', () => {
       const schema = SchemaGeneratorFields.buildSchema(collection, 'compositeWithEnum');
 
       expect(schema).toMatchObject({

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -16,7 +16,7 @@ import type {
   RecordData,
 } from '@forestadmin/datasource-toolkit';
 
-import { CollectionDecorator, SchemaUtils } from '@forestadmin/datasource-toolkit';
+import { CollectionDecorator, SchemaUtils, TypeGetter } from '@forestadmin/datasource-toolkit';
 import { filetypemime } from 'magic-bytes.js';
 
 /**
@@ -222,6 +222,9 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
         return Promise.all(newValues);
       }
 
+      // A nested enum is a scalar string, never binary: leave its value untouched.
+      if (TypeGetter.isEnumColumnType(columnType)) return value;
+
       if (typeof columnType !== 'string') {
         const entries = Object.entries(columnType).map(async ([key, type]) => [
           key,
@@ -263,6 +266,9 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     if (Array.isArray(columnType)) {
       return [this.replaceColumnType(columnType[0])];
     }
+
+    // A nested enum holds no binary: keep it as-is.
+    if (TypeGetter.isEnumColumnType(columnType)) return columnType;
 
     const entries = Object.entries(columnType).map(([key, type]) => [
       key,

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -222,13 +222,12 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
         return Promise.all(newValues);
       }
 
-      // A nested enum is a scalar string, never binary: leave its value untouched.
-      if (TypeGetter.isEnumColumnType(columnType)) return value;
-
       if (typeof columnType !== 'string') {
         const entries = Object.entries(columnType).map(async ([key, type]) => [
           key,
-          await this.convertValueHelper(toBackend, type, useHex, value[key]),
+          TypeGetter.isEnumField(type)
+            ? value[key]
+            : await this.convertValueHelper(toBackend, type, useHex, value[key]),
         ]);
 
         return Object.fromEntries(await Promise.all(entries));
@@ -267,12 +266,9 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
       return [this.replaceColumnType(columnType[0])];
     }
 
-    // A nested enum holds no binary: keep it as-is.
-    if (TypeGetter.isEnumColumnType(columnType)) return columnType;
-
     const entries = Object.entries(columnType).map(([key, type]) => [
       key,
-      this.replaceColumnType(type),
+      TypeGetter.isEnumField(type) ? type : this.replaceColumnType(type),
     ]);
 
     return Object.fromEntries(entries);

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -8,7 +8,7 @@ import type {
   OneToOneSchema,
 } from '@forestadmin/datasource-toolkit';
 
-import { CollectionUtils } from '@forestadmin/datasource-toolkit';
+import { CollectionUtils, TypeGetter } from '@forestadmin/datasource-toolkit';
 import { readFile, writeFile } from 'fs/promises';
 
 export default class TypingGenerator {
@@ -220,6 +220,10 @@ export default class TypingGenerator {
         columnType: field.columnType[0],
         enumValues: field.enumValues,
       })}>`;
+    }
+
+    if (TypeGetter.isEnumColumnType(field.columnType)) {
+      return this.getType({ columnType: 'Enum', enumValues: field.columnType.enumValues });
     }
 
     if (field.columnType === 'Enum') {

--- a/packages/datasource-customizer/src/typing-generator.ts
+++ b/packages/datasource-customizer/src/typing-generator.ts
@@ -222,10 +222,6 @@ export default class TypingGenerator {
       })}>`;
     }
 
-    if (TypeGetter.isEnumColumnType(field.columnType)) {
-      return this.getType({ columnType: 'Enum', enumValues: field.columnType.enumValues });
-    }
-
     if (field.columnType === 'Enum') {
       if (field.enumValues === undefined) return 'string';
 
@@ -253,7 +249,11 @@ export default class TypingGenerator {
     }
 
     return `{${TypingGenerator.sortedEntries(field.columnType)
-      .map(([key, subType]) => `'${key}': ${this.getType({ columnType: subType })}`)
+      .map(([key, subType]) =>
+        TypeGetter.isEnumField(subType)
+          ? `'${key}': ${this.getType({ columnType: 'Enum', enumValues: subType.enumValues })}`
+          : `'${key}': ${this.getType({ columnType: subType })}`,
+      )
       .join('; ')}}`;
   }
 }

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -146,6 +146,54 @@ describe('BinaryCollectionDecorator', () => {
     });
   });
 
+  describe('with a nested enum sibling of a binary field', () => {
+    let items: Collection;
+    let decoratedItems: BinaryCollectionDecorator;
+
+    beforeEach(() => {
+      items = factories.collection.build({
+        name: 'items',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.numericPrimaryKey().build(),
+            data: factories.columnSchema.build({
+              columnType: { pic: 'Binary', kind: { type: 'Enum', enumValues: ['a', 'b'] } },
+            }),
+          },
+        }),
+      });
+
+      const dataSource = factories.dataSource.buildWithCollections([items]);
+      decoratedItems = new DataSourceDecorator(dataSource, BinaryCollectionDecorator).getCollection(
+        'items',
+      );
+    });
+
+    test('schema should rewrite the binary but leave the nested enum untouched', () => {
+      expect(decoratedItems.schema.fields.data).toEqual(
+        expect.objectContaining({
+          columnType: { pic: 'String', kind: { type: 'Enum', enumValues: ['a', 'b'] } },
+        }),
+      );
+    });
+
+    test('list should preserve the enum value while converting the binary', async () => {
+      (items.list as jest.Mock).mockResolvedValue([
+        { id: 1, data: { pic: Buffer.from('0000', 'ascii'), kind: 'a' } },
+      ]);
+
+      const records = await decoratedItems.list(
+        factories.caller.build(),
+        new PaginatedFilter({}),
+        new Projection('id', 'data:pic', 'data:kind'),
+      );
+
+      expect(records).toEqual([
+        { id: 1, data: { pic: 'data:application/octet-stream;base64,MDAwMA==', kind: 'a' } },
+      ]);
+    });
+  });
+
   describe('list with a simple filter', () => {
     // Build params (30303030 is the hex representation of 0000)
     const conditionTree = new ConditionTreeLeaf('id', 'Equal', '30303030');

--- a/packages/datasource-customizer/test/typing-generator.test.ts
+++ b/packages/datasource-customizer/test/typing-generator.test.ts
@@ -40,6 +40,9 @@ describe('TypingGenerator', () => {
             complex: factories.columnSchema.build({
               columnType: { firstname: 'String', lastname: 'String' },
             }),
+            complexWithEnum: factories.columnSchema.build({
+              columnType: { name: 'String', kind: { type: 'Enum', enumValues: ['x', 'y'] } },
+            }),
             array: factories.columnSchema.build({ columnType: ['String'] }),
           },
         },
@@ -64,6 +67,7 @@ describe('TypingGenerator', () => {
             'array': Array<string> | null;
             'boolean': boolean | null;
             'complex': { 'firstname': string; 'lastname': string } | null;
+            'complexWithEnum': { 'kind': 'x' | 'y'; 'name': string } | null;
             'enumWithoutValues': string | null;
             'enumWithValues': 'a' | 'b' | 'c' | null;
             'id': number | null;

--- a/packages/datasource-mongoose/src/utils/schema/fields.ts
+++ b/packages/datasource-mongoose/src/utils/schema/fields.ts
@@ -11,6 +11,8 @@ import type {
 } from '@forestadmin/datasource-toolkit';
 import type { Model, SchemaType } from 'mongoose';
 
+import { TypeGetter } from '@forestadmin/datasource-toolkit';
+
 import FilterOperatorsGenerator from './filter-operators';
 import isSchemaType from './is-schema-type';
 import MongooseSchema from '../../mongoose/schema';
@@ -80,7 +82,7 @@ export default class FieldsGenerator {
 
   /** Build ColumnSchema from CleanSchema */
   private static buildColumnSchema(field: SchemaNode): ColumnSchema {
-    const columnType = this.getColumnType(field);
+    const { columnType, enumValues } = this.normalizeRootEnum(this.getColumnTypeRec(field));
     const schema: ColumnSchema = {
       columnType,
       filterOperators: FilterOperatorsGenerator.getSupportedOperators(columnType as PrimitiveTypes),
@@ -92,28 +94,29 @@ export default class FieldsGenerator {
       validation: field.isRequired ? [{ operator: 'Present' }] : null,
     };
 
-    if (columnType === 'Enum') {
-      schema.enumValues = this.getEnumValues(field as SchemaType);
-    }
+    if (enumValues) schema.enumValues = enumValues;
 
     return schema;
   }
 
-  /** Compute column type from CleanSchema */
-  private static getColumnType(field: SchemaNode): ColumnType {
-    const columnType = this.getColumnTypeRec(field);
-
-    // Enum fields are promoted to enum instead of string _only_ if they are at the root of the
-    // record.
-    if (columnType === 'String') {
-      const enumValues = this.getEnumValues(field as SchemaType);
-
-      if (enumValues && enumValues.every(v => typeof v === 'string')) {
-        return 'Enum';
-      }
+  /**
+   * At the root of the record (or a root-level array), an enum is exposed as a flat 'Enum' whose
+   * values live on the ColumnSchema. The inline `{ type: 'Enum', enumValues }` form produced by
+   * getColumnTypeRec is only kept for enums nested inside sub-documents.
+   */
+  private static normalizeRootEnum(columnType: ColumnType): {
+    columnType: ColumnType;
+    enumValues?: string[];
+  } {
+    if (TypeGetter.isEnumColumnType(columnType)) {
+      return { columnType: 'Enum', enumValues: columnType.enumValues };
     }
 
-    return columnType;
+    if (TypeGetter.isArrayOfEnumColumnType(columnType)) {
+      return { columnType: ['Enum'], enumValues: columnType[0].enumValues };
+    }
+
+    return { columnType };
   }
 
   /** Build ColumnType from CleanSchema recursively */
@@ -123,7 +126,19 @@ export default class FieldsGenerator {
         return 'Binary';
       }
 
-      if (['String', 'Number', 'Date', 'Boolean'].includes(field.instance)) {
+      if (field.instance === 'String') {
+        // A string enum keeps its values inline so they survive down to schema serialization,
+        // even when nested. normalizeRootEnum flattens it back to 'Enum' at the root.
+        const enumValues = this.getEnumValues(field as SchemaType);
+
+        if (enumValues && enumValues.every(v => typeof v === 'string')) {
+          return { type: 'Enum', enumValues };
+        }
+
+        return 'String';
+      }
+
+      if (['Number', 'Date', 'Boolean'].includes(field.instance)) {
         return field.instance as PrimitiveTypes;
       }
 

--- a/packages/datasource-mongoose/src/utils/schema/fields.ts
+++ b/packages/datasource-mongoose/src/utils/schema/fields.ts
@@ -7,11 +7,10 @@ import type {
   ColumnSchema,
   ColumnType,
   ManyToOneSchema,
+  NestedEnumColumnType,
   PrimitiveTypes,
 } from '@forestadmin/datasource-toolkit';
 import type { Model, SchemaType } from 'mongoose';
-
-import { TypeGetter } from '@forestadmin/datasource-toolkit';
 
 import FilterOperatorsGenerator from './filter-operators';
 import isSchemaType from './is-schema-type';
@@ -82,7 +81,7 @@ export default class FieldsGenerator {
 
   /** Build ColumnSchema from CleanSchema */
   private static buildColumnSchema(field: SchemaNode): ColumnSchema {
-    const { columnType, enumValues } = this.normalizeRootEnum(this.getColumnTypeRec(field));
+    const columnType = this.getColumnType(field);
     const schema: ColumnSchema = {
       columnType,
       filterOperators: FilterOperatorsGenerator.getSupportedOperators(columnType as PrimitiveTypes),
@@ -94,29 +93,28 @@ export default class FieldsGenerator {
       validation: field.isRequired ? [{ operator: 'Present' }] : null,
     };
 
-    if (enumValues) schema.enumValues = enumValues;
+    if (columnType === 'Enum') {
+      schema.enumValues = this.getEnumValues(field as SchemaType);
+    }
 
     return schema;
   }
 
-  /**
-   * At the root of the record (or a root-level array), an enum is exposed as a flat 'Enum' whose
-   * values live on the ColumnSchema. The inline `{ type: 'Enum', enumValues }` form produced by
-   * getColumnTypeRec is only kept for enums nested inside sub-documents.
-   */
-  private static normalizeRootEnum(columnType: ColumnType): {
-    columnType: ColumnType;
-    enumValues?: string[];
-  } {
-    if (TypeGetter.isEnumColumnType(columnType)) {
-      return { columnType: 'Enum', enumValues: columnType.enumValues };
+  /** Compute column type from CleanSchema */
+  private static getColumnType(field: SchemaNode): ColumnType {
+    const columnType = this.getColumnTypeRec(field);
+
+    // Enum fields are promoted to enum instead of string _only_ if they are at the root of the
+    // record.
+    if (columnType === 'String') {
+      const enumValues = this.getEnumValues(field as SchemaType);
+
+      if (enumValues && enumValues.every(v => typeof v === 'string')) {
+        return 'Enum';
+      }
     }
 
-    if (TypeGetter.isArrayOfEnumColumnType(columnType)) {
-      return { columnType: ['Enum'], enumValues: columnType[0].enumValues };
-    }
-
-    return { columnType };
+    return columnType;
   }
 
   /** Build ColumnType from CleanSchema recursively */
@@ -126,19 +124,7 @@ export default class FieldsGenerator {
         return 'Binary';
       }
 
-      if (field.instance === 'String') {
-        // A string enum keeps its values inline so they survive down to schema serialization,
-        // even when nested. normalizeRootEnum flattens it back to 'Enum' at the root.
-        const enumValues = this.getEnumValues(field as SchemaType);
-
-        if (enumValues && enumValues.every(v => typeof v === 'string')) {
-          return { type: 'Enum', enumValues };
-        }
-
-        return 'String';
-      }
-
-      if (['Number', 'Date', 'Boolean'].includes(field.instance)) {
+      if (['String', 'Number', 'Date', 'Boolean'].includes(field.instance)) {
         return field.instance as PrimitiveTypes;
       }
 
@@ -154,9 +140,21 @@ export default class FieldsGenerator {
     }
 
     return Object.entries(field).reduce(
-      (memo, [name, subSchema]) => ({ ...memo, [name]: this.getColumnTypeRec(subSchema) }),
+      (memo, [name, subSchema]) => ({ ...memo, [name]: this.getCompositeFieldType(subSchema) }),
       {},
     );
+  }
+
+  private static getCompositeFieldType(field: SchemaNode): ColumnType | NestedEnumColumnType {
+    if (isSchemaType(field) && field.instance === 'String') {
+      const enumValues = this.getEnumValues(field as SchemaType);
+
+      if (enumValues && enumValues.every(v => typeof v === 'string')) {
+        return { type: 'Enum', enumValues };
+      }
+    }
+
+    return this.getColumnTypeRec(field);
   }
 
   /** Get enum validator from field definition */

--- a/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
+++ b/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
@@ -132,7 +132,7 @@ describe('SchemaFieldsGenerator', () => {
           const fieldsSchema = FieldsGenerator.buildFieldsSchema(buildModel(schema));
 
           expect(fieldsSchema).toMatchObject({
-            nested: { columnType: { subEnum: { type: 'Enum', enumValues: enumValues } } },
+            nested: { columnType: { subEnum: { type: 'Enum', enumValues } } },
           });
         });
 

--- a/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
+++ b/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
@@ -109,19 +109,6 @@ describe('SchemaFieldsGenerator', () => {
         });
       });
 
-      describe('when the enum is a root-level array of strings', () => {
-        it('should build a flat Enum array column type with enum values', () => {
-          const enumValues = ['enum1', 'enum2'];
-          const schema = new Schema({ aField: [{ type: String, enum: enumValues }] });
-
-          const fieldsSchema = FieldsGenerator.buildFieldsSchema(buildModel(schema));
-
-          expect(fieldsSchema).toMatchObject({
-            aField: { columnType: ['Enum'], enumValues },
-          });
-        });
-      });
-
       describe('when the enum is nested inside a sub-document', () => {
         it('should keep the nested enum as an inline enum column type', () => {
           const enumValues = ['enum1', 'enum2'];

--- a/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
+++ b/packages/datasource-mongoose/test/utils/schema/fields_simple.test.ts
@@ -108,6 +108,46 @@ describe('SchemaFieldsGenerator', () => {
           expect(fieldsSchema).toMatchObject({ aField: { columnType: 'Number' } });
         });
       });
+
+      describe('when the enum is a root-level array of strings', () => {
+        it('should build a flat Enum array column type with enum values', () => {
+          const enumValues = ['enum1', 'enum2'];
+          const schema = new Schema({ aField: [{ type: String, enum: enumValues }] });
+
+          const fieldsSchema = FieldsGenerator.buildFieldsSchema(buildModel(schema));
+
+          expect(fieldsSchema).toMatchObject({
+            aField: { columnType: ['Enum'], enumValues },
+          });
+        });
+      });
+
+      describe('when the enum is nested inside a sub-document', () => {
+        it('should keep the nested enum as an inline enum column type', () => {
+          const enumValues = ['enum1', 'enum2'];
+          const schema = new Schema({
+            nested: { subEnum: { type: String, enum: enumValues } },
+          });
+
+          const fieldsSchema = FieldsGenerator.buildFieldsSchema(buildModel(schema));
+
+          expect(fieldsSchema).toMatchObject({
+            nested: { columnType: { subEnum: { type: 'Enum', enumValues: enumValues } } },
+          });
+        });
+
+        it('should keep a nested non-string enum as a plain string type', () => {
+          const schema = new Schema({
+            nested: { subEnum: { type: Number, enum: [1, 2] } },
+          });
+
+          const fieldsSchema = FieldsGenerator.buildFieldsSchema(buildModel(schema));
+
+          expect(fieldsSchema).toMatchObject({
+            nested: { columnType: { subEnum: 'Number' } },
+          });
+        });
+      });
     });
 
     describe('with array fields', () => {

--- a/packages/datasource-toolkit/src/interfaces/schema.ts
+++ b/packages/datasource-toolkit/src/interfaces/schema.ts
@@ -80,7 +80,13 @@ export type ManyToManySchema = {
   type: 'ManyToMany';
 };
 
-export type ColumnType = PrimitiveTypes | { [key: string]: ColumnType } | [ColumnType];
+export type NestedEnumColumnType = { type: 'Enum'; enumValues: string[] };
+
+export type ColumnType =
+  | PrimitiveTypes
+  | { [key: string]: ColumnType }
+  | [ColumnType]
+  | NestedEnumColumnType;
 
 export type PrimitiveTypes =
   | 'Boolean'

--- a/packages/datasource-toolkit/src/interfaces/schema.ts
+++ b/packages/datasource-toolkit/src/interfaces/schema.ts
@@ -84,9 +84,8 @@ export type NestedEnumColumnType = { type: 'Enum'; enumValues: string[] };
 
 export type ColumnType =
   | PrimitiveTypes
-  | { [key: string]: ColumnType }
-  | [ColumnType]
-  | NestedEnumColumnType;
+  | { [key: string]: ColumnType | NestedEnumColumnType }
+  | [ColumnType];
 
 export type PrimitiveTypes =
   | 'Boolean'

--- a/packages/datasource-toolkit/src/validation/type-getter.ts
+++ b/packages/datasource-toolkit/src/validation/type-getter.ts
@@ -1,4 +1,4 @@
-import type { ColumnType, PrimitiveTypes } from '../interfaces/schema';
+import type { ColumnType, NestedEnumColumnType, PrimitiveTypes } from '../interfaces/schema';
 
 import { DateTime } from 'luxon';
 import { validate as uuidValidate } from 'uuid';
@@ -43,6 +43,25 @@ export default class TypeGetter {
 
   static isArrayOfPrimitiveType(columnType: ColumnType): columnType is [PrimitiveTypes] {
     return Array.isArray(columnType) && this.isPrimitiveType(columnType[0]);
+  }
+
+  // A nested enum is carried inline as `{ type: 'Enum', enumValues: [...] }` so the enum values
+  // survive down to schema serialization. `type === 'Enum'` is a safe discriminant vs a
+  // `{[key]:ColumnType}` sub-document: nested enums are never promoted, so a real sub-field named
+  // `type` is never 'Enum'.
+  static isEnumColumnType(columnType: ColumnType): columnType is NestedEnumColumnType {
+    const candidate = columnType as NestedEnumColumnType;
+
+    return (
+      typeof columnType === 'object' &&
+      !Array.isArray(columnType) &&
+      candidate.type === 'Enum' &&
+      Array.isArray(candidate.enumValues)
+    );
+  }
+
+  static isArrayOfEnumColumnType(columnType: ColumnType): columnType is [NestedEnumColumnType] {
+    return Array.isArray(columnType) && this.isEnumColumnType(columnType[0]);
   }
 
   private static getDateType(value: string): PrimitiveTypes {

--- a/packages/datasource-toolkit/src/validation/type-getter.ts
+++ b/packages/datasource-toolkit/src/validation/type-getter.ts
@@ -45,23 +45,15 @@ export default class TypeGetter {
     return Array.isArray(columnType) && this.isPrimitiveType(columnType[0]);
   }
 
-  // A nested enum is carried inline as `{ type: 'Enum', enumValues: [...] }` so the enum values
-  // survive down to schema serialization. `type === 'Enum'` is a safe discriminant vs a
-  // `{[key]:ColumnType}` sub-document: nested enums are never promoted, so a real sub-field named
-  // `type` is never 'Enum'.
-  static isEnumColumnType(columnType: ColumnType): columnType is NestedEnumColumnType {
-    const candidate = columnType as NestedEnumColumnType;
+  static isEnumField(field: ColumnType | NestedEnumColumnType): field is NestedEnumColumnType {
+    const candidate = field as NestedEnumColumnType;
 
     return (
-      typeof columnType === 'object' &&
-      !Array.isArray(columnType) &&
+      typeof field === 'object' &&
+      !Array.isArray(field) &&
       candidate.type === 'Enum' &&
       Array.isArray(candidate.enumValues)
     );
-  }
-
-  static isArrayOfEnumColumnType(columnType: ColumnType): columnType is [NestedEnumColumnType] {
-    return Array.isArray(columnType) && this.isEnumColumnType(columnType[0]);
   }
 
   private static getDateType(value: string): PrimitiveTypes {

--- a/packages/datasource-toolkit/test/validation/type-getter.test.ts
+++ b/packages/datasource-toolkit/test/validation/type-getter.test.ts
@@ -167,4 +167,19 @@ describe('TypeGetter', () => {
       expect(TypeGetter.isArrayOfPrimitiveType(type as ColumnType)).toEqual(false);
     });
   });
+
+  describe('isEnumColumnType', () => {
+    it('should return true for a nested enum column type', () => {
+      expect(TypeGetter.isEnumColumnType({ type: 'Enum', enumValues: ['a', 'b'] })).toEqual(true);
+    });
+
+    it.each([
+      ['a plain enum primitive', 'Enum'],
+      ['a sub-document', { type: 'String', name: 'String' }],
+      ['an array', ['Enum']],
+      ['a sub-document with a type field holding an object', { type: { nested: 'String' } }],
+    ])('should return false for %s', (_, type) => {
+      expect(TypeGetter.isEnumColumnType(type as ColumnType)).toEqual(false);
+    });
+  });
 });

--- a/packages/datasource-toolkit/test/validation/type-getter.test.ts
+++ b/packages/datasource-toolkit/test/validation/type-getter.test.ts
@@ -168,9 +168,9 @@ describe('TypeGetter', () => {
     });
   });
 
-  describe('isEnumColumnType', () => {
-    it('should return true for a nested enum column type', () => {
-      expect(TypeGetter.isEnumColumnType({ type: 'Enum', enumValues: ['a', 'b'] })).toEqual(true);
+  describe('isEnumField', () => {
+    it('should return true for a composite enum field', () => {
+      expect(TypeGetter.isEnumField({ type: 'Enum', enumValues: ['a', 'b'] })).toEqual(true);
     });
 
     it.each([
@@ -179,7 +179,7 @@ describe('TypeGetter', () => {
       ['an array', ['Enum']],
       ['a sub-document with a type field holding an object', { type: { nested: 'String' } }],
     ])('should return false for %s', (_, type) => {
-      expect(TypeGetter.isEnumColumnType(type as ColumnType)).toEqual(false);
+      expect(TypeGetter.isEnumField(type as ColumnType)).toEqual(false);
     });
   });
 });

--- a/packages/forestadmin-client/src/schema/types.ts
+++ b/packages/forestadmin-client/src/schema/types.ts
@@ -17,7 +17,7 @@ export type ForestSchema = {
 export type ForestServerColumnType =
   | PrimitiveTypes
   | [ForestServerColumnType]
-  | { fields: Array<{ field: string; type: ForestServerColumnType }> };
+  | { fields: Array<{ field: string; type: ForestServerColumnType; enums?: string[] }> };
 
 export type ForestServerCollection = {
   name: string;

--- a/packages/plugin-flattener/src/flatten-column/customization.ts
+++ b/packages/plugin-flattener/src/flatten-column/customization.ts
@@ -4,7 +4,7 @@ import type {
   HookBeforeUpdateContext,
   TConditionTree,
 } from '@forestadmin/datasource-customizer';
-import type { ColumnType, RecordData } from '@forestadmin/datasource-toolkit';
+import type { ColumnType, NestedEnumColumnType, RecordData } from '@forestadmin/datasource-toolkit';
 
 import { ConditionTreeFactory, SchemaUtils, TypeGetter } from '@forestadmin/datasource-toolkit';
 import hashRecord from 'object-hash';
@@ -12,7 +12,9 @@ import hashRecord from 'object-hash';
 import { deepUpdateInPlace, getValue, unflattenPathsInPlace } from './helpers';
 
 export function makeField(columnName: string, path: string, baseColumnType: ColumnType) {
-  const columnType = getValue({ [columnName]: baseColumnType }, path) as ColumnType;
+  const columnType = getValue({ [columnName]: baseColumnType }, path) as
+    | ColumnType
+    | NestedEnumColumnType;
   if (!columnType) throw new Error(`Cannot add field '${path}' (dependency not found).`);
 
   const base = {
@@ -20,9 +22,7 @@ export function makeField(columnName: string, path: string, baseColumnType: Colu
     getValues: (records: RecordData[]) => records.map(r => getValue(r, path)),
   };
 
-  // A flattened nested enum becomes a top-level column: expose it as a plain Enum carrying its
-  // values, rather than the inline `{ type: 'Enum', enumValues }` shape used for nesting.
-  if (TypeGetter.isEnumColumnType(columnType)) {
+  if (TypeGetter.isEnumField(columnType)) {
     return { ...base, columnType: 'Enum' as ColumnType, enumValues: columnType.enumValues };
   }
 

--- a/packages/plugin-flattener/src/flatten-column/customization.ts
+++ b/packages/plugin-flattener/src/flatten-column/customization.ts
@@ -4,9 +4,9 @@ import type {
   HookBeforeUpdateContext,
   TConditionTree,
 } from '@forestadmin/datasource-customizer';
-import type { ColumnType } from '@forestadmin/datasource-toolkit';
+import type { ColumnType, RecordData } from '@forestadmin/datasource-toolkit';
 
-import { ConditionTreeFactory, SchemaUtils } from '@forestadmin/datasource-toolkit';
+import { ConditionTreeFactory, SchemaUtils, TypeGetter } from '@forestadmin/datasource-toolkit';
 import hashRecord from 'object-hash';
 
 import { deepUpdateInPlace, getValue, unflattenPathsInPlace } from './helpers';
@@ -15,11 +15,18 @@ export function makeField(columnName: string, path: string, baseColumnType: Colu
   const columnType = getValue({ [columnName]: baseColumnType }, path) as ColumnType;
   if (!columnType) throw new Error(`Cannot add field '${path}' (dependency not found).`);
 
-  return {
-    columnType,
+  const base = {
     dependencies: [columnName],
-    getValues: records => records.map(r => getValue(r, path)),
+    getValues: (records: RecordData[]) => records.map(r => getValue(r, path)),
   };
+
+  // A flattened nested enum becomes a top-level column: expose it as a plain Enum carrying its
+  // values, rather than the inline `{ type: 'Enum', enumValues }` shape used for nesting.
+  if (TypeGetter.isEnumColumnType(columnType)) {
+    return { ...base, columnType: 'Enum' as ColumnType, enumValues: columnType.enumValues };
+  }
+
+  return { ...base, columnType };
 }
 
 export function makeWriteHandler(path: string) {

--- a/packages/plugin-flattener/src/flatten-column/helpers.ts
+++ b/packages/plugin-flattener/src/flatten-column/helpers.ts
@@ -1,5 +1,7 @@
 import type { ColumnType, RecordData } from '@forestadmin/datasource-toolkit';
 
+import { TypeGetter } from '@forestadmin/datasource-toolkit';
+
 /**
  * Given the name of a column, its type and the maximum allowed depth, compute the list of paths
  * that can be flattened.
@@ -9,7 +11,8 @@ import type { ColumnType, RecordData } from '@forestadmin/datasource-toolkit';
  * // => ['address@@@streetName']
  */
 export function listPaths(columnName: string, type: ColumnType, level: number): string[] {
-  return level <= 0 || typeof type !== 'object'
+  // A nested enum is a leaf (its `enumValues`/`type` keys are not sub-fields to flatten).
+  return level <= 0 || typeof type !== 'object' || TypeGetter.isEnumColumnType(type)
     ? [columnName]
     : Object.keys(type)
         .map(key => listPaths(`${columnName}@@@${key}`, type[key], level - 1))

--- a/packages/plugin-flattener/src/flatten-column/helpers.ts
+++ b/packages/plugin-flattener/src/flatten-column/helpers.ts
@@ -11,11 +11,14 @@ import { TypeGetter } from '@forestadmin/datasource-toolkit';
  * // => ['address@@@streetName']
  */
 export function listPaths(columnName: string, type: ColumnType, level: number): string[] {
-  // A nested enum is a leaf (its `enumValues`/`type` keys are not sub-fields to flatten).
-  return level <= 0 || typeof type !== 'object' || TypeGetter.isEnumColumnType(type)
+  return level <= 0 || typeof type !== 'object'
     ? [columnName]
-    : Object.keys(type)
-        .map(key => listPaths(`${columnName}@@@${key}`, type[key], level - 1))
+    : Object.entries(type)
+        .map(([key, subType]) =>
+          TypeGetter.isEnumField(subType)
+            ? [`${columnName}@@@${key}`]
+            : listPaths(`${columnName}@@@${key}`, subType, level - 1),
+        )
         .flat();
 }
 

--- a/packages/plugin-flattener/test/flatten-column.test.ts
+++ b/packages/plugin-flattener/test/flatten-column.test.ts
@@ -40,6 +40,12 @@ describe('flattenColumn', () => {
                 address: { city: 'String' },
               },
             }),
+            editor: factories.columnSchema.build({
+              columnType: {
+                name: 'String',
+                kind: { type: 'Enum', enumValues: ['writer', 'illustrator'] },
+              },
+            }),
             meta: factories.columnSchema.build({ columnType: 'Json' }),
           },
         }),
@@ -154,6 +160,22 @@ describe('flattenColumn', () => {
     ).rejects.toThrow(
       "'book.meta' cannot be flattened using flattenColumn please use flattenJsonColumn.",
     );
+  });
+
+  describe('when flattening a column holding a nested enum', () => {
+    it('should expose the nested enum as a plain Enum field carrying its values', async () => {
+      const decorated = await customizer
+        .customizeCollection('book', book => book.use(flattenColumn, { columnName: 'editor' }))
+        .getDataSource(logger);
+
+      const { fields } = decorated.getCollection('book').schema;
+
+      expect(fields['editor@@@name']).toMatchObject({ columnType: 'String' });
+      expect(fields['editor@@@kind']).toMatchObject({
+        columnType: 'Enum',
+        enumValues: ['writer', 'illustrator'],
+      });
+    });
   });
 
   describe('when flattening a single level', () => {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nested enum support to the Mongoose datasource and related utilities
> - Introduces `NestedEnumColumnType` (`{ type: 'Enum', enumValues: string[] }`) in [schema.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1765/files#diff-5517ce84f6b48b67684b164ef9cbaec2d07d4f8dd567ded46bc9f3bdde8548ed) and a `TypeGetter.isEnumField` helper to detect inline enum sub-fields within composite column types.
> - Updates the Mongoose fields generator to emit `NestedEnumColumnType` for string-enum sub-documents instead of treating them as plain strings.
> - Propagates enum awareness through the schema generator, binary decorator, typing generator, and plugin-flattener so nested enums are preserved (not transformed) and correctly typed throughout the stack.
> - Behavioral Change: composite fields that previously had enum sub-fields serialized as plain strings will now appear as `Enum` type with an `enumValues` list in the Forest schema and generated TypeScript typings.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1765 opened
>
> - Modified `SchemaGeneratorFields.convertColumnType` method to sort enum values for nested enum sub-fields within composite column types [5ef4283]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4732be8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->