### PR TITLE
feat(workflow-executor): accept approval request id on native trigger submit

### DIFF
--- a/packages/workflow-executor/src/http/pending-data-validators.ts
+++ b/packages/workflow-executor/src/http/pending-data-validators.ts
@@ -26,6 +26,12 @@ const triggerActionPatchSchema = z
     // Whether the native submit actually executed the action, or only created an approval request
     // (non-blocking): downstream AI steps must be told an awaiting-approval action did NOT run.
     submissionOutcome: z.enum(['executed', 'pending-approval']).optional(),
+    // The approval request the native submit filed, when submissionOutcome is 'pending-approval'.
+    // Persisted so the run panel can deep-link to it (parity with the Full-AI path).
+    approvalRequest: z
+      .object({ id: z.string().min(1) })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/packages/workflow-executor/test/http/pending-data-validators.test.ts
+++ b/packages/workflow-executor/test/http/pending-data-validators.test.ts
@@ -125,6 +125,30 @@ describe('patchBodySchemas', () => {
       expect(parsed).toEqual({ userConfirmed: false });
     });
 
+    it('accepts a pending-approval submit carrying the approval request id', () => {
+      const parsed = schema.parse({
+        userConfirmed: true,
+        submissionOutcome: 'pending-approval',
+        approvalRequest: { id: 'appr-1' },
+      });
+
+      expect(parsed).toEqual({
+        userConfirmed: true,
+        submissionOutcome: 'pending-approval',
+        approvalRequest: { id: 'appr-1' },
+      });
+    });
+
+    it('rejects an approvalRequest with an empty id', () => {
+      expect(() => schema.parse({ userConfirmed: true, approvalRequest: { id: '' } })).toThrow();
+    });
+
+    it('rejects extra keys inside approvalRequest (strict)', () => {
+      expect(() =>
+        schema.parse({ userConfirmed: true, approvalRequest: { id: 'a', extra: 'leak' } }),
+      ).toThrow();
+    });
+
     it('rejects unknown fields (strict schema)', () => {
       expect(() =>
         schema.parse({ userConfirmed: true, actionResult: {}, extra: 'leak' }),


### PR DESCRIPTION
## What

Let a frontend-native (manual / AI-assisted) Trigger Action submit carry the id of the approval request it just filed, so the workflow run panel can deep-link to it — **parity with the Full-AI path**, where the executor files the approval and its id already flows through the step outcome.

`triggerActionPatchSchema` (pending-data validator) now accepts an optional, strict `approvalRequest: { id }`. It's persisted verbatim in `userConfirmation` (via `saveFrontendResult`'s `...existingExecution`), so `GET /runs/:runId` returns it and the front renders the copiable link.

## Why

PRD-688 specced "note + copiable link to the approval request" but only wired it for Full AI. In manual / AI-assisted the front creates the approval natively and had no way to hand its id to the executor (the strict validator rejected the field), so the run panel showed "This action requires approval…" **without the link**. This closes that gap.

## Compatibility

Optional field — older frontends that don't send it are unaffected. The paired frontend change (forestadmin PR #9860) sends the id but **retries without it** if an older executor rejects the payload, so deploy order is not load-bearing.

## Tests

`pending-data-validators.test.ts`: accepts a pending-approval submit with `approvalRequest.id`; rejects an empty id and extra keys (strict).

fixes PRD-820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept optional `approvalRequest` id on native trigger submit
> Adds an optional `approvalRequest` field to the `triggerActionPatchSchema` validator in [pending-data-validators.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1782/files#diff-3ea7ed8e1b0fbeae14884ba0498905c951e4a071e80bac7cb8408ab76d912198). When present, the field must be a strict object with a non-empty string `id`; payloads with an empty `id` or extra keys are rejected. New tests cover acceptance and rejection cases for this field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 292e9ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->