### PR TITLE
test(ai-proxy): stop failing the LLM suite on a provider outage

### DIFF
--- a/packages/ai-proxy/test/llm.integration.test.ts
+++ b/packages/ai-proxy/test/llm.integration.test.ts
@@ -412,6 +412,7 @@ providers.forEach(
 
         it('all models should support tool calls', async () => {
           const results: { model: string; success: boolean; error?: string }[] = [];
+          const unavailable: { model: string; error: string }[] = [];
 
           for (const model of modelsToTest) {
             const modelRouter = new Router({
@@ -464,11 +465,31 @@ providers.forEach(
                 throw new Error(`Infrastructure error testing model ${model}: ${errorMessage}`);
               }
 
+              // A provider 5xx says nothing about whether the model supports tool calls, so it
+              // cannot be answered by the denylist this test feeds. Counting it as a failure makes
+              // the suite fail on the provider's uptime instead of on our own contract.
+              if (errorMessage.includes('AIProviderUnavailableError')) {
+                unavailable.push({ model, error: errorMessage });
+
+                // eslint-disable-next-line no-continue
+                continue;
+              }
+
               results.push({ model, success: false, error: errorMessage });
             }
           }
 
           const failures = results.filter(r => !r.success);
+
+          if (unavailable.length > 0) {
+            const unavailableModelNames = unavailable.map(f => f.model).join(', ');
+            // eslint-disable-next-line no-console
+            console.warn(
+              `\n⚠️ ${unavailable.length} ${label} model(s) skipped, provider unavailable: ` +
+                `${unavailableModelNames}\n`,
+              unavailable,
+            );
+          }
 
           if (failures.length > 0) {
             const failedModelNames = failures.map(f => f.model).join(', ');
@@ -480,6 +501,10 @@ providers.forEach(
           }
 
           expect(failures).toEqual([]);
+
+          // Guards against the skip above hiding a total outage, which would otherwise let the
+          // suite pass green while having verified nothing.
+          expect(results.length).toBeGreaterThan(0);
         }, 300000); // 5 minutes for all models
       });
     });


### PR DESCRIPTION
`LLM Integration Tests (ai-proxy)` fails the whole suite when OpenAI has an outage, blocking PRs that have nothing to do with `ai-proxy`.

## What happened

It failed twice in a row on #1815, while `main` and two other feature branches were green — and a run on another branch that succeeded landed *between* my two failures, so it is correlated with time, not with the branch.

Same cause both times:

```
❌ 1 OpenAI model(s) failed tool support: gpt-3.5-turbo-16k
   error: 'AIProviderUnavailableError: OpenAI server error (HTTP 500):
           500 The server had an error while processing your request.'
```

## Why the test is wrong here

The suite exists to answer one question: does this model support tool calls? A provider 5xx carries no signal about that. It is also not actionable through the mechanism this test feeds — per `packages/ai-proxy/CLAUDE.md`, a model that fails here is meant to be added to the `supported-models.ts` denylist, and denylisting a model because the provider had a bad minute would encode an outage as a permanent capability claim.

The existing `isInfrastructureError` branch already separates rate limits, auth and network errors from real capability failures. Provider 5xx simply was not in that list, so it fell through to "failed tool support".

## The change

Models whose call raises `AIProviderUnavailableError` are collected separately and reported as skipped with a warning, instead of counted as failures. A genuine capability failure still fails the test.

To keep the skip from hiding a real problem, the test now also asserts that at least one model was actually verified — so a total provider outage fails loudly rather than passing green having checked nothing.

## Verification

- `yarn workspace @forestadmin/ai-proxy test` — 469 tests, 39 suites, green.
- `test/llm.integration.test.ts` run against the real APIs — 40 tests green, so OpenAI is healthy again and the check still does its job end to end.

One honest limitation: because every model was available during that run, the new skip branch was not itself exercised. It is matched on the `String(error)` prefix observed verbatim in the CI logs above.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip provider unavailability errors in the LLM integration test suite
> Updates the `all models should support tool calls` test in [llm.integration.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1817/files#diff-48feb2f9ecfdc5a8e078463454a6034c45dbf8a77706e9f83d551696eaaac759) to distinguish `AIProviderUnavailableError` failures from real test failures. Models that return this error are collected separately, logged as a warning, and excluded from the failure count. A final assertion checks that at least one model was actually tested, preventing a total outage from producing a false pass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efafeb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->