### PR TITLE
chore(deps): dedupe semver to unbreak npm publish in the release job

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15479,7 +15479,7 @@ semver-store@^0.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@~7.5.4:
+semver@7.5.4, semver@~7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -15501,20 +15501,10 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.2, semver@^7.7.2, semver@^7.7.3:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
-  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
-
-semver@^7.6.0:
+semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.2, semver@^7.7.3:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
-
-semver@^7.6.3:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## Problem

`workflow-executor` 1.19.0 and 1.20.0 were **tagged but never published to npm** — the `Release packages` job fails on every `npm publish` with:

```
npm error LRU is not a constructor
```

npm's `latest` is stuck at 1.17.2.

## Root cause (each link verified by local repro)

1. `@semantic-release/npm` publishes with the **repo-local `npm@11.7.0`** from `node_modules` (execa `preferLocal: true`) — the global `npm install -g npm@^11` in the job (#1757) never applies to publish.
2. The lockfile deduped **every `semver@^7.x` range onto the exact `semver@7.5.4` pin** (from `@commitlint/is-ignored`). semver ≤ 7.6.0 still depends on `lru-cache@^6` (old `new LRU()` API).
3. Yarn 1 "completes" bundled dependency trees from the lockfile: it stamped that old semver under `node_modules/npm/node_modules/libnpmpublish/` and hoisted its `lru-cache@6.0.0` over the `lru-cache@11.2.2` the npm tarball actually bundles.
4. The tree re-layout from #1763 (lerna 8→9, July 16) is what flipped this from working to broken — the last successful publish (1.17.2) ran hours before it.

Crash site, reproduced locally with the exact same stack as CI: `node_modules/npm/node_modules/libnpmpublish/node_modules/semver/classes/range.js:202`.

## Fix

`npx yarn-deduplicate --packages semver yarn.lock` — lockfile-only, 14 lines:

- `semver@7.5.4` pin stays isolated for commitlint
- all `^7.x` ranges resolve to **7.8.5** (no `lru-cache` dep since semver 7.6.1) → yarn no longer pollutes npm's bundled tree

Verified locally: `node_modules/.bin/npm publish --dry-run` on `packages/workflow-executor` fails before the dedupe, succeeds after (`+ @forestadmin/workflow-executor@1.20.0`). The yarn.lock change also busts the CI `node_modules` cache, so the release job reinstalls a clean tree.

## ⚠️ Follow-up needed after merge

semantic-release considers 1.19.0/1.20.0 **already released** (git tags exist), so merging this alone won't push them to npm. The next `fix:`/`feat:` commit touching `packages/workflow-executor` will release 1.20.1 and unblock npm. Docker images are unaffected (they published fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dedupe semver in yarn.lock to fix npm publish in the release job
> Updates [yarn.lock](https://github.com/ForestAdmin/agent-nodejs/pull/1766/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to deduplicate the `semver` package, resolving a conflict that was breaking the npm publish step in the release job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96bbd14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->