### PR TITLE
fix(workflow-executor): accept triggerType='mcp' in run mapper (PRD-832)

### DIFF
--- a/packages/workflow-executor/src/adapters/server-types.ts
+++ b/packages/workflow-executor/src/adapters/server-types.ts
@@ -191,6 +191,7 @@ export type ServerWorkflowRunState = 'started' | 'pending' | 'loading' | 'aborte
 export enum ServerWorkflowTriggerType {
   manual = 'manual',
   webhook = 'webhook',
+  mcp = 'mcp',
 }
 
 export interface ServerHydratedWorkflowRun {

--- a/packages/workflow-executor/src/types/validated/execution.ts
+++ b/packages/workflow-executor/src/types/validated/execution.ts
@@ -34,6 +34,7 @@ export type Step = z.infer<typeof StepSchema>;
 export enum TriggerType {
   Manual = 'manual',
   Webhook = 'webhook',
+  Mcp = 'mcp',
 }
 export const TriggerTypeSchema = z.nativeEnum(TriggerType);
 

--- a/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/run-to-available-step-mapper.test.ts
@@ -135,6 +135,14 @@ describe('toAvailableStepExecution', () => {
     expect(result?.triggerType).toBe(TriggerType.Webhook);
   });
 
+  it('should map an mcp-triggered run without failing validation', () => {
+    const run = makeRun({ triggerType: ServerWorkflowTriggerType.mcp });
+
+    const result = toAvailableStepExecution(run);
+
+    expect(result?.triggerType).toBe(TriggerType.Mcp);
+  });
+
   it('should default triggerType to manual when the orchestrator omits it', () => {
     const run = makeRun();
     delete run.triggerType;


### PR DESCRIPTION
## Description

Foundational fix for MCP workflow triggering (epic PRD-49).

A workflow run triggered via MCP carries `triggerType='mcp'`, but `@forestadmin/workflow-executor` only recognized `manual | webhook`. The run mapper validates the value against `AvailableStepExecutionSchema`, so **every MCP-triggered run failed at step 0** before executing:

```
error Malformed run reported as error runId="438" stepIndex=0
error="Run 438 mapper produced invalid AvailableStepExecution — triggerType: Invalid option: expected one of \"manual\"|\"webhook\""
```

Surfaced in the Forest UI as:
> Internal validation error occurred while preparing the step. Please contact support.

## Root cause

`triggerType` is **informational only** in the executor — its sole consumer is a Debug log context in `runner.ts`; no execution logic branches on it. The run was aborted purely because of an unrecognized value in a logged field.

## Fix

- `TriggerType` (`src/types/validated/execution.ts`) — add `Mcp = 'mcp'`
- `ServerWorkflowTriggerType` (`src/adapters/server-types.ts`) — add `mcp = 'mcp'`

Strict-enum approach, consistent with the executor's convention of mirroring the server contract. Unknown trigger types still fail loudly.

## Tests

Added a mapper test asserting an `mcp`-triggered run maps to a valid `AvailableStepExecution` with `triggerType` preserved (no downgrade to `manual`). Full suite green (1469 passed), lint clean.

## Notes

- Discovered while testing the MCP discover → trigger → poll flow end-to-end; unblocks PRD-740 validation.
- Follow-up idea: since `triggerType` is only logged, a drift-tolerant passthrough could avoid breaking on future server trigger types (`scheduled`, `api`, …).

fixes PRD-832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept `triggerType='mcp'` in workflow executor run mapper
> Adds `mcp` as a valid trigger type across the workflow executor by adding `Mcp = 'mcp'` to the `TriggerType` enum in [execution.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1786/files#diff-4285c4446f54a92ba0eafad2ebd1674b1b7b8283bea9f35ade68be87c332f207) and `mcp` to `ServerWorkflowTriggerType` in [server-types.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1786/files#diff-ff5d89f06fdc29dabcde5d6a100c90127ba5f27c6f9c06b58d427de3adce72dc). The run-to-available-step mapper now correctly maps `ServerWorkflowTriggerType.mcp` to `TriggerType.Mcp`, covered by a new test case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 249bbb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->