### PR TITLE
feat: handle multiple projection on relation fields

### DIFF
--- a/packages/agent/src/routes/capabilities.ts
+++ b/packages/agent/src/routes/capabilities.ts
@@ -39,6 +39,7 @@ export default class Capabilities extends BaseRoute {
       ),
       agentCapabilities: {
         canUseProjectionOnGetOne: true,
+        canUseMultipleFieldsProjectionOnRelation: true,
       },
       collections:
         collections?.map(collection => {

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -53,12 +53,14 @@ export default class QueryStringParser {
 
       const { schema } = collection;
       const rootFields = fields.toString().split(',');
-      const explicitRequest = rootFields.map(field => {
+      const explicitRequest = rootFields.flatMap(field => {
         const columnOrRelation = SchemaUtils.getField(schema, field, collection.name);
 
-        return columnOrRelation.type === 'Column'
-          ? field
-          : `${field}:${context.request.query[`fields[${field}]`]}`;
+        if (columnOrRelation.type === 'Column') return field;
+
+        const relationFields = String(context.request.query[`fields[${field}]`]);
+
+        return relationFields.split(',').map(subField => `${field}:${subField}`);
       });
 
       ProjectionValidator.validate(collection, explicitRequest);

--- a/packages/agent/test/routes/access/get.test.ts
+++ b/packages/agent/test/routes/access/get.test.ts
@@ -206,6 +206,33 @@ describe('GetRoute', () => {
             ['name', 'author:id', 'id'],
           );
         });
+
+        test('it should handle multiple projected fields on a belongsTo relation', async () => {
+          jest
+            .spyOn(dataSource.getCollection('books'), 'list')
+            .mockResolvedValue([{ title: 'test ' }]);
+          services.serializer.serialize = jest.fn().mockReturnValue('test');
+          const get = new Get(services, options, dataSource, 'books');
+          const context = createMockContext({
+            state: { user: { email: 'john.doe@domain.com' } },
+            customProperties: {
+              query: {
+                timezone: 'Europe/Paris',
+                'fields[books]': 'name,author',
+                'fields[author]': 'id,bookId',
+              },
+              params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+            },
+          });
+
+          await get.handleGet(context);
+
+          expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            ['name', 'author:id', 'author:bookId', 'id'],
+          );
+        });
       });
 
       describe('when an error happens', () => {

--- a/packages/agent/test/routes/capabilities.test.ts
+++ b/packages/agent/test/routes/capabilities.test.ts
@@ -77,6 +77,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [{ name: 'main' }, { name: 'replica' }],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
         });
@@ -98,6 +99,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
         });
@@ -117,6 +119,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
         });
@@ -138,6 +141,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [
             {


### PR DESCRIPTION
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple subfield projections on relation fields in query string parsing
> - `QueryStringParser.parseProjection` now uses `flatMap` to split `fields[relation]=a,b` into separate `relation:a` and `relation:b` tokens instead of a single comma-joined token.
> - The `/_internal/capabilities` response now includes `canUseMultipleFieldsProjectionOnRelation: true` under `agentCapabilities` to advertise this support.
> - Behavioral Change: agents receiving `fields[relation]` with multiple comma-separated values will now pass multiple projection entries to `collection.list` instead of one combined entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f6e226.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->