### PR TITLE
fix(agent-client): build static forms from the schema instead of probing /hooks/load [PRD-802]

### DIFF
--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -18,6 +18,7 @@ export default class FieldFormStates {
   private readonly layout: ForestServerActionFormLayoutElement[];
   private readonly hooks?: ForestSchemaAction['hooks'];
   private readonly fallbackFields?: ForestSchemaAction['fields'];
+  private readonly fallbackLayout?: ForestSchemaAction['layout'];
 
   constructor(
     actionName: string,
@@ -27,6 +28,7 @@ export default class FieldFormStates {
     ids: string[],
     hooks?: ForestSchemaAction['hooks'],
     fallbackFields?: ForestSchemaAction['fields'],
+    fallbackLayout?: ForestSchemaAction['layout'],
   ) {
     this.fields = [];
     this.actionName = actionName;
@@ -37,6 +39,7 @@ export default class FieldFormStates {
     this.layout = [];
     this.hooks = hooks;
     this.fallbackFields = fallbackFields;
+    this.fallbackLayout = fallbackLayout;
   }
 
   getFieldValues(): Record<string, unknown> {
@@ -78,6 +81,16 @@ export default class FieldFormStates {
   }
 
   async loadInitialState(): Promise<void> {
+    // hooks.load: false means the form is static: the schema already carries the complete form
+    // (fields with materialized defaults, and layout when any), so the request could only return
+    // the same data — and forest_liana agents < 9.20.1 don't even expose the route (404 noise in
+    // customers' metrics). Only probe when the schema gave us no fields to fall back on.
+    if (this.hooks && !this.hooks.load && this.fallbackFields) {
+      this.applyFallbackForm();
+
+      return;
+    }
+
     const requestBody = {
       data: {
         attributes: {
@@ -100,40 +113,34 @@ export default class FieldFormStates {
       this.layout.push(...(queryResults.layout ?? []));
       this.addFields(queryResults.fields);
     } catch (error) {
-      // When hooks.load is false, the behavior differs between backends:
-      //
-      // - Node agent (@forestadmin/agent): always responds to POST /hooks/load
-      //   with the form fields, even when hooks.load is false in the schema.
-      //   In this case the call above succeeds and fields are loaded normally.
-      //
-      // - Ruby agent (forest_liana): does NOT register a route for /hooks/load
-      //   when hooks.load is false. The POST returns a 404.
-      //   In this case we catch the 404 and continue with an empty form,
-      //   which matches the expected behavior (no dynamic fields to load).
-      //
-      // We always attempt the call so Node users get their fields,
-      // and only swallow 404 errors for Ruby users. Other errors (401, 500,
-      // network failures) are rethrown so they surface properly.
+      // Reached only when the schema provided no fallback fields for a static form: probe the
+      // agent anyway (Node agents answer with the form), and swallow the forest_liana < 9.20.1
+      // 404 as "no dynamic fields to load". Other errors (401, 500, network) surface properly.
       if (this.hooks && !this.hooks.load && HttpRequester.is404Error(error)) {
-        this.clearFieldsAndLayout();
-
-        if (this.fallbackFields?.length) {
-          this.addFields(
-            this.fallbackFields.map(f => ({
-              field: f.field,
-              type: f.type,
-              isRequired: f.isRequired ?? false,
-              isReadOnly: false,
-              value: f.defaultValue,
-              hook: f.hook,
-            })),
-          );
-        }
+        this.applyFallbackForm();
 
         return;
       }
 
       throw error;
+    }
+  }
+
+  private applyFallbackForm(): void {
+    this.clearFieldsAndLayout();
+    this.layout.push(...(this.fallbackLayout ?? []));
+
+    if (this.fallbackFields?.length) {
+      this.addFields(
+        this.fallbackFields.map(f => ({
+          field: f.field,
+          type: f.type,
+          isRequired: f.isRequired ?? false,
+          isReadOnly: false,
+          value: f.defaultValue,
+          hook: f.hook,
+        })),
+      );
     }
   }
 

--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -132,14 +132,15 @@ export default class FieldFormStates {
     this.layout.push(...(this.fallbackLayout ?? []));
 
     if (this.fallbackFields?.length) {
+      // Spread first: the schema is now the ONLY source for static forms, so every field prop
+      // (enums, description, widgetEdit, ...) must survive — dropping one starves consumers
+      // like ActionFieldEnum.getOptions() that the probe used to feed.
       this.addFields(
         this.fallbackFields.map(f => ({
-          field: f.field,
-          type: f.type,
+          ...f,
           isRequired: f.isRequired ?? false,
-          isReadOnly: false,
+          isReadOnly: f.isReadOnly ?? false,
           value: f.defaultValue,
-          hook: f.hook,
         })),
       );
     }

--- a/packages/agent-client/src/action-fields/field-form-states.ts
+++ b/packages/agent-client/src/action-fields/field-form-states.ts
@@ -113,10 +113,11 @@ export default class FieldFormStates {
       this.layout.push(...(queryResults.layout ?? []));
       this.addFields(queryResults.fields);
     } catch (error) {
-      // Reached only when the schema provided no fallback fields for a static form: probe the
-      // agent anyway (Node agents answer with the form), and swallow the forest_liana < 9.20.1
-      // 404 as "no dynamic fields to load". Other errors (401, 500, network) surface properly.
-      if (this.hooks && !this.hooks.load && HttpRequester.is404Error(error)) {
+      // Reached when the schema provided no fallback fields, or no hooks at all (legacy schemas):
+      // probe the agent anyway (Node agents answer with the form), and swallow the 404 of agents
+      // that don't expose the route as "no dynamic fields to load" — unless the schema explicitly
+      // declares a load hook, in which case a 404 is a real error. 401/500/network still surface.
+      if (!this.hooks?.load && HttpRequester.is404Error(error)) {
         this.applyFallbackForm();
 
         return;

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -95,10 +95,10 @@ export type ActionExecuteResult =
 
 export type ActionEndpointsByCollection = {
   [collectionName: string]: {
-    [actionName: string]: Pick<
-      ForestSchemaAction,
-      'id' | 'name' | 'endpoint' | 'hooks' | 'fields' | 'layout'
-    >;
+    // hooks/fields stay optional so legacy schemas that omit them keep probing /hooks/load:
+    // an absent value must stay distinguishable from an explicitly empty static form.
+    [actionName: string]: Pick<ForestSchemaAction, 'id' | 'name' | 'endpoint' | 'layout'> &
+      Partial<Pick<ForestSchemaAction, 'hooks' | 'fields'>>;
   };
 };
 export default class Action {

--- a/packages/agent-client/src/domains/action.ts
+++ b/packages/agent-client/src/domains/action.ts
@@ -95,7 +95,10 @@ export type ActionExecuteResult =
 
 export type ActionEndpointsByCollection = {
   [collectionName: string]: {
-    [actionName: string]: Pick<ForestSchemaAction, 'id' | 'name' | 'endpoint' | 'hooks' | 'fields'>;
+    [actionName: string]: Pick<
+      ForestSchemaAction,
+      'id' | 'name' | 'endpoint' | 'hooks' | 'fields' | 'layout'
+    >;
   };
 };
 export default class Action {

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -45,6 +45,7 @@ export default class Collection extends CollectionChart {
       ids,
       actionInfo.hooks,
       actionInfo.fields,
+      actionInfo.layout,
     );
 
     const action = new Action(
@@ -194,7 +195,7 @@ export default class Collection extends CollectionChart {
     actionEndpoints: ActionEndpointsByCollection,
     collectionName: string,
     actionName: string,
-  ): Pick<ForestSchemaAction, 'id' | 'endpoint' | 'hooks' | 'fields'> {
+  ): Pick<ForestSchemaAction, 'id' | 'endpoint' | 'hooks' | 'fields' | 'layout'> {
     const collection = actionEndpoints[collectionName];
     if (!collection) throw new Error(`Collection ${collectionName} not found in schema`);
 
@@ -208,6 +209,12 @@ export default class Collection extends CollectionChart {
       throw new Error(`Action ${actionName} not found in collection ${collectionName}`);
     }
 
-    return { id: action.id, endpoint: action.endpoint, hooks: action.hooks, fields: action.fields };
+    return {
+      id: action.id,
+      endpoint: action.endpoint,
+      hooks: action.hooks,
+      fields: action.fields,
+      layout: action.layout,
+    };
   }
 }

--- a/packages/agent-client/src/domains/collection.ts
+++ b/packages/agent-client/src/domains/collection.ts
@@ -195,7 +195,8 @@ export default class Collection extends CollectionChart {
     actionEndpoints: ActionEndpointsByCollection,
     collectionName: string,
     actionName: string,
-  ): Pick<ForestSchemaAction, 'id' | 'endpoint' | 'hooks' | 'fields' | 'layout'> {
+  ): Pick<ForestSchemaAction, 'id' | 'endpoint' | 'layout'> &
+    Partial<Pick<ForestSchemaAction, 'hooks' | 'fields'>> {
     const collection = actionEndpoints[collectionName];
     if (!collection) throw new Error(`Collection ${collectionName} not found in schema`);
 

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -364,6 +364,42 @@ describe('FieldFormStates', () => {
       expect(formStates.getFields()).toHaveLength(0);
     });
 
+    it('should probe and swallow the 404 when the schema has no hooks at all', async () => {
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+      );
+
+      const error404 = new AgentHttpError(404, null, 'Not Found');
+      httpRequester.query.mockRejectedValue(error404);
+
+      await formStates.loadInitialState();
+
+      expect(httpRequester.query).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/forest/actions/test-action/hooks/load' }),
+      );
+      expect(formStates.getFields()).toHaveLength(0);
+    });
+
+    it('should rethrow the 404 when the schema declares a load hook', async () => {
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+        { load: true, change: [] },
+      );
+
+      const error404 = new AgentHttpError(404, null, 'Not Found');
+      httpRequester.query.mockRejectedValue(error404);
+
+      await expect(formStates.loadInitialState()).rejects.toThrow();
+    });
+
     it('should throw when hooks.load is false but server returns 500', async () => {
       const formStates = new FieldFormStates(
         'testAction',

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -297,7 +297,7 @@ describe('FieldFormStates', () => {
       expect(formStates.getFields()).toHaveLength(0);
     });
 
-    it('should use fallback fields when hooks.load is false and server returns 404', async () => {
+    it('should build the form from the schema without any request when hooks.load is false', async () => {
       const fallbackFields = [
         { field: 'percentage', type: 'Number', isRequired: true, defaultValue: 10 },
         { field: 'note', type: 'String' },
@@ -313,16 +313,55 @@ describe('FieldFormStates', () => {
         fallbackFields,
       );
 
-      const error404 = new AgentHttpError(404, null, 'Not Found');
-      httpRequester.query.mockRejectedValue(error404);
-
       await formStates.loadInitialState();
 
+      expect(httpRequester.query).not.toHaveBeenCalled();
       expect(formStates.getFields()).toHaveLength(2);
       expect(formStates.getFields()[0].getName()).toBe('percentage');
       expect(formStates.getFields()[0].getValue()).toBe(10);
       expect(formStates.getFields()[1].getName()).toBe('note');
       expect(formStates.getFields()[1].getValue()).toBeUndefined();
+    });
+
+    it('should use the schema layout when hooks.load is false', async () => {
+      const fallbackFields = [{ field: 'note', type: 'String' }];
+      const fallbackLayout = [
+        { component: 'Separator' },
+        { component: 'Input', fieldId: 'note' },
+      ] as never[];
+
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+        { load: false, change: [] },
+        fallbackFields,
+        fallbackLayout,
+      );
+
+      await formStates.loadInitialState();
+
+      expect(httpRequester.query).not.toHaveBeenCalled();
+      expect(formStates.getLayout()).toEqual(fallbackLayout);
+    });
+
+    it('should skip the request when hooks.load is false and the static form is empty', async () => {
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+        { load: false, change: [] },
+        [],
+      );
+
+      await formStates.loadInitialState();
+
+      expect(httpRequester.query).not.toHaveBeenCalled();
+      expect(formStates.getFields()).toHaveLength(0);
     });
 
     it('should throw when hooks.load is false but server returns 500', async () => {

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -323,6 +323,39 @@ describe('FieldFormStates', () => {
       expect(formStates.getFields()[1].getValue()).toBeUndefined();
     });
 
+    it('should preserve enums, description and widget props on the skip path', async () => {
+      const fallbackFields = [
+        {
+          field: 'voucher_type',
+          type: 'Enum',
+          enums: ['credit', 'monthly_amount'],
+          isRequired: true,
+          defaultValue: 'credit',
+          description: 'Type of voucher',
+          hook: 'onFieldChanged',
+        },
+      ];
+
+      const formStates = new FieldFormStates(
+        'testAction',
+        '/forest/actions/test-action',
+        'users',
+        httpRequester,
+        ['1'],
+        { load: false, change: ['onFieldChanged'] },
+        fallbackFields,
+      );
+
+      await formStates.loadInitialState();
+
+      expect(httpRequester.query).not.toHaveBeenCalled();
+      const plainField = formStates.getFields()[0].getPlainField();
+      expect(plainField.enums).toEqual(['credit', 'monthly_amount']);
+      expect(plainField.description).toBe('Type of voucher');
+      expect(plainField.hook).toBe('onFieldChanged');
+      expect(plainField.value).toBe('credit');
+    });
+
     it('should use the schema layout when hooks.load is false', async () => {
       const fallbackFields = [{ field: 'note', type: 'String' }];
       const fallbackLayout = [

--- a/packages/agent-client/test/action-fields/field-form-states.test.ts
+++ b/packages/agent-client/test/action-fields/field-form-states.test.ts
@@ -334,6 +334,21 @@ describe('FieldFormStates', () => {
           description: 'Type of voucher',
           hook: 'onFieldChanged',
         },
+        {
+          field: 'plan',
+          type: 'String',
+          isRequired: true,
+          widgetEdit: {
+            parameters: {
+              static: {
+                options: [
+                  { label: 'Basic', value: 'basic' },
+                  { label: 'Premium', value: 'premium' },
+                ],
+              },
+            },
+          },
+        },
       ];
 
       const formStates = new FieldFormStates(
@@ -354,6 +369,11 @@ describe('FieldFormStates', () => {
       expect(plainField.description).toBe('Type of voucher');
       expect(plainField.hook).toBe('onFieldChanged');
       expect(plainField.value).toBe('credit');
+
+      expect(formStates.getMultipleChoiceField('plan').getOptions()).toEqual([
+        { label: 'Basic', value: 'basic' },
+        { label: 'Premium', value: 'premium' },
+      ]);
     });
 
     it('should use the schema layout when hooks.load is false', async () => {

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -196,8 +196,11 @@ export interface ForestSchemaAction {
     field: string;
     type: string;
     isRequired?: boolean;
+    isReadOnly?: boolean;
     defaultValue?: unknown;
     label?: string;
+    description?: string;
+    enums?: string[];
     hook?: string;
   }[];
   hooks: {

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -12,7 +12,7 @@ import type {
   RenderingPermissionV4,
   UserPermissionV4,
 } from './permissions/types';
-import type { ForestSchema } from './schema/types';
+import type { ForestSchema, ForestServerActionFormLayoutElement } from './schema/types';
 import type { RequestContextVariables } from './utils/context-variables';
 import type ContextVariables from './utils/context-variables';
 import type { HttpOptions } from './utils/http-options';
@@ -204,6 +204,8 @@ export interface ForestSchemaAction {
     load: boolean;
     change: unknown[];
   };
+  // Only emitted for static forms (hooks.load: false): the schema then carries the full form.
+  layout?: ForestServerActionFormLayoutElement[];
 }
 
 /**

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -202,6 +202,17 @@ export interface ForestSchemaAction {
     description?: string;
     enums?: string[];
     hook?: string;
+    // Widget options (dropdown/radio/checkbox/color values...) — the static form's only source
+    // for consumers like getMultipleChoiceField() once the /hooks/load probe is skipped.
+    widgetEdit?: {
+      parameters: {
+        static: {
+          options?: { label: string; value: string }[];
+          enableOpacity?: boolean;
+          quickPalette?: string[];
+        };
+      };
+    };
   }[];
   hooks: {
     load: boolean;

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -406,18 +406,19 @@ export default class AgentClientAgentPort implements AgentPort {
       endpoints[collectionName] = {};
 
       for (const action of schema.actions) {
-        // agent-client POSTs /hooks/load unconditionally; `hooks.load` tells it whether a 404
-        // there is expected (Ruby agent, swallowed → fallback to the static `fields` below) or
-        // a real error. Both `hooks` and `fields` must mirror the agent's real schema for form
-        // detection to work on Ruby agents.
+        // agent-client only POSTs /hooks/load when `hooks.load` is true (dynamic form); for static
+        // forms it builds the form from `fields`/`layout` directly, so no 404 probe reaches agents
+        // that don't expose the route. Both `hooks` and `fields` must mirror the agent's real
+        // schema for that decision to be correct.
         endpoints[collectionName][action.name] = {
           id: action.name,
           name: action.name,
           endpoint: action.endpoint,
           hooks: action.hooks ?? { load: false, change: [] },
-          // Zod envelope-validates `fields` as an array of opaque objects. Inner widget/parameters
-          // shape is owned by @forestadmin/forestadmin-client and consumed by agent-client below.
+          // Zod envelope-validates `fields`/`layout` as arrays of opaque objects. Inner shape is
+          // owned by @forestadmin/forestadmin-client and consumed by agent-client below.
           fields: (action.fields ?? []) as ActionEndpointsByCollection[string][string]['fields'],
+          layout: action.layout as ActionEndpointsByCollection[string][string]['layout'],
         };
       }
     }

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -408,16 +408,17 @@ export default class AgentClientAgentPort implements AgentPort {
       for (const action of schema.actions) {
         // agent-client only POSTs /hooks/load when `hooks.load` is true (dynamic form); for static
         // forms it builds the form from `fields`/`layout` directly, so no 404 probe reaches agents
-        // that don't expose the route. Both `hooks` and `fields` must mirror the agent's real
-        // schema for that decision to be correct.
+        // that don't expose the route. `hooks` and `fields` are forwarded WITHOUT defaults: a
+        // legacy schema omitting them must keep probing — coercing to {load: false} / [] would
+        // silently render dynamic or unknown forms as empty static ones.
         endpoints[collectionName][action.name] = {
           id: action.name,
           name: action.name,
           endpoint: action.endpoint,
-          hooks: action.hooks ?? { load: false, change: [] },
+          hooks: action.hooks,
           // Zod envelope-validates `fields`/`layout` as arrays of opaque objects. Inner shape is
           // owned by @forestadmin/forestadmin-client and consumed by agent-client below.
-          fields: (action.fields ?? []) as ActionEndpointsByCollection[string][string]['fields'],
+          fields: action.fields as ActionEndpointsByCollection[string][string]['fields'],
           layout: action.layout as ActionEndpointsByCollection[string][string]['layout'],
         };
       }

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -60,7 +60,7 @@ export type FieldSchema = z.infer<typeof FieldSchemaSchema>;
 // ActionSchema.fields / hooks content is a discriminated union owned by the upstream
 // `@forestadmin/forestadmin-client` lib and consumed downstream by `@forestadmin/agent-client`.
 // We validate the envelope shape only — detail re-validation would duplicate the lib's job.
-const ActionFieldsSchema = z.array(z.looseObject({})).optional();
+const LooseObjectArraySchema = z.array(z.looseObject({})).optional();
 const ActionHooksSchema = z
   .object({
     load: z.boolean(),
@@ -74,9 +74,9 @@ export const ActionSchemaSchema = z.object({
   endpoint: z.string().min(1),
   type: z.enum(['single', 'bulk', 'global']).optional(),
   /** Static form fields. Lets agent-client skip the /hooks/load probe on static forms. */
-  fields: ActionFieldsSchema,
+  fields: LooseObjectArraySchema,
   /** Static form layout, when the schema carries one. Envelope-validated like `fields`. */
-  layout: ActionFieldsSchema,
+  layout: LooseObjectArraySchema,
   /** Action lifecycle hooks. Drives agent-client's dynamic form loading. */
   hooks: ActionHooksSchema,
 });

--- a/packages/workflow-executor/src/types/validated/collection.ts
+++ b/packages/workflow-executor/src/types/validated/collection.ts
@@ -73,8 +73,10 @@ export const ActionSchemaSchema = z.object({
   displayName: z.string().min(1),
   endpoint: z.string().min(1),
   type: z.enum(['single', 'bulk', 'global']).optional(),
-  /** Static form fields. Used as fallback when the agent's /hooks/load route 404s (old Ruby agents). */
+  /** Static form fields. Lets agent-client skip the /hooks/load probe on static forms. */
   fields: ActionFieldsSchema,
+  /** Static form layout, when the schema carries one. Envelope-validated like `fields`. */
+  layout: ActionFieldsSchema,
   /** Action lifecycle hooks. Drives agent-client's dynamic form loading. */
   hooks: ActionHooksSchema,
 });

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -1073,8 +1073,10 @@ describe('AgentClientAgentPort', () => {
       );
     });
 
-    it('falls back to neutral hooks/fields when the schema omits them', async () => {
-      // Default schema in beforeEach has no hooks/fields on actions.
+    it('forwards omitted hooks/fields as-is so agent-client keeps probing /hooks/load', async () => {
+      // Default schema in beforeEach has no hooks/fields on actions. They must NOT be coerced to
+      // {load: false} / []: agent-client would then skip the probe and render an empty static
+      // form where a legacy agent could have answered with the real one.
       await port.executeAction({ collection: 'users', action: 'sendEmail', id: [1] }, { user });
 
       expect(mockedCreateRemoteAgentClient).toHaveBeenCalledWith(
@@ -1082,8 +1084,8 @@ describe('AgentClientAgentPort', () => {
           actionEndpoints: expect.objectContaining({
             users: expect.objectContaining({
               sendEmail: expect.objectContaining({
-                hooks: { load: false, change: [] },
-                fields: [],
+                hooks: undefined,
+                fields: undefined,
               }),
             }),
           }),


### PR DESCRIPTION
## Context

`@forestadmin/agent-client` (used by the workflow executor) POSTs `<action>/hooks/load` unconditionally when opening an action form, even when the schema says `hooks.load: false` (static form). Agents that don't expose the route answer 404:

- forest_liana < 9.20.1, for every action without a load hook — fixed agent-side in 9.20.1 ([PRD-801](https://linear.app/forestadmin/issue/PRD-801)), but only for endpoints under the `/forest` engine mount;
- actions whose custom endpoints are **proxied outside the agent** (reported by Qonto): no agent-side fix can cover those, the 404s keep polluting the customer's HTTP metrics.

The probe is unnecessary for static forms: the Node agent sets `hooks.load = !schema.staticForm`, and for static forms the schema already carries the complete form — fields with materialized defaults (`setFieldsDefaultValue`) and layout when any (`generator-actions.ts`).

## Changes

- **agent-client** — `FieldFormStates.loadInitialState`: when `hooks.load` is false and the schema provided fields, build the form from `fields`/`layout` without any HTTP call. When the schema gave no fields, keep the existing behavior (probe + swallow 404 as "no dynamic fields"). Fallback logic extracted into `applyFallbackForm`, which now also restores the schema layout.
- **forestadmin-client** — `ForestSchemaAction` gains the optional `layout` that the Node agent already emits for static forms.
- **workflow-executor** — the schema envelope validates and threads `layout` through `buildActionEndpoints`.

## Tests

- new: `hooks.load: false` + schema fields → form built, **no request at all**;
- new: schema layout restored in that path;
- new: empty static form (`fields: []`) → no request, empty form;
- kept: no schema fields → probe still happens, 404 swallowed, 500 rethrown, successful response used (Node compatibility for old schemas).

347 agent-client + 1466 workflow-executor + 283 forestadmin-client tests green.

## Known limitation

The orchestrator's `getCollectionSchema` response doesn't expose action `layout` yet, so static Node forms consumed through the executor lose their layout elements until forestadmin-server passes it through (fields and values are unaffected — same degradation the 404 fallback already had). Tracked as a follow-up in PRD-802.

Linear: PRD-802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build static action forms from schema layout instead of probing `/hooks/load`
> - When `hooks.load` is `false` and fallback fields are present in the schema, `FieldFormStates.loadInitialState` now skips the `/hooks/load` request and builds the form directly from schema fields and layout.
> - A new private `applyFallbackForm` method in [`field-form-states.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1775/files#diff-7ab5307c436664b3183f218254bb7e09882031d99c6b49a865e1280f22b2531d) consolidates fallback form construction, including clearing state, applying layout, and setting field defaults.
> - [`ActionEndpointsByCollection`](https://github.com/ForestAdmin/agent-nodejs/pull/1775/files#diff-c434b5b3c0debe1a1c3629c2828238cc6ab1609dce58c3b2f6dae384ef677b81) now treats `hooks` and `fields` as optional and includes `layout`; omitting them preserves legacy probing behavior.
> - [`AgentClientAgentPort.buildActionEndpoints`](https://github.com/ForestAdmin/agent-nodejs/pull/1775/files#diff-1e123e0cbe27612cfd4c2f0c74aa6529888468059a8106cdc6bab8375b9b141a) forwards `hooks`, `fields`, and `layout` as-is from the schema without defaulting, so absence is propagated correctly.
> - Behavioral Change: 404 responses from `/hooks/load` are now rethrown when `hooks.load` is `true`; they are only swallowed when hooks are absent or `load` is `false`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1775 opened
>
> - Modified `FieldFormStates.applyFallbackForm` method to preserve all schema-provided field properties when applying fallback forms for static actions [1178315]
> - Extended `ForestSchemaAction` interface in `forestadmin-client` to include optional field properties [1178315]
> - Renamed `ActionFieldsSchema` constant to `LooseObjectArraySchema` in `workflow-executor` validated collection module [1178315]
> - Added `widgetEdit` property with `parameters.static.options`, `enableOpacity`, and `quickPalette` to the `ForestSchemaAction` interface fields definition in `forestadmin-client` to support static form rendering without probing `/hooks/load` [3e1646f]
> - Extended `FieldFormStates.loadInitialState` test to verify that `getMultipleChoiceField` returns options from schema-provided `widgetEdit.parameters.static.options` when load hook is disabled [3e1646f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bc4223.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

## Behavior changes (for the changelog)

- `hooks.load: false` + `fields` provided now means **"trust the schema, skip the `/hooks/load` call"** (previously: probe and swallow an eventual 404). External consumers of `@forestadmin/agent-client` that coerced absent hooks/fields to `{load: false}` / `[]` (as the executor did) must forward them as-is, or every legacy schema would render as an empty static form.
- Legacy schemas (no `hooks` at all) whose agent 404s on `/hooks/load`: the 404 was previously **rethrown** (visible error at form load) and is now **swallowed** (empty form; a real problem surfaces at action execution instead). Schemas that explicitly declare `hooks.load: true` still rethrow the 404.
