### PR TITLE
feat(forestadmin-client): export the permission evaluator

### DIFF
--- a/packages/forestadmin-client/src/index.ts
+++ b/packages/forestadmin-client/src/index.ts
@@ -37,11 +37,22 @@ export { IpWhitelistConfiguration } from './ip-whitelist/types';
 // These types are used for the agent-generator package
 export {
   CollectionActionEvent,
+  CustomActionEvent,
   EnvironmentPermissionsV4,
   RenderingPermissionV4,
   UserPermissionV4,
 } from './permissions/types';
 export { UserInfo } from './auth/types';
+
+export { default as generateActionsFromPermissions } from './permissions/generate-actions-from-permissions';
+export {
+  ActionPermission,
+  ActionPermissions,
+} from './permissions/generate-actions-from-permissions';
+export {
+  generateCollectionActionIdentifier,
+  generateCustomActionIdentifier,
+} from './permissions/generate-action-identifier';
 
 export default function createForestAdminClient(
   options: ForestAdminClientOptions,

--- a/packages/forestadmin-client/test/permissions/generate-actions-from-permissions.test.ts
+++ b/packages/forestadmin-client/test/permissions/generate-actions-from-permissions.test.ts
@@ -29,6 +29,28 @@ describe('generateActionsFromPermissions', () => {
     });
   });
 
+  describe('when a collection descriptor is missing a CRUD flag', () => {
+    it('should throw rather than resolve the missing flag to a denial', () => {
+      const generate = () =>
+        generateActionsFromPermissions({
+          collections: {
+            'collection-id': {
+              collection: {
+                addEnabled: true,
+                browseEnabled: true,
+                editEnabled: true,
+                exportEnabled: true,
+                readEnabled: true,
+              },
+              actions: {},
+            },
+          },
+        } as unknown as Parameters<typeof generateActionsFromPermissions>[0]);
+
+      expect(generate).toThrow(TypeError);
+    });
+  });
+
   describe('when rights are set by collection', () => {
     describe('collection access rights', () => {
       describe('globally allowed', () => {


### PR DESCRIPTION
fixes PRD-682

`forestadmin-client` now exports the permission evaluator, so the BFF can call it instead of carrying a copy.

This replaces the original approach on this branch. The first version forked the evaluator into `agent-bff` and added a sha256 drift gate to detect divergence from upstream. Exporting it is strictly less code: no copy, no gate, no re-review every time upstream moves. The fork had no consumer outside #1804, so switching cost nothing.

## New public exports

| Symbol | Kind |
| -- | -- |
| `generateActionsFromPermissions` | function (default export of its module) |
| `ActionPermissions`, `ActionPermission` | types |
| `generateCollectionActionIdentifier`, `generateCustomActionIdentifier` | functions |
| `CustomActionEvent` | enum, added to the existing value-export block |

Additive only. Nothing existing was removed or renamed. `CollectionActionEvent` was already exported.

## The characterization test

A CRUD descriptor missing a flag slips through the `typeof !== 'boolean'` filter and then crashes reading `.roles`. That crash is pre-existing upstream behavior and this PR does not change it. The payload is unreachable in production: the SaaS always sends all six descriptors.

The test pins the crash so nobody guards it away by accident. It is what replaces the deleted drift gate, and I checked it is not vacuous: guarding the crash locally makes it fail with "Received function did not throw", then I reverted.

If you would rather see the crash fixed than pinned, that is a separate PR on upstream, not this one.

## Scope

Only `forestadmin-client`. No agent-bff code here. The consumer side is #1804, stacked on this branch.

## How to test

```bash
yarn workspace @forestadmin/forestadmin-client build
yarn workspace @forestadmin/forestadmin-client test
yarn workspace @forestadmin/forestadmin-client lint
```

284 tests pass, lint clean. Note the build: dependent packages resolve this one through `dist/`, so the new exports are invisible to them until it runs.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
