### PR TITLE
feat(workflow-executor): surface widget options and field descriptions to the AI form-fill [PRD-809]

### DIFF
--- a/packages/agent-client/src/action-fields/action-field-multiple-choice.ts
+++ b/packages/agent-client/src/action-fields/action-field-multiple-choice.ts
@@ -4,7 +4,8 @@ import FieldGetter from './field-getter';
 
 export default class ActionFieldMultipleChoice extends FieldGetter {
   getOptions(): PlainFieldOption[] | undefined {
-    return this.getPlainField().widgetEdit?.parameters.static.options;
+    // Non-choice widgets emit `parameters` without a `static` key — guard the whole path.
+    return this.getPlainField().widgetEdit?.parameters?.static?.options;
   }
 
   getOption(label: string): PlainFieldOption | undefined {

--- a/packages/agent-client/src/action-fields/action-field.ts
+++ b/packages/agent-client/src/action-fields/action-field.ts
@@ -29,6 +29,10 @@ export default abstract class ActionField {
     return this.field?.getPlainField().isRequired;
   }
 
+  getPlainField() {
+    return this.field?.getPlainField();
+  }
+
   getMultipleChoiceField() {
     return this.fieldsFormStates.getMultipleChoiceField(this.name);
   }

--- a/packages/agent-client/test/action-fields/action-field-multiple-choice.test.ts
+++ b/packages/agent-client/test/action-fields/action-field-multiple-choice.test.ts
@@ -40,6 +40,19 @@ describe('ActionFieldMultipleChoice', () => {
 
       expect(field.getOptions()).toBeUndefined();
     });
+
+    it('should return undefined (not throw) for a non-choice widget whose parameters have no static', () => {
+      const plainField = {
+        field: 'testField',
+        type: 'String',
+        isRequired: false,
+        isReadOnly: false,
+        widgetEdit: { parameters: { placeholder: 'Type here' } },
+      } as unknown as PlainField;
+      const field = new ActionFieldMultipleChoice(plainField);
+
+      expect(field.getOptions()).toBeUndefined();
+    });
   });
 
   describe('getOption', () => {

--- a/packages/agent-client/test/action-fields/action-fields.test.ts
+++ b/packages/agent-client/test/action-fields/action-fields.test.ts
@@ -80,6 +80,32 @@ describe('ActionField implementations', () => {
     });
   });
 
