### PR TITLE
feat(agent-bff): serve the static OpenAPI document behind the agent gate

### DIFF
--- a/packages/agent-bff/package.json
+++ b/packages/agent-bff/package.json
@@ -31,6 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "8.5.0",
     "@forestadmin/agent-client": "1.13.0",
     "@forestadmin/datasource-toolkit": "1.54.0",
     "@forestadmin/forestadmin-client": "1.41.3",
@@ -40,9 +41,11 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@redocly/cli": "2.35.1",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/koa": "^2.13.5",
     "@types/supertest": "^6.0.2",
+    "openapi3-ts": "4.6.1",
     "supertest": "^7.1.3"
   }
 }

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -19,16 +19,17 @@ import createDataRoutesMiddleware from './data/data-routes-middleware';
 import { extractErrorMessage } from './errors';
 import { unauthorized } from './http/bff-http-error';
 import BFFHttpServer from './http/bff-http-server';
+import BODY_LIMIT from './http/body-limit';
 import createErrorMiddleware from './http/error-middleware';
 import ForestServerClient from './oauth/forest-server-client';
 import createOAuthRoutes from './oauth/oauth-routes';
 import createInMemorySessionStore from './oauth/session-store';
 import createTokenCipher from './oauth/token-cipher';
+import createOpenApiRoutes from './openapi/openapi-routes';
 import createReadModel from './read-model/create-read-model';
 import createTimezoneMiddleware from './timezone/timezone-middleware';
 import version from './version';
 
-const BODY_LIMIT = '16kb';
 const SESSION_TTL_SECONDS = 24 * 60 * 60;
 
 function isAgentPath(path: string): boolean {
@@ -194,6 +195,7 @@ function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] 
     createAuthModeMiddleware({ authSecret: forestAuthSecret }),
     apiKeyStep,
     createPerKeyOriginMiddleware(),
+    createOpenApiRoutes({ version }),
     createTimezoneMiddleware({ defaultTimezone }),
     ...buildAgentRouteMiddlewares(config, logger),
   ];

