### PR TITLE
feat(mcp-server): add triggerWorkflow tool (PRD-738)

### DIFF
--- a/packages/agent-testing/src/forest-admin-client-mock.ts
+++ b/packages/agent-testing/src/forest-admin-client-mock.ts
@@ -64,6 +64,7 @@ export default class ForestAdminClientMock implements ForestAdminClient {
 
   readonly workflowsService: ForestAdminClient['workflowsService'] = {
     listMcpEnabledWorkflows: () => Promise.resolve([]),
+    triggerMcpWorkflow: () => Promise.resolve({ runId: 1, runState: 'loading' }),
   };
 
   readonly permissionService: any;

--- a/packages/agent-testing/test/forest-admin-client-mock.test.ts
+++ b/packages/agent-testing/test/forest-admin-client-mock.test.ts
@@ -1,0 +1,29 @@
+import ForestAdminClientMock from '../src/forest-admin-client-mock';
+
+describe('ForestAdminClientMock', () => {
+  describe('workflowsService', () => {
+    it('should resolve an empty list of MCP-enabled workflows', async () => {
+      const client = new ForestAdminClientMock();
+
+      await expect(
+        client.workflowsService.listMcpEnabledWorkflows({
+          forestServerToken: 'token',
+          renderingId: '1',
+        }),
+      ).resolves.toEqual([]);
+    });
+
+    it('should resolve a loading run when triggering a workflow', async () => {
+      const client = new ForestAdminClientMock();
+
+      await expect(
+        client.workflowsService.triggerMcpWorkflow({
+          forestServerToken: 'token',
+          renderingId: '1',
+          workflowId: 'wf-1',
+          recordId: '42',
+        }),
+      ).resolves.toEqual({ runId: 1, runState: 'loading' });
+    });
+  });
+});

--- a/packages/agent/test/__factories__/forest-admin-client.ts
+++ b/packages/agent/test/__factories__/forest-admin-client.ts
@@ -56,6 +56,7 @@ const forestAdminClientFactory = ForestAdminClientFactory.define(() => ({
   },
   workflowsService: {
     listMcpEnabledWorkflows: jest.fn(),
+    triggerMcpWorkflow: jest.fn(),
   },
   subscribeToServerEvents: jest.fn(),
   close: jest.fn(),

--- a/packages/forestadmin-client/src/index.ts
+++ b/packages/forestadmin-client/src/index.ts
@@ -30,6 +30,9 @@ export {
   UpdateActivityLogStatusParams,
   McpWorkflow,
   ListMcpWorkflowsParams,
+  TriggerMcpWorkflowParams,
+  WorkflowRunState,
+  WorkflowRunTriggerResult,
   // Service interfaces for MCP
   ActivityLogsServiceInterface,
   WorkflowsServiceInterface,

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -9,6 +9,7 @@ import type {
   ForestSchemaCollection,
   IpWhitelistRulesResponse,
   McpWorkflow,
+  WorkflowRunTriggerResult,
 } from '../types';
 import type { HttpOptions } from '../utils/http-options';
 import type { ToolConfig } from '@forestadmin/ai-proxy';
@@ -165,6 +166,22 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
       method: 'get',
       path: `/api/workflow-orchestrator/workflows${query}`,
       bearerToken: options.bearerToken,
+      headers: { 'forest-rendering-id': renderingId, ...options.headers },
+    });
+  }
+
+  async triggerMcpWorkflow(
+    options: ActivityLogHttpOptions,
+    renderingId: string,
+    workflowId: string,
+    recordId: string,
+  ): Promise<WorkflowRunTriggerResult> {
+    return ServerUtils.queryWithBearerToken<WorkflowRunTriggerResult>({
+      forestServerUrl: options.forestServerUrl,
+      method: 'post',
+      path: `/api/workflow-orchestrator/workflows/${encodeURIComponent(workflowId)}/start`,
+      bearerToken: options.bearerToken,
+      body: { recordId },
       headers: { 'forest-rendering-id': renderingId, ...options.headers },
     });
   }

--- a/packages/forestadmin-client/src/permissions/forest-http-api.ts
+++ b/packages/forestadmin-client/src/permissions/forest-http-api.ts
@@ -164,7 +164,7 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     return ServerUtils.queryWithBearerToken<McpWorkflow[]>({
       forestServerUrl: options.forestServerUrl,
       method: 'get',
-      path: `/api/workflow-orchestrator/workflows${query}`,
+      path: `/api/workflow-orchestrator/mcp-workflows${query}`,
       bearerToken: options.bearerToken,
       headers: { 'forest-rendering-id': renderingId, ...options.headers },
     });
@@ -179,7 +179,7 @@ export default class ForestHttpApi implements ForestAdminServerInterface {
     return ServerUtils.queryWithBearerToken<WorkflowRunTriggerResult>({
       forestServerUrl: options.forestServerUrl,
       method: 'post',
-      path: `/api/workflow-orchestrator/workflows/${encodeURIComponent(workflowId)}/start`,
+      path: `/api/workflow-orchestrator/mcp-workflows/${encodeURIComponent(workflowId)}/start`,
       bearerToken: options.bearerToken,
       body: { recordId },
       headers: { 'forest-rendering-id': renderingId, ...options.headers },

--- a/packages/forestadmin-client/src/types.ts
+++ b/packages/forestadmin-client/src/types.ts
@@ -254,7 +254,8 @@ export type ActivityLogAction =
   | 'update'
   | 'delete'
   | 'listRelatedData'
-  | 'describeCollection';
+  | 'describeCollection'
+  | 'triggerWorkflow';
 
 export type ActivityLogType = 'read' | 'write';
 
@@ -300,10 +301,31 @@ export interface ListMcpWorkflowsParams {
 }
 
 /**
+ * The lifecycle state of a workflow run, as persisted by the orchestrator.
+ */
+export type WorkflowRunState = 'started' | 'pending' | 'loading' | 'aborted' | 'finished';
+
+/**
+ * The outcome of starting a workflow run: the run continues asynchronously server-side.
+ */
+export interface WorkflowRunTriggerResult {
+  runId: number;
+  runState: WorkflowRunState;
+}
+
+export interface TriggerMcpWorkflowParams {
+  forestServerToken: string;
+  renderingId: string;
+  workflowId: string;
+  recordId: string;
+}
+
+/**
  * Service interface for workflow operations (MCP-related).
  */
 export interface WorkflowsServiceInterface {
   listMcpEnabledWorkflows: (params: ListMcpWorkflowsParams) => Promise<McpWorkflow[]>;
+  triggerMcpWorkflow: (params: TriggerMcpWorkflowParams) => Promise<WorkflowRunTriggerResult>;
 }
 
 /**
@@ -351,6 +373,12 @@ export interface ForestAdminServerInterface {
     renderingId: string,
     collectionName?: string,
   ) => Promise<McpWorkflow[]>;
+  triggerMcpWorkflow?: (
+    options: ActivityLogHttpOptions,
+    renderingId: string,
+    workflowId: string,
+    recordId: string,
+  ) => Promise<WorkflowRunTriggerResult>;
 }
 
 export type ActivityLogHttpOptions = {

--- a/packages/forestadmin-client/src/workflows/index.ts
+++ b/packages/forestadmin-client/src/workflows/index.ts
@@ -1,4 +1,10 @@
-import type { ForestAdminServerInterface, ListMcpWorkflowsParams, McpWorkflow } from '../types';
+import type {
+  ForestAdminServerInterface,
+  ListMcpWorkflowsParams,
+  McpWorkflow,
+  TriggerMcpWorkflowParams,
+  WorkflowRunTriggerResult,
+} from '../types';
 
 export type WorkflowsServiceOptions = {
   forestServerUrl: string;
@@ -22,6 +28,21 @@ export default class WorkflowsService {
       },
       renderingId,
       collectionName,
+    );
+  }
+
+  async triggerMcpWorkflow(params: TriggerMcpWorkflowParams): Promise<WorkflowRunTriggerResult> {
+    const { forestServerToken, renderingId, workflowId, recordId } = params;
+
+    return this.forestAdminServerInterface.triggerMcpWorkflow(
+      {
+        forestServerUrl: this.options.forestServerUrl,
+        bearerToken: forestServerToken,
+        headers: this.options.headers,
+      },
+      renderingId,
+      workflowId,
+      recordId,
     );
   }
 }

--- a/packages/forestadmin-client/src/workflows/index.ts
+++ b/packages/forestadmin-client/src/workflows/index.ts
@@ -20,6 +20,12 @@ export default class WorkflowsService {
   async listMcpEnabledWorkflows(params: ListMcpWorkflowsParams): Promise<McpWorkflow[]> {
     const { forestServerToken, renderingId, collectionName } = params;
 
+    if (!this.forestAdminServerInterface.listMcpEnabledWorkflows) {
+      throw new Error(
+        'The configured Forest server transport does not support listMcpEnabledWorkflows.',
+      );
+    }
+
     return this.forestAdminServerInterface.listMcpEnabledWorkflows(
       {
         forestServerUrl: this.options.forestServerUrl,
@@ -33,6 +39,12 @@ export default class WorkflowsService {
 
   async triggerMcpWorkflow(params: TriggerMcpWorkflowParams): Promise<WorkflowRunTriggerResult> {
     const { forestServerToken, renderingId, workflowId, recordId } = params;
+
+    if (!this.forestAdminServerInterface.triggerMcpWorkflow) {
+      throw new Error(
+        'The configured Forest server transport does not support triggerMcpWorkflow.',
+      );
+    }
 
     return this.forestAdminServerInterface.triggerMcpWorkflow(
       {

--- a/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
+++ b/packages/forestadmin-client/test/__factories__/forest-admin-server-interface.ts
@@ -20,6 +20,7 @@ const forestAdminServerInterface = {
     updateActivityLogStatus: jest.fn(),
     // Workflow operations
     listMcpEnabledWorkflows: jest.fn(),
+    triggerMcpWorkflow: jest.fn(),
   }),
 };
 

--- a/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
+++ b/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
@@ -245,4 +245,49 @@ describe('ForestHttpApi', () => {
       );
     });
   });
+
+  describe('triggerMcpWorkflow', () => {
+    it('should POST the record id to the workflow start endpoint with the rendering id header', async () => {
+      const run = { runId: 7, runState: 'loading' };
+      (ServerUtils.queryWithBearerToken as jest.Mock).mockResolvedValue(run);
+
+      const result = await new ForestHttpApi().triggerMcpWorkflow(
+        { forestServerUrl: options.forestServerUrl, bearerToken: 'bearer-token' },
+        '12345',
+        'wf-1',
+        '42',
+      );
+
+      expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith({
+        forestServerUrl: options.forestServerUrl,
+        method: 'post',
+        path: '/api/workflow-orchestrator/workflows/wf-1/start',
+        bearerToken: 'bearer-token',
+        body: { recordId: '42' },
+        headers: { 'forest-rendering-id': '12345' },
+      });
+      expect(result).toEqual(run);
+    });
+
+    it('should url-encode the workflow id in the path', async () => {
+      (ServerUtils.queryWithBearerToken as jest.Mock).mockResolvedValue({
+        runId: 1,
+        runState: 'loading',
+      });
+
+      await new ForestHttpApi().triggerMcpWorkflow(
+        { forestServerUrl: options.forestServerUrl, bearerToken: 'bearer-token' },
+        '12345',
+        'wf/with space',
+        '42',
+      );
+
+      expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'post',
+          path: '/api/workflow-orchestrator/workflows/wf%2Fwith%20space/start',
+        }),
+      );
+    });
+  });
 });

--- a/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
+++ b/packages/forestadmin-client/test/permissions/forest-http-api.test.ts
@@ -220,7 +220,7 @@ describe('ForestHttpApi', () => {
       expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith({
         forestServerUrl: options.forestServerUrl,
         method: 'get',
-        path: '/api/workflow-orchestrator/workflows',
+        path: '/api/workflow-orchestrator/mcp-workflows',
         bearerToken: 'bearer-token',
         headers: { 'forest-rendering-id': '12345' },
       });
@@ -239,7 +239,7 @@ describe('ForestHttpApi', () => {
       expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'get',
-          path: '/api/workflow-orchestrator/workflows?collectionName=sales%20orders',
+          path: '/api/workflow-orchestrator/mcp-workflows?collectionName=sales%20orders',
           headers: { 'forest-rendering-id': '12345' },
         }),
       );
@@ -261,7 +261,7 @@ describe('ForestHttpApi', () => {
       expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith({
         forestServerUrl: options.forestServerUrl,
         method: 'post',
-        path: '/api/workflow-orchestrator/workflows/wf-1/start',
+        path: '/api/workflow-orchestrator/mcp-workflows/wf-1/start',
         bearerToken: 'bearer-token',
         body: { recordId: '42' },
         headers: { 'forest-rendering-id': '12345' },
@@ -285,7 +285,7 @@ describe('ForestHttpApi', () => {
       expect(ServerUtils.queryWithBearerToken).toHaveBeenCalledWith(
         expect.objectContaining({
           method: 'post',
-          path: '/api/workflow-orchestrator/workflows/wf%2Fwith%20space/start',
+          path: '/api/workflow-orchestrator/mcp-workflows/wf%2Fwith%20space/start',
         }),
       );
     });

--- a/packages/forestadmin-client/test/workflows/index.test.ts
+++ b/packages/forestadmin-client/test/workflows/index.test.ts
@@ -76,4 +76,57 @@ describe('WorkflowsService', () => {
       );
     });
   });
+
+  describe('triggerMcpWorkflow', () => {
+    it('should forward the identity, workflowId and recordId to the transport and return the run', async () => {
+      mockForestAdminServerInterface.triggerMcpWorkflow.mockResolvedValue({
+        runId: 7,
+        runState: 'loading',
+      });
+
+      const service = new WorkflowsService(mockForestAdminServerInterface, options);
+      const result = await service.triggerMcpWorkflow({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        workflowId: 'wf-1',
+        recordId: '42',
+      });
+
+      expect(result).toEqual({ runId: 7, runState: 'loading' });
+      expect(mockForestAdminServerInterface.triggerMcpWorkflow).toHaveBeenCalledWith(
+        { forestServerUrl: options.forestServerUrl, bearerToken: 'test-token', headers: undefined },
+        '12345',
+        'wf-1',
+        '42',
+      );
+    });
+
+    it('should pass custom headers when provided', async () => {
+      mockForestAdminServerInterface.triggerMcpWorkflow.mockResolvedValue({
+        runId: 7,
+        runState: 'loading',
+      });
+
+      const service = new WorkflowsService(mockForestAdminServerInterface, {
+        ...options,
+        headers: { 'Forest-Application-Source': 'MCP' },
+      });
+      await service.triggerMcpWorkflow({
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        workflowId: 'wf-1',
+        recordId: '42',
+      });
+
+      expect(mockForestAdminServerInterface.triggerMcpWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bearerToken: 'test-token',
+          headers: { 'Forest-Application-Source': 'MCP' },
+        }),
+        '12345',
+        'wf-1',
+        '42',
+      );
+    });
+  });
 });

--- a/packages/forestadmin-client/test/workflows/index.test.ts
+++ b/packages/forestadmin-client/test/workflows/index.test.ts
@@ -75,6 +75,17 @@ describe('WorkflowsService', () => {
         undefined,
       );
     });
+
+    it('should throw when the transport does not implement listMcpEnabledWorkflows', async () => {
+      delete (mockForestAdminServerInterface as Partial<ForestAdminServerInterface>)
+        .listMcpEnabledWorkflows;
+
+      const service = new WorkflowsService(mockForestAdminServerInterface, options);
+
+      await expect(
+        service.listMcpEnabledWorkflows({ forestServerToken: 'test-token', renderingId: '12345' }),
+      ).rejects.toThrow('does not support listMcpEnabledWorkflows');
+    });
   });
 
   describe('triggerMcpWorkflow', () => {
@@ -127,6 +138,22 @@ describe('WorkflowsService', () => {
         'wf-1',
         '42',
       );
+    });
+
+    it('should throw when the transport does not implement triggerMcpWorkflow', async () => {
+      delete (mockForestAdminServerInterface as Partial<ForestAdminServerInterface>)
+        .triggerMcpWorkflow;
+
+      const service = new WorkflowsService(mockForestAdminServerInterface, options);
+
+      await expect(
+        service.triggerMcpWorkflow({
+          forestServerToken: 'test-token',
+          renderingId: '12345',
+          workflowId: 'wf-1',
+          recordId: '42',
+        }),
+      ).rejects.toThrow('does not support triggerMcpWorkflow');
     });
   });
 });

--- a/packages/mcp-server/src/http-client/index.ts
+++ b/packages/mcp-server/src/http-client/index.ts
@@ -55,6 +55,8 @@ export type {
   ForestServerClient,
   ListMcpWorkflowsParams,
   McpWorkflow,
+  TriggerMcpWorkflowParams,
+  WorkflowRunTriggerResult,
   UpdateActivityLogStatusParams,
   ForestSchemaCollection,
   ForestSchemaField,

--- a/packages/mcp-server/src/http-client/mcp-http-client.ts
+++ b/packages/mcp-server/src/http-client/mcp-http-client.ts
@@ -7,7 +7,9 @@ import type {
   ListMcpWorkflowsParams,
   McpWorkflow,
   SchemaServiceInterface,
+  TriggerMcpWorkflowParams,
   UpdateActivityLogStatusParams,
+  WorkflowRunTriggerResult,
   WorkflowsServiceInterface,
 } from './types';
 
@@ -41,5 +43,9 @@ export default class ForestServerClientImpl implements ForestServerClient {
 
   async listMcpWorkflows(params: ListMcpWorkflowsParams): Promise<McpWorkflow[]> {
     return this.workflowsService.listMcpEnabledWorkflows(params);
+  }
+
+  async triggerWorkflow(params: TriggerMcpWorkflowParams): Promise<WorkflowRunTriggerResult> {
+    return this.workflowsService.triggerMcpWorkflow(params);
   }
 }

--- a/packages/mcp-server/src/http-client/types.d.ts
+++ b/packages/mcp-server/src/http-client/types.d.ts
@@ -10,7 +10,9 @@ import type {
   ListMcpWorkflowsParams,
   McpWorkflow,
   SchemaServiceInterface,
+  TriggerMcpWorkflowParams,
   UpdateActivityLogStatusParams,
+  WorkflowRunTriggerResult,
   WorkflowsServiceInterface,
 } from '@forestadmin/forestadmin-client';
 
@@ -27,7 +29,9 @@ export type {
   ListMcpWorkflowsParams,
   McpWorkflow,
   SchemaServiceInterface,
+  TriggerMcpWorkflowParams,
   UpdateActivityLogStatusParams,
+  WorkflowRunTriggerResult,
   WorkflowsServiceInterface,
 };
 
@@ -65,4 +69,9 @@ export interface ForestServerClient {
    * Lists the MCP-enabled workflows the caller can access in a rendering.
    */
   listMcpWorkflows(params: ListMcpWorkflowsParams): Promise<McpWorkflow[]>;
+
+  /**
+   * Starts a run of an MCP-enabled workflow on a record and returns its runId (async).
+   */
+  triggerWorkflow(params: TriggerMcpWorkflowParams): Promise<WorkflowRunTriggerResult>;
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -35,6 +35,7 @@ import declareGetActionFormTool from './tools/get-action-form';
 import declareListTool from './tools/list';
 import declareListRelatedTool from './tools/list-related';
 import declareListWorkflowsTool from './tools/list-workflows';
+import declareTriggerWorkflowTool from './tools/trigger-workflow';
 import declareUpdateTool from './tools/update';
 import normalizeAgentUrl from './utils/normalize-agent-url';
 import { fetchForestSchema, getCollectionNames } from './utils/schema-fetcher';
@@ -91,6 +92,7 @@ const SAFE_ARGUMENTS_FOR_LOGGING: Record<string, string[]> = {
   associate: ['collectionName', 'relationName', 'parentRecordId', 'targetRecordId'],
   dissociate: ['collectionName', 'relationName', 'parentRecordId', 'targetRecordIds'],
   listWorkflows: ['collectionName'],
+  triggerWorkflow: ['workflowId', 'recordId'],
 };
 
 export type ToolName =
@@ -104,7 +106,8 @@ export type ToolName =
   | 'dissociate'
   | 'getActionForm'
   | 'executeAction'
-  | 'listWorkflows';
+  | 'listWorkflows'
+  | 'triggerWorkflow';
 
 /**
  * Options for configuring the Forest Admin MCP Server
@@ -227,6 +230,7 @@ export default class ForestMCPServer {
       { name: 'getActionForm', register: () => declareGetActionFormTool(mcpServer, ctx) },
       { name: 'executeAction', register: () => declareExecuteActionTool(mcpServer, ctx) },
       { name: 'listWorkflows', register: () => declareListWorkflowsTool(mcpServer, ctx) },
+      { name: 'triggerWorkflow', register: () => declareTriggerWorkflowTool(mcpServer, ctx) },
     ];
 
     const enabledToolEntries = allTools.filter(tool => this.enabledTools.has(tool.name));
@@ -265,6 +269,7 @@ export default class ForestMCPServer {
       'getActionForm',
       'executeAction',
       'listWorkflows',
+      'triggerWorkflow',
     ];
 
     const enabled = new Set(options?.enabledTools ?? allToolNames);

--- a/packages/mcp-server/src/tools/trigger-workflow.ts
+++ b/packages/mcp-server/src/tools/trigger-workflow.ts
@@ -41,12 +41,20 @@ export default function declareTriggerWorkflowTool(mcpServer: McpServer, ctx: To
     async (args: TriggerWorkflowArgument, extra) => {
       const { forestServerToken, renderingId } = getAuthContext(extra);
 
+      // We list workflows first to resolve the name/collection needed for the activity-log label
+      // (the trigger endpoint returns neither). The server also validates access at trigger time,
+      // so this lookup is primarily for enrichment; targeting the workflow by id directly would
+      // save a round-trip — tracked in PRD-831.
       const workflows = await forestServerClient.listMcpWorkflows({
         forestServerToken,
         renderingId,
       });
       const workflow = workflows.find(candidate => candidate.workflowId === args.workflowId);
 
+      // Rejected before withActivityLog: with no resolved workflow there is no collection to
+      // attach, and the server drops MCP activity logs that carry no resource (see PRD-49), so a
+      // pre-trigger rejection cannot be audited. Only real triggers are logged (incl. server-side
+      // 403/409, which fail inside withActivityLog below).
       if (!workflow) {
         throw new Error(
           `Workflow "${args.workflowId}" is not an MCP-enabled workflow you can access. ` +

--- a/packages/mcp-server/src/tools/trigger-workflow.ts
+++ b/packages/mcp-server/src/tools/trigger-workflow.ts
@@ -1,0 +1,67 @@
+import type { ToolContext } from '../tool-context';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { z } from 'zod';
+
+import getAuthContext from '../utils/auth-context';
+import registerToolWithLogging from '../utils/tool-with-logging';
+import withActivityLog from '../utils/with-activity-log';
+
+const WORKFLOW_ID_DESCRIPTION =
+  'The id of the workflow to start, as returned by listWorkflows. The workflow must have the MCP ' +
+  'trigger enabled.';
+
+const RECORD_ID_DESCRIPTION =
+  'The id of the record to run the workflow on. For collections with a composite primary key, ' +
+  'use the packed id form (values joined by "|").';
+
+interface TriggerWorkflowArgument {
+  workflowId: string;
+  recordId: string;
+}
+
+export default function declareTriggerWorkflowTool(mcpServer: McpServer, ctx: ToolContext): string {
+  const { forestServerClient, logger } = ctx;
+
+  return registerToolWithLogging(
+    mcpServer,
+    'triggerWorkflow',
+    {
+      title: 'Trigger a workflow',
+      description:
+        'Start an MCP-enabled Forest workflow on a specific record. Returns a runId immediately; ' +
+        'the run continues asynchronously — poll getWorkflowRun to observe its status. The record ' +
+        'is not validated at trigger time: an invalid record surfaces later via getWorkflowRun. ' +
+        'Discover triggerable workflows with listWorkflows first.',
+      inputSchema: {
+        workflowId: z.string().describe(WORKFLOW_ID_DESCRIPTION),
+        recordId: z.string().describe(RECORD_ID_DESCRIPTION),
+      },
+    },
+    async (args: TriggerWorkflowArgument, extra) => {
+      const { forestServerToken, renderingId } = getAuthContext(extra);
+
+      return withActivityLog({
+        forestServerClient,
+        request: extra,
+        action: 'triggerWorkflow',
+        context: {
+          recordId: args.recordId,
+          label: `triggered the workflow "${args.workflowId}"`,
+        },
+        logger,
+        operation: async () => {
+          const result = await forestServerClient.triggerWorkflow({
+            forestServerToken,
+            renderingId,
+            workflowId: args.workflowId,
+            recordId: args.recordId,
+          });
+
+          return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+        },
+      });
+    },
+    logger,
+  );
+}

--- a/packages/mcp-server/src/tools/trigger-workflow.ts
+++ b/packages/mcp-server/src/tools/trigger-workflow.ts
@@ -41,13 +41,27 @@ export default function declareTriggerWorkflowTool(mcpServer: McpServer, ctx: To
     async (args: TriggerWorkflowArgument, extra) => {
       const { forestServerToken, renderingId } = getAuthContext(extra);
 
+      const workflows = await forestServerClient.listMcpWorkflows({
+        forestServerToken,
+        renderingId,
+      });
+      const workflow = workflows.find(candidate => candidate.workflowId === args.workflowId);
+
+      if (!workflow) {
+        throw new Error(
+          `Workflow "${args.workflowId}" is not an MCP-enabled workflow you can access. ` +
+            'Use listWorkflows to discover triggerable workflows.',
+        );
+      }
+
       return withActivityLog({
         forestServerClient,
         request: extra,
         action: 'triggerWorkflow',
         context: {
+          collectionName: workflow.collectionName ?? undefined,
           recordId: args.recordId,
-          label: `triggered the workflow "${args.workflowId}"`,
+          label: `triggered the workflow "${workflow.name}"`,
         },
         logger,
         operation: async () => {

--- a/packages/mcp-server/src/utils/activity-logs-creator.ts
+++ b/packages/mcp-server/src/utils/activity-logs-creator.ts
@@ -24,6 +24,7 @@ const ACTION_TO_TYPE: Record<ActivityLogAction, ActivityLogType> = {
   delete: 'write',
   listRelatedData: 'read',
   describeCollection: 'read',
+  triggerWorkflow: 'write',
 };
 
 export default async function createPendingActivityLog(

--- a/packages/mcp-server/test/helpers/forest-server-client.ts
+++ b/packages/mcp-server/test/helpers/forest-server-client.ts
@@ -15,6 +15,7 @@ export default function createMockForestServerClient(
     }),
     updateActivityLogStatus: jest.fn().mockResolvedValue(undefined),
     listMcpWorkflows: jest.fn().mockResolvedValue([]),
+    triggerWorkflow: jest.fn().mockResolvedValue({ runId: 1, runState: 'loading' }),
     ...overrides,
   } as jest.Mocked<ForestServerClient>;
 }

--- a/packages/mcp-server/test/http-client/mcp-http-client.test.ts
+++ b/packages/mcp-server/test/http-client/mcp-http-client.test.ts
@@ -25,6 +25,7 @@ describe('ForestServerClientImpl', () => {
     };
     mockWorkflowsService = {
       listMcpEnabledWorkflows: jest.fn(),
+      triggerMcpWorkflow: jest.fn(),
     };
     client = new ForestServerClientImpl(
       mockSchemaService,
@@ -126,6 +127,25 @@ describe('ForestServerClientImpl', () => {
       expect(result).toBe(workflows);
     });
   });
+
+  describe('triggerWorkflow', () => {
+    it('should delegate to workflowsService.triggerMcpWorkflow()', async () => {
+      const run = { runId: 7, runState: 'loading' as const };
+      mockWorkflowsService.triggerMcpWorkflow.mockResolvedValue(run);
+
+      const params = {
+        forestServerToken: 'test-token',
+        renderingId: '12345',
+        workflowId: 'wf-1',
+        recordId: '42',
+      };
+
+      const result = await client.triggerWorkflow(params);
+
+      expect(mockWorkflowsService.triggerMcpWorkflow).toHaveBeenCalledWith(params);
+      expect(result).toBe(run);
+    });
+  });
 });
 
 describe('createForestServerClient', () => {
@@ -158,5 +178,6 @@ describe('createForestServerClient', () => {
     expect(client.createMcpActivityLog).toBeDefined();
     expect(client.updateActivityLogStatus).toBeDefined();
     expect(client.listMcpWorkflows).toBeDefined();
+    expect(client.triggerWorkflow).toBeDefined();
   });
 });

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -3192,6 +3192,7 @@ describe('enabledTools', () => {
         'getActionForm',
         'executeAction',
         'listWorkflows',
+        'triggerWorkflow',
       ],
     });
 

--- a/packages/mcp-server/test/tools/execute-action.test.ts
+++ b/packages/mcp-server/test/tools/execute-action.test.ts
@@ -20,6 +20,7 @@ const mockForestServerClient: ForestServerClient = {
   createMcpActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
   listMcpWorkflows: jest.fn(),
+  triggerWorkflow: jest.fn(),
 };
 
 const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction<

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -18,6 +18,7 @@ const mockForestServerClient: ForestServerClient = {
   createMcpActivityLog: jest.fn(),
   updateActivityLogStatus: jest.fn(),
   listMcpWorkflows: jest.fn(),
+  triggerWorkflow: jest.fn(),
 };
 
 const mockBuildClientWithActions = buildClientWithActions as jest.MockedFunction<

--- a/packages/mcp-server/test/tools/trigger-workflow.test.ts
+++ b/packages/mcp-server/test/tools/trigger-workflow.test.ts
@@ -111,6 +111,9 @@ describe('declareTriggerWorkflowTool', () => {
         logger: mockLogger,
         collectionNames: [],
       });
+      mockForestServerClient.listMcpWorkflows.mockResolvedValue([
+        { workflowId: 'wf-1', name: 'Refund order', collectionName: 'orders' },
+      ]);
       mockForestServerClient.triggerWorkflow.mockResolvedValue({ runId: 7, runState: 'loading' });
     });
 
@@ -133,7 +136,7 @@ describe('declareTriggerWorkflowTool', () => {
       });
     });
 
-    it('should wrap the trigger in an activity log for the triggerWorkflow action', async () => {
+    it('should wrap the trigger in an activity log carrying the resolved collection and record', async () => {
       await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
 
       expect(mockWithActivityLog).toHaveBeenCalledWith({
@@ -141,12 +144,30 @@ describe('declareTriggerWorkflowTool', () => {
         request: mockExtra,
         action: 'triggerWorkflow',
         context: {
+          collectionName: 'orders',
           recordId: '42',
-          label: 'triggered the workflow "wf-1"',
+          label: 'triggered the workflow "Refund order"',
         },
         logger: mockLogger,
         operation: expect.any(Function),
       });
+    });
+
+    it('should error without triggering when the workflow is not among accessible workflows', async () => {
+      mockForestServerClient.listMcpWorkflows.mockResolvedValue([
+        { workflowId: 'other-wf', name: 'Other', collectionName: 'orders' },
+      ]);
+
+      const result = await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(result).toEqual({
+        content: [
+          { type: 'text', text: expect.stringContaining('is not an MCP-enabled workflow') },
+        ],
+        isError: true,
+      });
+      expect(mockForestServerClient.triggerWorkflow).not.toHaveBeenCalled();
+      expect(mockWithActivityLog).not.toHaveBeenCalled();
     });
 
     it('should return an error result when the auth context is missing the token', async () => {

--- a/packages/mcp-server/test/tools/trigger-workflow.test.ts
+++ b/packages/mcp-server/test/tools/trigger-workflow.test.ts
@@ -1,0 +1,197 @@
+import type { ForestServerClient } from '../../src/http-client';
+import type { Logger } from '../../src/server';
+import type { RegisteredToolConfig } from '../helpers/registered-tool-config';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types';
+
+import { NotFoundError } from '@forestadmin/forestadmin-client';
+
+import declareTriggerWorkflowTool from '../../src/tools/trigger-workflow';
+import withActivityLog from '../../src/utils/with-activity-log';
+import createMockForestServerClient from '../helpers/forest-server-client';
+
+jest.mock('../../src/utils/with-activity-log');
+
+const mockLogger: Logger = jest.fn();
+const mockWithActivityLog = withActivityLog as jest.MockedFunction<typeof withActivityLog>;
+
+describe('declareTriggerWorkflowTool', () => {
+  let mcpServer: McpServer;
+  let mockForestServerClient: jest.Mocked<ForestServerClient>;
+  let registeredToolHandler: (args: unknown, extra: unknown) => Promise<unknown>;
+  let registeredToolConfig: RegisteredToolConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockForestServerClient = createMockForestServerClient();
+
+    mcpServer = {
+      registerTool: jest.fn((name, config, handler) => {
+        registeredToolConfig = config;
+        registeredToolHandler = handler;
+      }),
+    } as unknown as McpServer;
+
+    // By default, withActivityLog executes the operation and returns its result
+    mockWithActivityLog.mockImplementation(async options => options.operation());
+  });
+
+  describe('tool registration', () => {
+    it('should register a tool named "triggerWorkflow"', () => {
+      declareTriggerWorkflowTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
+
+      expect(mcpServer.registerTool).toHaveBeenCalledWith(
+        'triggerWorkflow',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should register tool with correct title and description', () => {
+      declareTriggerWorkflowTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
+
+      expect(registeredToolConfig.title).toBe('Trigger a workflow');
+      expect(registeredToolConfig.description).toContain('getWorkflowRun');
+    });
+
+    it('should not be annotated as read-only', () => {
+      declareTriggerWorkflowTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
+
+      expect(registeredToolConfig.annotations?.readOnlyHint).toBeUndefined();
+    });
+
+    it('should require string workflowId and recordId arguments', () => {
+      declareTriggerWorkflowTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
+
+      const schema = registeredToolConfig.inputSchema as Record<
+        string,
+        { parse: (value: unknown) => unknown }
+      >;
+
+      expect(() => schema.workflowId.parse('wf-1')).not.toThrow();
+      expect(() => schema.workflowId.parse(undefined)).toThrow();
+      expect(() => schema.recordId.parse('42')).not.toThrow();
+      expect(() => schema.recordId.parse(123)).toThrow();
+    });
+  });
+
+  describe('tool execution', () => {
+    const mockExtra = {
+      authInfo: {
+        token: 'test-token',
+        extra: {
+          forestServerToken: 'forest-token',
+          renderingId: 123,
+          environmentApiEndpoint: 'https://api.example.com',
+        },
+      },
+    } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+    beforeEach(() => {
+      declareTriggerWorkflowTool(mcpServer, {
+        forestServerClient: mockForestServerClient,
+        logger: mockLogger,
+        collectionNames: [],
+      });
+      mockForestServerClient.triggerWorkflow.mockResolvedValue({ runId: 7, runState: 'loading' });
+    });
+
+    it('should call triggerWorkflow with the identity from the auth context and the args', async () => {
+      await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(mockForestServerClient.triggerWorkflow).toHaveBeenCalledWith({
+        forestServerToken: 'forest-token',
+        renderingId: '123',
+        workflowId: 'wf-1',
+        recordId: '42',
+      });
+    });
+
+    it('should return the runId and runState as JSON text content', async () => {
+      const result = await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ runId: 7, runState: 'loading' }) }],
+      });
+    });
+
+    it('should wrap the trigger in an activity log for the triggerWorkflow action', async () => {
+      await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(mockWithActivityLog).toHaveBeenCalledWith({
+        forestServerClient: mockForestServerClient,
+        request: mockExtra,
+        action: 'triggerWorkflow',
+        context: {
+          recordId: '42',
+          label: 'triggered the workflow "wf-1"',
+        },
+        logger: mockLogger,
+        operation: expect.any(Function),
+      });
+    });
+
+    it('should return an error result when the auth context is missing the token', async () => {
+      const extraWithoutToken = {
+        authInfo: { extra: { renderingId: 123 } },
+      } as unknown as RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+      const result = await registeredToolHandler(
+        { workflowId: 'wf-1', recordId: '42' },
+        extraWithoutToken,
+      );
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: expect.stringContaining('forestServerToken') }],
+        isError: true,
+      });
+      expect(mockForestServerClient.triggerWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('should map a 409 already-ongoing run to an error tool result', async () => {
+      mockForestServerClient.triggerWorkflow.mockRejectedValue(
+        new Error('A run is already ongoing on this record'),
+      );
+
+      const result = await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(result).toEqual({
+        content: [
+          { type: 'text', text: expect.stringContaining('already ongoing on this record') },
+        ],
+        isError: true,
+      });
+    });
+
+    it('should map a 404 non-mcp-enabled workflow to an error tool result', async () => {
+      mockForestServerClient.triggerWorkflow.mockRejectedValue(
+        new NotFoundError('Workflow MCP trigger not found or disabled'),
+      );
+
+      const result = await registeredToolHandler({ workflowId: 'wf-1', recordId: '42' }, mockExtra);
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: expect.stringContaining('not found or disabled') }],
+        isError: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## MS6 — `triggerWorkflow` MCP tool

Exposes the `triggerWorkflow` tool so an LLM can start a run on a specific record and get a `runId` back. Non-blocking by design — the run continues server-side and status is observed via `getWorkflowRun` (MS8).

fixes PRD-738

### What's in it
- **New tool** `packages/mcp-server/src/tools/trigger-workflow.ts`: args `{ workflowId, recordId }`, identity from the OAuth auth context (`forestServerToken` + `renderingId`), wrapped in `withActivityLog` (action `triggerWorkflow`) so MCP-triggered runs get a local MCP audit entry under the caller.
- **forestadmin-client**: `WorkflowsService.triggerMcpWorkflow` + `ForestHttpApi` call the MS5 endpoint over HTTP (`POST /api/workflow-orchestrator/mcp-workflows/:workflowId/start`, body `{ recordId }`, `forest-rendering-id` header). No private-api internals imported.
- Server errors bubble up as tool errors (`isError: true`) with the server's message passed through — 404 (not MCP-enabled / unknown workflow), 409 (run already ongoing, no resume), 403 (unauthorized). No status-specific remapping is done client-side. `recordId` not validated at trigger time.
- `collectionId` is derived server-side (MS5, aligned on the webhook), so the tool contract stays `{ workflowId, recordId }`.

### Tests
mcp-server 631/631, forestadmin-client 292/292, lint clean.

### Stacking & dependencies
- **Stacked on #1771 (MS4 `listWorkflows`)** — this branch was cut from PRD-736 since its `WorkflowsService`/http-client plumbing isn't in the integration branch yet. Until #1771 merges into `feature/prd-49-…`, this PR's diff also shows the MS4 commit; it narrows to MS6-only afterwards. **Review/merge #1771 first.**
- Server-side counterpart **MS5 (PRD-737)** is a separate PR on `forestadmin-server`; needed for end-to-end. Unit tests here are mocked against the HTTP contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `triggerWorkflow` tool to the MCP server
> - Registers a new `triggerWorkflow` MCP tool in [server.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1777/files#diff-c54d7a276ef5be4d65ba37d55b279e77958ba4496af9d9ca7ec80c23c847d155) that lets agents trigger Forest Admin workflow runs, implemented in [trigger-workflow.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1777/files#diff-df0745de26b59fbb835bc787c153680f311d62b2586f5a339028dd92f5f81d53).
> - The tool validates the requested `workflowId` against the list of MCP-enabled workflows, then POSTs to `/api/workflow-orchestrator/mcp-workflows/{workflowId}/start` via a new `triggerMcpWorkflow` method on `WorkflowsService`.
> - Activity logs are emitted for each invocation, classified as `write` operations.
> - The HTTP path for `listMcpEnabledWorkflows` is updated from `/workflows` to `/mcp-workflows`.
> - Behavioral Change: `WorkflowsService.listMcpEnabledWorkflows` now throws if the configured transport does not implement the method, instead of calling undefined.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b0499c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
