### PR TITLE
docs(workflow-executor): document CREATE on public schema for PG15+ [force release]

### DIFF
--- a/packages/workflow-executor/README.md
+++ b/packages/workflow-executor/README.md
@@ -144,6 +144,12 @@ GRANT USAGE, CREATE ON SCHEMA analytics TO "<user>";
 
 (Note: Postgres checks the database-level `CREATE` privilege for `CREATE SCHEMA IF NOT EXISTS` even when the schema exists, so the executor gates the statement on an existence probe rather than relying on `IF NOT EXISTS`.)
 
+Using `DATABASE_SCHEMA=public` on a dedicated database is the simplest setup — `public` always exists, so no `CREATE` on the database is needed. On Postgres 15+, though, `public` no longer grants `CREATE` to non-owner roles by default, so the executor still needs it to create its tables there:
+
+```sql
+GRANT USAGE, CREATE ON SCHEMA public TO "<user>";
+```
+
 ---
 
 ## OAuth-protected MCP connectors


### PR DESCRIPTION
## Why

Two goals in one small change:

1. **Trigger a `workflow-executor` npm release.** 1.19.0 and 1.20.0 were tagged but never published to npm (the semver/lru-cache `npm publish` crash, fixed in #1766). semantic-release won't retry an already-tagged version, so a fresh release-worthy commit is needed. `[force release]` in the subject cuts a **patch** (1.20.1) that will finally push the current code to npm and update the `latest` dist-tag.

2. **Real doc fix.** `DATABASE_SCHEMA=public` on a dedicated database is the simplest setup, but Postgres 15 removed PUBLIC's default `CREATE` on the `public` schema — so a non-owner DB user still needs an explicit `GRANT USAGE, CREATE ON SCHEMA public` for the executor to create its tables. The existing README examples only covered a custom (`analytics`) schema. This is the exact scenario a client hit.

## Change

README-only: one paragraph + SQL snippet in the `DATABASE_SCHEMA` section.

## After merge

Confirm `npm view @forestadmin/workflow-executor version` shows the new patch (should move off 1.17.2), then `latest` is current again and `npx @forestadmin/workflow-executor@latest` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `GRANT CREATE ON SCHEMA public` requirement for Postgres 15+ in workflow-executor
> Updates [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1767/files#diff-84aa4115ae7aaddeae8ef0aa0f2f1fae55b5692e9eb4340a0ec43f2c3c3c0b3b) to note that on Postgres 15+, non-owner roles no longer have `CREATE` on the `public` schema by default. Adds an SQL snippet showing the required `GRANT USAGE, CREATE ON SCHEMA public` statement for the executor user.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e47e380. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->