--- a/packages/agent-bff/src/http/body-limit.ts
+++ b/packages/agent-bff/src/http/body-limit.ts
@@ -1,0 +1,3 @@
+const BODY_LIMIT = '16kb';
+
+export default BODY_LIMIT;

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -1,0 +1,267 @@
+import type { OpenAPIObject } from 'openapi3-ts/oas31';
+
+import { OpenAPIRegistry, OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
+
+import {
+  ActionRequestSchema,
+  CountRequestSchema,
+  CountResponseSchema,
+  ErrorResponseSchema,
+  ListRequestSchema,
+  ListResponseSchema,
+  MessagelessErrorResponseSchema,
+  RelationCountRequestSchema,
+  RelationListRequestSchema,
+} from './schemas';
+import { z } from './zod-openapi';
+import BODY_LIMIT from '../http/body-limit';
+
+export const OPENAPI_VERSION = '3.1.0';
+export const ROUTE_PREFIX = '/agent/v1';
+
+const SESSION_SCHEME = 'bffSession';
+const API_KEY_SCHEME = 'bffApiKey';
+
+const SECURITY = [{ [API_KEY_SCHEME]: [] }];
+
+const ERROR_STATUSES: Record<string, string> = {
+  400: 'Malformed body, a malformed URL-encoded path segment, an invalid filter operator, a filter nested too deep, ambiguous credentials, an unsupported page, a missing or invalid timezone, an unknown submitted action field, or a rejected action form (type action_error)',
+  401: 'Missing, invalid, or expired credentials',
+  403: 'The action needs approval before it runs (the body carries the approving roles), the Forest identity behind the API key is not allowed, the origin is not allowed for this key, or the agent refused the collection, relation, or action',
+  404: 'Unknown collection, relation, or action',
+  413: `The request body exceeds the BFF limit of ${BODY_LIMIT}`,
+  415: 'The request declares a character set the server cannot decode. Other content types are NOT rejected: a form-urlencoded body is parsed and validated like JSON (its values arrive as strings, so typed fields such as page.limit fail with 400), while any other non-JSON content type is read as an absent body, silently dropping filters and pagination',
+  422: 'A field is unknown, not filterable, or is a nested relation path',
+  429: 'The agent rate-limited the request',
+  500: 'The agent payload could not be mapped to the BFF contract',
+  501: 'The BFF is running without an agent configured, so the proxy is not implemented',
+  502: 'The agent could not be reached',
+  503: 'The agent schema is unavailable, the agent returned a 5xx, or the API key could not be resolved',
+};
+
+const UNSUPPORTED_RESULT_DESCRIPTION =
+  'Either the BFF runs without an agent configured, or the action returned a result shape the ' +
+  'BFF cannot normalize. The second case carries no message field.';
+
+function errorResponses(statuses: string[], executeResults: boolean): Record<string, unknown> {
+  return Object.fromEntries(
+    statuses.map(status => {
+      const description = ERROR_STATUSES[status];
+
+      if (!description) throw new Error(`No OpenAPI description for error status ${status}`);
+
+      if (status === '501' && executeResults) {
+        return [
+          status,
+          {
+            description: UNSUPPORTED_RESULT_DESCRIPTION,
+            content: {
+              'application/json': {
+                schema: z.union([ErrorResponseSchema, MessagelessErrorResponseSchema]),
+              },
+            },
+          },
+        ];
+      }
+
+      const response: Record<string, unknown> = {
+        description,
+        content: { 'application/json': { schema: ErrorResponseSchema } },
+      };
+
+      if (status === '503') {
+        response.headers = {
+          'Retry-After': {
+            description:
+              'Seconds to wait before retrying. Set when the API key could not be resolved.',
+            required: false,
+            schema: { type: 'integer' },
+          },
+        };
+      }
+
+      return [status, response];
+    }),
+  );
+}
+
+const DATA_ERRORS = [
+  '400',
+  '401',
+  '403',
+  '404',
+  '413',
+  '415',
+  '422',
+  '429',
+  '500',
+  '501',
+  '502',
+  '503',
+];
+
+interface RouteDefinition {
+  path: string;
+  operationId: string;
+  summary: string;
+  request: z.ZodType;
+  response: z.ZodType;
+  responseDescription: string;
+  params: string[];
+  bodyRequired?: boolean;
+  executeResults?: boolean;
+}
+
+const ROUTES: RouteDefinition[] = [
+  {
+    path: '/{collection}/list',
+    operationId: 'listRecords',
+    summary: 'List records of a collection',
+    request: ListRequestSchema,
+    response: ListResponseSchema,
+    responseDescription: 'A page of records',
+    params: ['collection'],
+  },
+  {
+    path: '/{collection}/count',
+    operationId: 'countRecords',
+    summary: 'Count records of a collection',
+    request: CountRequestSchema,
+    response: CountResponseSchema,
+    responseDescription: 'The matching record count',
+    params: ['collection'],
+  },
+  {
+    path: '/{collection}/relations/{relation}/list',
+    operationId: 'listRelatedRecords',
+    summary: 'List records of a to-many relation',
+    request: RelationListRequestSchema,
+    response: ListResponseSchema,
+    responseDescription: 'A page of related records',
+    params: ['collection', 'relation'],
+    bodyRequired: true,
+  },
+  {
+    path: '/{collection}/relations/{relation}/count',
+    operationId: 'countRelatedRecords',
+    summary: 'Count records of a to-many relation',
+    request: RelationCountRequestSchema,
+    response: CountResponseSchema,
+    responseDescription: 'The matching related record count',
+    params: ['collection', 'relation'],
+    bodyRequired: true,
+  },
+  {
+    path: '/{collection}/actions/{action}/form',
+    operationId: 'getActionForm',
+    summary: 'Load the form of a custom action',
+    request: ActionRequestSchema,
+    response: z.unknown(),
+    responseDescription: 'The action form fields',
+    params: ['collection', 'action'],
+    bodyRequired: true,
+  },
+  {
+    path: '/{collection}/actions/{action}/execute',
+    operationId: 'executeAction',
+    summary: 'Execute a custom action',
+    request: ActionRequestSchema,
+    response: z.unknown(),
+    responseDescription: 'The normalized action result',
+    params: ['collection', 'action'],
+    bodyRequired: true,
+    executeResults: true,
+  },
+];
+
+const PARAM_DESCRIPTIONS: Record<string, string> = {
+  collection: 'The exact collection name from the agent schema.',
+  relation: 'The relation field name. Only to-many relations expose list and count.',
+  action: 'The exact action name from the agent schema, URL-encoded. Not a slug, not an index.',
+};
+
+function buildParams(names: string[]) {
+  return z.object(
+    Object.fromEntries(
+      names.map(name => [name, z.string().openapi({ description: PARAM_DESCRIPTIONS[name] })]),
+    ),
+  );
+}
+
+const TIMEZONE_HEADER_PARAM = z.object({
+  'X-Forest-Timezone': z
+    .string()
+    .optional()
+    .openapi({
+      description:
+        'An IANA timezone. Takes precedence over the `timezone` body field; the BFF default ' +
+        'applies when neither is sent.',
+    }),
+});
+
+export function generateOpenApiDocument(version: string): OpenAPIObject {
+  const registry = new OpenAPIRegistry();
+
+  registry.registerComponent('securitySchemes', SESSION_SCHEME, {
+    type: 'http',
+    scheme: 'bearer',
+    description:
+      'Mode 1: the BFF session token issued after the OAuth login. It authenticates the caller ' +
+      'but the data and action routes reject it until the BFF mints an agent token from the ' +
+      'OAuth principal, so no operation lists it yet. Use the API key today.',
+  });
+  registry.registerComponent('securitySchemes', API_KEY_SCHEME, {
+    type: 'apiKey',
+    in: 'header',
+    name: 'X-Forest-Bff-Key',
+    description: 'Mode 2: a BFF API key. Never send both this and an Authorization header.',
+  });
+
+  ROUTES.forEach(route => {
+    registry.registerPath({
+      method: 'post',
+      path: `${ROUTE_PREFIX}${route.path}`,
+      operationId: route.operationId,
+      summary: route.summary,
+      security: SECURITY,
+      request: {
+        params: buildParams(route.params),
+        headers: TIMEZONE_HEADER_PARAM,
+        body: {
+          required: route.bodyRequired === true,
+          content: { 'application/json': { schema: route.request } },
+        },
+      },
+      responses: {
+        200: {
+          description: route.responseDescription,
+          content: { 'application/json': { schema: route.response } },
+        },
+        ...errorResponses(DATA_ERRORS, route.executeResults === true),
+      },
+    });
+  });
+
+  return new OpenApiGeneratorV31(registry.definitions).generateDocument({
+    openapi: OPENAPI_VERSION,
+    info: {
+      title: 'Forest Admin BFF',
+      version,
+      license: { name: 'GPL-3.0', url: 'https://www.gnu.org/licenses/gpl-3.0.html' },
+      description:
+        'Runtime routes are generic: one path per operation, with the collection, relation and ' +
+        'action passed as path segments. The timezone is resolved from the `X-Forest-Timezone` ' +
+        'header first, then a `timezone` body field, then the BFF default when one is ' +
+        'configured. A deployment without a default rejects a request carrying neither with ' +
+        '400 missing_timezone, so send one of the two to be safe. Sending a content type other ' +
+        'than application/json is not an error: a form-urlencoded body is parsed like JSON, ' +
+        'while any other content type is read as absent, which silently drops any filter, ' +
+        'sort, or page.',
+    },
+    servers: [{ url: '/' }],
+  });
+}
+
+export function serializeOpenApi(document: OpenAPIObject): string {
+  return JSON.stringify(document, null, 2);
+}

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -1,0 +1,27 @@
+import type { Middleware } from 'koa';
+
+import { generateOpenApiDocument, serializeOpenApi } from './openapi-document';
+
+export const OPENAPI_PATH = '/agent/openapi.json';
+
+const READ_METHODS = new Set(['GET', 'HEAD']);
+
+export interface OpenApiRoutesOptions {
+  version: string;
+}
+
+export default function createOpenApiRoutes({ version }: OpenApiRoutesOptions): Middleware {
+  const document = serializeOpenApi(generateOpenApiDocument(version));
+
+  return async function openApiRoutes(ctx, next) {
+    if (!READ_METHODS.has(ctx.method) || ctx.path !== OPENAPI_PATH) {
+      await next();
+
+      return;
+    }
+
+    ctx.status = 200;
+    ctx.type = 'application/json';
+    ctx.body = document;
+  };
+}

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -22,6 +22,7 @@ export default function createOpenApiRoutes({ version }: OpenApiRoutesOptions): 
 
     ctx.status = 200;
     ctx.type = 'application/json';
+    ctx.set('Cache-Control', 'no-store');
     ctx.body = document;
   };
 }

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -1,0 +1,170 @@
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
+import { z } from './zod-openapi';
+import { MAX_FILTER_DEPTH } from '../validation/capabilities-validator';
+
+const OPERATORS = [...allOperators] as [string, ...string[]];
+
+const ConditionTreeLeafSchema = z
+  .object({
+    field: z.string(),
+    operator: z.enum(OPERATORS),
+    value: z.unknown().optional(),
+  })
+  .openapi('ConditionTreeLeaf', {
+    description:
+      'A single condition. `operator` is PascalCase and must be one the target field supports; ' +
+      'an unsupported one returns 400 invalid_filter_operator listing the valid operators.',
+  });
+
+const ConditionTreeSchema: z.ZodType = z
+  .lazy(() =>
+    z.union([
+      ConditionTreeLeafSchema,
+      z.object({
+        aggregator: z.enum(['And', 'Or']),
+        conditions: z.array(ConditionTreeSchema),
+      }),
+    ]),
+  )
+  .openapi('ConditionTree', {
+    description:
+      'Either a leaf condition or a branch nesting more conditions. A branch must carry its ' +
+      '`aggregator`: the BFF forwards a branch without one, but the agent then parses it as ' +
+      'neither leaf nor branch and answers 400. On top-level list and count, nesting deeper ' +
+      `than ${MAX_FILTER_DEPTH} levels is rejected and each field is checked against the ` +
+      'collection capabilities; relation list and count forward the filter without either check.',
+  });
+
+const SortClauseSchema = z
+  .object({
+    field: z.string(),
+    direction: z.enum(['asc', 'desc']).optional(),
+  })
+  .openapi('SortClause', { description: 'Omitting `direction` sorts ascending.' });
+
+const PageSchema = z
+  .object({
+    limit: z.number().int().positive(),
+    offset: z.number().int().nonnegative(),
+  })
+  .openapi('Page', {
+    description:
+      'The agent paginates by page number, so `offset` must be a whole multiple of `limit`. ' +
+      'Any other offset is rejected with 400 invalid_request.',
+  });
+
+const TimezoneSchema = z.string().openapi({
+  description:
+    'Used when the X-Forest-Timezone header is absent. The header wins when both are sent. A ' +
+    'deployment with no configured default rejects a request carrying neither with 400 ' +
+    'missing_timezone.',
+});
+
+export const ListRequestSchema = z
+  .object({
+    filter: ConditionTreeSchema.optional(),
+    projection: z.array(z.string()).optional(),
+    sort: z.array(SortClauseSchema).optional(),
+    page: PageSchema.optional(),
+    timezone: TimezoneSchema.optional(),
+  })
+  .openapi('ListRequest');
+
+export const CountRequestSchema = z
+  .object({
+    filter: ConditionTreeSchema.optional(),
+    timezone: TimezoneSchema.optional(),
+  })
+  .openapi('CountRequest');
+
+const ParentIdSchema = z.union([z.string().regex(/\S/), z.number()]).openapi('ParentId', {
+  description:
+    'The parent record id, opaque: a composite or packed id must be passed unchanged. A ' +
+    'blank string is rejected.',
+});
+
+export const RelationListRequestSchema = ListRequestSchema.extend({
+  parentId: ParentIdSchema,
+}).openapi('RelationListRequest', {
+  description:
+    'Filter, sort and projection apply to the FOREIGN collection; the parent only resolves ' +
+    'which records are related.',
+});
+
+export const RelationCountRequestSchema = CountRequestSchema.extend({
+  parentId: ParentIdSchema,
+}).openapi('RelationCountRequest');
+
+export const ActionRequestSchema = z
+  .object({
+    recordIds: z.array(z.union([z.string(), z.number()])),
+    values: z.record(z.string(), z.unknown()).optional(),
+    timezone: TimezoneSchema.optional(),
+  })
+  .openapi('ActionRequest', {
+    description:
+      '`recordIds` is required, even on a global action: send an empty array when the action ' +
+      'targets no record. Every id is coerced to a string before reaching the agent.',
+  });
+
+const ForestRecordMetaSchema = z
+  .object({
+    collection: z.string(),
+    primaryKey: z.record(z.string(), z.union([z.string(), z.number()])),
+  })
+  .openapi('ForestRecordMeta', {
+    description:
+      'The record identity, unpacked from the agent id. A composite primary key carries one ' +
+      'entry per column.',
+  });
+
+export const ListResponseSchema = z
+  .object({
+    data: z.array(
+      z.record(z.string(), z.unknown()).and(z.object({ __forest: ForestRecordMetaSchema })),
+    ),
+    meta: z.object({ countStatus: z.literal('not_requested') }),
+  })
+  .openapi('ListResponse', {
+    description:
+      'Records are flat, each carrying a `__forest` envelope. The list never carries a total: ' +
+      'call the count endpoint for that, which is why `countStatus` is always `not_requested`.',
+  });
+
+export const CountResponseSchema = z
+  .union([
+    z.object({ count: z.number(), countStatus: z.literal('available') }),
+    z.object({ count: z.null(), countStatus: z.literal('deactivated') }),
+  ])
+  .openapi('CountResponse', {
+    description:
+      'Two shapes only: a number with `available`, or null with `deactivated` when the ' +
+      'collection disables count. The pair never disagrees.',
+  });
+
+export const ErrorResponseSchema = z
+  .object({
+    error: z.object({
+      type: z.string(),
+      status: z.number().int(),
+      message: z.string(),
+      details: z.unknown().optional(),
+    }),
+  })
+  .openapi('ErrorResponse');
+
+export const MessagelessErrorResponseSchema = z
+  .object({
+    error: z.object({
+      type: z.string(),
+      status: z.number().int(),
+      details: z.unknown().optional(),
+    }),
+  })
+  .openapi('MessagelessErrorResponse', {
+    description:
+      'The unsupported-action-result body, which carries no message field unlike every other error.',
+  });
+
+export { ConditionTreeSchema, OPERATORS };

