### PR TITLE
feat(agent-bff): emit the OpenAPI document from a forest-bff openapi subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ lerna-debug.log
 .env.executors
 .forestadmin-schema.json
 
+# forest-bff openapi --output default destination
+openapi.json
+
 # yarn
 yarn-error.log
 .vscode/settings.json

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -5,8 +5,8 @@ agent from a browser without learning MCP or JSON:API.
 
 It is a bootable Koa 3 server with a `/health` endpoint, a version header, env-driven config
 validation, OAuth (Mode 1) + API-key (Mode 2) auth, and a hardened request edge (timezone, CORS,
-auth-mode precedence, structured error contract). The data-endpoint proxy and OpenAPI generation
-land in later slices.
+auth-mode precedence, structured error contract), and it serves and exports its own OpenAPI
+document. The data-endpoint proxy lands in a later slice.
 
 ## Usage
 

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -16,6 +16,25 @@ Packaged / production — run the bin:
 forest-bff
 ```
 
+Export the OpenAPI document without booting the server. Needs no configuration, so
+it works in CI to commit the document, diff it, or generate a client:
+
+```bash
+forest-bff openapi > openapi.json          # stdout, redirected
+forest-bff openapi --output                # writes ./openapi.json
+forest-bff openapi --output docs/api.json  # writes that path
+```
+
+`--output` takes the next argument as the destination unless it is empty or starts with
+`-`; the default `openapi.json` is written only when `--output` is the last argument, and
+a leftover token is rejected like any other extra. A missing parent directory is created,
+an existing file is overwritten, and a destination that cannot be written exits 1 with the
+path on stderr. The path is confirmed on stderr, so stdout stays empty and pipeable.
+
+`forest-bff --help` and `forest-bff --version` print to stdout and exit 0, ignoring
+anything that follows. An unknown command, or an argument other than `--output` after
+`openapi`, exits 1 with the reason on stderr.
+
 Local development — copy the env template, fill it in, and start with it loaded:
 
 ```bash

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -1,0 +1,136 @@
+import type BFFHttpServer from './http/bff-http-server';
+import type { Logger } from './ports/logger-port';
+
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+import runCli from './cli-core';
+import { extractErrorMessage } from './errors';
+import { generateOpenApiDocument, serializeOpenApi } from './openapi/openapi-document';
+import version from './version';
+
+export const DEFAULT_OUTPUT_FILE = 'openapi.json';
+
+const OUTPUT_FLAG = '--output';
+
+export const USAGE = `Usage: forest-bff [command]
+
+Commands:
+  (none)      Start the BFF server, configured from the environment.
+  openapi     Write the OpenAPI document to stdout. Needs no configuration.
+              --output [file]  Write to a file instead of stdout, defaulting
+                               to ${DEFAULT_OUTPUT_FILE} in the current directory.
+
+Options:
+  -h, --help     Show this help and exit.
+  -v, --version  Show the package version and exit.`;
+
+export const HINT = "Run 'forest-bff --help' for usage.";
+
+const HELP_FLAGS = new Set(['-h', '--help']);
+const VERSION_FLAGS = new Set(['-v', '--version']);
+
+export interface DispatchOutcome {
+  exitCode: number;
+  server?: BFFHttpServer;
+}
+
+export function printOpenApi(
+  write: (chunk: string) => void = chunk => process.stdout.write(chunk),
+) {
+  write(`${serializeOpenApi(generateOpenApiDocument(version))}\n`);
+}
+
+function rejectCli(reason: string): DispatchOutcome {
+  process.stderr.write(`${reason}\n${HINT}\n`);
+
+  return { exitCode: 1 };
+}
+
+interface OutputOption {
+  file?: string;
+  extras: string[];
+}
+
+function parseOutputOption(rest: string[]): OutputOption {
+  const index = rest.indexOf(OUTPUT_FLAG);
+
+  if (index === -1) return { extras: rest };
+
+  const candidate = rest[index + 1];
+  const takesValue = candidate !== undefined && candidate !== '' && !candidate.startsWith('-');
+
+  return {
+    file: takesValue ? candidate : DEFAULT_OUTPUT_FILE,
+    extras: [...rest.slice(0, index), ...rest.slice(index + (takesValue ? 2 : 1))],
+  };
+}
+
+function writeOpenApiFile(file: string): DispatchOutcome {
+  const asDirectory = file.endsWith('/') || file.endsWith(path.sep);
+  const destination = path.resolve(
+    process.cwd(),
+    asDirectory ? path.join(file, DEFAULT_OUTPUT_FILE) : file,
+  );
+
+  try {
+    mkdirSync(path.dirname(destination), { recursive: true });
+    printOpenApi(chunk => writeFileSync(destination, chunk));
+  } catch (error) {
+    process.stderr.write(`Cannot write ${destination}: ${extractErrorMessage(error)}\n`);
+
+    return { exitCode: 1 };
+  }
+
+  process.stderr.write(`Wrote the OpenAPI document to ${destination}\n`);
+
+  return { exitCode: 0 };
+}
+
+export default async function dispatchCli(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  logger?: Logger,
+): Promise<DispatchOutcome> {
+  const [subcommand, ...rest] = argv;
+
+  if (subcommand === undefined) {
+    return { exitCode: 0, server: await runCli(env, logger) };
+  }
+
+  if (HELP_FLAGS.has(subcommand)) {
+    process.stdout.write(`${USAGE}\n`);
+
+    return { exitCode: 0 };
+  }
+
+  if (VERSION_FLAGS.has(subcommand)) {
+    process.stdout.write(`${version}\n`);
+
+    return { exitCode: 0 };
+  }
+
+  if (subcommand !== 'openapi') {
+    return rejectCli(
+      subcommand === OUTPUT_FLAG
+        ? `${OUTPUT_FLAG} only applies to the openapi command`
+        : `Unknown command: ${subcommand}`,
+    );
+  }
+
+  const { file, extras } = parseOutputOption(rest);
+
+  if (extras.length > 0) {
+    return rejectCli(
+      `openapi accepts only --output, got: ${extras.map(extra => JSON.stringify(extra)).join(' ')}`,
+    );
+  }
+
+  if (file !== undefined) {
+    return writeOpenApiFile(file);
+  }
+
+  printOpenApi();
+
+  return { exitCode: 0 };
+}

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -35,10 +35,8 @@ export interface DispatchOutcome {
   server?: BFFHttpServer;
 }
 
