### PR TITLE
chore(ci): dont cancel releases job to prevent skipped publishes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,14 @@ jobs:
   release:
     name: Release packages
     runs-on: ubuntu-latest
+    # Serialize releases per branch so concurrent merges can't run multi-semantic-release
+    # in parallel: an overlapping run sees the branch as "behind remote" and silently skips
+    # publishing. cancel-in-progress must stay false — a release must never be interrupted
+    # mid-publish. The tip run (github.sha == branch head, matching the sha-keyed dist cache)
+    # then drains the whole pending backlog.
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     needs: [build-api-reference, send-coverage, lint]
     if: |
       github.event_name == 'push'


### PR DESCRIPTION
## Problem

`build.yml` has no `concurrency` key, so **Release packages** jobs from successive merges can overlap, and `multi-semantic-release` skips any run whose checkout is no longer the branch tip (`The local branch main is behind the remote one, therefore a new version won't be published`).

### Verified forensics of today's incident (2026-07-24)

- 08:28 — #1776 merged → its release run publishes `agent@1.90.0`, `agent-testing@1.1.55`, `forest-cloud@1.12.154` cleanly.
- 08:42 — #1778 merged (`feat(workflow-executor)`, PRD-809).
- 08:43 — #1779 merged (`fix(ai-proxy)`).
- #1778's release job: checkout `d6d937103`, but tip was already `ff6589fcf` → **behind → skips all 23 packages** → `workflow-executor@1.22.0` not published.
- 08:50–08:52 — #1779's release job **attempt 1** (at tip, running concurrently with #1778's): releases ai-proxy partway — pushes release commit `f7abb4b08` + tag `@forestadmin/ai-proxy@1.12.2` — then `npm publish` fails with a transient sigstore error (`TLOG_CREATE_ENTRY_ERROR`, 409) → **the package never reached npm** → msr aborts before workflow-executor → job failure.
- 08:55 — **attempt 2** (re-run): checkout is frozen at `ff6589fcf` but remote now has `f7abb4b08` → behind → `Released 0 of 23` → job green.

Net: npm has `ai-proxy@1.12.1` and `workflow-executor@1.21.1`; git has a ghost tag `ai-proxy@1.12.2`; main is green.

## Fix (this PR)

Per-branch `concurrency` group on the `release` job, `cancel-in-progress: false` — release runs serialize instead of overlapping, and a release is never interrupted mid-publish.

## What this deliberately does NOT do

- **No `ref:` tip checkout / no `git reset`**: the dist cache is keyed by `github.sha` (`fail-on-cache-miss: true`); releasing from another ref would publish stale artifacts.
- **Does not fix the re-run trap** (structural): a re-run of a partially-released job can never publish — its checkout sha is frozen while its own attempt-1 pushes moved the tip. **After a failed release, do not re-run: push a new commit (or merge the next PR) instead.**
- **Does not fix the ghost release**: `@forestadmin/ai-proxy@1.12.2` is tagged in git but absent from npm; semantic-release now considers it released and will never publish it. Needs a manual decision (publish from the tag manually, drop the tag so it re-releases, or fold it into the next ai-proxy release).

## Effect on the current backlog

Merging this PR is a push to `main`: its release run (serialized, at tip) will publish the pending `@forestadmin/workflow-executor@1.22.0` (verified: no 1.22.0 tag exists, feat is pending) and dispatch the Docker image build. It will NOT resurrect `ai-proxy@1.12.2` (see ghost release above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