--- a/packages/agent-bff/src/openapi/zod-openapi.ts
+++ b/packages/agent-bff/src/openapi/zod-openapi.ts
@@ -1,0 +1,7 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+// eslint-disable-next-line import/prefer-default-export
+export { z };

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -1,0 +1,345 @@
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
+import {
+  OPENAPI_VERSION,
+  ROUTE_PREFIX,
+  generateOpenApiDocument,
+  serializeOpenApi,
+} from '../../src/openapi/openapi-document';
+
+const document = generateOpenApiDocument('9.9.9');
+const schemas = document.components?.schemas as Record<string, Record<string, unknown>>;
+
+function leafOperators(): string[] {
+  const leaf = schemas.ConditionTreeLeaf as {
+    properties: { operator: { enum: string[] } };
+  };
+
+  return leaf.properties.operator.enum;
+}
+
+describe('generateOpenApiDocument', () => {
+  it('should emit OpenAPI 3.1.0 with the package version', () => {
+    expect(document.openapi).toBe(OPENAPI_VERSION);
+    expect(document.info.version).toBe('9.9.9');
+  });
+
+  it('should serve every path under the /agent/v1 prefix', () => {
+    const paths = Object.keys(document.paths ?? {});
+
+    expect(paths).toHaveLength(6);
+    expect(paths.every(path => path.startsWith(`${ROUTE_PREFIX}/`))).toBe(true);
+  });
+
+  it('should expose the six generic runtime routes', () => {
+    expect(Object.keys(document.paths ?? {}).sort()).toEqual([
+      `${ROUTE_PREFIX}/{collection}/actions/{action}/execute`,
+      `${ROUTE_PREFIX}/{collection}/actions/{action}/form`,
+      `${ROUTE_PREFIX}/{collection}/count`,
+      `${ROUTE_PREFIX}/{collection}/list`,
+      `${ROUTE_PREFIX}/{collection}/relations/{relation}/count`,
+      `${ROUTE_PREFIX}/{collection}/relations/{relation}/list`,
+    ]);
+  });
+
+  it('should declare every filter operator in PascalCase', () => {
+    expect(leafOperators()).toEqual([...allOperators]);
+  });
+
+  it('should declare no snake_case operator, since a request in that casing is rejected', () => {
+    expect(leafOperators().filter(operator => operator.includes('_'))).toEqual([]);
+  });
+
+  it('should require both field and operator on a filter leaf', () => {
+    expect(schemas.ConditionTreeLeaf.required).toEqual(['field', 'operator']);
+  });
+
+  it('should make sort direction optional, since omitting it sorts ascending', () => {
+    expect(schemas.SortClause.required).toEqual(['field']);
+  });
+
+  it('should accept a parent id as a non-blank string or a number', () => {
+    expect(schemas.ParentId.anyOf).toEqual([
+      { type: 'string', pattern: '\\S' },
+      { type: 'number' },
+    ]);
+  });
+
+  it('should require the aggregator on a branch, since the agent 400s without it', () => {
+    const tree = schemas.ConditionTree as { anyOf: Record<string, unknown>[] };
+    const branch = tree.anyOf[1] as { required: string[] };
+
+    expect(branch.required.sort()).toEqual(['aggregator', 'conditions']);
+  });
+
+  it('should describe the filter as a tree that nests itself', () => {
+    const tree = schemas.ConditionTree as { anyOf: Record<string, unknown>[] };
+    const branch = tree.anyOf[1] as {
+      properties: { conditions: { items: { $ref: string } } };
+    };
+
+    expect(tree.anyOf[0]).toEqual({ $ref: '#/components/schemas/ConditionTreeLeaf' });
+    expect(branch.properties.conditions.items.$ref).toBe('#/components/schemas/ConditionTree');
+  });
+
+  it('should pair a count with available and a null with deactivated, never the reverse', () => {
+    const count = schemas.CountResponse as {
+      anyOf: { properties: { count: unknown; countStatus: { enum: string[] } } }[];
+    };
+
+    expect(count.anyOf).toHaveLength(2);
+    expect(count.anyOf[0].properties).toEqual({
+      count: { type: 'number' },
+      countStatus: { type: 'string', enum: ['available'] },
+    });
+    expect(count.anyOf[1].properties).toEqual({
+      count: { type: 'null' },
+      countStatus: { type: 'string', enum: ['deactivated'] },
+    });
+  });
+
+  it('should pin the list count status to not_requested, since a list never carries a total', () => {
+    const list = schemas.ListResponse as {
+      properties: { meta: { properties: { countStatus: { enum: string[] } } } };
+    };
+
+    expect(list.properties.meta.properties.countStatus.enum).toEqual(['not_requested']);
+  });
+
+  it('should still define the session scheme, since OAuth authenticates the doc route itself', () => {
+    expect(document.components?.securitySchemes).toEqual({
+      bffSession: expect.objectContaining({ type: 'http', scheme: 'bearer' }),
+      bffApiKey: expect.objectContaining({
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-Forest-Bff-Key',
+      }),
+    });
+  });
+
+  it('should secure every operation with the API key only, the one mode the routes accept', () => {
+    const operations = Object.values(document.paths ?? {}).map(
+      path => (path as { post: { security: unknown } }).post,
+    );
+
+    expect(operations).toHaveLength(6);
+    operations.forEach(operation => {
+      expect(operation.security).toEqual([{ bffApiKey: [] }]);
+    });
+  });
+
+  it('should say in the session scheme why no operation accepts it yet', () => {
+    const session = (
+      document.components?.securitySchemes as Record<string, { description: string }>
+    ).bffSession;
+
+    expect(session.description).toContain('reject it until');
+  });
+
+  it('should require a body where parentId or recordIds is mandatory', () => {
+    const requiredByPath = Object.fromEntries(
+      Object.entries(document.paths ?? {}).map(([path, item]) => [
+        path,
+        (item as { post: { requestBody: { required?: boolean } } }).post.requestBody.required ===
+          true,
+      ]),
+    );
+
+    expect(requiredByPath).toEqual({
+      [`${ROUTE_PREFIX}/{collection}/list`]: false,
+      [`${ROUTE_PREFIX}/{collection}/count`]: false,
+      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/list`]: true,
+      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/count`]: true,
+      [`${ROUTE_PREFIX}/{collection}/actions/{action}/form`]: true,
+      [`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`]: true,
+    });
+  });
+
+  it('should document every error status a data route can return', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, unknown> };
+    };
+
+    expect(Object.keys(list.post.responses).sort()).toEqual([
+      '200',
+      '400',
+      '401',
+      '403',
+      '404',
+      '413',
+      '415',
+      '422',
+      '429',
+      '500',
+      '501',
+      '502',
+      '503',
+    ]);
+  });
+
+  it('should document 502, which any agent transport failure returns', () => {
+    Object.values(document.paths ?? {}).forEach(path => {
+      expect(
+        Object.keys((path as { post: { responses: Record<string, unknown> } }).post.responses),
+      ).toContain('502');
+    });
+  });
+
+  it('should document 413, since the BFF caps the body at 16kb', () => {
+    Object.values(document.paths ?? {}).forEach(path => {
+      expect(
+        Object.keys((path as { post: { responses: Record<string, unknown> } }).post.responses),
+      ).toContain('413');
+    });
+  });
+
+  it('should declare 501 everywhere, since the agent stub returns it on every route', () => {
+    Object.values(document.paths ?? {}).forEach(path => {
+      expect(
+        Object.keys((path as { post: { responses: Record<string, unknown> } }).post.responses),
+      ).toContain('501');
+    });
+  });
+
+  it('should allow a messageless 501 body on execute, which the result mapper returns', () => {
+    const execute = document.paths?.[`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`] as {
+      post: {
+        responses: Record<string, { content: Record<string, { schema: { anyOf: unknown[] } }> }>;
+      };
+    };
+
+    expect(execute.post.responses['501'].content['application/json'].schema.anyOf).toEqual([
+      { $ref: '#/components/schemas/ErrorResponse' },
+      { $ref: '#/components/schemas/MessagelessErrorResponse' },
+    ]);
+
+    const messageless = schemas.MessagelessErrorResponse as {
+      properties: { error: { required: string[] } };
+    };
+
+    expect(messageless.properties.error.required).toEqual(['type', 'status']);
+  });
+
+  it('should keep a plain error body for the 501 the agent stub returns on other routes', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: {
+        responses: Record<string, { content: Record<string, { schema: { $ref: string } }> }>;
+      };
+    };
+
+    expect(list.post.responses['501'].content['application/json'].schema.$ref).toBe(
+      '#/components/schemas/ErrorResponse',
+    );
+  });
+
+  it('should declare the timezone header as a parameter, not only in prose', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { parameters: { name: string; in: string; required?: boolean }[] };
+    };
+    const header = list.post.parameters.find(parameter => parameter.in === 'header');
+
+    expect(header).toEqual(expect.objectContaining({ name: 'X-Forest-Timezone', in: 'header' }));
+    expect(header?.required).not.toBe(true);
+  });
+
+  it('should describe an invalid filter operator under 400, the status it actually returns', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { description: string }> };
+    };
+
+    expect(list.post.responses['400'].description).toContain('invalid filter operator');
+    expect(list.post.responses['422'].description).not.toContain('operator');
+  });
+
+  it('should distinguish a form body, which is parsed, from other non-JSON bodies, which drop', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { description: string }> };
+    };
+
+    expect(list.post.responses['415'].description).toContain('NOT rejected');
+    expect(list.post.responses['415'].description).toContain('form-urlencoded');
+    expect(document.info.description).toContain('form-urlencoded');
+    expect(document.info.description).toContain('silently');
+  });
+
+  it('should name the 403s the BFF itself emits, not only the agent passthrough', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { description: string }> };
+    };
+
+    expect(list.post.responses['403'].description).toContain('needs approval');
+    expect(list.post.responses['403'].description).toContain('Forest identity');
+  });
+
+  it('should warn that a missing timezone is a 400 when no default is configured', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { description: string }> };
+    };
+
+    expect(list.post.responses['400'].description).toContain('missing or invalid timezone');
+    expect(document.info.description).toContain('missing_timezone');
+  });
+
+  it('should accept a timezone on an action body, which the middleware reads there too', () => {
+    expect(Object.keys(schemas.ActionRequest.properties as object)).toContain('timezone');
+  });
+
+  it('should declare Retry-After on 503, the only status that sets it', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { headers?: Record<string, unknown> }> };
+    };
+
+    expect(Object.keys(list.post.responses['503'].headers ?? {})).toEqual(['Retry-After']);
+    expect(list.post.responses['429'].headers).toBeUndefined();
+  });
+
+  it('should not promise a Retry-After on 429, where no code path sets one', () => {
+    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
+      post: { responses: Record<string, { description: string }> };
+    };
+
+    expect(list.post.responses['429'].description).not.toContain('Retry-After');
+  });
+
+  it('should give every response a description, which the OpenAPI struct rule requires', () => {
+    const responses = Object.values(document.paths ?? {}).flatMap(path =>
+      Object.values(
+        (path as { post: { responses: Record<string, { description?: string }> } }).post.responses,
+      ),
+    );
+
+    expect(responses.length).toBeGreaterThan(0);
+    responses.forEach(response => expect(typeof response.description).toBe('string'));
+  });
+
+  it('should require recordIds on an action, since the middleware rejects a missing array', () => {
+    expect(schemas.ActionRequest.required).toEqual(['recordIds']);
+  });
+
+  it('should type a primary key value as a string or a number, matching the record mapper', () => {
+    const meta = schemas.ForestRecordMeta as {
+      properties: { primaryKey: { additionalProperties: { anyOf: unknown[] } } };
+    };
+
+    expect(meta.properties.primaryKey.additionalProperties.anyOf).toEqual([
+      { type: 'string' },
+      { type: 'number' },
+    ]);
+  });
+
+  it('should carry the package license, which the OpenAPI recommended ruleset requires', () => {
+    expect(document.info.license).toEqual({
+      name: 'GPL-3.0',
+      url: 'https://www.gnu.org/licenses/gpl-3.0.html',
+    });
+  });
+});
+
+describe('serializeOpenApi', () => {
+  it('should produce indented JSON that parses back to the same document', () => {
+    const serialized = serializeOpenApi(document);
+
+    expect(serialized).toContain('\n  ');
+    expect(JSON.parse(serialized)).toEqual(JSON.parse(JSON.stringify(document)));
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -77,6 +77,16 @@ describe('GET /agent/openapi.json', () => {
         expect(Object.keys(response.body.paths)).toHaveLength(6);
       });
     });
+
+    it('should forbid caching, matching the no-store the api key path already sets', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.headers['cache-control']).toBe('no-store');
+      });
+    });
   });
 
   describe('when the document is requested at the root instead of under /agent', () => {

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -1,0 +1,189 @@
+import type { Logger } from '../../src/ports/logger-port';
+
+import request from 'supertest';
+
+import runCli from '../../src/cli-core';
+import { issueBffAccessToken } from '../../src/oauth/bff-token';
+import { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
+
+const VALID_ENV = {
+  FOREST_AUTH_SECRET: 'auth-secret',
+  FOREST_ENV_SECRET: 'env-secret',
+  FOREST_SERVER_URL: 'https://api.forestadmin.com',
+  FOREST_APP_URL: 'https://app.forestadmin.com',
+  AGENT_URL: 'https://agent.example.com',
+  HTTP_PORT: '0',
+} satisfies NodeJS.ProcessEnv;
+
+const noopLogger: Logger = () => undefined;
+
+function sessionToken(): string {
+  return issueBffAccessToken({
+    sid: 'session-1',
+    user: {
+      id: 1,
+      email: 'user@example.com',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      team: 'Operations',
+      permissionLevel: 'admin',
+      role: 'admin',
+      tags: {},
+      renderingId: 1,
+    },
+    renderingId: 1,
+    authSecret: VALID_ENV.FOREST_AUTH_SECRET,
+    expiresInSeconds: 900,
+  });
+}
+
+async function withServer(
+  env: NodeJS.ProcessEnv,
+  run: (server: Awaited<ReturnType<typeof runCli>>) => Promise<void>,
+): Promise<void> {
+  const server = await runCli(env, noopLogger);
+
+  try {
+    await run(server);
+  } finally {
+    await server.stop();
+  }
+}
+
+describe('GET /agent/openapi.json', () => {
+  describe('when no credentials are sent', () => {
+    it('should return 401 and never the document, since the route sits behind the agent gate', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback).get(OPENAPI_PATH);
+
+        expect(response.status).toBe(401);
+        expect(response.body).toEqual({
+          error: expect.objectContaining({ type: 'unauthorized', status: 401 }),
+        });
+        expect(response.text).not.toContain('openapi');
+      });
+    });
+  });
+
+  describe('when a valid session token is sent', () => {
+    it('should serve the OpenAPI document', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.status).toBe(200);
+        expect(response.body.openapi).toBe('3.1.0');
+        expect(Object.keys(response.body.paths)).toHaveLength(6);
+      });
+    });
+  });
+
+  describe('when the document is requested at the root instead of under /agent', () => {
+    it('should return 404, since only the /agent path is mounted', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback).get('/openapi.json');
+
+        expect(response.status).toBe(404);
+        expect(response.text).not.toContain('openapi');
+      });
+    });
+  });
+
+  describe('when the agent url is absent, so data endpoints fall back to the stub', () => {
+    it('should still serve the document, since it never calls the agent', async () => {
+      await withServer({ ...VALID_ENV, AGENT_URL: undefined }, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.status).toBe(200);
+        expect(response.body.openapi).toBe('3.1.0');
+      });
+    });
+  });
+
+  describe('when the auth secret is absent, so the whole agent edge is disabled', () => {
+    it('should not serve the document, since an ungated document leaks the API surface', async () => {
+      await withServer({ ...VALID_ENV, FOREST_AUTH_SECRET: undefined }, async server => {
+        const response = await request(server.callback).get(OPENAPI_PATH);
+
+        expect(response.status).toBe(404);
+        expect(response.text).not.toContain('"openapi"');
+      });
+    });
+  });
+
+  describe('when the document is requested twice', () => {
+    it('should return the byte-identical document, since it is built once at boot', async () => {
+      await withServer(VALID_ENV, async server => {
+        const token = sessionToken();
+        const first = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${token}`);
+        const second = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${token}`);
+
+        expect(first.text).toBe(second.text);
+      });
+    });
+  });
+
+  describe('when the path is written as a variant of the canonical one', () => {
+    it.each([
+      ['a trailing slash', '/agent/openapi.json/'],
+      ['a different case', '/agent/OpenAPI.json'],
+      ['a percent-encoded letter', '/agent/%6fpenapi.json'],
+      ['a dot segment', '/agent/./openapi.json'],
+      ['a parent-dir segment', '/agent/x/../openapi.json'],
+      ['a doubled leading slash', '//agent/openapi.json'],
+    ])('should not serve the document to an unauthenticated caller using %s', async (_, path) => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback).get(path);
+
+        expect(response.status).toBeGreaterThanOrEqual(400);
+        expect(response.text).not.toContain('"openapi"');
+      });
+    });
+  });
+
+  describe('when an authenticated caller uses a non-canonical path', () => {
+    it('should serve the document only on the exact path', async () => {
+      await withServer(VALID_ENV, async server => {
+        const authorized = request(server.callback)
+          .get('/agent/openapi.json/')
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect((await authorized).text).not.toContain('"openapi"');
+      });
+    });
+  });
+
+  describe('when the document is requested with HEAD', () => {
+    it('should answer 200 without a body, since HEAD carries no payload', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .head(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when a method other than GET or HEAD is used', () => {
+    it('should fall through without serving the document', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .post(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`)
+          .send({});
+
+        expect(response.status).toBeGreaterThanOrEqual(400);
+        expect(response.text).not.toContain('"openapi"');
+      });
+    });
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { generateOpenApiDocument, serializeOpenApi } from '../../src/openapi/openapi-document';
+
+const REDOCLY_BIN = path.join(
+  path.dirname(require.resolve('@redocly/cli/package.json')),
+  'bin/cli.js',
+);
+
+describe('the generated OpenAPI document', () => {
+  let directory: string;
+
+  beforeAll(() => {
+    directory = mkdtempSync(path.join(tmpdir(), 'bff-openapi-'));
+  });
+
+  afterAll(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('should pass redocly lint, which is what a consumer runs before generating a client', () => {
+    const file = path.join(directory, 'openapi.json');
+    writeFileSync(file, serializeOpenApi(generateOpenApiDocument('1.0.0')));
+
+    const result = spawnSync(process.execPath, [REDOCLY_BIN, 'lint', file], { encoding: 'utf8' });
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+    expect({ status: result.status, output }).toEqual({
+      status: 0,
+      output: expect.stringContaining('is valid'),
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,13 @@
     json-schema-to-ts "^3.1.1"
     standardwebhooks "^1.0.0"
 
+"@asteasolutions/zod-to-openapi@8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz#f073822daad87c4ab2ae991ee86b1a5070ac9942"
+  integrity sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==
+  dependencies:
+    openapi3-ts "^4.1.2"
+
 "@aws-crypto/crc32@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-5.2.0.tgz#cfcc22570949c98c6689cfcbd2d693d36cdae2e1"
@@ -3406,6 +3413,11 @@
     semver "^7.5.3"
     signale "^1.4.0"
     stream-buffers "^3.0.2"
+
+"@redocly/cli@2.35.1":
+  version "2.35.1"
+  resolved "https://registry.yarnpkg.com/@redocly/cli/-/cli-2.35.1.tgz#391392a0857ce009990c5ff2eebe9066460f0795"
+  integrity sha512-8XcUIR6bCI4KmVg6RJyzL3peZhld/tu7oO8WGVaHp43byhcds6ProHlfqEFa+dZA+qA+dUMebgRELVOe5AW4Lg==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -13643,6 +13655,13 @@ openai@^6.37.0:
   resolved "https://registry.yarnpkg.com/openai/-/openai-6.42.0.tgz#497bb98294a2aadcc90a655736c1d43c32ffd5d9"
   integrity sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==
 
+openapi3-ts@4.6.1, openapi3-ts@^4.1.2:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-4.6.1.tgz#aaabcab1cf1d17cf754fb49f3041f3cf808e1f38"
+  integrity sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA==
+  dependencies:
+    yaml "^2.9.0"
+
 openid-client@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.7.1.tgz#34cace862a3e6472ed7d0a8616ef73b7fb85a9c3"
@@ -17781,7 +17800,7 @@ yallist@^5.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
-yaml@2.9.0:
+yaml@2.9.0, yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
**Stacked on #1809** (`chore/dedupe-zod-single-v4-resolution`). Base is that branch, not `main`; #1809 must be reviewed and merged first. Hard prerequisite: `@asteasolutions/zod-to-openapi` takes zod as a peer dependency, so without the dedupe yarn can bind it to a different zod copy than the one agent-bff builds its schemas from.

fixes PRD-886

## What

`GET /agent/openapi.json` serves an OpenAPI 3.1 document describing the six generic BFF routes (list, count, relation list/count, action form/execute). Generated from Zod, built once at boot, static: path placeholders only, no tenant data. The only environment-derived value is the package version.

## Why this mount point

The BFF has no deny-by-default gate: auth applies only to paths under `/agent`. Mounting the route inside the `agentScoped` chain, right after the auth middlewares, inherits the existing gate, so an unauthenticated request gets a 401 before path matching. Root mounting would have made the document public. The route sits before `buildAgentRouteMiddlewares`, so it answers even when `AGENT_URL` is unset and never calls the agent.

## How

- New `src/openapi/` module: `extendZodWithOpenApi` loaded once, request/response/error schemas, registry plus `OpenApiGeneratorV31`, and a `serializeOpenApi` shared with the future CLI subcommand.
- Schemas written against the code, not prior docs: `/agent/v1` prefix, recursive condition-tree filter, PascalCase operators (required), `sort[].direction` optional, `page.offset` must be a multiple of `limit`, `parentId` string or number, `recordIds` required even when empty.
- Every status a route actually returns is declared, including 502 (transport failure), 413 (16kb body cap), 429 (agent rate-limiting). 501 is declared only on execute and points at a separate schema because that body carries no `message` field.
- Additive: the only edit outside `src/openapi/` is one line in the `cli-core.ts` middleware chain. No existing route, handler, or schema changed.

Known limits: action `200` responses are typed `unknown` (belongs with the action work); relation list/count skip capabilities validation, so their 422 field errors are unreachable, and the `ConditionTree` description says so (#1801 fixes the validation gap). Per-collection unfolding is PRD-684/PRD-685.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test
yarn workspace @forestadmin/agent-bff lint
```

Against a running agent:

```bash
FOREST_AUTH_SECRET=... FOREST_ENV_SECRET=... FOREST_SERVER_URL=... \
FOREST_APP_URL=... AGENT_URL=http://localhost:3009/forest HTTP_PORT=4599 \
node packages/agent-bff/dist/cli.js

curl -i localhost:4599/agent/openapi.json                        # 401, no document
curl -i localhost:4599/openapi.json                              # 404
curl -s -H "X-Forest-Bff-Key: <session>" \
  localhost:4599/agent/openapi.json | npx @redocly/cli lint -    # valid
```

Ran on this branch: 767 tests pass (41 added), lint and build clean. `redocly lint` runs inside the suite, so the document cannot go invalid unnoticed. An end-to-end pass against a live agent covered the 401 gate (no leak in the body), the root 404, the authenticated 200, redocly validation over HTTP, and eight unauthenticated path variants (trailing slash, case change, `%6f`, dot segments, `..`, doubled slash): none serves the document.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
