### PR TITLE
docs(mcp-server): document FOREST_AGENT_URL in the standalone env vars

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -63,6 +63,7 @@ yarn start:dev       # Development (loads .env file automatically)
 | `FOREST_AUTH_SECRET` | **Yes** | - | Your Forest Admin authentication secret (must match your agent) |
 | `MCP_SERVER_PORT` | No | `3931` | Port for the HTTP server |
 | `FOREST_MCP_ENABLED_TOOLS` | No | - | Comma-separated list of tools to enable (allowlist) |
+| `FOREST_AGENT_URL` | No | your environment's back-end URL | URL the MCP server uses to reach the back-end's data layer. Set it when the server runs next to a self-hosted back-end at an internal address (e.g. `http://localhost:3310`), instead of the public URL registered in Forest |
 
 #### Example Configuration
 


### PR DESCRIPTION
`FOREST_AGENT_URL` is read by the standalone CLI (`packages/mcp-server/src/cli.ts` → `agentUrl`, `server.ts:132-136`) but was missing from the README's standalone env-var table (documented nowhere, in fact).

It sets the URL the MCP server uses to reach the back-end's data layer, defaulting to the environment's registered back-end URL. Relevant for self-hosted setups where the MCP server runs next to the agent at an internal address.

Adds one row to the standalone env-var table. Companion to ForestAdmin/docs#16 (public docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `FOREST_AGENT_URL` in the MCP server standalone environment variables
> Adds a `FOREST_AGENT_URL` entry to the environment variables table in [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1773/files#diff-46a7a23fdaae3bf8011f1ddca552c21b774309bc427c931469d104619efa28a8), describing it as the URL the MCP server uses to reach the back-end's data layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9825077.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->