### PR TITLE
fix(agent-bff): wrap action errors in the standard error envelope

### DIFF
--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -19,7 +19,12 @@ import {
   requireAgentToken,
   resolveReadModel,
 } from '../http/agent-route-helpers';
-import { actionRequiresApproval, invalidRequest, unknownAction } from '../http/bff-local-errors';
+import {
+  actionError,
+  actionRequiresApproval,
+  invalidRequest,
+  unknownAction,
+} from '../http/bff-local-errors';
 
 const ACTION_ROUTE = /^\/agent\/v1\/([^/]+)\/actions\/([^/]+)\/(form|execute)$/;
 
@@ -134,10 +139,7 @@ async function handleExecute(
     }
 
     if (error instanceof ActionFormValidationError) {
-      ctx.status = 400;
-      ctx.body = { type: 'error', status: 400, message: error.message, html: error.html ?? null };
-
-      return;
+      throw actionError(error.message, error.html !== undefined ? { html: error.html } : undefined);
     }
 
     throw mapAgentError(error, { logger });

--- a/packages/agent-bff/src/http/bff-local-errors.ts
+++ b/packages/agent-bff/src/http/bff-local-errors.ts
@@ -40,6 +40,10 @@ export function unsupportedActionResult(message = 'Unsupported action result'): 
   return new BffHttpError(501, 'unsupported_action_result', message);
 }
 
+export function actionError(message = 'The action failed', details?: unknown): BffHttpError {
+  return new BffHttpError(400, 'action_error', message, details);
+}
+
 export function actionRequiresApproval(
   message = 'This action requires an approval before it can run',
   details?: unknown,

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -525,7 +525,7 @@ describe('action execute', () => {
     );
   });
 
-  it('renders a native action Error as HTTP 400 with the forwarded html', async () => {
+  it('wraps a native action Error in the error envelope, carrying html in details', async () => {
     const form = makeAction({
       execute: jest.fn(async () => {
         throw new ActionFormValidationError('Refund failed', '<strong>Nope</strong>');
@@ -538,14 +538,16 @@ describe('action execute', () => {
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
-      type: 'error',
-      status: 400,
-      message: 'Refund failed',
-      html: '<strong>Nope</strong>',
+      error: {
+        type: 'action_error',
+        status: 400,
+        message: 'Refund failed',
+        details: { html: '<strong>Nope</strong>' },
+      },
     });
   });
 
-  it('defaults html to null on the error body when the action Error carries none', async () => {
+  it('omits details entirely when the action Error carries no html', async () => {
     const form = makeAction({
       execute: jest.fn(async () => {
         throw new ActionFormValidationError('Refund failed');
@@ -558,11 +560,21 @@ describe('action execute', () => {
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
-      type: 'error',
-      status: 400,
-      message: 'Refund failed',
-      html: null,
+      error: { type: 'action_error', status: 400, message: 'Refund failed' },
     });
+    expect(Object.keys(response.body.error)).not.toContain('details');
+  });
+
+  it('keeps a successful action result flat, discriminated by body.type', async () => {
+    const form = makeAction({ execute: jest.fn(async () => ({ success: 'Refunded' })) });
+
+    const response = await request(execApp(clientOf(form)).callback())
+      .post('/agent/v1/users/actions/approve/execute')
+      .send({ recordIds: ['42'] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.type).toBe('success');
+    expect(response.body.error).toBeUndefined();
   });
 
   it('rejects an unknown submitted field as 400 invalid_request', async () => {


### PR DESCRIPTION
fixes PRD-867

## Problem

Every BFF failure goes out in the shared envelope. Except one. A native action error
(`resultBuilder.error(...)`) came out flat, no wrapper:

```json
{ "type": "error", "status": 400, "message": "SAR already filed", "html": "<strong>…</strong>" }
```

Everything else:

```json
{ "error": { "type": "unknown_field", "status": 422, "message": "..." } }
```

PRD-641 says the Zendesk client branches on `error.type`. That branch never fires here.
`response.error` is `undefined`, so the client skips it and reads a business failure as a success. The
agent's message and its `html` are dropped. Nothing crashes, the result is just wrong.

Found during the PRD-674 manual QA, against a real agent.

## Root cause

`action-routes-middleware.ts` assigned `ctx.status` / `ctx.body` by hand for
`ActionFormValidationError`. That bypasses `toErrorBody`, the function that owns the envelope shape.
That is how the two shapes drifted apart.

## Fix

Throw a `BffHttpError` instead of writing the body. The error middleware runs it through
`toErrorBody`, so this response cannot drift again:

```json
{ "error": { "type": "action_error", "status": 400, "message": "...", "details": { "html": "..." } } }
```

The agent's `html` rides in `details`, the envelope's only extension point.

`toErrorBody` already omits `details` when undefined, and `ActionFormValidationError.html` is already
optional. So "key absent, not `null`" needed no extra code. The old `?? null` was what forced the
explicit `null`.

## Scope

Unchanged: the four other action result shapes. `success`, `webhook`, `redirect` stay flat on
`body.type`. `unsupported_action_result` (501) was already enveloped. A new test pins a success as
flat, so nobody wraps the rest by accident.

Breaking change, taken on purpose. `type: "error"` was one of five action result shapes and two tests
asserted it. Uniformising costs that symmetry: a failure now reads `body.error.type` while the other
outcomes read `body.type`. What it buys is one error path in the client instead of two. Free today
because no consumer exists. After PRD-678 writes the Zendesk client it breaks a shipped integration.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test
```

On an action whose `execute` returns `resultBuilder.error(msg, { html })`:

| | Body |
| --- | --- |
| before | `{ type: "error", status: 400, message, html }` |
| after | `{ error: { type: "action_error", status: 400, message, details: { html } } }` |

Manually, through the PRD-674 QA suite (`qa-execute-e2e.sh` section 8, updated to assert the envelope
and no top-level `type`): an already-filed SAR returns the enveloped 400, and the same action on an
unfiled SAR still returns 200. So the error branch is what gets exercised, not a permanently broken
action.

## Validation

- 706 tests / 54 suites pass, lint clean.
- Reverted the fix, re-ran the three new tests: 2 fail. They discriminate instead of passing both ways.
- `macroscope codereview` against `origin/main`: completed, zero findings.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
