### PR TITLE
fix(agent): authorize create with linked one-to-one on the foreign collection

### DIFF
--- a/packages/agent/src/routes/modification/create.ts
+++ b/packages/agent/src/routes/modification/create.ts
@@ -1,4 +1,9 @@
-import type { CompositeId, ManyToOneSchema, RecordData } from '@forestadmin/datasource-toolkit';
+import type {
+  CompositeId,
+  ManyToOneSchema,
+  OneToOneSchema,
+  RecordData,
+} from '@forestadmin/datasource-toolkit';
 import type Router from '@koa/router';
 import type { Context } from 'koa';
 
@@ -80,18 +85,29 @@ export default class CreateRoute extends CollectionRoute {
     return record;
   }
 
+  private getLinkedOneToOneRelations(
+    relations: Record<string, RecordData>,
+  ): Array<{ linked: RecordData; relation: OneToOneSchema }> {
+    return Object.entries(relations)
+      .map(([field, linked]) => ({
+        linked,
+        relation: SchemaUtils.getRelation(this.collection.schema, field, this.collection.name),
+      }))
+      .filter(
+        (entry): entry is { linked: RecordData; relation: OneToOneSchema } =>
+          entry.linked !== null && entry.relation.type === 'OneToOne',
+      );
+  }
+
   private async assertCanEditLinkedOneToOneRelations(
     context: Context,
     relations: Record<string, RecordData>,
   ): Promise<void> {
-    const promises = Object.entries(relations).map(async ([field, linked]) => {
-      const relation = SchemaUtils.getRelation(this.collection.schema, field, this.collection.name);
-      if (linked === null || relation.type !== 'OneToOne') return;
-
-      await this.services.authorization.assertCanEdit(context, relation.foreignCollection);
-    });
-
-    await Promise.all(promises);
+    await Promise.all(
+      this.getLinkedOneToOneRelations(relations).map(({ relation }) =>
+        this.services.authorization.assertCanEdit(context, relation.foreignCollection),
+      ),
+    );
   }
 
   private async linkOneToOneRelations(
@@ -101,32 +117,31 @@ export default class CreateRoute extends CollectionRoute {
   ): Promise<void> {
     const caller = QueryStringParser.parseCaller(context);
 
-    const promises = Object.entries(relations).map(async ([field, linked]) => {
-      const relation = SchemaUtils.getRelation(this.collection.schema, field, this.collection.name);
-      if (linked === null || relation.type !== 'OneToOne') return;
+    const promises = this.getLinkedOneToOneRelations(relations).map(
+      async ({ linked, relation }) => {
+        const foreignCollection = this.dataSource.getCollection(relation.foreignCollection);
+        const scope = await this.services.authorization.getScope(foreignCollection, context);
 
-      const foreignCollection = this.dataSource.getCollection(relation.foreignCollection);
-      const scope = await this.services.authorization.getScope(foreignCollection, context);
+        // Load the value that will be used as originKey (=== parentId[0] most of the time)
+        const originValue = record[relation.originKeyTarget];
 
-      // Load the value that will be used as originKey (=== parentId[0] most of the time)
-      const originValue = record[relation.originKeyTarget];
+        // Break old relation (may update zero or one records).
+        const oldFkOwner = new ConditionTreeLeaf(relation.originKey, 'Equal', originValue);
+        await foreignCollection.update(
+          caller,
+          new Filter({ conditionTree: ConditionTreeFactory.intersect(oldFkOwner, scope) }),
+          { [relation.originKey]: null },
+        );
 
-      // Break old relation (may update zero or one records).
-      const oldFkOwner = new ConditionTreeLeaf(relation.originKey, 'Equal', originValue);
-      await foreignCollection.update(
-        caller,
-        new Filter({ conditionTree: ConditionTreeFactory.intersect(oldFkOwner, scope) }),
-        { [relation.originKey]: null },
-      );
-
-      // Create new relation (will update exactly one record).
-      const newFkOwner = ConditionTreeFactory.matchRecords(foreignCollection.schema, [linked]);
-      await foreignCollection.update(
-        caller,
-        new Filter({ conditionTree: ConditionTreeFactory.intersect(newFkOwner, scope) }),
-        { [relation.originKey]: originValue },
-      );
-    });
+        // Create new relation (will update exactly one record).
+        const newFkOwner = ConditionTreeFactory.matchRecords(foreignCollection.schema, [linked]);
+        await foreignCollection.update(
+          caller,
+          new Filter({ conditionTree: ConditionTreeFactory.intersect(newFkOwner, scope) }),
+          { [relation.originKey]: originValue },
+        );
+      },
+    );
 
     await Promise.all(promises);
   }

--- a/packages/agent/src/routes/modification/create.ts
+++ b/packages/agent/src/routes/modification/create.ts
@@ -26,6 +26,9 @@ export default class CreateRoute extends CollectionRoute {
     const rawRecord = serializer.deserialize(this.collection, context.request.body);
 
     const [record, relations] = await this.makeRecord(context, rawRecord);
+
+    await this.assertCanEditLinkedOneToOneRelations(context, relations);
+
     const newRecord = await this.createRecord(context, record);
 
     await this.linkOneToOneRelations(context, newRecord, relations);
@@ -77,6 +80,20 @@ export default class CreateRoute extends CollectionRoute {
     return record;
   }
 
+  private async assertCanEditLinkedOneToOneRelations(
+    context: Context,
+    relations: Record<string, RecordData>,
+  ): Promise<void> {
+    const promises = Object.entries(relations).map(async ([field, linked]) => {
+      const relation = SchemaUtils.getRelation(this.collection.schema, field, this.collection.name);
+      if (linked === null || relation.type !== 'OneToOne') return;
+
+      await this.services.authorization.assertCanEdit(context, relation.foreignCollection);
+    });
+
+    await Promise.all(promises);
+  }
+
   private async linkOneToOneRelations(
     context: Context,
     record: RecordData,
@@ -88,10 +105,8 @@ export default class CreateRoute extends CollectionRoute {
       const relation = SchemaUtils.getRelation(this.collection.schema, field, this.collection.name);
       if (linked === null || relation.type !== 'OneToOne') return;
 
-      // Permissions
       const foreignCollection = this.dataSource.getCollection(relation.foreignCollection);
       const scope = await this.services.authorization.getScope(foreignCollection, context);
-      await this.services.authorization.assertCanEdit(context, foreignCollection.name);
 
       // Load the value that will be used as originKey (=== parentId[0] most of the time)
       const originValue = record[relation.originKeyTarget];

--- a/packages/agent/src/routes/modification/create.ts
+++ b/packages/agent/src/routes/modification/create.ts
@@ -91,7 +91,7 @@ export default class CreateRoute extends CollectionRoute {
       // Permissions
       const foreignCollection = this.dataSource.getCollection(relation.foreignCollection);
       const scope = await this.services.authorization.getScope(foreignCollection, context);
-      await this.services.authorization.assertCanEdit(context, this.collection.name);
+      await this.services.authorization.assertCanEdit(context, foreignCollection.name);
 
       // Load the value that will be used as originKey (=== parentId[0] most of the time)
       const originValue = record[relation.originKeyTarget];

--- a/packages/agent/test/routes/modification/create.test.ts
+++ b/packages/agent/test/routes/modification/create.test.ts
@@ -219,7 +219,7 @@ describe('CreateRoute', () => {
         expect(assertCanEdit).toHaveBeenCalledWith(context, 'passports');
       });
 
-      test('does not update the foreign collection when the user cannot edit it', async () => {
+      test('does not create the parent nor update the foreign collection when the user cannot edit it', async () => {
         const create = new CreateRoute(services, options, dataSource, 'persons');
         const context = createMockContext({
           ...defaultContext,
@@ -239,11 +239,13 @@ describe('CreateRoute', () => {
 
         const error = new Error('Forbidden');
         (services.authorization.assertCanEdit as jest.Mock).mockRejectedValueOnce(error);
-        const spy = jest.spyOn(dataSource.getCollection('passports'), 'update').mockClear();
+        const create$ = jest.spyOn(dataSource.getCollection('persons'), 'create').mockClear();
+        const update$ = jest.spyOn(dataSource.getCollection('passports'), 'update').mockClear();
 
         await expect(create.handleCreate(context)).rejects.toThrow(error);
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(create$).not.toHaveBeenCalled();
+        expect(update$).not.toHaveBeenCalled();
       });
 
       describe('when the given relation is null', () => {

--- a/packages/agent/test/routes/modification/create.test.ts
+++ b/packages/agent/test/routes/modification/create.test.ts
@@ -190,6 +190,60 @@ describe('CreateRoute', () => {
         });
       });
 
+      test('checks the edit permission on the foreign collection', async () => {
+        const create = new CreateRoute(services, options, dataSource, 'persons');
+        const context = createMockContext({
+          ...defaultContext,
+          requestBody: {
+            data: {
+              type: 'persons',
+              attributes: { name: 'John' },
+              relationships: {
+                passport: {
+                  data: { type: 'passports', id: '1d162304-78bf-599e-b197-93590ac3d314' },
+                },
+              },
+            },
+            jsonapi: { version: '1.0' },
+          },
+        });
+
+        const assertCanEdit = services.authorization.assertCanEdit as jest.Mock;
+        assertCanEdit.mockClear();
+
+        await create.handleCreate(context);
+
+        expect(assertCanEdit).toHaveBeenCalledTimes(1);
+        expect(assertCanEdit).toHaveBeenCalledWith(context, 'passports');
+      });
+
+      test('does not update the foreign collection when the user cannot edit it', async () => {
+        const create = new CreateRoute(services, options, dataSource, 'persons');
+        const context = createMockContext({
+          ...defaultContext,
+          requestBody: {
+            data: {
+              type: 'persons',
+              attributes: { name: 'John' },
+              relationships: {
+                passport: {
+                  data: { type: 'passports', id: '1d162304-78bf-599e-b197-93590ac3d314' },
+                },
+              },
+            },
+            jsonapi: { version: '1.0' },
+          },
+        });
+
+        const error = new Error('Forbidden');
+        (services.authorization.assertCanEdit as jest.Mock).mockRejectedValueOnce(error);
+        const spy = jest.spyOn(dataSource.getCollection('passports'), 'update').mockClear();
+
+        await expect(create.handleCreate(context)).rejects.toThrow(error);
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
       describe('when the given relation is null', () => {
         test('should return null value in the body', async () => {
           const create = new CreateRoute(services, options, dataSource, 'persons');

--- a/packages/agent/test/routes/modification/create.test.ts
+++ b/packages/agent/test/routes/modification/create.test.ts
@@ -99,11 +99,30 @@ describe('CreateRoute', () => {
           fields: {
             id: factories.columnSchema.uuidPrimaryKey().build(),
             name: factories.columnSchema.build(),
+            countryId: factories.columnSchema.build({ columnType: 'Uuid' }),
             passport: {
               type: 'OneToOne',
               foreignCollection: 'passports',
               originKey: 'personId',
               originKeyTarget: 'id',
+            },
+            visa: {
+              type: 'OneToOne',
+              foreignCollection: 'visas',
+              originKey: 'personId',
+              originKeyTarget: 'id',
+            },
+            license: {
+              type: 'OneToOne',
+              foreignCollection: 'licenses',
+              originKey: 'personId',
+              originKeyTarget: 'id',
+            },
+            country: {
+              type: 'ManyToOne',
+              foreignCollection: 'countries',
+              foreignKey: 'countryId',
+              foreignKeyTarget: 'id',
             },
           },
         }),
@@ -122,6 +141,23 @@ describe('CreateRoute', () => {
               foreignKeyTarget: 'id',
             },
           },
+        }),
+      }),
+      ...['visas', 'licenses'].map(name =>
+        factories.collection.build({
+          name,
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              personId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            },
+          }),
+        }),
+      ),
+      factories.collection.build({
+        name: 'countries',
+        schema: factories.collectionSchema.build({
+          fields: { id: factories.columnSchema.uuidPrimaryKey().build() },
         }),
       }),
     ]);
@@ -192,7 +228,7 @@ describe('CreateRoute', () => {
         });
       });
 
-      test('checks the edit permission on the foreign collection', async () => {
+      test('checks the edit permission once per linked one-to-one foreign collection', async () => {
         const create = new CreateRoute(services, options, dataSource, 'persons');
         const context = createMockContext({
           ...defaultContext,
@@ -203,6 +239,11 @@ describe('CreateRoute', () => {
               relationships: {
                 passport: {
                   data: { type: 'passports', id: '1d162304-78bf-599e-b197-93590ac3d314' },
+                },
+                visa: { data: { type: 'visas', id: '2d162304-78bf-599e-b197-93590ac3d314' } },
+                license: { data: null },
+                country: {
+                  data: { type: 'countries', id: '3d162304-78bf-599e-b197-93590ac3d314' },
                 },
               },
             },
@@ -215,11 +256,15 @@ describe('CreateRoute', () => {
 
         await create.handleCreate(context);
 
-        expect(assertCanEdit).toHaveBeenCalledTimes(1);
+        const checkedCollections = assertCanEdit.mock.calls.map(([, name]) => name);
+        expect(checkedCollections.sort()).toEqual(['passports', 'visas']);
         expect(assertCanEdit).toHaveBeenCalledWith(context, 'passports');
+        expect(assertCanEdit).toHaveBeenCalledWith(context, 'visas');
+        expect(assertCanEdit).not.toHaveBeenCalledWith(context, 'licenses');
+        expect(assertCanEdit).not.toHaveBeenCalledWith(context, 'countries');
       });
 
-      test('does not create the parent nor update the foreign collection when the user cannot edit it', async () => {
+      test('does not create the parent nor update any foreign collection when one edit is denied', async () => {
         const create = new CreateRoute(services, options, dataSource, 'persons');
         const context = createMockContext({
           ...defaultContext,
@@ -231,6 +276,7 @@ describe('CreateRoute', () => {
                 passport: {
                   data: { type: 'passports', id: '1d162304-78bf-599e-b197-93590ac3d314' },
                 },
+                visa: { data: { type: 'visas', id: '2d162304-78bf-599e-b197-93590ac3d314' } },
               },
             },
             jsonapi: { version: '1.0' },
@@ -238,14 +284,25 @@ describe('CreateRoute', () => {
         });
 
         const error = new Error('Forbidden');
-        (services.authorization.assertCanEdit as jest.Mock).mockRejectedValueOnce(error);
+        const assertCanEdit = services.authorization.assertCanEdit as jest.Mock;
+        assertCanEdit.mockImplementation((_, name) =>
+          name === 'passports' ? Promise.reject(error) : Promise.resolve(),
+        );
         const create$ = jest.spyOn(dataSource.getCollection('persons'), 'create').mockClear();
-        const update$ = jest.spyOn(dataSource.getCollection('passports'), 'update').mockClear();
+        const passportUpdate$ = jest
+          .spyOn(dataSource.getCollection('passports'), 'update')
+          .mockClear();
+        const visaUpdate$ = jest.spyOn(dataSource.getCollection('visas'), 'update').mockClear();
 
-        await expect(create.handleCreate(context)).rejects.toThrow(error);
+        try {
+          await expect(create.handleCreate(context)).rejects.toThrow(error);
 
-        expect(create$).not.toHaveBeenCalled();
-        expect(update$).not.toHaveBeenCalled();
+          expect(create$).not.toHaveBeenCalled();
+          expect(passportUpdate$).not.toHaveBeenCalled();
+          expect(visaUpdate$).not.toHaveBeenCalled();
+        } finally {
+          assertCanEdit.mockReset();
+        }
       });
 
       describe('when the given relation is null', () => {

--- a/packages/agent/test/routes/modification/create.test.ts
+++ b/packages/agent/test/routes/modification/create.test.ts
@@ -62,6 +62,8 @@ describe('CreateRoute', () => {
 
       await create.handleCreate(context);
 
+      expect(services.authorization.assertCanAdd).toHaveBeenCalledWith(context, 'books');
+
       expect(collection.create).toHaveBeenCalledWith(
         {
           email: 'john.doe@domain.com',


### PR DESCRIPTION
## Problem

When a record is created with a linked `OneToOne` relation, the create route asserted `edit` on the **parent** collection, then performed two `update` calls on the **foreign** collection (null out the old owner's FK, write the linked record's FK).

A user with `add` + `edit` on the parent but no `edit` on the foreign collection could therefore rewrite the FK of an arbitrary foreign record and break another record's existing relation. The writes were already scope-bounded, but the collection-level `edit` permission on the foreign collection was bypassed entirely.

Same bug class as #1818 (authorize on the wrong side of the relation), on the write side.

## Fix

In the one-to-one linking branch of `create.ts`, assert `edit` on the foreign collection, mirroring `updateOneToOne` in `update-relation.ts`. The parent-side `assertCanAdd` at the start of the route is unchanged.

fixes PRD-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authorize edit on linked OneToOne foreign collections before creating parent record
> - Adds `assertCanEditLinkedOneToOneRelations` in [`create.ts`](https://github.com/ForestAdmin/agent-nodejs/pull/1819/files#diff-e88a452638f94fc3d1f83d5cb2c21a332ecde1ab6b0df16ca7eea27e653ee8dc) that checks edit permission on each linked OneToOne foreign collection before the parent record is created.
> - Moves authorization out of `linkOneToOneRelations` (where it incorrectly checked the parent collection) and into the earlier pre-creation step.
> - If any foreign collection edit check fails, neither the parent create nor the foreign update are executed.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1819 opened
>
> - Added authorization checks in `CreateRoute` to verify edit permissions on foreign collections when creating records with linked one-to-one relations [fa336e0]
> - Refactored `CreateRoute` to extract one-to-one relation filtering logic into a reusable helper method [fa336e0]
> - Updated `CreateRoute.linkOneToOneRelations` method to process filtered one-to-one relations [fa336e0]
> - Extended test data source schema to include multiple relation types for authorization testing [fa336e0]
> - Updated and expanded authorization tests to verify edit permission checks across multiple one-to-one relations [fa336e0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21b0044.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->