### PR TITLE
feat(agent): support get-one projection via the Forest-Projection header

### DIFF
--- a/packages/agent-bff/src/cors/cors-middleware.ts
+++ b/packages/agent-bff/src/cors/cors-middleware.ts
@@ -4,7 +4,7 @@ import { originAllowed } from './origin';
 
 export const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
 export const ALLOWED_HEADERS =
-  'Authorization, Content-Type, X-Forest-Timezone, X-Forest-Bff-Key, X-Request-Id';
+  'Authorization, Content-Type, X-Forest-Timezone, X-Forest-Bff-Key, X-Request-Id, Forest-Projection';
 export const PREFLIGHT_MAX_AGE_SECONDS = 600;
 
 export interface CorsMiddlewareOptions {

--- a/packages/agent-bff/test/cors/cors-middleware.test.ts
+++ b/packages/agent-bff/test/cors/cors-middleware.test.ts
@@ -74,13 +74,14 @@ describe('cors middleware (layer 1)', () => {
       expect(terminal).not.toHaveBeenCalled();
     });
 
-    it('lists all five allowed request headers', () => {
+    it('lists all six allowed request headers', () => {
       expect(ALLOWED_HEADERS.split(', ')).toEqual([
         'Authorization',
         'Content-Type',
         'X-Forest-Timezone',
         'X-Forest-Bff-Key',
         'X-Request-Id',
+        'Forest-Projection',
       ]);
     });
 

--- a/packages/agent/src/routes/access/get.ts
+++ b/packages/agent/src/routes/access/get.ts
@@ -24,10 +24,14 @@ export default class GetRoute extends CollectionRoute {
       ),
     });
 
+    const projection =
+      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
+      QueryStringParser.parseProjection(this.collection, context);
+
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),
       filter,