-export function printOpenApi(
-  write: (chunk: string) => void = chunk => process.stdout.write(chunk),
-) {
-  write(`${serializeOpenApi(generateOpenApiDocument(version))}\n`);
+export function renderOpenApi(): string {
+  return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
 }
 
 function rejectCli(reason: string): DispatchOutcome {
@@ -75,7 +73,7 @@ function writeOpenApiFile(file: string): DispatchOutcome {
 
   try {
     mkdirSync(path.dirname(destination), { recursive: true });
-    printOpenApi(chunk => writeFileSync(destination, chunk));
+    writeFileSync(destination, renderOpenApi());
   } catch (error) {
     process.stderr.write(`Cannot write ${destination}: ${extractErrorMessage(error)}\n`);
 
@@ -130,7 +128,7 @@ export default async function dispatchCli(
     return writeOpenApiFile(file);
   }
 
-  printOpenApi();
+  process.stdout.write(renderOpenApi());
 
   return { exitCode: 0 };
 }

--- a/packages/agent-bff/src/cli.ts
+++ b/packages/agent-bff/src/cli.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 /* istanbul ignore file */
-import runCli, { reportFatalError } from './cli-core';
+import { reportFatalError } from './cli-core';
+import dispatchCli from './cli-dispatch';
 
 if (require.main === module) {
-  runCli(process.env).catch(reportFatalError);
+  dispatchCli(process.argv.slice(2), process.env)
+    .then(({ exitCode }) => {
+      if (exitCode !== 0) process.exitCode = exitCode;
+    })
+    .catch(reportFatalError);
 }

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -1,0 +1,508 @@
+import type BFFHttpServer from '../../src/http/bff-http-server';
+import type { Logger } from '../../src/ports/logger-port';
+
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import http from 'http';
+import { tmpdir } from 'os';
+import path from 'path';
+import request from 'supertest';
+
+import dispatchCli, {
+  DEFAULT_OUTPUT_FILE,
+  HINT,
+  USAGE,
+  printOpenApi,
+} from '../../src/cli-dispatch';
+import { issueBffAccessToken } from '../../src/oauth/bff-token';
+import { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
+import version from '../../src/version';
+
+const VALID_ENV = {
+  FOREST_AUTH_SECRET: 'auth-secret',
+  FOREST_ENV_SECRET: 'env-secret',
+  FOREST_SERVER_URL: 'https://api.forestadmin.com',
+  FOREST_APP_URL: 'https://app.forestadmin.com',
+  AGENT_URL: 'https://agent.example.com',
+  HTTP_PORT: '0',
+} satisfies NodeJS.ProcessEnv;
+
+const noopLogger: Logger = () => undefined;
+
+function capture(): { write: (chunk: string) => void; text: () => string } {
+  const chunks: string[] = [];
+
+  return { write: chunk => chunks.push(chunk), text: () => chunks.join('') };
+}
+
+describe('printOpenApi', () => {
+  it('should write a parseable OpenAPI 3.1 document', () => {
+    const output = capture();
+    printOpenApi(output.write);
+
+    expect(JSON.parse(output.text()).openapi).toBe('3.1.0');
+  });
+
+  it('should end with a newline, so the output pipes cleanly', () => {
+    const output = capture();
+    printOpenApi(output.write);
+
+    expect(output.text().endsWith('\n')).toBe(true);
+  });
+});
+
+describe('dispatchCli', () => {
+  describe('when the openapi subcommand is given', () => {
+    it('should emit the document, exit 0, and never bind a socket', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const listen = jest.spyOn(http.Server.prototype, 'listen');
+
+      try {
+        const outcome = await dispatchCli(['openapi'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(JSON.parse(stdout.mock.calls[0][0] as string).openapi).toBe('3.1.0');
+        expect(listen).not.toHaveBeenCalled();
+      } finally {
+        listen.mockRestore();
+        stdout.mockRestore();
+      }
+    });
+
+    it('should emit the document with no configuration at all, since export needs none', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      try {
+        await dispatchCli(['openapi'], {}, noopLogger);
+
+        const document = JSON.parse(stdout.mock.calls[0][0] as string);
+
+        expect(Object.keys(document.paths)).toHaveLength(6);
+      } finally {
+        stdout.mockRestore();
+      }
+    });
+  });
+
+  describe('when the export is piped to a file or another tool', () => {
+    it('should write nothing to stdout but the document, since console.info also targets stdout', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const info = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+
+      try {
+        await dispatchCli(['openapi'], {}, noopLogger);
+
+        expect(info).not.toHaveBeenCalled();
+        expect(stdout).toHaveBeenCalledTimes(1);
+      } finally {
+        stdout.mockRestore();
+        info.mockRestore();
+      }
+    });
+  });
+
+  describe('when no subcommand is given', () => {
+    it('should boot the server, preserving the packaged bin behavior', async () => {
+      const outcome = await dispatchCli([], VALID_ENV, noopLogger);
+
+      try {
+        expect(outcome.exitCode).toBe(0);
+        expect(outcome.server).toBeDefined();
+      } finally {
+        await outcome.server?.stop();
+      }
+    });
+  });
+
+  describe.each([
+    ['--help', '--help'],
+    ['-h', '-h'],
+  ])('when %s is given', (_, flag) => {
+    it('should print usage on stdout and exit 0, as POSIX expects for a help request', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli([flag], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(stdout.mock.calls.map(call => call[0]).join('')).toBe(`${USAGE}\n`);
+        expect(stderr).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe.each([
+    ['--version', '--version'],
+    ['-v', '-v'],
+  ])('when %s is given', (_, flag) => {
+    it('should print the bare version on stdout and exit 0', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli([flag], {}, noopLogger);
+        const printed = stdout.mock.calls.map(call => call[0]).join('');
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(printed).toBe(`${version}\n`);
+      } finally {
+        stdout.mockRestore();
+      }
+    });
+  });
+
+  describe('when a command fails', () => {
+    it('should point at --help rather than dump the whole usage on stderr', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        await dispatchCli(['bogus'], {}, noopLogger);
+        const written = stderr.mock.calls.map(call => call[0]).join('');
+
+        expect(written).toBe(`Unknown command: bogus\n${HINT}\n`);
+        expect(written.split('\n')).toHaveLength(3);
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when openapi is given extra arguments', () => {
+    it('should name the extra arguments rather than echo the whole command line', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi', 'extra', 'more'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `openapi accepts only --output, got: "extra" "more"\n${HINT}\n`,
+        );
+        expect(stdout).not.toHaveBeenCalled();
+      } finally {
+        stderr.mockRestore();
+        stdout.mockRestore();
+      }
+    });
+  });
+
+  describe.each([
+    ['--help', '--help'],
+    ['--version', '--version'],
+  ])('when %s is given an extra argument', (_, flag) => {
+    it('should still answer and exit 0, since GNU tools ignore what follows a help request', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli([flag, 'extra'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(stdout).toHaveBeenCalled();
+        expect(stderr).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when an unknown subcommand is given', () => {
+    it('should exit non-zero with the usage line on stderr', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['bogus'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `Unknown command: bogus\n${HINT}\n`,
+        );
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+
+    it('should report it as unknown even with extra arguments, not as taking none', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['bogus', 'extra'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `Unknown command: bogus\n${HINT}\n`,
+        );
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+
+    it('should not emit a document, so a typo never looks like a successful export', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        await dispatchCli(['bogus'], {}, noopLogger);
+
+        expect(stdout).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+  });
+});
+
+describe('dispatchCli --output', () => {
+  let directory: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    directory = realpathSync(mkdtempSync(path.join(tmpdir(), 'bff-output-')));
+    process.chdir(directory);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  function expectedDocument(): string {
+    const output = capture();
+    printOpenApi(output.write);
+
+    return output.text();
+  }
+
+  async function exportQuietly(argv: string[]) {
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      return await dispatchCli(argv, {}, noopLogger);
+    } finally {
+      stderr.mockRestore();
+    }
+  }
+
+  describe('when --output is given with no value', () => {
+    it(`should write ${DEFAULT_OUTPUT_FILE} in the current directory and keep stdout empty`, async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi', '--output'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(readFileSync(path.join(directory, DEFAULT_OUTPUT_FILE), 'utf8')).toBe(
+          expectedDocument(),
+        );
+        expect(stdout).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+
+    it('should confirm on stderr where the document landed, keeping stdout pipeable', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        await dispatchCli(['openapi', '--output'], {}, noopLogger);
+
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `Wrote the OpenAPI document to ${path.join(directory, DEFAULT_OUTPUT_FILE)}\n`,
+        );
+        expect(stdout).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when --output is given a path', () => {
+    it('should write the document there rather than to the default name', async () => {
+      const target = path.join(directory, 'nested-name.json');
+
+      const outcome = await dispatchCli(['openapi', '--output', target], {}, noopLogger);
+
+      expect(outcome).toEqual({ exitCode: 0 });
+      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+    });
+
+    it(`should treat a trailing slash as a directory and write ${DEFAULT_OUTPUT_FILE} inside it`, async () => {
+      const outcome = await exportQuietly(['openapi', '--output', 'build/']);
+
+      expect(outcome).toEqual({ exitCode: 0 });
+      expect(readFileSync(path.join(directory, 'build', DEFAULT_OUTPUT_FILE), 'utf8')).toBe(
+        expectedDocument(),
+      );
+    });
+
+    it('should create a missing parent directory, so a CI path needs no mkdir first', async () => {
+      const target = path.join(directory, 'docs', 'nested', 'api.json');
+
+      const outcome = await exportQuietly(['openapi', '--output', target]);
+
+      expect(outcome).toEqual({ exitCode: 0 });
+      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+    });
+
+    it('should resolve a relative path against the current directory', async () => {
+      const outcome = await exportQuietly(['openapi', '--output', 'relative.json']);
+
+      expect(outcome).toEqual({ exitCode: 0 });
+      expect(readFileSync(path.join(directory, 'relative.json'), 'utf8')).toBe(expectedDocument());
+    });
+  });
+
+  describe('when the destination already holds a file', () => {
+    it('should overwrite it, since an export is expected to refresh the document', async () => {
+      const target = path.join(directory, 'stale.json');
+      writeFileSync(target, '{"openapi":"stale"}');
+
+      const outcome = await exportQuietly(['openapi', '--output', target]);
+
+      expect(outcome).toEqual({ exitCode: 0 });
+      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+    });
+  });
+
+  describe('when the token after --output starts with a dash', () => {
+    it('should reject it as an extra and write nothing, never a file named after a flag', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi', '--output', '--help'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `openapi accepts only --output, got: "--help"\n${HINT}\n`,
+        );
+        expect(() => readFileSync(path.join(directory, '--help'))).toThrow();
+        expect(() => readFileSync(path.join(directory, DEFAULT_OUTPUT_FILE))).toThrow();
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe.each([
+    ['an equals form', ['openapi', '--output=out.json'], '--output=out.json'],
+    ['a doubled flag', ['openapi', '--output', 'a.json', '--output'], '--output'],
+    ['an empty destination', ['openapi', '--output', ''], ''],
+  ])('when %s is used', (_, argv, reported) => {
+    it('should reject it, since the parser accepts one --output with a plain value', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(argv, {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `openapi accepts only --output, got: ${JSON.stringify(reported)}\n${HINT}\n`,
+        );
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when the destination cannot be written', () => {
+    it('should name the path and exit 1 without leaking a stack trace', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi', '--output', directory], {}, noopLogger);
+        const written = stderr.mock.calls.map(call => call[0]).join('');
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(written).toContain(`Cannot write ${directory}: `);
+        expect(written).not.toContain('at ');
+        expect(written).not.toContain(HINT);
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when --output is used as the command itself', () => {
+    it('should say it belongs to openapi rather than report an unknown command', async () => {
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['--output'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 1 });
+        expect(stderr.mock.calls.map(call => call[0]).join('')).toBe(
+          `--output only applies to the openapi command\n${HINT}\n`,
+        );
+        expect(() => readFileSync(path.join(directory, DEFAULT_OUTPUT_FILE))).toThrow();
+      } finally {
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  describe('when no --output is given', () => {
+    it('should keep writing to stdout and create no file', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi'], {}, noopLogger);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(stdout).toHaveBeenCalledTimes(1);
+        expect(() => readFileSync(path.join(directory, DEFAULT_OUTPUT_FILE))).toThrow();
+      } finally {
+        stdout.mockRestore();
+      }
+    });
+  });
+});
+
+describe('the CLI export and the HTTP route', () => {
+  it('should produce the same document, since both use one generator', async () => {
+    const output = capture();
+    printOpenApi(output.write);
+
+    const outcome = await dispatchCli([], VALID_ENV, noopLogger);
+
+    expect(outcome.server).toBeDefined();
+
+    try {
+      const response = await request((outcome.server as BFFHttpServer).callback)
+        .get(OPENAPI_PATH)
+        .set(
+          'Authorization',
+          `Bearer ${issueBffAccessToken({
+            sid: 'session-1',
+            user: {
+              id: 1,
+              email: 'user@example.com',
+              firstName: 'Ada',
+              lastName: 'Lovelace',
+              team: 'Operations',
+              permissionLevel: 'admin',
+              role: 'admin',
+              tags: {},
+              renderingId: 1,
+            },
+            renderingId: 1,
+            authSecret: VALID_ENV.FOREST_AUTH_SECRET,
+            expiresInSeconds: 900,
+          })}`,
+        );
+
+      expect(output.text()).toBe(`${response.text}\n`);
+    } finally {
+      await outcome.server?.stop();
+    }
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -11,7 +11,7 @@ import dispatchCli, {
   DEFAULT_OUTPUT_FILE,
   HINT,
   USAGE,
-  printOpenApi,
+  renderOpenApi,
 } from '../../src/cli-dispatch';
 import { issueBffAccessToken } from '../../src/oauth/bff-token';
 import { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
@@ -28,25 +28,13 @@ const VALID_ENV = {
 
 const noopLogger: Logger = () => undefined;
 
-function capture(): { write: (chunk: string) => void; text: () => string } {
-  const chunks: string[] = [];
-
-  return { write: chunk => chunks.push(chunk), text: () => chunks.join('') };
-}
-
-describe('printOpenApi', () => {
-  it('should write a parseable OpenAPI 3.1 document', () => {
-    const output = capture();
-    printOpenApi(output.write);
-
-    expect(JSON.parse(output.text()).openapi).toBe('3.1.0');
+describe('renderOpenApi', () => {
+  it('should return a parseable OpenAPI 3.1 document', () => {
+    expect(JSON.parse(renderOpenApi()).openapi).toBe('3.1.0');
   });
 
   it('should end with a newline, so the output pipes cleanly', () => {
-    const output = capture();
-    printOpenApi(output.write);
-
-    expect(output.text().endsWith('\n')).toBe(true);
+    expect(renderOpenApi().endsWith('\n')).toBe(true);
   });
 });
 
@@ -273,10 +261,7 @@ describe('dispatchCli --output', () => {
   });
 
   function expectedDocument(): string {
-    const output = capture();
-    printOpenApi(output.write);
-
-    return output.text();
+    return renderOpenApi();
   }
 
   async function exportQuietly(argv: string[]) {
@@ -469,8 +454,7 @@ describe('dispatchCli --output', () => {
 
 describe('the CLI export and the HTTP route', () => {
   it('should produce the same document, since both use one generator', async () => {
-    const output = capture();
-    printOpenApi(output.write);
+    const exported = renderOpenApi();
 
     const outcome = await dispatchCli([], VALID_ENV, noopLogger);
 
@@ -500,7 +484,7 @@ describe('the CLI export and the HTTP route', () => {
           })}`,
         );
 
-      expect(output.text()).toBe(`${response.text}\n`);
+      expect(exported).toBe(`${response.text}\n`);
     } finally {
       await outcome.server?.stop();
     }

--- a/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
@@ -12,9 +12,17 @@ const REDOCLY_BIN = path.join(
 
 describe('the generated OpenAPI document', () => {
   let directory: string;
+  let status: number | null;
+  let output: string;
 
   beforeAll(() => {
     directory = mkdtempSync(path.join(tmpdir(), 'bff-openapi-'));
+    const file = path.join(directory, 'openapi.json');
+    writeFileSync(file, serializeOpenApi(generateOpenApiDocument('1.0.0')));
+
+    const result = spawnSync(process.execPath, [REDOCLY_BIN, 'lint', file], { encoding: 'utf8' });
+    status = result.status;
+    output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
   });
 
   afterAll(() => {
@@ -22,15 +30,15 @@ describe('the generated OpenAPI document', () => {
   });
 
   it('should pass redocly lint, which is what a consumer runs before generating a client', () => {
-    const file = path.join(directory, 'openapi.json');
-    writeFileSync(file, serializeOpenApi(generateOpenApiDocument('1.0.0')));
-
-    const result = spawnSync(process.execPath, [REDOCLY_BIN, 'lint', file], { encoding: 'utf8' });
-    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
-
-    expect({ status: result.status, output }).toEqual({
+    expect({ status, output }).toEqual({
       status: 0,
       output: expect.stringContaining('is valid'),
     });
+  });
+
+  it('should warn only that the session scheme is unused, which is deliberate', () => {
+    expect(output).toContain('You have 1 warning');
+    expect(output).toContain('bffSession" is never used');
+    expect(output).not.toMatch(/You have \d+ error/);
   });
 });


### PR DESCRIPTION
**Stacked on #1810** (`feature/prd-886-openapi-static-document`), which is itself stacked on #1809. The base is #1810's branch, not `main`: both parents must be reviewed and merged first, in order (#1809, then #1810, then this). The diff below is only this branch's commit.

Adds `forest-bff openapi`: writes the OpenAPI document to stdout, or to a file with `--output`, without booting the server.

fixes PRD-887

## Why a CLI at all

`GET /agent/openapi.json` is auth-gated, so a CI job, a codegen step, or a client dev without credentials has no HTTP path to the document. The CLI is that path. It needs no configuration:

```bash
forest-bff openapi > openapi.json          # stdout
forest-bff openapi --output                # writes ./openapi.json
forest-bff openapi --output docs/api.json  # writes that path, creating docs/
```

## argv contract

Previously `forest-bff <anything>` ignored argv and booted the server. Now argv is parsed:

| Invocation | Before | After |
|---|---|---|
| `forest-bff` | boots the server | boots the server, unchanged |
| `forest-bff openapi` | booted the server | document on stdout, exit 0 |
| `forest-bff openapi --output [path]` | booted the server | writes the file, exit 0 |
| `forest-bff --help` / `-h` | booted the server | usage on stdout, exit 0 |
| `forest-bff --version` / `-v` | booted the server | bare version on stdout, exit 0 |
| `forest-bff bogus` | booted the server | exit 1, reason on stderr |
| `forest-bff openapi extra` | booted the server | exit 1, names the extra |

`--help` and `--version` print to stdout, exit 0, and ignore what follows them: GNU tools treat a help request as a success, never an error. `openapi` is the strict one, because a typo there would otherwise produce a wrong export instead of a message.

A deployment that passed a stray flag and silently got a server will now fail on upgrade. The repo's own `start` scripts pass no arguments.

## --output parsing

The token after `--output` is the destination only when it exists, is non-empty, and does not start with `-`. Otherwise the default `openapi.json` applies and the leftover token is rejected as an extra. So `openapi --output --help` exits 1 and writes nothing, rather than creating a file named `--help`.

Extras are validated before any write, so an invalid command line never leaves an artifact behind. `--output=path` and a repeated `--output` are rejected the same way.

A missing parent directory is created. An existing file is overwritten, like `>` and every codegen exporter. An unwritable destination exits 1 with `Cannot write <path>: <reason>`, no stack trace.

The success line goes to **stderr**, not stdout: `--output` must leave stdout empty so the no-flag form stays pipeable, and so a CI job can keep redirecting without catching a log line.

## Stdout purity

An export piped to a file must contain only the document. This is easy to break silently: `createConsoleLogger` sends `Info` to `console.info`, which writes to **stdout**. Any future log on the export path would corrupt every pipe without failing anything.

Verified rather than assumed: a test pins one single `process.stdout.write` call and asserts `console.info` is never reached. The export path never calls `parseConfig`, never constructs a logger, never binds a socket, and `process.exitCode` is set instead of calling `process.exit()`, so a slow pipe cannot truncate the write.

## Scope and safety

The no-argv path is untouched: same `runCli`, same config parsing, same middleware chain. Hand-rolled argv switch in its own `cli-dispatch.ts`, no arg-parsing dependency.

`openapi.json` is added to `.gitignore`: `--output` has a default filename, and a dev running it from the package would otherwise commit the artifact by accident.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test
yarn workspace @forestadmin/agent-bff lint

cd packages/agent-bff
env -i PATH="$PATH" node dist/cli.js openapi | npx @redocly/cli lint -   # valid, no config
node dist/cli.js openapi --output && cat openapi.json | head -3          # 0, file written
node dist/cli.js openapi --output --help; echo $?                        # 1, no file created
node dist/cli.js --output; echo $?                                       # 1, points at openapi
```

Ran on this branch: 809 tests pass (777 before, 32 added), lint and build clean.

An end-to-end script drove the packaged binary through 40 checks, all passing: every argv path with its exit code and stream, the export under an empty environment, byte equality between the CLI export and the body the route serves, no socket bound, no truncation through a real pipe and a real redirect, `--output` writing the default name and an explicit path, a created parent directory, a dash token refused as a filename, and a directory destination failing with its path named.

## Known limitations

`DispatchOutcome.exitCode` is typed `number` and the type admits `{exitCode: 1, server}`, a combination the code never produces. Harmless today since the only consumer reads `exitCode` alone.

`--output` writes with `writeFileSync`, which truncates before writing. A mid-write failure such as `ENOSPC` leaves a partial file, same as `>` and `curl -o`.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
