### PR TITLE
fix(ai-proxy): exclude deprecated *-chat-latest OpenAI models

### DIFF
--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -42,6 +42,8 @@ const OPENAI_UNSUPPORTED_PATTERNS = [
   // Models that only support v1/responses, not v1/chat/completions
   '-pro',
   '-deep-research',
+  // Deprecated by OpenAI (return 404 on invocation): gpt-5-chat-latest, gpt-5.1-chat-latest
+  '-chat-latest',
 ];
 
 const OPENAI_UNSUPPORTED_MODELS = [


### PR DESCRIPTION
## Problem

The `LLM Integration Tests (ai-proxy)` job (`llm.integration.test.ts` → *all models should support tool calls*) fails on any PR because OpenAI **deprecated** `gpt-5-chat-latest` and `gpt-5.1-chat-latest`. These aliases are still returned by the `/models` list endpoint but now return `404 ... has been deprecated` when invoked, so they slip through `isModelSupportingTools` and make the test fail.

Example failure: https://github.com/ForestAdmin/agent-nodejs/actions/runs/30013576126/job/89429761208

## Fix

Add the `-chat-latest` pattern to `OPENAI_UNSUPPORTED_PATTERNS` in `packages/ai-proxy/src/supported-models.ts`. This excludes the deprecated `*-chat-latest` alias family (and any future ones) from the dynamically-fetched model list, following the file's existing convention ("If a model fails the llm.integration test, add it here").

Unrelated to any feature work — this unblocks CI for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude deprecated `-chat-latest` OpenAI models in ai-proxy
> Adds `'-chat-latest'` to the `OPENAI_UNSUPPORTED_PATTERNS` array in [supported-models.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1779/files#diff-c8703b3b65d1492f147178cbdc7ea897138fe0c4fe9c842993d4141d7a8a6cd3), so any model name containing that substring is classified as unsupported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 413d19f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->