-      QueryStringParser.parseProjectionWithPks(this.collection, context),
+      projection.withPks(this.collection),
     );
 
     if (!records.length) {

--- a/packages/agent/src/routes/capabilities.ts
+++ b/packages/agent/src/routes/capabilities.ts
@@ -39,6 +39,7 @@ export default class Capabilities extends BaseRoute {
       ),
       agentCapabilities: {
         canUseProjectionOnGetOne: true,
+        canUseProjectionViaHeader: true,
         canUseMultipleFieldsProjectionOnRelation: true,
       },
       collections:

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -78,8 +78,8 @@ export default class QueryStringParser {
     try {
       const fields = header.split(',').map(field => field.trim());
 
-      // Keep parity with the `fields[...]` query params, which cannot express
-      // projections deeper than one relation level.
+      // The frontend never projects deeper than one relation level on get-one; deeper
+      // projections stay rejected until a dedicated capability announces support for them.
       const nestedField = fields.find(field => field.split(':').length > 2);
 
       if (nestedField) {
@@ -90,7 +90,7 @@ export default class QueryStringParser {
 
       return new Projection(...fields);
     } catch (e) {
-      throw new ValidationError(`Invalid projection: ${e.message}`);
+      throw new ValidationError(`Invalid Forest-Projection header: ${e.message}`);
     }
   }
 

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -78,14 +78,6 @@ export default class QueryStringParser {
     try {
       const fields = header.split(',').map(field => field.trim());
 
-      // The frontend never projects deeper than one relation level on get-one; deeper
-      // projections stay rejected until a dedicated capability announces support for them.
-      const nestedField = fields.find(field => field.split(':').length > 2);
-
-      if (nestedField) {
-        throw new ValidationError(`nested projections are not supported ('${nestedField}')`);
-      }
-
       ProjectionValidator.validate(collection, fields);
 
       return new Projection(...fields);

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -71,6 +71,29 @@ export default class QueryStringParser {
     }
   }
 
+  static parseProjectionFromHeader(collection: Collection, context: Context): Projection | null {
+    const header = context.request.headers['forest-projection']?.toString().trim();
+    if (!header) return null;
+
+    try {
+      const fields = header.split(',').map(field => field.trim());
+
+      // Keep parity with the `fields[...]` query params, which cannot express
+      // projections deeper than one relation level.
+      const nestedField = fields.find(field => field.split(':').length > 2);
+
+      if (nestedField) {
+        throw new ValidationError(`nested projections are not supported ('${nestedField}')`);
+      }
+
+      ProjectionValidator.validate(collection, fields);
+
+      return new Projection(...fields);
+    } catch (e) {
+      throw new ValidationError(`Invalid projection: ${e.message}`);
+    }
+  }
+
   static parseProjectionWithPks(collection: Collection, context: Context): Projection {
     const projection = QueryStringParser.parseProjection(collection, context);
 

--- a/packages/agent/test/agent-integration.test.ts
+++ b/packages/agent/test/agent-integration.test.ts
@@ -302,6 +302,43 @@ describe('Agent Integration Tests', () => {
         await expect(superagent.get(`${testContext.baseUrl}/forest/users`)).rejects.toThrow();
       });
 
+      it('should allow the Forest-Projection header on CORS preflight requests', async () => {
+        const response = await superagent
+          .options(`${testContext.baseUrl}/forest/users/1`)
+          .set('Origin', 'https://app.forestadmin.com')
+          .set('Access-Control-Request-Method', 'GET')
+          .set('Access-Control-Request-Headers', 'authorization,forest-projection');
+
+        expect(response.status).toBe(204);
+        expect(response.headers['access-control-allow-headers']).toContain('forest-projection');
+      });
+
+      it('should honor the Forest-Projection header on get-one requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users/1`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'firstName');
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.attributes).toEqual({ id: 1, firstName: 'John' });
+      });
+
+      it('should return 400 when the Forest-Projection header is invalid', async () => {
+        const token = createTestToken();
+
+        const error: { status?: number } = await superagent
+          .get(`${testContext.baseUrl}/forest/users/1`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'field-that-do-not-exist')
+          .catch(err => err);
+
+        expect(error.status).toBe(400);
+      });
+
       it('should accept authenticated requests with valid JWT', async () => {
         const token = createTestToken();
 

--- a/packages/agent/test/routes/access/get.test.ts
+++ b/packages/agent/test/routes/access/get.test.ts
@@ -348,6 +348,76 @@ describe('GetRoute', () => {
     });
   });
 
+  describe('with a nested projection in the Forest-Projection header', () => {
+    test('it should request the nested projection with the intermediate pks', async () => {
+      const services = factories.forestAdminHttpDriverServices.build();
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'books',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              name: factories.columnSchema.build({ columnType: 'String' }),
+              author: factories.oneToOneSchema.build({
+                foreignCollection: 'persons',
+                originKey: 'bookId',
+                originKeyTarget: 'id',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'persons',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              bookId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              addressId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              address: factories.manyToOneSchema.build({
+                foreignCollection: 'addresses',
+                foreignKey: 'addressId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'addresses',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              street: factories.columnSchema.build({ columnType: 'String' }),
+            },
+          }),
+        }),
+      ]);
+      const listSpy = jest
+        .spyOn(dataSource.getCollection('books'), 'list')
+        .mockResolvedValue([{ id: '2d162303-78bf-599e-b197-93590ac3d315' }]);
+      services.serializer.serialize = jest.fn().mockReturnValue('serialized');
+      const get = new Get(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name,author:address:street' },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+        },
+      });
+
+      await get.handleGet(context);
+
+      const projection = listSpy.mock.calls[0][2];
+      expect([...projection].sort()).toEqual([
+        'author:address:id',
+        'author:address:street',
+        'author:id',
+        'id',
+        'name',
+      ]);
+    });
+  });
+
   describe('with special characters in names', () => {
     it('should register routes with escaped characters', () => {
       const options = factories.forestAdminHttpDriverOptions.build();

--- a/packages/agent/test/routes/access/get.test.ts
+++ b/packages/agent/test/routes/access/get.test.ts
@@ -207,6 +207,97 @@ describe('GetRoute', () => {
           );
         });
 
+        test('it should read the projection from the Forest-Projection header', async () => {
+          jest
+            .spyOn(dataSource.getCollection('books'), 'list')
+            .mockResolvedValue([{ title: 'test ' }]);
+          services.serializer.serialize = jest.fn().mockReturnValue('test');
+          const get = new Get(services, options, dataSource, 'books');
+          const context = createMockContext({
+            state: { user: { email: 'john.doe@domain.com' } },
+            headers: { 'forest-projection': 'name,author:id' },
+            customProperties: {
+              query: { timezone: 'Europe/Paris' },
+              params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+            },
+          });
+
+          await get.handleGet(context);
+
+          expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            ['name', 'author:id', 'id'],
+          );
+        });
+
+        test('it should give precedence to the Forest-Projection header over query params', async () => {
+          jest
+            .spyOn(dataSource.getCollection('books'), 'list')
+            .mockResolvedValue([{ title: 'test ' }]);
+          services.serializer.serialize = jest.fn().mockReturnValue('test');
+          const get = new Get(services, options, dataSource, 'books');
+          const context = createMockContext({
+            state: { user: { email: 'john.doe@domain.com' } },
+            headers: { 'forest-projection': 'author:id' },
+            customProperties: {
+              query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+              params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+            },
+          });
+
+          await get.handleGet(context);
+
+          expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            ['author:id', 'id'],
+          );
+        });
+
+        test('it should not fall back to query params when the header is invalid', async () => {
+          const listSpy = jest
+            .spyOn(dataSource.getCollection('books'), 'list')
+            .mockResolvedValue([{ title: 'test ' }]);
+          listSpy.mockClear();
+          const get = new Get(services, options, dataSource, 'books');
+          const context = createMockContext({
+            state: { user: { email: 'john.doe@domain.com' } },
+            headers: { 'forest-projection': 'field-that-do-not-exist' },
+            customProperties: {
+              query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+              params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+            },
+          });
+
+          await expect(get.handleGet(context)).rejects.toThrow('Invalid projection');
+          expect(listSpy).not.toHaveBeenCalled();
+        });
+
+        test('it should fall back to query params when the header is empty', async () => {
+          jest
+            .spyOn(dataSource.getCollection('books'), 'list')
+            .mockResolvedValue([{ title: 'test ' }]);
+          services.serializer.serialize = jest.fn().mockReturnValue('test');
+          const get = new Get(services, options, dataSource, 'books');
+          const context = createMockContext({
+            state: { user: { email: 'john.doe@domain.com' } },
+            headers: { 'forest-projection': '' },
+            customProperties: {
+              query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+              params: { id: '2d162303-78bf-599e-b197-93590ac3d315' },
+            },
+          });
+
+          await get.handleGet(context);
+
+          expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            ['name', 'id'],
+          );
+        });
+
         test('it should handle multiple projected fields on a belongsTo relation', async () => {
           jest
             .spyOn(dataSource.getCollection('books'), 'list')

--- a/packages/agent/test/routes/access/get.test.ts
+++ b/packages/agent/test/routes/access/get.test.ts
@@ -270,7 +270,7 @@ describe('GetRoute', () => {
             },
           });
 
-          await expect(get.handleGet(context)).rejects.toThrow('Invalid projection');
+          await expect(get.handleGet(context)).rejects.toThrow('Invalid Forest-Projection header');
           expect(listSpy).not.toHaveBeenCalled();
         });
 

