### PR TITLE
fix(agent): authorize associate-related on the foreign collection and scope the many-to-many link

### DIFF
--- a/packages/agent/src/routes/modification/associate-related.ts
+++ b/packages/agent/src/routes/modification/associate-related.ts
@@ -12,6 +12,8 @@ import {
   CollectionUtils,
   ConditionTreeFactory,
   ConditionTreeLeaf,
+  Filter,
+  Projection,
   SchemaUtils,
 } from '@forestadmin/datasource-toolkit';
 
@@ -30,7 +32,7 @@ export default class AssociateRelatedRoute extends RelationRoute {
   }
 
   public async handleAssociateRelatedRoute(context: Context): Promise<void> {
-    await this.services.authorization.assertCanEdit(context, this.collection.name);
+    await this.services.authorization.assertCanEdit(context, this.foreignCollection.name);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const body = context.request.body as any;
@@ -43,7 +45,7 @@ export default class AssociateRelatedRoute extends RelationRoute {
     if (relation.type === 'OneToMany') {
       await this.associateOneToMany(caller, scope, relation, parentId, targetedRelationId, context);
     } else {
-      await this.associateManyToMany(caller, relation, parentId, targetedRelationId);
+      await this.associateManyToMany(caller, scope, relation, parentId, targetedRelationId);
     }
 
     context.response.status = HttpCode.NoContent;
@@ -81,20 +83,31 @@ export default class AssociateRelatedRoute extends RelationRoute {
 
   async associateManyToMany(
     caller: Caller,
+    scope: ConditionTree,
     relation: ManyToManySchema,
     parentId: CompositeId,
     targetedRelationId: CompositeId,
   ) {
-    let [id] = SchemaUtils.getPrimaryKeys(this.foreignCollection.schema);
-    const foreign = await CollectionUtils.getValue(
-      this.foreignCollection,
+    const foreignFilter = new Filter({
+      conditionTree: ConditionTreeFactory.intersect(
+        ConditionTreeFactory.matchIds(this.foreignCollection.schema, [targetedRelationId]),
+        scope,
+      ),
+    });
+    const [foreignRecordInScope] = await this.foreignCollection.list(
       caller,
-      targetedRelationId,
-      id,
+      foreignFilter,
+      new Projection(relation.foreignKeyTarget),
     );
-    [id] = SchemaUtils.getPrimaryKeys(this.collection.schema);
-    const origin = await CollectionUtils.getValue(this.collection, caller, parentId, id);
-    const record = { [relation.originKey]: origin, [relation.foreignKey]: foreign };
+
+    if (!foreignRecordInScope) return;
+
+    const [originId] = SchemaUtils.getPrimaryKeys(this.collection.schema);
+    const origin = await CollectionUtils.getValue(this.collection, caller, parentId, originId);
+    const record = {
+      [relation.originKey]: origin,
+      [relation.foreignKey]: foreignRecordInScope[relation.foreignKeyTarget],
+    };
 
     const throughCollection = this.dataSource.getCollection(relation.throughCollection);
     await throughCollection.create(caller, [record]);

--- a/packages/agent/src/routes/modification/associate-related.ts
+++ b/packages/agent/src/routes/modification/associate-related.ts
@@ -102,8 +102,12 @@ export default class AssociateRelatedRoute extends RelationRoute {
 
     if (!foreignRecordInScope) return;
 
-    const [originId] = SchemaUtils.getPrimaryKeys(this.collection.schema);
-    const origin = await CollectionUtils.getValue(this.collection, caller, parentId, originId);
+    const origin = await CollectionUtils.getValue(
+      this.collection,
+      caller,
+      parentId,
+      relation.originKeyTarget,
+    );
     const record = {
       [relation.originKey]: origin,
       [relation.foreignKey]: foreignRecordInScope[relation.foreignKeyTarget],

--- a/packages/agent/test/routes/modification/associate-related.test.ts
+++ b/packages/agent/test/routes/modification/associate-related.test.ts
@@ -196,13 +196,14 @@ describe('AssociateRelatedRoute', () => {
         schema: factories.collectionSchema.build({
           fields: {
             id: factories.columnSchema.uuidPrimaryKey().build(),
+            reference: factories.columnSchema.build({ columnType: 'Uuid' }),
             manyToManyRelationField: factories.manyToManySchema.build({
               throughCollection: 'librariesBooks',
               foreignCollection: 'libraries',
               foreignKey: 'libraryId',
               foreignKeyTarget: 'reference',
               originKey: 'bookId',
-              originKeyTarget: 'id',
+              originKeyTarget: 'reference',
             }),
           },
         }),
@@ -231,9 +232,13 @@ describe('AssociateRelatedRoute', () => {
       const scope = factories.conditionTreeLeaf.build();
       services.authorization.getScope = jest.fn().mockResolvedValue(scope);
       const resolvedReference = 'aaaaaaaa-e89b-12d3-a456-999999999999';
+      const resolvedOrigin = 'bbbbbbbb-e89b-12d3-a456-888888888888';
       jest
         .spyOn(dataSource.getCollection('libraries'), 'list')
         .mockResolvedValue([{ reference: resolvedReference }]);
+      jest
+        .spyOn(dataSource.getCollection('books'), 'list')
+        .mockResolvedValue([{ reference: resolvedOrigin }]);
       const context = createMockContext({
         state: { user: { email: 'john.doe@domain.com' } },
         requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
@@ -273,7 +278,7 @@ describe('AssociateRelatedRoute', () => {
         },
         [
           {
-            bookId: '123e4567-e89b-12d3-a456-111111111111',
+            bookId: resolvedOrigin,
             libraryId: resolvedReference,
           },
         ],

--- a/packages/agent/test/routes/modification/associate-related.test.ts
+++ b/packages/agent/test/routes/modification/associate-related.test.ts
@@ -1,4 +1,4 @@
-import { Filter } from '@forestadmin/datasource-toolkit';
+import { Filter, Projection } from '@forestadmin/datasource-toolkit';
 import { createMockContext } from '@shopify/jest-koa-mocks';
 
 import AssociateRelatedRoute from '../../../src/routes/modification/associate-related';
@@ -112,8 +112,37 @@ describe('AssociateRelatedRoute', () => {
         }),
         { bookId: '123e4567-e89b-12d3-a456-111111111111' },
       );
-      expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'books');
+      expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'bookPersons');
+      expect(services.authorization.assertCanEdit).not.toHaveBeenCalledWith(context, 'books');
       expect(context.response.status).toEqual(HttpCode.NoContent);
+    });
+
+    test('does not update the related records when the user cannot edit the foreign collection', async () => {
+      const { services, dataSource, options } = setupWithOneToManyRelation();
+
+      const route = new AssociateRelatedRoute(
+        services,
+        options,
+        dataSource,
+        'books',
+        'myBookPersons',
+      );
+
+      const error = new Error('Forbidden');
+      (services.authorization.assertCanEdit as jest.Mock).mockRejectedValueOnce(error);
+
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      await expect(route.handleAssociateRelatedRoute(context)).rejects.toThrow(error);
+
+      expect(dataSource.getCollection('bookPersons').update).not.toHaveBeenCalled();
     });
   });
 
@@ -199,6 +228,9 @@ describe('AssociateRelatedRoute', () => {
 
       const scope = factories.conditionTreeLeaf.build();
       services.authorization.getScope = jest.fn().mockResolvedValue(scope);
+      jest
+        .spyOn(dataSource.getCollection('libraries'), 'list')
+        .mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-222222222222' }]);
       const context = createMockContext({
         state: { user: { email: 'john.doe@domain.com' } },
         requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
@@ -212,6 +244,23 @@ describe('AssociateRelatedRoute', () => {
       await route.handleAssociateRelatedRoute(context);
 
       // then
+      expect(dataSource.getCollection('libraries').list).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'john.doe@domain.com' }),
+        new Filter({
+          conditionTree: factories.conditionTreeBranch.build({
+            aggregator: 'And',
+            conditions: [
+              factories.conditionTreeLeaf.build({
+                operator: 'Equal',
+                value: '123e4567-e89b-12d3-a456-222222222222',
+                field: 'id',
+              }),
+              scope,
+            ],
+          }),
+        }),
+        new Projection('id'),
+      );
       expect(dataSource.getCollection('librariesBooks').create).toHaveBeenCalledWith(
         {
           email: 'john.doe@domain.com',
@@ -226,8 +275,66 @@ describe('AssociateRelatedRoute', () => {
           },
         ],
       );
-      expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'books');
+      expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'libraries');
+      expect(services.authorization.assertCanEdit).not.toHaveBeenCalledWith(context, 'books');
       expect(context.response.status).toEqual(HttpCode.NoContent);
+    });
+
+    test('does not create the relation when the target is hidden by the scope', async () => {
+      const { services, dataSource, options } = setupWithManyToManyRelation();
+
+      const route = new AssociateRelatedRoute(
+        services,
+        options,
+        dataSource,
+        'books',
+        'manyToManyRelationField',
+      );
+
+      services.authorization.getScope = jest
+        .fn()
+        .mockResolvedValue(factories.conditionTreeLeaf.build());
+      jest.spyOn(dataSource.getCollection('libraries'), 'list').mockResolvedValue([]);
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      await route.handleAssociateRelatedRoute(context);
+
+      expect(dataSource.getCollection('librariesBooks').create).not.toHaveBeenCalled();
+      expect(context.response.status).toEqual(HttpCode.NoContent);
+    });
+
+    test('does not create the relation when the user cannot edit the foreign collection', async () => {
+      const { services, dataSource, options } = setupWithManyToManyRelation();
+
+      const route = new AssociateRelatedRoute(
+        services,
+        options,
+        dataSource,
+        'books',
+        'manyToManyRelationField',
+      );
+
+      const error = new Error('Forbidden');
+      (services.authorization.assertCanEdit as jest.Mock).mockRejectedValueOnce(error);
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
+        customProperties: {
+          query: { timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      await expect(route.handleAssociateRelatedRoute(context)).rejects.toThrow(error);
+
+      expect(dataSource.getCollection('librariesBooks').create).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent/test/routes/modification/associate-related.test.ts
+++ b/packages/agent/test/routes/modification/associate-related.test.ts
@@ -112,6 +112,7 @@ describe('AssociateRelatedRoute', () => {
         }),
         { bookId: '123e4567-e89b-12d3-a456-111111111111' },
       );
+      expect(services.authorization.assertCanEdit).toHaveBeenCalledTimes(1);
       expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'bookPersons');
       expect(services.authorization.assertCanEdit).not.toHaveBeenCalledWith(context, 'books');
       expect(context.response.status).toEqual(HttpCode.NoContent);
@@ -157,6 +158,7 @@ describe('AssociateRelatedRoute', () => {
         schema: factories.collectionSchema.build({
           fields: {
             id: factories.columnSchema.uuidPrimaryKey().build(),
+            reference: factories.columnSchema.build({ columnType: 'Uuid' }),
             manyToManyRelationField: factories.manyToManySchema.build({
               throughCollection: 'librariesBooks',
               foreignCollection: 'books',
@@ -198,7 +200,7 @@ describe('AssociateRelatedRoute', () => {
               throughCollection: 'librariesBooks',
               foreignCollection: 'libraries',
               foreignKey: 'libraryId',
-              foreignKeyTarget: 'id',
+              foreignKeyTarget: 'reference',
               originKey: 'bookId',
               originKeyTarget: 'id',
             }),
@@ -228,9 +230,10 @@ describe('AssociateRelatedRoute', () => {
 
       const scope = factories.conditionTreeLeaf.build();
       services.authorization.getScope = jest.fn().mockResolvedValue(scope);
+      const resolvedReference = 'aaaaaaaa-e89b-12d3-a456-999999999999';
       jest
         .spyOn(dataSource.getCollection('libraries'), 'list')
-        .mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-222222222222' }]);
+        .mockResolvedValue([{ reference: resolvedReference }]);
       const context = createMockContext({
         state: { user: { email: 'john.doe@domain.com' } },
         requestBody: { data: [{ id: '123e4567-e89b-12d3-a456-222222222222' }] },
@@ -259,7 +262,7 @@ describe('AssociateRelatedRoute', () => {
             ],
           }),
         }),
-        new Projection('id'),
+        new Projection('reference'),
       );
       expect(dataSource.getCollection('librariesBooks').create).toHaveBeenCalledWith(
         {
@@ -271,16 +274,17 @@ describe('AssociateRelatedRoute', () => {
         [
           {
             bookId: '123e4567-e89b-12d3-a456-111111111111',
-            libraryId: '123e4567-e89b-12d3-a456-222222222222',
+            libraryId: resolvedReference,
           },
         ],
       );
+      expect(services.authorization.assertCanEdit).toHaveBeenCalledTimes(1);
       expect(services.authorization.assertCanEdit).toHaveBeenCalledWith(context, 'libraries');
       expect(services.authorization.assertCanEdit).not.toHaveBeenCalledWith(context, 'books');
       expect(context.response.status).toEqual(HttpCode.NoContent);
     });
 
-    test('does not create the relation when the target is hidden by the scope', async () => {
+    test('does not create the relation when the scoped lookup returns no record', async () => {
       const { services, dataSource, options } = setupWithManyToManyRelation();
 
       const route = new AssociateRelatedRoute(


### PR DESCRIPTION
## Problem

The associate-related route asserted `edit` on the **parent** collection, then performed the write on the **foreign** collection (OneToMany — sets the foreign record's FK) or created a row in the **through** collection (ManyToMany). A caller with `edit` on the parent but no `edit` on the foreign collection could reassign/hijack a foreign record or link an arbitrary one. Same bug class as #1818 (PRD-898) and #1819 (PRD-916), on the write side. The mirror route `dissociate-delete-related` was already fixed for this in #1190, leaving associate/dissociate asymmetric.

Second, distinct defect in the same route: `associateManyToMany` fetched the foreign scope but only the OneToMany branch used it, so a foreign record hidden by the caller's scope could still be linked by id.

## Fix

1. **Permission** — assert `edit` on `this.foreignCollection.name` (one assertion, shared by both branches), mirroring `dissociate-delete-related`.
2. **Scope (ManyToMany)** — resolve the target through a scope-intersected `list` and skip the link when it returns nothing, consistent with the OneToMany branch's scoped write. Out-of-scope targets are left untouched rather than 403'd, matching how the OneToMany branch and `update-relation` already behave.

Incidental correctness improvement: the ManyToMany branch now stores the resolved record's `foreignKeyTarget` value in the through row instead of the raw requested id. When `foreignKeyTarget` is the PK (common case) this is identical; when it is a non-PK column the old code stored the wrong value. It also no longer creates a dangling through row for a nonexistent foreign id.

## ⚠️ Behavioral change (permission tightening)

A role with `edit` on the **parent** but **not** on the target/foreign collection could previously associate; it now receives a 403. This aligns associate with `dissociate-delete-related`, one-to-one update, and count-related, which already require edit on the target collection. Projects whose roles were configured with parent-edit-only on a related collection will need edit on the target collection to associate. Shipped as a `fix(` (patch), consistent with the sibling PRD-898/916 security fixes.

## Tests

- Both branches assert the edit check targets the foreign collection (`bookPersons` / `libraries`), exactly once, and never the parent (`books`).
- Denial tests: when `assertCanEdit` rejects, no foreign update / through create happens.
- ManyToMany: asserts the `list` is called with the scope-intersected filter + `Projection`, and that no through row is created when the scoped lookup returns nothing. The fixture uses a **non-PK `foreignKeyTarget`** so the test pins that the through row stores the scope-resolved record's value, not the raw requested id.
- Empirically verified the mutants (revert to parent-side permission; drop the scope guard; drop scope from the filter; link the raw id) each fail the suite.

## Adversarial review

Three independent review passes (refutation, test-attack, parity/regression) confirmed: the permission target is correct under renames/customizer, the scope intersection handles composite PKs and null scope, there is no existence oracle (out-of-scope and nonexistent both yield an empty scoped list), and associate is now symmetric with dissociate on both permission and ManyToMany scope. Residual items surfaced are all pre-existing and separately tracked: parent-side scope on the origin resolution (PRD-909), unscoped to-one reads (PRD-907/917).

fixes PRD-922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix authorization and scope handling in `AssociateRelatedRoute` for many-to-many links
> - Changes the edit permission check in `handleAssociateRelatedRoute` to assert on the foreign collection instead of the origin collection.
> - Scopes the foreign record lookup in `associateManyToMany` by intersecting the target ID filter with the resolved scope, using only the `foreignKeyTarget` field via `Projection`.
> - If no foreign record is found within scope, the join record is not created.
> - The through record is now written using the `foreignKeyTarget` field value rather than the foreign record's primary key.
> - Behavioral Change: many-to-many association requests that previously succeeded may now be rejected or silently skipped if the foreign record is outside the user's scope.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1820 opened
>
> - Changed `AssociateRelatedRoute.associateOneToMany` to retrieve the origin value using `relation.originKeyTarget` instead of the collection's primary key [c6095b0]
> - Updated many-to-many association test to validate origin key resolution using `originKeyTarget` [c6095b0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f577f38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->