+  describe('getPlainField', () => {
+    it('returns the underlying plain field', async () => {
+      await setupFields([
+        {
+          field: 'plan',
+          type: 'String',
+          isRequired: true,
+          isReadOnly: false,
+          description: 'Plan',
+          value: undefined,
+        },
+      ]);
+      const field = new ActionFieldString('plan', fieldFormStates);
+
+      expect(field.getPlainField()).toEqual(
+        expect.objectContaining({ field: 'plan', description: 'Plan' }),
+      );
+    });
+
+    it('returns undefined when the field is absent from the form', () => {
+      const field = new ActionFieldString('missing', fieldFormStates);
+
+      expect(field.getPlainField()).toBeUndefined();
+    });
+  });
+
   describe('ActionFieldCheckboxGroup', () => {
     const options = [
       { label: 'Option A', value: 'a' },

--- a/packages/mcp-server/src/tools/get-action-form.ts
+++ b/packages/mcp-server/src/tools/get-action-form.ts
@@ -12,6 +12,17 @@ interface GetActionFormArgument {
   values?: Record<string, unknown>;
 }
 
+// Options may be {value,label} objects or bare primitives — normalize to a consistent shape.
+function toAllowedValue(option: unknown): { value: string | number | null; label: string } {
+  if (option !== null && typeof option === 'object') {
+    const { value, label } = option as { value: string | number | null; label: string };
+
+    return { value, label };
+  }
+
+  return { value: option as string | number, label: String(option) };
+}
+
 export default function declareGetActionFormTool(mcpServer: McpServer, ctx: ToolContext): string {
   const { forestServerClient, logger, collectionNames } = ctx;
   const argumentShape = createActionArgumentShape(collectionNames);
@@ -32,7 +43,7 @@ Workflow:
 5. Only then call executeAction with the same values
 
 The response includes:
-- fields: Array of form fields with name, type, current value, isRequired flag, and enumValues (for Enum type fields)
+- fields: Array of form fields with name, type, current value, isRequired flag, description (hint), enumValues (Enum fields), and allowedValues (choice widgets — submit the value, not the label)
 - canExecute: Boolean indicating if all required fields have values (ready to execute)
 - requiredFields: Array of field names that are required but missing values (empty when canExecute is true)
 - skippedFields: Array of field names that were skipped because they no longer exist in the form (due to dynamic form behavior)`,
@@ -73,11 +84,13 @@ The response includes:
             type: 'text',
             text: JSON.stringify({
               fields: fields.map(field => {
+                const description = field.getPlainField()?.description;
                 const baseField = {
                   name: field.getName(),
                   type: field.getType(),
                   value: field.getValue(),
                   isRequired: field.isRequired() ?? false,
+                  ...(description ? { description } : {}),
                 };
 
                 if (field.getType() === 'Enum') {
@@ -86,7 +99,11 @@ The response includes:
                   return { ...baseField, enumValues: enumField.getOptions() ?? null };
                 }
 
-                return baseField;
+                const widgetOptions = field.getMultipleChoiceField().getOptions();
+
+                return widgetOptions?.length
+                  ? { ...baseField, allowedValues: widgetOptions.map(toAllowedValue) }
+                  : baseField;
               }),
               canExecute,
               requiredFields,

--- a/packages/mcp-server/test/tools/get-action-form.test.ts
+++ b/packages/mcp-server/test/tools/get-action-form.test.ts
@@ -305,12 +305,16 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => undefined,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
         {
           getName: () => 'message',
           getType: () => 'String',
           getValue: () => 'Default message',
           isRequired: () => false,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -352,12 +356,16 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => 'Test Subject',
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
         {
           getName: () => 'message',
           getType: () => 'String',
           getValue: () => 'Test Message',
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -390,12 +398,16 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => undefined,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
         {
           getName: () => 'message',
           getType: () => 'String',
           getValue: () => 'Test Message',
           isRequired: () => false,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -428,6 +440,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'Number',
           getValue: () => 0,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -460,6 +474,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'Boolean',
           getValue: () => false,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -492,6 +508,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => '',
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -524,6 +542,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => null,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -556,6 +576,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => undefined,
           isRequired: () => false,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -588,12 +610,16 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'Enum',
           getValue: () => undefined,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
         {
           getName: () => 'message',
           getType: () => 'String',
           getValue: () => undefined,
           isRequired: () => false,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -629,6 +655,73 @@ describe('declareGetActionFormTool', () => {
         { name: 'message', type: 'String', value: undefined, isRequired: false },
       ]);
       expect(mockGetEnumField).toHaveBeenCalledWith('status');
+    });
+
+    it('should return description and allowedValues for choice widget fields', async () => {
+      const mockFields = [
+        {
+          getName: () => 'plan',
+          getType: () => 'String',
+          getValue: () => undefined,
+          isRequired: () => true,
+          getPlainField: () => ({ description: 'Subscription plan' }),
+          getMultipleChoiceField: () => ({
+            getOptions: () => [
+              { label: 'Basic', value: 'basic' },
+              { label: 'Premium', value: 'premium' },
+            ],
+          }),
+        },
+        {
+          getName: () => 'priority',
+          getType: () => 'String',
+          getValue: () => undefined,
+          isRequired: () => false,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => ['low', 'high'] }),
+        },
+      ];
+      const mockGetFields = jest.fn().mockReturnValue(mockFields);
+      const mockTryToSetFields = jest.fn().mockResolvedValue([]);
+      const mockAction = jest.fn().mockResolvedValue({
+        getFields: mockGetFields,
+        tryToSetFields: mockTryToSetFields,
+      });
+      const mockCollection = jest.fn().mockReturnValue({ action: mockAction });
+      mockBuildClientWithActions.mockResolvedValue({
+        rpcClient: { collection: mockCollection },
+        authData: { userId: 1, renderingId: '123', environmentId: 1, projectId: 1 },
+      } as unknown as ReturnType<typeof buildClientWithActions>);
+
+      const result = await registeredToolHandler(
+        { collectionName: 'users', actionName: 'subscribe', recordIds: [1] },
+        mockExtra,
+      );
+
+      const parsedResult = JSON.parse((result as { content: { text: string }[] }).content[0].text);
+      expect(parsedResult.fields).toEqual([
+        {
+          name: 'plan',
+          type: 'String',
+          value: undefined,
+          isRequired: true,
+          description: 'Subscription plan',
+          allowedValues: [
+            { value: 'basic', label: 'Basic' },
+            { value: 'premium', label: 'Premium' },
+          ],
+        },
+        {
+          name: 'priority',
+          type: 'String',
+          value: undefined,
+          isRequired: false,
+          allowedValues: [
+            { value: 'low', label: 'low' },
+            { value: 'high', label: 'high' },
+          ],
+        },
+      ]);
     });
 
     it('should handle empty fields array', async () => {
@@ -668,6 +761,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => 'Test Subject',
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);
@@ -707,6 +802,8 @@ describe('declareGetActionFormTool', () => {
           getType: () => 'String',
           getValue: () => undefined,
           isRequired: () => true,
+          getPlainField: () => ({}),
+          getMultipleChoiceField: () => ({ getOptions: () => undefined }),
         },
       ];
       const mockGetFields = jest.fn().mockReturnValue(mockFields);

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -78,6 +78,17 @@ function restoreFieldNames(
   return Object.fromEntries(Object.entries(values).map(([k, v]) => [camelToOriginal[k] ?? k, v]));
 }
 
+// Options may be {value,label} objects or bare primitives — normalize to a consistent shape.
+function toAllowedValue(option: unknown): { value: string | number | null; label: string } {
+  if (option !== null && typeof option === 'object') {
+    const { value, label } = option as { value: string | number | null; label: string };
+
+    return { value, label };
+  }
+
+  return { value: option as string | number, label: String(option) };
+}
+
 export default class AgentClientAgentPort implements AgentPort {
   private readonly agentUrl: string;
   private readonly authSecret: string;
@@ -293,16 +304,26 @@ export default class AgentClientAgentPort implements AgentPort {
       const skippedFields = values ? await act.tryToSetFields(values) : [];
 
       const fields = act.getFields().map((field): ActionFormField => {
-        const base = {
+        const description = field.getPlainField()?.description;
+
+        const base: ActionFormField = {
           name: field.getName(),
           type: field.getType(),
           value: field.getValue(),
           isRequired: field.isRequired() ?? false,
+          ...(description ? { description } : {}),
         };
 
-        return field.getType() === 'Enum'
-          ? { ...base, enumValues: act.getEnumField(field.getName()).getOptions() ?? undefined }
-          : base;
+        if (field.getType() === 'Enum') {
+          return {
+            ...base,
+            enumValues: act.getEnumField(field.getName()).getOptions() ?? undefined,
+          };
+        }
+
+        const options = field.getMultipleChoiceField().getOptions();
+
+        return options?.length ? { ...base, allowedValues: options.map(toAllowedValue) } : base;
       });
 
       const requiredFields = fields

--- a/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
+++ b/packages/workflow-executor/src/executors/trigger-record-action-step-executor.ts
@@ -306,7 +306,16 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
     const fieldLines = form.fields
       .map(field => {
         const parts = [`- ${field.name} (${field.type}${field.isRequired ? ', required' : ''})`];
+        if (field.description) parts.push(`hint: ${field.description}`);
         if (field.enumValues?.length) parts.push(`allowed: ${field.enumValues.join(', ')}`);
+
+        if (field.allowedValues?.length) {
+          parts.push(
+            `allowed: ${field.allowedValues
+              .map(o => (String(o.value) === o.label ? String(o.value) : `${o.value} (${o.label})`))
+              .join(', ')}`,
+          );
+        }
 
         if (field.value !== undefined && field.value !== null) {
           parts.push(`current: ${JSON.stringify(field.value)}`);
@@ -321,7 +330,9 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
       description:
         'Provide values for the action form fields you have enough context to fill. ' +
         'Return a `values` object keyed by field name. Leave a field OUT entirely if you are ' +
-        'not sure — never guess or assume. For Enum fields use exactly one of the allowed values.',
+        'not sure — never guess or assume. For single-choice fields (Enum/dropdown/radio) submit ' +
+        'exactly one of the allowed values; for multi-select fields (checkboxes / list types) ' +
+        'submit an array of allowed values. Submit the value, not the label.',
       schema: z.object({
         values: z
           .record(z.string(), z.unknown())
@@ -351,6 +362,8 @@ export default class TriggerRecordActionStepExecutor extends RecordStepExecutor<
         required: field.isRequired,
         current: field.value,
         ...(field.enumValues?.length ? { allowed: field.enumValues } : {}),
+        ...(field.allowedValues?.length ? { allowed: field.allowedValues } : {}),
+        ...(field.description ? { hint: field.description } : {}),
       })),
       workflowContext: [contextMessage, ...previousStepsMessages].map(message => message.content),
     });

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -64,8 +64,10 @@ export type ActionFormField = {
   type: string;
   value?: unknown;
   isRequired: boolean;
-  // Allowed values for an Enum field — the AI must pick one of these or leave the field empty.
   enumValues?: string[];
+  // Choice-widget values (dropdown/radio/checkboxes); the AI submits `value`, `label` is for humans.
+  allowedValues?: { value: string | number | null; label: string }[];
+  description?: string;
 };
 
 export type ActionForm = {

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -928,12 +928,21 @@ describe('AgentClientAgentPort', () => {
   });
 
   describe('getActionForm', () => {
-    function makeField(over: { name: string; type?: string; value?: unknown; required?: boolean }) {
+    function makeField(over: {
+      name: string;
+      type?: string;
+      value?: unknown;
+      required?: boolean;
+      description?: string;
+      options?: unknown[];
+    }) {
       return {
         getName: () => over.name,
         getType: () => over.type ?? 'String',
         getValue: () => over.value,
         isRequired: () => over.required ?? false,
+        getPlainField: () => ({ description: over.description }),
+        getMultipleChoiceField: () => ({ getOptions: () => over.options }),
       };
     }
 
@@ -982,6 +991,51 @@ describe('AgentClientAgentPort', () => {
       expect(form.canExecute).toBe(true);
       expect(form.requiredFields).toEqual([]);
       expect(mockAction.tryToSetFields).not.toHaveBeenCalled();
+    });
+
+    it('surfaces widget options and descriptions, normalizing primitive options', async () => {
+      mockAction.getFields.mockReturnValue([
+        makeField({
+          name: 'plan',
+          type: 'String',
+          required: true,
+          description: 'Subscription plan',
+          options: [
+            { label: 'Basic', value: 'basic' },
+            { label: 'Premium', value: 'premium' },
+          ],
+        }),
+        makeField({ name: 'priority', type: 'String', options: ['low', 'high'] }),
+      ]);
+
+      const form = await port.getActionForm(
+        { collection: 'users', action: 'subscribe', id: [1] },
+        user,
+      );
+
+      expect(form.fields).toEqual([
+        {
+          name: 'plan',
+          type: 'String',
+          value: undefined,
+          isRequired: true,
+          description: 'Subscription plan',
+          allowedValues: [
+            { value: 'basic', label: 'Basic' },
+            { value: 'premium', label: 'Premium' },
+          ],
+        },
+        {
+          name: 'priority',
+          type: 'String',
+          value: undefined,
+          isRequired: false,
+          allowedValues: [
+            { value: 'low', label: 'low' },
+            { value: 'high', label: 'high' },
+          ],
+        },
+      ]);
     });
 
     it('builds the form against no record when the id is omitted (global action)', async () => {

--- a/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/trigger-record-action-step-executor.test.ts
@@ -1013,6 +1013,67 @@ describe('TriggerRecordActionStepExecutor', () => {
       );
     });
 
+    it('renders field descriptions and choice options in the AI fill prompt', async () => {
+      const agentPort = makeMockAgentPort();
+      (agentPort.getActionForm as jest.Mock)
+        .mockResolvedValueOnce({
+          fields: [
+            {
+              name: 'plan',
+              type: 'String',
+              isRequired: true,
+              description: 'Subscription plan',
+              allowedValues: [
+                { value: 'basic', label: 'Basic' },
+                { value: 'premium', label: 'Premium' },
+              ],
+            },
+            {
+              name: 'priority',
+              type: 'String',
+              isRequired: false,
+              allowedValues: [
+                { value: 'low', label: 'low' },
+                { value: 'high', label: 'high' },
+              ],
+            },
+          ],
+          canExecute: false,
+          requiredFields: ['plan'],
+          skippedFields: [],
+        })
+        .mockResolvedValueOnce({
+          fields: [{ name: 'plan', type: 'String', isRequired: true, value: 'basic' }],
+          canExecute: true,
+          requiredFields: [],
+          skippedFields: [],
+        });
+      const mockModel = makeMockModel({ values: { plan: 'basic' } }, 'fill_action_form');
+      const context = makeContext({
+        model: mockModel.model,
+        agentPort,
+        runStore: makeMockRunStore(),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: {
+            selectedRecordStepId: 'workflow-start',
+            actionName: 'send-welcome-email',
+          },
+        }),
+      });
+
+      await new TriggerRecordActionStepExecutor(context).execute();
+
+      const prompt = (mockModel.invoke.mock.calls[0][0] as { content: unknown }[])
+        .map(m => m.content)
+        .filter((c): c is string => typeof c === 'string')
+        .join('\n');
+      // object option → "value (label)"; primitive option (value === label) → bare value.
+      expect(prompt).toContain('hint: Subscription plan');
+      expect(prompt).toContain('allowed: basic (Basic), premium (Premium)');
+      expect(prompt).toContain('allowed: low, high');
+    });
+
     it('falls back to the AI-assisted review state when a required field stays empty', async () => {
       const agentPort = makeMockAgentPort();
       (agentPort.getActionForm as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Context
Follow-up to #1775 (now merged): agent-client builds static action forms from the schema, which now carries `widgetEdit`/`description`. This wires those through to the AI form-fill.

The executor's AI form-fill only received `{name, type, value, isRequired, enumValues}`. Two properties never reached the AI:
- **choice-widget options** (dropdown/radio/checkbox) — allowed values in `widgetEdit.parameters.static.options`, the functional twin of `enums`. Without them, required choice fields are unfillable → FullyAutomated steps fall back to pause.
- **`description`** — the admin-authored per-field hint.

Pre-existing limitation (the port dropped them even from the probe response), surfaced by the static-form move.

## Change
- **agent-client**: `ActionField.getPlainField()` passthrough (reuses `FieldGetter.getPlainField()`) → consumers read `description`/`widgetEdit` generically, no per-widget dispatch.
- **workflow-executor**: `ActionFormField` gains `description?` and `allowedValues?: {value,label}[]`; `getActionForm` maps them (options normalized — the schema also allows bare-primitive options); `askAiToFillForm` renders `hint:` and `allowed:` (AI submits the value, not the label).
- **mcp-server** `get-action-form`: mirrors the same field shape.

## Tests
- workflow-executor adapter: options + description surfaced, primitive options normalized, Enum path unchanged.
- mcp-server: same on the tool response.

fixes PRD-809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface widget options and field descriptions to AI form-fill prompts
> - Extends `ActionFormField` in [agent-port.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1778/files#diff-6a26a0f86a146665060c75502f9eb8cafd3880a779128d5a82d9020b1fab18cf) with `allowedValues` and `description` fields, and populates them in `AgentClientAgentPort.getActionForm` and the MCP `getActionForm` tool handler.
> - Adds `getPlainField()` to `ActionField` to expose field metadata (e.g. description), and fixes optional chaining in `ActionFieldMultipleChoice.getOptions` to avoid runtime errors on non-choice widgets.
> - Updates `TriggerRecordActionStepExecutor.askAiToFillForm` to include field descriptions as hints and format allowed values as `value (label)` in the AI prompt, with instructions distinguishing single-choice vs multi-select semantics and directing the model to submit values rather than labels.
> - Behavioral Change: AI-submitted field values for choice widgets may change as the model now receives structured value/label pairs and explicit submission instructions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b887396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->