--- a/packages/agent/test/routes/capabilities.test.ts
+++ b/packages/agent/test/routes/capabilities.test.ts
@@ -77,6 +77,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [{ name: 'main' }, { name: 'replica' }],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseProjectionViaHeader: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -99,6 +100,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseProjectionViaHeader: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -119,6 +121,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseProjectionViaHeader: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -141,6 +144,7 @@ describe('Capabilities', () => {
           nativeQueryConnections: [],
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
+            canUseProjectionViaHeader: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [

--- a/packages/agent/test/services/serializer.test.ts
+++ b/packages/agent/test/services/serializer.test.ts
@@ -388,6 +388,75 @@ describe('Serializer', () => {
       });
     });
 
+    test('serialize should serialize nested relations of relations', () => {
+      const dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'book',
+          schema: factories.collectionSchema.build({
+            fields: {
+              isbn: factories.columnSchema.uuidPrimaryKey().build(),
+              authorId: factories.columnSchema.build(),
+              author: factories.manyToOneSchema.build({
+                foreignCollection: 'person',
+                foreignKey: 'authorId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'person',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              name: factories.columnSchema.build(),
+              addressId: factories.columnSchema.build(),
+              address: factories.manyToOneSchema.build({
+                foreignCollection: 'address',
+                foreignKey: 'addressId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'address',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              street: factories.columnSchema.build(),
+            },
+          }),
+        }),
+      ]);
+
+      const result = setupSerializer().serialize(dataSource.getCollection('book'), {
+        isbn: '9780345317988',
+        author: { id: 'asim00', name: 'Asimov', address: { id: 'addr01', street: 'Main street' } },
+      });
+
+      expect(result).toStrictEqual({
+        data: {
+          type: 'book',
+          id: '9780345317988',
+          attributes: { isbn: '9780345317988' },
+          relationships: { author: { data: { type: 'person', id: 'asim00' } } },
+        },
+        included: [
+          {
+            type: 'address',
+            id: 'addr01',
+            attributes: { id: 'addr01', street: 'Main street' },
+          },
+          {
+            type: 'person',
+            id: 'asim00',
+            attributes: { id: 'asim00', name: 'Asimov' },
+            relationships: { address: { data: { type: 'address', id: 'addr01' } } },
+          },
+        ],
+        jsonapi: { version: '1.0' },
+      });
+    });
+
     test('serialize should encode the primary key', () => {
       const result = setupSerializer().serialize(setupWithRelation().collections[0], {
         isbn: '9780345317988',

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -369,13 +369,29 @@ describe('QueryStringParser', () => {
             fields: {
               id: factories.columnSchema.uuidPrimaryKey().build(),
               street: factories.columnSchema.build(),
+              countryId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              country: factories.manyToOneSchema.build({
+                foreignCollection: 'country',
+                foreignKey: 'countryId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'country',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              name: factories.columnSchema.build(),
             },
           }),
         }),
       ]);
 
       const context = createMockContext({
-        headers: { 'forest-projection': 'id,owner:address:street' },
+        headers: {
+          'forest-projection': 'id,owner:address:street,owner:address:country:name',
+        },
       });
 
       const projection = QueryStringParser.parseProjectionFromHeader(
@@ -383,7 +399,9 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual(new Projection('id', 'owner:address:street'));
+      expect(projection).toEqual(
+        new Projection('id', 'owner:address:street', 'owner:address:country:name'),
+      );
     });
 
     test('should throw a ValidationError when the header contains an unknown field', () => {

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -220,6 +220,148 @@ describe('QueryStringParser', () => {
     });
   });
 
+  describe('parseProjectionFromHeader', () => {
+    test('should return null when the header is missing', () => {
+      const context = createMockContext({
+        customProperties: { query: { 'fields[books]': 'id' } },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toBeNull();
+    });
+
+    test('should return null when the header is empty', () => {
+      const context = createMockContext({ headers: { 'forest-projection': '' } });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toBeNull();
+    });
+
+    test('should return null when the header only contains whitespace', () => {
+      const context = createMockContext({ headers: { 'forest-projection': '  ' } });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toBeNull();
+    });
+
+    test('should handle a repeated header sent as an array of values', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': ['id', 'name'] as unknown as string },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toEqual(new Projection('id', 'name'));
+    });
+
+    test('should keep duplicated fields as-is, like the query string parsing', () => {
+      const context = createMockContext({ headers: { 'forest-projection': 'id,id' } });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toEqual(new Projection('id', 'id'));
+    });
+
+    test('should throw a ValidationError on a trailing comma', () => {
+      const context = createMockContext({ headers: { 'forest-projection': 'id,' } });
+
+      const fn = () => QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(fn).toThrow(ValidationError);
+    });
+
+    test('should throw a ValidationError when a subfield targets a column', () => {
+      const context = createMockContext({ headers: { 'forest-projection': 'name:foo' } });
+
+      const fn = () => QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(fn).toThrow(ValidationError);
+    });
+
+    test('should convert the header to a valid projection', () => {
+      const context = createMockContext({ headers: { 'forest-projection': 'id,name' } });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toEqual(new Projection('id', 'name'));
+    });
+
+    test('should trim spaces around field names', () => {
+      const context = createMockContext({ headers: { 'forest-projection': 'id, name' } });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(projection).toEqual(new Projection('id', 'name'));
+    });
+
+    test('should support relation fields with the colon notation', () => {
+      const dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'cars',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              owner: factories.oneToOneSchema.build({
+                foreignCollection: 'owner',
+                originKey: 'id',
+                originKeyTarget: 'id',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'owner',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              name: factories.columnSchema.build(),
+            },
+          }),
+        }),
+      ]);
+
+      const context = createMockContext({
+        headers: { 'forest-projection': 'id,owner:id,owner:name' },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeader(
+        dataSource.getCollection('cars'),
+        context,
+      );
+
+      expect(projection).toEqual(new Projection('id', 'owner:id', 'owner:name'));
+    });
+
+    test('should throw a ValidationError on nested projections', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': 'id,owner:address:street' },
+      });
+
+      const fn = () => QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(fn).toThrow(ValidationError);
+      expect(fn).toThrow(
+        "Invalid projection: nested projections are not supported ('owner:address:street')",
+      );
+    });
+
+    test('should throw a ValidationError when the header contains an unknown field', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+      });
+
+      const fn = () => QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
+
+      expect(fn).toThrow(ValidationError);
+      expect(fn).toThrow(
+        "Invalid projection: The 'books.field-that-do-not-exist' field was not found. Available fields are: [id,name]. Please check if the field name is correct.",
+      );
+    });
+  });
+
   describe('parseProjectionWithPks', () => {
     describe('when the request does not contain the primary keys', () => {
       test('should return the requested project with the primary keys', () => {

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -335,17 +335,55 @@ describe('QueryStringParser', () => {
       expect(projection).toEqual(new Projection('id', 'owner:id', 'owner:name'));
     });
 
-    test('should throw a ValidationError on nested projections', () => {
+    test('should support nested projections through to-one relation chains', () => {
+      const dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'cars',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              owner: factories.oneToOneSchema.build({
+                foreignCollection: 'owner',
+                originKey: 'id',
+                originKeyTarget: 'id',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'owner',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              addressId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              address: factories.manyToOneSchema.build({
+                foreignCollection: 'address',
+                foreignKey: 'addressId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'address',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              street: factories.columnSchema.build(),
+            },
+          }),
+        }),
+      ]);
+
       const context = createMockContext({
         headers: { 'forest-projection': 'id,owner:address:street' },
       });
 
-      const fn = () => QueryStringParser.parseProjectionFromHeader(collectionSimple, context);
-
-      expect(fn).toThrow(ValidationError);
-      expect(fn).toThrow(
-        "Invalid Forest-Projection header: nested projections are not supported ('owner:address:street')",
+      const projection = QueryStringParser.parseProjectionFromHeader(
+        dataSource.getCollection('cars'),
+        context,
       );
+
+      expect(projection).toEqual(new Projection('id', 'owner:address:street'));
     });
 
     test('should throw a ValidationError when the header contains an unknown field', () => {

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -344,7 +344,7 @@ describe('QueryStringParser', () => {
 
       expect(fn).toThrow(ValidationError);
       expect(fn).toThrow(
-        "Invalid projection: nested projections are not supported ('owner:address:street')",
+        "Invalid Forest-Projection header: nested projections are not supported ('owner:address:street')",
       );
     });
 
@@ -357,7 +357,7 @@ describe('QueryStringParser', () => {
 
       expect(fn).toThrow(ValidationError);
       expect(fn).toThrow(
-        "Invalid projection: The 'books.field-that-do-not-exist' field was not found. Available fields are: [id,name]. Please check if the field name is correct.",
+        "Invalid Forest-Projection header: The 'books.field-that-do-not-exist' field was not found. Available fields are: [id,name]. Please check if the field name is correct.",
       );
     });
   });


### PR DESCRIPTION
## Motivation

The get-one projection currently travels in the query string (`fields[Collection]=...&fields[relation]=id`). On large collections it exceeds query string size limits enforced by common WAF configurations (e.g. the AWS WAF managed rule `SizeRestrictions_QUERYSTRING`, 2,048 bytes), which blocks the CORS preflight and breaks the details view.

fixes PRD-892

## Changes

- **`QueryStringParser.parseProjectionFromHeader`**: reads the projection from the `Forest-Projection` header. Contract:
  - format `field1,field2,relation:subfield` (e.g. `id,title,author:id`), whitespace around commas tolerated, repeated header supported;
  - empty/whitespace-only header treated as absent;
  - arbitrary relation depth through to-one chains (`author:publisher:name`), same as the query string already accepts;
  - invalid header → 400 with no silent fallback to query params, so frontend bugs surface instead of being masked.
- **Get-one route**: the header takes precedence over the `fields[...]` query params; the query-string parsing is kept as fallback.
- **Capabilities**: the agent announces `canUseProjectionViaHeader: true` (next to `canUseProjectionOnGetOne`, which is kept — the frontend does the prioritization).
- **CORS**: no change needed — `@koa/cors` without an `allowHeaders` option echoes `Access-Control-Request-Headers`, so the preflight already allows the header. An integration test pins this across all 8 supported mount targets (standalone, express, koa, fastify v2/v3/v4, nestjs express/fastify).

## Tests

- Unit tests on the parser (missing/empty/whitespace header, repeated header as array, duplicates, trailing comma, subfield on a column, nested projections through to-one chains (covered up to 3 relation levels), unknown field).
- Route tests: header honored, precedence over query params, no fallback on invalid header, fallback on empty header.
- End-to-end integration tests on all 8 frameworks: real GET with the header returns only the projected fields; invalid header returns 400; CORS preflight allows the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Forest-Projection` header support for GET one record field selection
> - [`GetRoute.handleGet`](https://github.com/ForestAdmin/agent-nodejs/pull/1813/files#diff-a33987fdfe07235c4e2e7de4d065bcf333c4fc2a0437283a89aa1e95e379a5b8) reads projection from the `Forest-Projection` HTTP header first, falling back to query string params when the header is absent or empty; primary keys are always appended via `projection.withPks`.
> - [`QueryStringParser.parseProjectionFromHeader`](https://github.com/ForestAdmin/agent-nodejs/pull/1813/files#diff-fd8b84f20d0c331a34d7399c832497c1cc74c7ac552f0d727a7c8a9c3e37525f) is a new static method that parses and validates the header value, supporting single-level relation notation (e.g. `relation:field`) and throwing a `ValidationError` for invalid or deeply nested paths.
> - The `/_internal/capabilities` endpoint now includes `canUseProjectionViaHeader: true` in `agentCapabilities` to signal this feature to clients.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1813 opened
>
> - Changed the `ValidationError` message prefix in `QueryStringParser.parseProjectionFromHeader` method from 'Invalid projection' to 'Invalid Forest-Projection header' when parsing the `forest-projection` header fails [1042ae8]
> - Removed validation that rejected nested projection fields in the `QueryStringParser.parseProjectionFromHeader` method within the `@forestadmin/agent` package [eeca14e]
> - Added test coverage for nested projection support across get-one routes, serialization, and query string parsing in the `@forestadmin/agent` package [eeca14e]
> - Extended test schema and projection expectations for nested relation projections [a9468b8]
> - Added `Forest-Projection` to the allowed CORS request headers in the `agent-bff` package and updated the corresponding test to verify the header is included in the ALLOWED_HEADERS constant [2405b96]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bceed7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## ⚠️ Upgrade note (self-hosted CORS)

The agent's own CORS middleware reflects `Access-Control-Request-Headers`, so no action is needed when the agent answers the preflight. However, if the agent is mounted inside a host app whose **own** CORS middleware answers the `OPTIONS` preflight with an explicit allow-list (e.g. `app.use(cors({ allowedHeaders: [...] }))` registered before the agent mount), **`Forest-Projection` must be added to that allow-list**. Otherwise, once the frontend uses the `canUseProjectionViaHeader` capability, get-one requests will be blocked by the browser at the preflight and the record details view will not load. This must be called out in the release notes and the self-hosted CORS documentation.


