### PR TITLE
chore(security): patch 5 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "**/@forestadmin/mcp-server/express/body-parser": "^2.3.0",
     "**/@forestadmin/ai-proxy/express/body-parser": "^2.3.0",
     "**/@modelcontextprotocol/sdk/express/body-parser": "^2.3.0",
-    "**/@nestjs/platform-express/express/body-parser": "^2.3.0"
+    "**/@nestjs/platform-express/express/body-parser": "^2.3.0",
+    "**/@nestjs/platform-fastify/find-my-way": "^9.7.0"
   }
 }

--- a/packages/_example/package.json
+++ b/packages/_example/package.json
@@ -24,7 +24,7 @@
     "fastify4": "npm:fastify@^4.29.0",
     "koa": "^3.0.1",
     "mariadb": "^3.0.2",
-    "mongoose": "8.22.1",
+    "mongoose": "8.24.1",
     "mysql2": "^3.0.1",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13",

--- a/packages/datasource-mongo/package.json
+++ b/packages/datasource-mongo/package.json
@@ -15,7 +15,7 @@
     "@forestadmin/datasource-mongoose": "1.14.0",
     "@forestadmin/datasource-toolkit": "1.54.0",
     "json-stringify-pretty-compact": "^3.0.0",
-    "mongoose": "8.22.1",
+    "mongoose": "8.24.1",
     "tunnel-ssh": "^5.2.0"
   },
   "files": [

--- a/packages/datasource-mongoose/package.json
+++ b/packages/datasource-mongoose/package.json
@@ -20,7 +20,7 @@
     "luxon": "^3.2.1"
   },
   "devDependencies": {
-    "mongoose": "8.22.1"
+    "mongoose": "8.24.1"
   },
   "peerDependencies": {
     "mongoose": "6.x || 7.x || 8.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8607,10 +8607,10 @@ finalhandler@~1.3.1:
     statuses "~2.0.2"
     unpipe "~1.0.0"
 
-find-my-way@9.6.0, find-my-way@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-9.6.0.tgz#d8e78d98d02ba749c86526edaca780c094073313"
-  integrity sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==
+find-my-way@9.6.0, find-my-way@^9.6.0, find-my-way@^9.7.0:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-9.7.0.tgz#e33ea02bcaf4199a24eea3faa9926985dee4de58"
+  integrity sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-querystring "^1.0.0"
@@ -12670,10 +12670,10 @@ mongodb@~6.20.0:
     bson "^6.10.4"
     mongodb-connection-string-url "^3.0.2"
 
-mongoose@8.22.1:
-  version "8.22.1"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.22.1.tgz#6b873d88b883c9b283e2a3b94cdc541d108ea94a"
-  integrity sha512-c0bzt7ElI1CwWiyFSgg9bfhlFcblAoPwr+gmDcLCryClyKaeixWhP9KDGnr13kRPE8KPAuUN3ZZ3jSDxSPvoTg==
+mongoose@8.24.1:
+  version "8.24.1"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.24.1.tgz#d0a79544353777e15f5a51ece25b127c4695427c"
+  integrity sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==
   dependencies:
     bson "^6.10.4"
     kareem "2.6.3"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary
2 fixed, 0 ignored, 17 deferred, 1 resolutions added, 0 resolutions removed, 0 could-not-auto-fix. | label: :lock: security applied

## Fixed
| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [ ] | [#442](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/442) | mongoose | npm | 8.22.1 → 8.24.1 | medium | direct dep in `packages/datasource-mongo`, `packages/datasource-mongoose` and `packages/_example` (`mongoose` pin) — lockfile alert cleared by the same bump |
| - [ ] | [#440](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/440) | mongoose | npm | 8.22.1 → 8.24.1 | medium | direct dep in `packages/datasource-mongoose/package.json` |
| - [ ] | [#439](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/439) | mongoose | npm | 8.22.1 → 8.24.1 | medium | direct dep in `packages/datasource-mongo/package.json` |
| - [ ] | [#438](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/438) | mongoose | npm | 8.22.1 → 8.24.1 | medium | direct dep in `packages/_example/package.json` |
| - [ ] | [#437](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/437) | find-my-way | npm | 9.6.0 → 9.7.0 | high | scoped root resolution `**/@nestjs/platform-fastify/find-my-way` → `^9.7.0` (`@nestjs/platform-fastify@11.1.28` pins `find-my-way "9.6.0"` exactly, so a resolution is the only way to move it without a nestjs bump) |

## Ignored
None.

## Deferred
Opened less than 7 days ago (2026-08-06 run):
[#446](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/446),
[#449](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/449),
[#450](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/450),
[#451](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/451),
[#452](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/452),
[#454](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/454),
[#455](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/455),
[#456](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/456),
[#457](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/457),
[#458](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/458),
[#459](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/459),
[#460](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/460),
[#461](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/461),
[#462](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/462),
[#463](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/463),
[#464](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/464),
[#465](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/465).

## Resolutions added
| Alert | Package + pinned range | Parent chain tried | Why the bump wasn't viable | Form |
|---|---|---|---|---|
| [#437](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/437) | `find-my-way` → `^9.7.0` | `@nestjs/platform-fastify@11.1.28` → `find-my-way "9.6.0"` (exact pin on 9.6.0, not a range) | The parent pins `find-my-way` at exactly `9.6.0`; no available `@nestjs/platform-fastify` release ships `find-my-way >= 9.7.0` yet, so an ancestor bump can't reach the patched version. A repo-wide `find-my-way` pin would break the legacy `fastify`/`fastify2`/`fastify4` alias dev-deps (they require the incompatible v4/v2/v8 majors), so the fix is scoped to the `@nestjs/platform-fastify` subtree. | scoped |

## Resolutions removed
None. A spot-check of `lodash` confirmed its pin is still load-bearing (removing it lets `forest-cli` pull `lodash@4.17.23`, which does not satisfy the original `^4.18.0` pin), so a full audit was deferred to a follow-up rather than churn each entry blindly in this run.

## Could not auto-fix
None from this run. Note: three legacy `find-my-way` versions (`2.2.5`, `4.5.1`, `8.2.2`) also fall inside GHSA-c96f-x56v-gq3h's reported range `<= 9.6.0`, but they are pulled in exclusively by the `fastify`/`fastify2`/`fastify4` aliased dev-deps in `packages/agent` (devDependencies, used by the framework-mounter unit/integration tests) and `packages/_example` (demo app). No production package depends on those older majors, and no upstream patch exists for them (`first_patched_version` for GHSA-c96f-x56v-gq3h is `9.7.0`, in the v9 line only). If Dependabot keeps alert 437 open after this merge due to those legacy versions, it'll be surfaced on the next run — the practical (nestjs-served) attack surface is already patched by the resolution above.

## Risks
- **mongoose 8.22.1 → 8.24.1**: patch/minor jump inside 8.x. 8.24 does not touch model definition APIs used by `datasource-mongo` (schema-inference / OdmBuilder) or `datasource-mongoose` (BaseCollection bridge); primary changes are updates to bson deps and a fix to the prototype-pollution vector in update casting. No test changes expected.
- **find-my-way 9.6.0 → 9.7.0**: patch bump, `fastify@5.10.0` declares `find-my-way ^9.6.0` so `9.7.0` is in-range. The fix is a router-lookup guard against inherited-object-property method names on HTTP/2; behavior for regular HTTP routing is unchanged.

## Manual testing
Covered by CI.

## Validation
✅ CI green (Actions + commit statuses; app-based checks not monitored)
