### PR TITLE
fix(agent): authorize count-related on the target collection instead of the parent

### DIFF
--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -209,8 +209,8 @@ async function handleRelation(
     throw unknownRelation(`Unknown relation: ${deps.collection}.${relation}`);
   }
 
-  // The agent's count-related authorizes only the parent, so an unguarded foreign collection would
-  // leak a hidden collection's rows/count. Guard it here, mirroring the parent allow-list check.
+  // The agent checks browse permission on the foreign collection, but BFF exposure is a separate
+  // allow-list: a browsable collection may still be hidden here. Mirror the parent allow-list check.
   if (!readModel.isCollectionAllowed(foreignCollection)) {
     throw unknownCollection();
   }

--- a/packages/agent/src/routes/access/count-related.ts
+++ b/packages/agent/src/routes/access/count-related.ts
@@ -17,7 +17,7 @@ export default class CountRelatedRoute extends RelationRoute {
   }
 
   public async handleCountRelated(context: Context): Promise<void> {
-    await this.services.authorization.assertCanBrowse(context, this.collection.name);
+    await this.services.authorization.assertCanBrowse(context, this.foreignCollection.name);
 
     if (this.foreignCollection.schema.countable) {
       const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);

--- a/packages/agent/test/routes/access/count-related.test.ts
+++ b/packages/agent/test/routes/access/count-related.test.ts
@@ -147,7 +147,7 @@ describe('CountRelatedRoute', () => {
         expect(context.response.body).toEqual({ count: 1568 });
       });
 
-      test("should check the user's permission", async () => {
+      test("should check the user's permission on the related collection", async () => {
         const { services, dataSource, options } = setupWithOneToManyRelation();
 
         const oneToManyRelationName = 'myBookPersons';
@@ -167,10 +167,31 @@ describe('CountRelatedRoute', () => {
         await count.handleCountRelated(context);
         expect(services.authorization.assertCanBrowse as jest.Mock).toHaveBeenCalledWith(
           context,
-          'books',
+          'bookPersons',
         );
 
         expect(context.response.body).toEqual({ count: 1568 });
+      });
+
+      test('should not count when the user cannot browse the related collection', async () => {
+        const { services, dataSource, options } = setupWithOneToManyRelation();
+
+        const count = new CountRelatedRoute(
+          services,
+          options,
+          dataSource,
+          'books',
+          'myBookPersons',
+        );
+
+        const error = new Error('Forbidden');
+        (services.authorization.assertCanBrowse as jest.Mock).mockRejectedValueOnce(error);
+        const aggregateRelation = jest.spyOn(CollectionUtils, 'aggregateRelation').mockClear();
+
+        const context = setupContext();
+        await expect(count.handleCountRelated(context)).rejects.toThrow(error);
+
+        expect(aggregateRelation).not.toHaveBeenCalled();
       });
 
       test('it should apply the scope', async () => {

--- a/packages/agent/test/routes/access/count-related.test.ts
+++ b/packages/agent/test/routes/access/count-related.test.ts
@@ -165,33 +165,11 @@ describe('CountRelatedRoute', () => {
 
         const context = setupContext();
         await count.handleCountRelated(context);
-        expect(services.authorization.assertCanBrowse as jest.Mock).toHaveBeenCalledWith(
-          context,
-          'bookPersons',
-        );
+        const assertCanBrowse = services.authorization.assertCanBrowse as jest.Mock;
+        expect(assertCanBrowse).toHaveBeenCalledTimes(1);
+        expect(assertCanBrowse).toHaveBeenCalledWith(context, 'bookPersons');
 
         expect(context.response.body).toEqual({ count: 1568 });
-      });
-
-      test('should not count when the user cannot browse the related collection', async () => {
-        const { services, dataSource, options } = setupWithOneToManyRelation();
-
-        const count = new CountRelatedRoute(
-          services,
-          options,
-          dataSource,
-          'books',
-          'myBookPersons',
-        );
-
-        const error = new Error('Forbidden');
-        (services.authorization.assertCanBrowse as jest.Mock).mockRejectedValueOnce(error);
-        const aggregateRelation = jest.spyOn(CollectionUtils, 'aggregateRelation').mockClear();
-
-        const context = setupContext();
-        await expect(count.handleCountRelated(context)).rejects.toThrow(error);
-
-        expect(aggregateRelation).not.toHaveBeenCalled();
       });
 
       test('it should apply the scope', async () => {
@@ -312,6 +290,27 @@ describe('CountRelatedRoute', () => {
     });
 
     describe('when an error happens', () => {
+      test('should not count when the user cannot browse the related collection', async () => {
+        const { services, dataSource, options } = setupWithOneToManyRelation();
+
+        const count = new CountRelatedRoute(
+          services,
+          options,
+          dataSource,
+          'books',
+          'myBookPersons',
+        );
+
+        const error = new Error('Forbidden');
+        (services.authorization.assertCanBrowse as jest.Mock).mockRejectedValueOnce(error);
+        const aggregateRelation = jest.spyOn(CollectionUtils, 'aggregateRelation').mockClear();
+
+        const context = setupContext();
+        await expect(count.handleCountRelated(context)).rejects.toThrow(error);
+
+        expect(aggregateRelation).not.toHaveBeenCalled();
+      });
+
       test('should return an HTTP 400 response when the request is malformed', async () => {
         const { services, dataSource, options } = setupWithOneToManyRelation();
 


### PR DESCRIPTION
## Description

`count-related` checked the `browse` permission on the **parent** collection, so a caller with no access to the related collection could still get the number of related records (and probe it further with filters).

The two sibling routes already authorize on the foreign collection (`list-related`, `csv-related`) since #823 — this route was simply missed by that fix. The scope in `count-related` already used the foreign collection, only the permission check was off.

## Changes

- `assertCanBrowse` now targets `this.foreignCollection.name` in `count-related.ts`
- Updated the permission test to assert the check targets the related collection (and only it), and added a test verifying the count is not performed when browsing the related collection is denied
- Reworded an `agent-bff` comment that documented the old parent-side behavior (the BFF exposure allow-list guard itself is unchanged and still needed)

## Side effect worth noting

`assertCanBrowse` also validates the `segmentQuery` permission against the collection name, so live-query segments on related counts are now validated against the foreign collection (matching `list-related`) instead of the parent.

fixes PRD-898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CountRelatedRoute` to authorize browse on the foreign collection instead of the parent
> The `handleCountRelated` method in [count-related.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1818/files#diff-1cef97fcb7b807016c3cd191321e043ec804c12626bce8fd93cfda09621eba71) was checking browse permission against the parent collection rather than the related (foreign) collection. It now calls `assertCanBrowse` with `this.foreignCollection.name`, matching the actual resource being accessed. Tests in [count-related.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1818/files#diff-8d0e155b7eaf797eb3a3a49614401bb1cf527f3dea9c4c873d148b4a47ae6788) are updated to assert the correct collection name and cover the case where authorization failure prevents the count query from running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f19e3f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->