### PR TITLE
fix(workflow-executor): carry the collection name on step error logs

### DIFF
--- a/packages/workflow-executor/src/executors/base-step-executor.ts
+++ b/packages/workflow-executor/src/executors/base-step-executor.ts
@@ -39,18 +39,12 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   }
 
   async execute(): Promise<StepExecutionResult> {
-    const { baseRecordRef } = this.context;
-
     this.context.logger('Debug', 'Step context', {
       ...this.logCtx,
-      collection: baseRecordRef.collectionName,
       stepInput: this.context.stepDefinition,
     });
 
-    this.context.logger('Info', 'Step execution started', {
-      ...this.logCtx,
-      collection: baseRecordRef.collectionName,
-    });
+    this.context.logger('Info', 'Step execution started', this.logCtx);
 
     try {
       // Idempotency guard — mutating executors override this. Runs before doExecute so a cache
@@ -391,13 +385,14 @@ export default abstract class BaseStepExecutor<TStep extends StepDefinition = St
   }
 
   protected get logCtx() {
-    const { runId, stepId, stepIndex, stepDefinition } = this.context;
+    const { runId, stepId, stepIndex, stepDefinition, baseRecordRef } = this.context;
 
     return {
       runId,
       stepId,
       stepIndex,
       stepType: stepDefinition.type,
+      collection: baseRecordRef.collectionName,
       ...this.getExtraLogContext(),
     };
   }


### PR DESCRIPTION
Companion to ForestAdmin/forestadmin-server#8415 (PRD-842).

## Why

A client's step error logs are the **only** place the server's technical message surfaces. The operator deliberately sees a generic *"This step couldn't be completed…"*, so when a step fails for a schema reason, the client's own tech diagnoses it from these logs — `base-step-executor` logs `error.message` plus `cause` and `stack` at `Error` level for every `WorkflowExecutorError`, which includes every `WorkflowPortError`.

Those logs carried `runId`, `stepId`, `stepIndex` and `stepType` — but **not the collection**, even though the `Debug` and `Info` logs did. On exactly the failure this came from (*"collection X has no usable primary key"*) the collection is the one field you want to filter on.

## What changed

`collection` moves **into `logCtx`** rather than being added to each `catch` branch. That way it reaches all three error sites at once — timeout, `WorkflowExecutorError`, unexpected — and any log site added later gets it for free, which is how it came to be missing in the first place.

The two `Debug`/`Info` call sites that spread it manually are simplified accordingly, so there is one source of truth.

`baseRecordRef` is non-optional on `ExecutionContext` (`execution-context.ts:29`), so the getter cannot throw while logging an error — worth stating since it now runs on the error path.

## Verification

- `tsc --noEmit` clean.
- Full suite: **1469 passed**. Two SQLite store suites timed out in `beforeEach` on the full run (259s, loaded machine) and **pass in isolation in 17s** — unrelated to a log-context getter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BaseStepExecutor` to include collection name in step error logs
> Moves the `collection` field into the `logCtx` getter in [base-step-executor.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1791/files#diff-f2629617b13363027748d444be5374dd404d26c2f031b0b1a967cceb01d6c6d9) so it is available to all log calls, including error logs. Previously, `collection` was only added manually to the 'Step execution started' log and was absent from other log invocations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ec9d2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->