### PR TITLE
chore(deps): dedupe zod to a single v4 resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "**/forest-cli/joi": "^17.13.4",
     "axios": "^1.18.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "4.3.6",
     "**/@hono/node-server": "^2.0.5",
     "**/@forestadmin/agent/express/body-parser": "^1.20.6",
     "**/@fastify/express/express/body-parser": "^1.20.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17903,15 +17903,10 @@ zod-to-json-schema@^3.25.1:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
   integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
-zod@4.3.6:
+zod@4.3.6, "zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4", zod@^4.3.5:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
-
-"zod@^3.25 || ^4.0", "zod@^3.25.76 || ^4", zod@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
-  integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Pins `zod` to one v4 resolution via the root `resolutions` block. Lockfile drops from two v4 entries (4.3.6, 4.3.5) to one, single copy on disk at 4.3.6. No source code touched.

fixes PRD-888

## Why

`agent-bff` and `workflow-executor` pin `4.3.6` exact, `ai-proxy` and `mcp-server` ask `^4.3.5`. Nothing is broken today. It breaks the moment something takes zod as a **peer** dep: yarn v1 binds it to whichever copy sits at the root while `agent-bff` builds schemas from its own, and cross-copy zod introspection quietly returns nothing. `@asteasolutions/zod-to-openapi` is that shape and the OpenAPI work adds it next.

Aligning the ranges instead does not work. `^4.3.6` floats to 4.4.3, so you get three resolutions. Exact pins in the two packages leave the transitive OR ranges (`^3.25 || ^4.0`, `^3.25.76 || ^4`, `^3.25.32 || ^4.2.0`) on their own 4.3.5 entry, because yarn v1 does not dedupe on its own.

Bare name, no `**/` glob, like the other version pins in that block.

## Scope and safety

No v3-only consumer exists in the tree. `hono` (`^3.23.8`) and `langsmith` (`^4.3.6`) declare zod as a devDependency of a transitive package, so neither is installed or resolved. Every range actually present accepts 4.3.6.

`resolutions` is not published: downstream consumers still get `^4.3.5`. What protects `agent-bff` published is its own exact pin, untouched here.

## How to test

```bash
yarn install
grep -A2 '^zod@' yarn.lock   # one v4 entry, version 4.3.6
yarn build
```

| Package | Result |
|---|---|
| `mcp-server` | 728 passed |
| `ai-proxy` | 429 passed, 40 skipped |
| `agent-bff` | 726 passed |
| `workflow-executor` | 1476 passed, 7 skipped |
| `agent` | 1008 passed |

`yarn build` green on 24 projects.

## Known limitations

Two failures hit while validating, both reproduced on a clean `main` without this diff:

- Full `yarn test` fails ~69 suites on `Cannot find module '@anthropic-ai/sdk/lib/transform-json-schema'` (required by `@langchain/anthropic`). Same count, same 44 errors on `main`, zero mentions of zod.
- `mcp-server`'s `enabledTools` test flakes on `EADDRINUSE`, a port race. 728/728 on two re-runs.

`ai-proxy` and `mcp-server` still declare `^4.3.5` while the resolution forces 4.3.6. Harmonising is a follow-up, not needed for the invariant.

The pin freezes zod at 4.3.6 while upstream is at 4.4.3. Upgrades go through the root resolution now.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
