### PR TITLE
feat(agent-bff): mint an agent token from the OAuth principal

### DIFF
--- a/packages/agent-bff/src/api-key/agent-token.ts
+++ b/packages/agent-bff/src/api-key/agent-token.ts
@@ -17,34 +17,61 @@ export interface IssueAgentTokenFromPrincipalParams {
   authSecret: string;
 }
 
+const POSITIVE_INTEGER = /^[1-9]\d*$/;
+
 function tagsToRecord(tags: { key: string; value: string }[]): Record<string, string> {
   return tags.reduce((memo, { key, value }) => ({ ...memo, [key]: value }), {});
 }
 
-export function issueAgentToken({ identity, authSecret }: IssueAgentTokenParams): string {
-  const { user, renderingId } = identity;
-  const firstName = user.firstName ?? '';
-  const lastName = user.lastName ?? '';
-  const tags = tagsToRecord(user.tags);
+interface AgentCallerClaims {
+  id: number;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  team: string;
+  renderingId: number;
+  tags: Record<string, string>;
+  permissionLevel: string;
+  role?: string;
+}
 
-  // snake_case aliases: Ruby/Python agents splat JWT claims into Caller (snake_case kwargs).
+function signWithSnakeCaseAliasesForRubyAndPythonAgents(
+  claims: AgentCallerClaims,
+  authSecret: string,
+): string {
+  const firstName = claims.firstName ?? '';
+  const lastName = claims.lastName ?? '';
+
   return jsonwebtoken.sign(
     {
-      id: user.id,
-      email: user.email,
+      ...claims,
       firstName,
       lastName,
-      team: user.team,
-      renderingId,
-      tags,
-      permissionLevel: user.permissionLevel,
       first_name: firstName,
       last_name: lastName,
-      rendering_id: renderingId,
-      permission_level: user.permissionLevel,
+      rendering_id: claims.renderingId,
+      permission_level: claims.permissionLevel,
     },
     authSecret,
     { algorithm: 'HS256', expiresIn: AGENT_TOKEN_EXPIRES_IN },
+  );
+}
+
+export function issueAgentToken({ identity, authSecret }: IssueAgentTokenParams): string {
+  const { user, renderingId } = identity;
+
+  return signWithSnakeCaseAliasesForRubyAndPythonAgents(
+    {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      team: user.team,
+      renderingId,
+      tags: tagsToRecord(user.tags),
+      permissionLevel: user.permissionLevel,
+    },
+    authSecret,
   );
 }
 
@@ -52,32 +79,22 @@ export function issueAgentTokenFromPrincipal({
   principal,
   authSecret,
 }: IssueAgentTokenFromPrincipalParams): string {
-  const renderingId = Number(principal.rendering_id);
-
-  if (!Number.isInteger(renderingId)) {
+  if (!POSITIVE_INTEGER.test(String(principal.rendering_id))) {
     throw unauthorized('The session carries no usable rendering');
   }
 
-  const firstName = principal.first_name ?? '';
-  const lastName = principal.last_name ?? '';
-
-  return jsonwebtoken.sign(
+  return signWithSnakeCaseAliasesForRubyAndPythonAgents(
     {
       id: principal.id,
       email: principal.email,
-      firstName,
-      lastName,
+      firstName: principal.first_name,
+      lastName: principal.last_name,
       team: principal.team,
-      renderingId,
+      renderingId: Number(principal.rendering_id),
       tags: principal.tags ?? {},
       permissionLevel: principal.permission_level,
       role: principal.role,
-      first_name: firstName,
-      last_name: lastName,
-      rendering_id: renderingId,
-      permission_level: principal.permission_level,
     },
     authSecret,
-    { algorithm: 'HS256', expiresIn: AGENT_TOKEN_EXPIRES_IN },
   );
 }

--- a/packages/agent-bff/src/api-key/agent-token.ts
+++ b/packages/agent-bff/src/api-key/agent-token.ts
@@ -1,4 +1,5 @@
 import type { ResolvedApiKeyIdentity } from './api-key-client';
+import type { BffAccessTokenPayload } from '../oauth/bff-token';
 
 import jsonwebtoken from 'jsonwebtoken';
 
@@ -6,6 +7,11 @@ export const AGENT_TOKEN_EXPIRES_IN = '5m';
 
 export interface IssueAgentTokenParams {
   identity: ResolvedApiKeyIdentity;
+  authSecret: string;
+}
+
+export interface IssueAgentTokenFromPrincipalParams {
+  principal: BffAccessTokenPayload;
   authSecret: string;
 }
 
@@ -34,6 +40,34 @@ export function issueAgentToken({ identity, authSecret }: IssueAgentTokenParams)
       last_name: lastName,
       rendering_id: renderingId,
       permission_level: user.permissionLevel,
+    },
+    authSecret,
+    { algorithm: 'HS256', expiresIn: AGENT_TOKEN_EXPIRES_IN },
+  );
+}
+
+export function issueAgentTokenFromPrincipal({
+  principal,
+  authSecret,
+}: IssueAgentTokenFromPrincipalParams): string {
+  const renderingId = Number(principal.rendering_id);
+  const firstName = principal.first_name ?? '';
+  const lastName = principal.last_name ?? '';
+
+  return jsonwebtoken.sign(
+    {
+      id: principal.id,
+      email: principal.email,
+      firstName,
+      lastName,
+      team: principal.team,
+      renderingId,
+      tags: principal.tags ?? {},
+      permissionLevel: principal.permission_level,
+      first_name: firstName,
+      last_name: lastName,
+      rendering_id: renderingId,
+      permission_level: principal.permission_level,
     },
     authSecret,
     { algorithm: 'HS256', expiresIn: AGENT_TOKEN_EXPIRES_IN },

--- a/packages/agent-bff/src/api-key/agent-token.ts
+++ b/packages/agent-bff/src/api-key/agent-token.ts
@@ -3,6 +3,8 @@ import type { BffAccessTokenPayload } from '../oauth/bff-token';
 
 import jsonwebtoken from 'jsonwebtoken';
 
+import { unauthorized } from '../http/bff-http-error';
+
 export const AGENT_TOKEN_EXPIRES_IN = '5m';
 
 export interface IssueAgentTokenParams {
@@ -51,6 +53,11 @@ export function issueAgentTokenFromPrincipal({
   authSecret,
 }: IssueAgentTokenFromPrincipalParams): string {
   const renderingId = Number(principal.rendering_id);
+
+  if (!Number.isInteger(renderingId)) {
+    throw unauthorized('The session carries no usable rendering');
+  }
+
   const firstName = principal.first_name ?? '';
   const lastName = principal.last_name ?? '';
 
@@ -64,6 +71,7 @@ export function issueAgentTokenFromPrincipal({
       renderingId,
       tags: principal.tags ?? {},
       permissionLevel: principal.permission_level,
+      role: principal.role,
       first_name: firstName,
       last_name: lastName,
       rendering_id: renderingId,

--- a/packages/agent-bff/src/auth/auth-mode-middleware.ts
+++ b/packages/agent-bff/src/auth/auth-mode-middleware.ts
@@ -4,6 +4,7 @@ import type { Middleware } from 'koa';
 import jsonwebtoken from 'jsonwebtoken';
 
 import { extractBearerToken, resolveAuthMode } from './auth-mode';
+import { issueAgentTokenFromPrincipal } from '../api-key/agent-token';
 import { sessionExpired, unauthorized } from '../http/bff-http-error';
 import { BFF_ACCESS_TOKEN_TYPE } from '../oauth/bff-token';
 
@@ -61,7 +62,10 @@ export default function createAuthModeMiddleware({
     ctx.state.authMode = mode;
 
     if (mode === 'oauth') {
-      ctx.state.principal = verifyBffAccess(bearer as string, authSecret);
+      const principal = verifyBffAccess(bearer as string, authSecret);
+      ctx.state.principal = principal;
+      ctx.state.agentToken = issueAgentTokenFromPrincipal({ principal, authSecret });
+      ctx.set('Cache-Control', 'no-store');
     }
 
     await next();

--- a/packages/agent-bff/src/http/agent-route-helpers.ts
+++ b/packages/agent-bff/src/http/agent-route-helpers.ts
@@ -25,9 +25,6 @@ export async function resolveReadModel(store: ReadModelStore): Promise<ReadModel
   }
 }
 
-// The agent token is minted only on the API-key path; the OAuth path sets a principal but no agent
-// token yet. Fail closed instead of calling the agent with `Bearer undefined`.
-// TODO(PRD-637): mint an agent token from the OAuth principal so agent routes work in OAuth mode.
 export function requireAgentToken(ctx: Context): string {
   const token = ctx.state.agentToken as string | undefined;
   if (!token) throw unauthorized('No agent credentials for this request');

--- a/packages/agent-bff/src/oauth/bff-token.ts
+++ b/packages/agent-bff/src/oauth/bff-token.ts
@@ -23,6 +23,7 @@ export interface BffAccessTokenPayload {
   team: string;
   rendering_id: string;
   permission_level: string;
+  role: string;
   tags: Record<string, string>;
 }
 
@@ -43,6 +44,7 @@ export function issueBffAccessToken({
     team: user.team,
     rendering_id: String(renderingId),
     permission_level: user.permissionLevel,
+    role: user.role,
     tags: user.tags ?? {},
   };
 

--- a/packages/agent-bff/src/oauth/bff-token.ts
+++ b/packages/agent-bff/src/oauth/bff-token.ts
@@ -23,7 +23,7 @@ export interface BffAccessTokenPayload {
   team: string;
   rendering_id: string;
   permission_level: string;
-  role: string;
+  role?: string;
   tags: Record<string, string>;
 }
 

--- a/packages/agent-bff/test/api-key/agent-token.test.ts
+++ b/packages/agent-bff/test/api-key/agent-token.test.ts
@@ -136,13 +136,26 @@ describe('issueAgentTokenFromPrincipal', () => {
     expect(claims.sid).toBeUndefined();
   });
 
-  it('should fail closed when rendering_id is not a usable integer', () => {
-    expect(() =>
-      issueAgentTokenFromPrincipal({
-        principal: { ...PRINCIPAL, rendering_id: 'not-a-number' },
-        authSecret: AUTH_SECRET,
-      }),
-    ).toThrow(expect.objectContaining({ status: 401, type: 'unauthorized' }));
+  it.each([['not-a-number'], [''], ['0'], ['-1'], ['0x11'], ['1e3'], ['1.5'], [' 17 ']])(
+    'should fail closed when rendering_id is %p',
+    raw => {
+      expect(() =>
+        issueAgentTokenFromPrincipal({
+          principal: { ...PRINCIPAL, rendering_id: raw },
+          authSecret: AUTH_SECRET,
+        }),
+      ).toThrow(expect.objectContaining({ status: 401, type: 'unauthorized' }));
+    },
+  );
+
+  it('should omit the role claim entirely when the session predates it', () => {
+    const { role, ...withoutRole } = PRINCIPAL;
+    const token = issueAgentTokenFromPrincipal({
+      principal: withoutRole as typeof PRINCIPAL,
+      authSecret: AUTH_SECRET,
+    });
+
+    expect(jsonwebtoken.verify(token, AUTH_SECRET)).not.toHaveProperty('role');
   });
 
   it('should coerce missing names and tags rather than emitting undefined', () => {

--- a/packages/agent-bff/test/api-key/agent-token.test.ts
+++ b/packages/agent-bff/test/api-key/agent-token.test.ts
@@ -1,10 +1,25 @@
 import type { ResolvedApiKeyIdentity } from '../../src/api-key/api-key-client';
+import type { BffAccessTokenPayload } from '../../src/oauth/bff-token';
 
 import jsonwebtoken from 'jsonwebtoken';
 
-import { issueAgentToken } from '../../src/api-key/agent-token';
+import { issueAgentToken, issueAgentTokenFromPrincipal } from '../../src/api-key/agent-token';
 
 const AUTH_SECRET = 'auth-secret';
+
+const PRINCIPAL: BffAccessTokenPayload = {
+  type: 'bff_access',
+  sid: 'session-1',
+  id: 42,
+  email: 'ada@example.com',
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  team: 'Support',
+  rendering_id: '17',
+  permission_level: 'admin',
+  role: 'Support agent',
+  tags: { region: 'eu' },
+};
 
 const IDENTITY: ResolvedApiKeyIdentity = {
   user: {
@@ -71,6 +86,82 @@ describe('issueAgentToken', () => {
       lastName: '',
       first_name: '',
       last_name: '',
+    });
+  });
+});
+
+describe('issueAgentTokenFromPrincipal', () => {
+  it('should expire 5 minutes after issuance, like the api-key path', () => {
+    const token = issueAgentTokenFromPrincipal({ principal: PRINCIPAL, authSecret: AUTH_SECRET });
+    const decoded = jsonwebtoken.decode(token) as { iat: number; exp: number };
+
+    expect(decoded.exp - decoded.iat).toBe(300);
+  });
+
+  it('should send rendering_id as a number, since Caller.renderingId is numeric', () => {
+    const token = issueAgentTokenFromPrincipal({ principal: PRINCIPAL, authSecret: AUTH_SECRET });
+
+    expect(jsonwebtoken.verify(token, AUTH_SECRET)).toMatchObject({
+      renderingId: 17,
+      rendering_id: 17,
+    });
+  });
+
+  it('should emit the api-key claims plus the OAuth role', () => {
+    const fromKey = jsonwebtoken.verify(
+      issueAgentToken({ identity: IDENTITY, authSecret: AUTH_SECRET }),
+      AUTH_SECRET,
+    ) as Record<string, unknown>;
+    const fromPrincipal = jsonwebtoken.verify(
+      issueAgentTokenFromPrincipal({ principal: PRINCIPAL, authSecret: AUTH_SECRET }),
+      AUTH_SECRET,
+    ) as Record<string, unknown>;
+
+    const claimNames = (claims: Record<string, unknown>) =>
+      Object.keys(claims)
+        .filter(name => name !== 'iat' && name !== 'exp')
+        .sort();
+
+    expect(claimNames(fromPrincipal)).toEqual([...claimNames(fromKey), 'role'].sort());
+    expect(fromPrincipal.role).toBe('Support agent');
+  });
+
+  it('should never forward the session-only type and sid claims', () => {
+    const claims = jsonwebtoken.verify(
+      issueAgentTokenFromPrincipal({ principal: PRINCIPAL, authSecret: AUTH_SECRET }),
+      AUTH_SECRET,
+    ) as Record<string, unknown>;
+
+    expect(claims.type).toBeUndefined();
+    expect(claims.sid).toBeUndefined();
+  });
+
+  it('should fail closed when rendering_id is not a usable integer', () => {
+    expect(() =>
+      issueAgentTokenFromPrincipal({
+        principal: { ...PRINCIPAL, rendering_id: 'not-a-number' },
+        authSecret: AUTH_SECRET,
+      }),
+    ).toThrow(expect.objectContaining({ status: 401, type: 'unauthorized' }));
+  });
+
+  it('should coerce missing names and tags rather than emitting undefined', () => {
+    const token = issueAgentTokenFromPrincipal({
+      principal: {
+        ...PRINCIPAL,
+        first_name: undefined as unknown as string,
+        last_name: undefined as unknown as string,
+        tags: undefined as unknown as Record<string, string>,
+      },
+      authSecret: AUTH_SECRET,
+    });
+
+    expect(jsonwebtoken.verify(token, AUTH_SECRET)).toMatchObject({
+      firstName: '',
+      lastName: '',
+      first_name: '',
+      last_name: '',
+      tags: {},
     });
   });
 });

--- a/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
+++ b/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
@@ -17,11 +17,12 @@ const PRINCIPAL = {
   team: 'Ops',
   rendering_id: '42',
   permission_level: 'admin',
+  role: 'Support agent',
   tags: { seat: 'a1' },
 };
 
 function bffAccess(expiresIn: string | number, type = 'bff_access') {
-  return jsonwebtoken.sign({ type, ...PRINCIPAL }, AUTH_SECRET, {
+  return jsonwebtoken.sign({ ...PRINCIPAL, type }, AUTH_SECRET, {
     algorithm: 'HS256',
     expiresIn,
   } as jsonwebtoken.SignOptions);
@@ -99,11 +100,37 @@ describe('auth mode middleware', () => {
       lastName: 'Doe',
       team: 'Ops',
       permissionLevel: 'admin',
+      role: 'Support agent',
       tags: { seat: 'a1' },
       first_name: 'Jane',
       last_name: 'Doe',
       permission_level: 'admin',
     });
+  });
+
+  it('rejects a minted agent token presented back as a session bearer', async () => {
+    const minted = (
+      await request(buildApp())
+        .get('/agent/x')
+        .set('Authorization', `Bearer ${bffAccess('15m')}`)
+    ).body.agentToken;
+
+    const replay = await request(buildApp())
+      .get('/agent/x')
+      .set('Authorization', `Bearer ${minted}`);
+
+    expect(replay.status).toBe(401);
+    expect(replay.body.error.type).toBe('unauthorized');
+  });
+
+  it('expires the agent token after AGENT_TOKEN_EXPIRES_IN', async () => {
+    const response = await request(buildApp())
+      .get('/agent/x')
+      .set('Authorization', `Bearer ${bffAccess('15m')}`);
+
+    const claims = decodeAgentToken(response.body.agentToken);
+
+    expect((claims.exp as number) - (claims.iat as number)).toBe(5 * 60);
   });
 
   it('sends rendering_id to the agent as a number, matching Caller.renderingId', async () => {
@@ -125,7 +152,7 @@ describe('auth mode middleware', () => {
     expect(response.body.cacheControl).toBe('no-store');
   });
 
-  it('mints no agent token when no credential is presented', async () => {
+  it('does not mint an agent token on the api-key branch', async () => {
     const response = await request(buildApp()).get('/agent/x').set(BFF_KEY_HEADER, RAW_KEY);
 
     expect(response.body.agentToken).toBeNull();

--- a/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
+++ b/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
@@ -8,8 +8,20 @@ import createErrorMiddleware from '../../src/http/error-middleware';
 const AUTH_SECRET = 'test-secret';
 const RAW_KEY = `fbff_${'a'.repeat(16)}_${'b'.repeat(64)}`;
 
+const PRINCIPAL = {
+  sid: 's1',
+  id: 7,
+  email: 'jane@example.com',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  team: 'Ops',
+  rendering_id: '42',
+  permission_level: 'admin',
+  tags: { seat: 'a1' },
+};
+
 function bffAccess(expiresIn: string | number, type = 'bff_access') {
-  return jsonwebtoken.sign({ type, sid: 's1' }, AUTH_SECRET, {
+  return jsonwebtoken.sign({ type, ...PRINCIPAL }, AUTH_SECRET, {
     algorithm: 'HS256',
     expiresIn,
   } as jsonwebtoken.SignOptions);
@@ -22,10 +34,21 @@ function buildApp() {
   app.use(createAuthModeMiddleware({ authSecret: AUTH_SECRET }));
   app.use(async ctx => {
     ctx.status = 200;
-    ctx.body = { authMode: ctx.state.authMode };
+    ctx.body = {
+      authMode: ctx.state.authMode,
+      agentToken: ctx.state.agentToken ?? null,
+      cacheControl: ctx.response.get('Cache-Control') || null,
+    };
   });
 
   return app.callback();
+}
+
+function decodeAgentToken(token: string) {
+  return jsonwebtoken.verify(token, AUTH_SECRET, { algorithms: ['HS256'] }) as Record<
+    string,
+    unknown
+  >;
 }
 
 describe('auth mode middleware', () => {
@@ -60,6 +83,52 @@ describe('auth mode middleware', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.authMode).toBe('oauth');
+  });
+
+  it('mints an agent token from the principal so agent routes work in oauth mode', async () => {
+    const response = await request(buildApp())
+      .get('/agent/x')
+      .set('Authorization', `Bearer ${bffAccess('15m')}`);
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body.agentToken).toBe('string');
+    expect(decodeAgentToken(response.body.agentToken)).toMatchObject({
+      id: 7,
+      email: 'jane@example.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      team: 'Ops',
+      permissionLevel: 'admin',
+      tags: { seat: 'a1' },
+      first_name: 'Jane',
+      last_name: 'Doe',
+      permission_level: 'admin',
+    });
+  });
+
+  it('sends rendering_id to the agent as a number, matching Caller.renderingId', async () => {
+    const response = await request(buildApp())
+      .get('/agent/x')
+      .set('Authorization', `Bearer ${bffAccess('15m')}`);
+
+    const claims = decodeAgentToken(response.body.agentToken);
+
+    expect(claims.renderingId).toBe(42);
+    expect(claims.rendering_id).toBe(42);
+  });
+
+  it('marks an oauth response no-store, since it carries a minted credential', async () => {
+    const response = await request(buildApp())
+      .get('/agent/x')
+      .set('Authorization', `Bearer ${bffAccess('15m')}`);
+
+    expect(response.body.cacheControl).toBe('no-store');
+  });
+
+  it('mints no agent token when no credential is presented', async () => {
+    const response = await request(buildApp()).get('/agent/x').set(BFF_KEY_HEADER, RAW_KEY);
+
+    expect(response.body.agentToken).toBeNull();
   });
 
   it('accepts a lowercase bearer scheme (auth schemes are case-insensitive)', async () => {

--- a/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
+++ b/packages/agent-bff/test/auth/auth-mode-middleware.test.ts
@@ -144,7 +144,7 @@ describe('auth mode middleware', () => {
     expect(claims.rendering_id).toBe(42);
   });
 
-  it('marks an oauth response no-store, since it carries a minted credential', async () => {
+  it('marks an oauth response no-store, mirroring the api-key branch', async () => {
     const response = await request(buildApp())
       .get('/agent/x')
       .set('Authorization', `Bearer ${bffAccess('15m')}`);

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -190,7 +190,10 @@ describe('runCli', () => {
           .set('X-Forest-Timezone', 'Europe/Paris')
           .send({});
 
-        expect(response.body.error?.type).not.toBe('unauthorized');
+        expect(response.status).toBe(503);
+        expect(response.body.error).toEqual(
+          expect.objectContaining({ type: 'schema_unavailable', status: 503 }),
+        );
       } finally {
         await server.stop();
       }

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -145,10 +145,11 @@ describe('runCli', () => {
     });
 
     it('should let an oauth Bearer request through the guard to timezone resolution', async () => {
-      const token = jsonwebtoken.sign({ type: 'bff_access' }, VALID_ENV.FOREST_AUTH_SECRET, {
-        algorithm: 'HS256',
-        expiresIn: '15m',
-      });
+      const token = jsonwebtoken.sign(
+        { type: 'bff_access', sid: 's1', rendering_id: '1', tags: {} },
+        VALID_ENV.FOREST_AUTH_SECRET,
+        { algorithm: 'HS256', expiresIn: '15m' },
+      );
       const server = await runCli({ ...VALID_ENV, FOREST_ENV_SECRET: undefined }, noopLogger);
 
       try {
@@ -158,6 +159,38 @@ describe('runCli', () => {
 
         expect(response.status).toBe(400);
         expect(response.body.error.type).toBe('missing_timezone');
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should carry an oauth Bearer past requireAgentToken on a data route', async () => {
+      const token = jsonwebtoken.sign(
+        {
+          type: 'bff_access',
+          sid: 's1',
+          id: 1,
+          email: 'a@b.c',
+          first_name: 'A',
+          last_name: 'B',
+          team: 'T',
+          rendering_id: '1',
+          permission_level: 'admin',
+          tags: {},
+        },
+        VALID_ENV.FOREST_AUTH_SECRET,
+        { algorithm: 'HS256', expiresIn: '15m' },
+      );
+      const server = await runCli(VALID_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/users/list')
+          .set('Authorization', `Bearer ${token}`)
+          .set('X-Forest-Timezone', 'Europe/Paris')
+          .send({});
+
+        expect(response.body.error?.type).not.toBe('unauthorized');
       } finally {
         await server.stop();
       }

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -4,12 +4,12 @@ import request from 'supertest';
 import createPerKeyOriginMiddleware from '../../src/cors/per-key-origin';
 import createErrorMiddleware from '../../src/http/error-middleware';
 
-function buildApp(allowedOrigins: string[]) {
+function buildApp(allowedOrigins?: string[]) {
   const app = new Koa();
   app.silent = true;
   app.use(createErrorMiddleware({ logger: () => undefined }));
   app.use(async (ctx, next) => {
-    ctx.state.apiKeyIdentity = { allowedOrigins };
+    if (allowedOrigins !== undefined) ctx.state.apiKeyIdentity = { allowedOrigins };
     await next();
   });
   app.use(createPerKeyOriginMiddleware());
@@ -63,5 +63,14 @@ describe('per-key origin middleware (layer 2)', () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error.type).toBe('origin_not_allowed');
+  });
+
+  it('does not restrict an oauth request, which carries no per-key identity', async () => {
+    const response = await request(buildApp().callback())
+      .get('/agent/x')
+      .set('Origin', 'https://anything.com');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ reached: true });
   });
 });

--- a/packages/agent-bff/test/oauth/bff-token.test.ts
+++ b/packages/agent-bff/test/oauth/bff-token.test.ts
@@ -44,6 +44,7 @@ describe('bff-token', () => {
       expect(payload.last_name).toBe('Lovelace');
       expect(payload.rendering_id).toBe('17');
       expect(payload.permission_level).toBe('admin');
+      expect(payload.role).toBe('Admin');
       expect(payload.tags).toEqual({ plan: 'pro' });
     });
 
@@ -79,7 +80,7 @@ describe('bff-token', () => {
     it('should not leak any non-whitelisted user field into the payload', () => {
       const token = issueBffAccessToken({
         sid: 'sid-4',
-        user: { ...USER, role: 'SHOULD-NOT-LEAK' as string } as UserInfo,
+        user: { ...USER, secret: 'SHOULD-NOT-LEAK' } as UserInfo,
         renderingId: 17,
         authSecret: AUTH_SECRET,
         expiresInSeconds: 900,


### PR DESCRIPTION
fixes PRD-866

## Problem

OAuth `bff_access` tokens authenticate successfully, but Mode 1 requests fail on agent routes because no downstream agent token is created.

## Fix

- Mint an agent token from the validated OAuth principal.
- Preserve the caller identity, including `role`, permissions, tags, and numeric `renderingId`.
- Map claims explicitly and exclude session-only `type` and `sid` claims.
- Fail closed when the principal has no usable rendering.
- Add regression coverage for OAuth routing, token claims, expiry, replay, and Mode 2 compatibility.

## Scope and safety

- Changes are limited to `packages/agent-bff`.
- No SaaS round-trip is added.
- Mode 2 API-key authentication is unchanged.
- Session and CORS behavior outside the agent chain is unchanged.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test
yarn workspace @forestadmin/agent-bff build
yarn workspace @forestadmin/agent-bff lint
```

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
