### PR TITLE
feat(agent): accept the Forest-Projection header on list, relationship and csv routes

### DIFF
--- a/packages/agent/src/routes/access/csv-related.ts
+++ b/packages/agent/src/routes/access/csv-related.ts
@@ -25,7 +25,6 @@ export default class CsvRelatedRoute extends RelationRoute {
     await this.services.authorization.assertCanExport(context, this.foreignCollection.name);
 
     const { header } = context.request.query as Record<string, string>;
-    CsvRouteContext.buildResponse(context);
 
     const projection =
       QueryStringParser.parseProjectionFromHeader(this.foreignCollection, context) ??
@@ -34,6 +33,10 @@ export default class CsvRelatedRoute extends RelationRoute {
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);
     const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
+
+    // Set the download headers only once nothing can throw anymore: a 400 wearing a
+    // Content-Disposition: attachment would download an error file instead of showing it.
+    CsvRouteContext.buildResponse(context);
 
     const gen = CsvGenerator.generate(
       caller,

--- a/packages/agent/src/routes/access/csv-related.ts
+++ b/packages/agent/src/routes/access/csv-related.ts
@@ -26,9 +26,10 @@ export default class CsvRelatedRoute extends RelationRoute {
 
     const { header } = context.request.query as Record<string, string>;
 
-    const projection =
-      QueryStringParser.parseProjectionFromHeader(this.foreignCollection, context) ??
-      QueryStringParser.parseProjection(this.foreignCollection, context);
+    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+      this.foreignCollection,
+      context,
+    );
     const scope = await this.services.authorization.getScope(this.foreignCollection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);

--- a/packages/agent/src/routes/access/csv-related.ts
+++ b/packages/agent/src/routes/access/csv-related.ts
@@ -27,7 +27,9 @@ export default class CsvRelatedRoute extends RelationRoute {
     const { header } = context.request.query as Record<string, string>;
     CsvRouteContext.buildResponse(context);
 
-    const projection = QueryStringParser.parseProjection(this.foreignCollection, context);
+    const projection =
+      QueryStringParser.parseProjectionFromHeader(this.foreignCollection, context) ??
+      QueryStringParser.parseProjection(this.foreignCollection, context);
     const scope = await this.services.authorization.getScope(this.foreignCollection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);

--- a/packages/agent/src/routes/access/csv-related.ts
+++ b/packages/agent/src/routes/access/csv-related.ts
@@ -34,8 +34,6 @@ export default class CsvRelatedRoute extends RelationRoute {
     const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);
     const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
 
-    // Set the download headers only once nothing can throw anymore: a 400 wearing a
-    // Content-Disposition: attachment would download an error file instead of showing it.
     CsvRouteContext.buildResponse(context);
 
     const gen = CsvGenerator.generate(

--- a/packages/agent/src/routes/access/csv.ts
+++ b/packages/agent/src/routes/access/csv.ts
@@ -27,8 +27,6 @@ export default class CsvRoute extends CollectionRoute {
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);
 
-    // Set the download headers only once nothing can throw anymore: a 400 wearing a
-    // Content-Disposition: attachment would download an error file instead of showing it.
     CsvRouteContext.buildResponse(context);
 
     const list = this.collection.list.bind(this.collection);

--- a/packages/agent/src/routes/access/csv.ts
+++ b/packages/agent/src/routes/access/csv.ts
@@ -19,7 +19,6 @@ export default class CsvRoute extends CollectionRoute {
     await this.services.authorization.assertCanExport(context, this.collection.name);
 
     const { header } = context.request.query as Record<string, string>;
-    CsvRouteContext.buildResponse(context);
 
     const projection =
       QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
@@ -27,6 +26,10 @@ export default class CsvRoute extends CollectionRoute {
     const scope = await this.services.authorization.getScope(this.collection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);
+
+    // Set the download headers only once nothing can throw anymore: a 400 wearing a
+    // Content-Disposition: attachment would download an error file instead of showing it.
+    CsvRouteContext.buildResponse(context);
 
     const list = this.collection.list.bind(this.collection);
 

--- a/packages/agent/src/routes/access/csv.ts
+++ b/packages/agent/src/routes/access/csv.ts
@@ -21,7 +21,9 @@ export default class CsvRoute extends CollectionRoute {
     const { header } = context.request.query as Record<string, string>;
     CsvRouteContext.buildResponse(context);
 
-    const projection = QueryStringParser.parseProjection(this.collection, context);
+    const projection =
+      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
+      QueryStringParser.parseProjection(this.collection, context);
     const scope = await this.services.authorization.getScope(this.collection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);

--- a/packages/agent/src/routes/access/csv.ts
+++ b/packages/agent/src/routes/access/csv.ts
@@ -20,9 +20,7 @@ export default class CsvRoute extends CollectionRoute {
 
     const { header } = context.request.query as Record<string, string>;
 
-    const projection =
-      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
-      QueryStringParser.parseProjection(this.collection, context);
+    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
     const scope = await this.services.authorization.getScope(this.collection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);

--- a/packages/agent/src/routes/access/get.ts
+++ b/packages/agent/src/routes/access/get.ts
@@ -24,9 +24,7 @@ export default class GetRoute extends CollectionRoute {
       ),
     });
 
-    const projection =
-      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
-      QueryStringParser.parseProjection(this.collection, context);
+    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
 
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),

--- a/packages/agent/src/routes/access/list-related.ts
+++ b/packages/agent/src/routes/access/list-related.ts
@@ -27,13 +27,17 @@ export default class ListRelatedRoute extends RelationRoute {
       scope,
     );
 
+    const projection =
+      QueryStringParser.parseProjectionFromHeader(this.foreignCollection, context) ??
+      QueryStringParser.parseProjection(this.foreignCollection, context);
+
     const records = await CollectionUtils.listRelation(
       this.collection,
       parentId,
       this.relationName,
       QueryStringParser.parseCaller(context),
       paginatedFilter,
-      QueryStringParser.parseProjectionWithPks(this.foreignCollection, context),
+      projection.withPks(this.foreignCollection),
     );
 
     context.response.body = this.services.serializer.serializeWithSearchMetadata(

--- a/packages/agent/src/routes/access/list-related.ts
+++ b/packages/agent/src/routes/access/list-related.ts
@@ -27,9 +27,10 @@ export default class ListRelatedRoute extends RelationRoute {
       scope,
     );
 
-    const projection =
-      QueryStringParser.parseProjectionFromHeader(this.foreignCollection, context) ??
-      QueryStringParser.parseProjection(this.foreignCollection, context);
+    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+      this.foreignCollection,
+      context,
+    );
 
     const records = await CollectionUtils.listRelation(
       this.collection,

--- a/packages/agent/src/routes/access/list.ts
+++ b/packages/agent/src/routes/access/list.ts
@@ -20,10 +20,14 @@ export default class ListRoute extends CollectionRoute {
       paginatedFilter,
     );
 
+    const projection =
+      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
+      QueryStringParser.parseProjection(this.collection, context);
+
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),
       paginatedFilter,
-      QueryStringParser.parseProjectionWithPks(this.collection, context),
+      projection.withPks(this.collection),
     );
 
     context.response.body = this.services.serializer.serializeWithSearchMetadata(

--- a/packages/agent/src/routes/access/list.ts
+++ b/packages/agent/src/routes/access/list.ts
@@ -20,9 +20,7 @@ export default class ListRoute extends CollectionRoute {
       paginatedFilter,
     );
 
-    const projection =
-      QueryStringParser.parseProjectionFromHeader(this.collection, context) ??
-      QueryStringParser.parseProjection(this.collection, context);
+    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
 
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),

--- a/packages/agent/src/routes/capabilities.ts
+++ b/packages/agent/src/routes/capabilities.ts
@@ -40,6 +40,9 @@ export default class Capabilities extends BaseRoute {
       agentCapabilities: {
         canUseProjectionOnGetOne: true,
         canUseProjectionViaHeader: true,
+        // Covers every record-listing route: list, relationship list and their csv exports.
+        // canUseProjectionViaHeader alone only guarantees get-one (agent 1.93.x).
+        canUseProjectionViaHeaderOnList: true,
         canUseMultipleFieldsProjectionOnRelation: true,
       },
       collections:

--- a/packages/agent/src/routes/capabilities.ts
+++ b/packages/agent/src/routes/capabilities.ts
@@ -40,8 +40,6 @@ export default class Capabilities extends BaseRoute {
       agentCapabilities: {
         canUseProjectionOnGetOne: true,
         canUseProjectionViaHeader: true,
-        // Covers every record-listing route: list, relationship list and their csv exports.
-        // canUseProjectionViaHeader alone only guarantees get-one (agent 1.93.x).
         canUseProjectionViaHeaderOnList: true,
         canUseMultipleFieldsProjectionOnRelation: true,
       },

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -86,6 +86,13 @@ export default class QueryStringParser {
     }
   }
 
+  static parseProjectionFromHeaderOrQuery(collection: Collection, context: Context): Projection {
+    return (
+      QueryStringParser.parseProjectionFromHeader(collection, context) ??
+      QueryStringParser.parseProjection(collection, context)
+    );
+  }
+
   static parseSearch(collection: Collection, context: Context): string {
     const { query, body } = context.request as any;
     const search =

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -86,14 +86,6 @@ export default class QueryStringParser {
     }
   }
 
-  static parseProjectionWithPks(collection: Collection, context: Context): Projection {
-    const projection = QueryStringParser.parseProjection(collection, context);
-
-    // Primary keys are not explicitly listed in the projections that the frontend
-    // is sending, but are still required for the frontend to work.
-    return projection.withPks(collection);
-  }
-
   static parseSearch(collection: Collection, context: Context): string {
     const { query, body } = context.request as any;
     const search =

--- a/packages/agent/test/agent-integration.test.ts
+++ b/packages/agent/test/agent-integration.test.ts
@@ -339,6 +339,60 @@ describe('Agent Integration Tests', () => {
         expect(error.status).toBe(400);
       });
 
+      it('should honor the Forest-Projection header on list requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'firstName');
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toHaveLength(3);
+        expect(response.body.data[0].attributes).toEqual({ id: 1, firstName: 'John' });
+      });
+
+      it('should honor the Forest-Projection header on relationship list requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users/1/relationships/posts`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'title');
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toHaveLength(2);
+        expect(response.body.data[0].attributes).toEqual({ id: 1, title: 'First Post' });
+      });
+
+      it('should ignore the Forest-Projection header on count requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users/count`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'field-that-do-not-exist');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ count: 3 });
+      });
+
+      it('should ignore the Forest-Projection header on relationship count requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users/1/relationships/posts/count`)
+          .query({ timezone: 'Europe/Paris' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'field-that-do-not-exist');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ count: 2 });
+      });
+
       it('should accept authenticated requests with valid JWT', async () => {
         const token = createTestToken();
 

--- a/packages/agent/test/agent-integration.test.ts
+++ b/packages/agent/test/agent-integration.test.ts
@@ -367,6 +367,19 @@ describe('Agent Integration Tests', () => {
         expect(response.body.data[0].attributes).toEqual({ id: 1, title: 'First Post' });
       });
 
+      it('should honor the Forest-Projection header on csv export requests', async () => {
+        const token = createTestToken();
+
+        const response = await superagent
+          .get(`${testContext.baseUrl}/forest/users.csv`)
+          .query({ timezone: 'Europe/Paris', header: 'firstName' })
+          .set('Authorization', `Bearer ${token}`)
+          .set('Forest-Projection', 'firstName');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toBe('firstName\nJohn\nJane\nBob\n');
+      });
+
       it('should ignore the Forest-Projection header on count requests', async () => {
         const token = createTestToken();
 

--- a/packages/agent/test/routes/access/count-related.test.ts
+++ b/packages/agent/test/routes/access/count-related.test.ts
@@ -147,6 +147,34 @@ describe('CountRelatedRoute', () => {
         expect(context.response.body).toEqual({ count: 1568 });
       });
 
+      test('should ignore the Forest-Projection header', async () => {
+        const { services, dataSource, options } = setupWithOneToManyRelation();
+
+        const count = new CountRelatedRoute(
+          services,
+          options,
+          dataSource,
+          'books',
+          'myBookPersons',
+        );
+
+        jest
+          .spyOn(CollectionUtils, 'aggregateRelation')
+          .mockResolvedValue([{ value: 1568, group: {} }]);
+
+        const context = createMockContext({
+          headers: { 'forest-projection': 'field-that-do-not-exist' },
+          customProperties: {
+            query: { timezone: 'Europe/Paris' },
+            params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' },
+          },
+          state: { user: { email: 'john.doe@domain.com' } },
+        });
+        await count.handleCountRelated(context);
+
+        expect(context.response.body).toEqual({ count: 1568 });
+      });
+
       test("should check the user's permission on the related collection", async () => {
         const { services, dataSource, options } = setupWithOneToManyRelation();
 

--- a/packages/agent/test/routes/access/count.test.ts
+++ b/packages/agent/test/routes/access/count.test.ts
@@ -51,6 +51,21 @@ describe('CountRoute', () => {
         expect(context.response.body).toEqual({ count: 2 });
       });
 
+      test('should ignore the Forest-Projection header', async () => {
+        const aggregateSpy = jest.fn().mockReturnValue([{ value: 2 }]);
+        dataSource.getCollection('books').aggregate = aggregateSpy;
+        const count = new Count(services, options, dataSource, 'books');
+        const context = createMockContext({
+          headers: { 'forest-projection': 'field-that-do-not-exist' },
+          customProperties: { query: { timezone: 'Europe/Paris' } },
+          state: { user: { email: 'john.doe@domain.com' } },
+        });
+
+        await count.handleCount(context);
+
+        expect(context.response.body).toEqual({ count: 2 });
+      });
+
       test('should check that the user has permission to count', async () => {
         const aggregateSpy = jest.fn().mockReturnValue([{ value: 2 }]);
         dataSource.getCollection('books').aggregate = aggregateSpy;

--- a/packages/agent/test/routes/access/csv-related.test.ts
+++ b/packages/agent/test/routes/access/csv-related.test.ts
@@ -89,7 +89,7 @@ describe('CsvRelatedRoute', () => {
         state: { user: { email: 'john.doe@domain.com' } },
         headers: { 'forest-projection': 'name' },
         customProperties: {
-          query: { 'fields[persons]': 'id', header: 'name', timezone: 'Europe/Paris' },
+          query: { 'fields[persons]': 'id', header: 'Name column', timezone: 'Europe/Paris' },
           params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
         },
       });
@@ -103,7 +103,7 @@ describe('CsvRelatedRoute', () => {
       expect(csvGenerator).toHaveBeenCalledWith(
         expect.anything(),
         ['name'],
-        'name',
+        'Name column',
         expect.anything(),
         limitExportSize,
         dataSource.getCollection('persons'),
@@ -126,6 +126,24 @@ describe('CsvRelatedRoute', () => {
       await expect(csvRoute.handleRelatedCsv(context)).rejects.toThrow(
         'Invalid Forest-Projection header',
       );
+    });
+
+    it('should not set the download headers when the projection is invalid', async () => {
+      const { options, services, dataSource } = setupWithOneToManyRelation();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books', 'myPersons');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          query: { filename: 'export', header: 'id', timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      await expect(csvRoute.handleRelatedCsv(context)).rejects.toThrow(
+        'Invalid Forest-Projection header',
+      );
+      expect(context.response.headers['content-disposition']).toBeUndefined();
     });
 
     it('calls the csv generator with the right params', async () => {

--- a/packages/agent/test/routes/access/csv-related.test.ts
+++ b/packages/agent/test/routes/access/csv-related.test.ts
@@ -82,6 +82,52 @@ describe('CsvRelatedRoute', () => {
       });
     });
 
+    it('should give precedence to the Forest-Projection header over query params', async () => {
+      const { options, services, dataSource } = setupWithOneToManyRelation();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books', 'myPersons');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name' },
+        customProperties: {
+          query: { 'fields[persons]': 'id', header: 'name', timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      jest.spyOn(CollectionUtils, 'listRelation').mockResolvedValue([]);
+      const csvGenerator = jest.spyOn(CsvGenerator, 'generate');
+
+      await csvRoute.handleRelatedCsv(context);
+
+      await readCsv(context.response.body as AsyncGenerator<string>);
+      expect(csvGenerator).toHaveBeenCalledWith(
+        expect.anything(),
+        ['name'],
+        'name',
+        expect.anything(),
+        limitExportSize,
+        dataSource.getCollection('persons'),
+        expect.any(Function),
+      );
+    });
+
+    it('should not fall back to query params when the header is invalid', async () => {
+      const { options, services, dataSource } = setupWithOneToManyRelation();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books', 'myPersons');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          query: { 'fields[persons]': 'id', header: 'id', timezone: 'Europe/Paris' },
+          params: { parentId: '123e4567-e89b-12d3-a456-111111111111' },
+        },
+      });
+
+      await expect(csvRoute.handleRelatedCsv(context)).rejects.toThrow(
+        'Invalid Forest-Projection header',
+      );
+    });
+
     it('calls the csv generator with the right params', async () => {
       // given
       const { options, services, dataSource } = setupWithOneToManyRelation();

--- a/packages/agent/test/routes/access/csv.test.ts
+++ b/packages/agent/test/routes/access/csv.test.ts
@@ -108,6 +108,48 @@ describe('CsvRoute', () => {
       );
     });
 
+    it('should give precedence to the Forest-Projection header over query params', async () => {
+      const { options, services, dataSource } = setup();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name' },
+        customProperties: {
+          query: { 'fields[books]': 'id', header: 'name', timezone: 'Europe/Paris' },
+        },
+      });
+
+      dataSource.getCollection('books').list = jest.fn().mockReturnValue([]);
+      const csvGenerator = jest.spyOn(CsvGenerator, 'generate');
+
+      await csvRoute.handleCsv(context);
+
+      await readCsv(context.response.body as AsyncGenerator<string>);
+      expect(csvGenerator).toHaveBeenCalledWith(
+        expect.anything(),
+        ['name'],
+        'name',
+        expect.anything(),
+        limitExportSize,
+        dataSource.getCollection('books'),
+        expect.any(Function),
+      );
+    });
+
+    it('should not fall back to query params when the header is invalid', async () => {
+      const { options, services, dataSource } = setup();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          query: { 'fields[books]': 'id', header: 'id', timezone: 'Europe/Paris' },
+        },
+      });
+
+      await expect(csvRoute.handleCsv(context)).rejects.toThrow('Invalid Forest-Projection header');
+    });
+
     it('should return the records as the csv format', async () => {
       const { options, services, dataSource } = setup();
 

--- a/packages/agent/test/routes/access/csv.test.ts
+++ b/packages/agent/test/routes/access/csv.test.ts
@@ -115,7 +115,7 @@ describe('CsvRoute', () => {
         state: { user: { email: 'john.doe@domain.com' } },
         headers: { 'forest-projection': 'name' },
         customProperties: {
-          query: { 'fields[books]': 'id', header: 'name', timezone: 'Europe/Paris' },
+          query: { 'fields[books]': 'id', header: 'Name column', timezone: 'Europe/Paris' },
         },
       });
 
@@ -128,7 +128,7 @@ describe('CsvRoute', () => {
       expect(csvGenerator).toHaveBeenCalledWith(
         expect.anything(),
         ['name'],
-        'name',
+        'Name column',
         expect.anything(),
         limitExportSize,
         dataSource.getCollection('books'),
@@ -148,6 +148,21 @@ describe('CsvRoute', () => {
       });
 
       await expect(csvRoute.handleCsv(context)).rejects.toThrow('Invalid Forest-Projection header');
+    });
+
+    it('should not set the download headers when the projection is invalid', async () => {
+      const { options, services, dataSource } = setup();
+      const csvRoute = new CsvRoute(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          query: { filename: 'export', header: 'id', timezone: 'Europe/Paris' },
+        },
+      });
+
+      await expect(csvRoute.handleCsv(context)).rejects.toThrow('Invalid Forest-Projection header');
+      expect(context.response.headers['content-disposition']).toBeUndefined();
     });
 
     it('should return the records as the csv format', async () => {

--- a/packages/agent/test/routes/access/list-related.test.ts
+++ b/packages/agent/test/routes/access/list-related.test.ts
@@ -254,6 +254,80 @@ describe('ListRelatedRoute', () => {
     });
   });
 
+  describe('with the Forest-Projection header', () => {
+    test('it should read the projection of the foreign collection from the header', async () => {
+      const { services, dataSource, options } = setupWithOneToManyRelation();
+      services.serializer.serializeWithSearchMetadata = jest.fn().mockReturnValue('serialized');
+      const route = new ListRelatedRoute(services, options, dataSource, 'books', 'myPersons');
+      const listRelationSpy = jest.spyOn(CollectionUtils, 'listRelation').mockResolvedValue([]);
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name' },
+        customProperties: {
+          params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' },
+          query: { timezone: 'Europe/Paris' },
+        },
+      });
+
+      await route.handleListRelated(context);
+
+      expect(listRelationSpy).toHaveBeenCalledWith(
+        dataSource.getCollection('books'),
+        ['2d162303-78bf-599e-b197-93590ac3d315'],
+        'myPersons',
+        expect.anything(),
+        expect.anything(),
+        ['name', 'id'],
+      );
+    });
+
+    test('it should give precedence to the header over the fields query params', async () => {
+      const { services, dataSource, options } = setupWithOneToManyRelation();
+      services.serializer.serializeWithSearchMetadata = jest.fn().mockReturnValue('serialized');
+      const route = new ListRelatedRoute(services, options, dataSource, 'books', 'myPersons');
+      const listRelationSpy = jest.spyOn(CollectionUtils, 'listRelation').mockResolvedValue([]);
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name' },
+        customProperties: {
+          params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' },
+          query: { timezone: 'Europe/Paris', 'fields[persons]': 'id' },
+        },
+      });
+
+      await route.handleListRelated(context);
+
+      expect(listRelationSpy).toHaveBeenCalledWith(
+        dataSource.getCollection('books'),
+        ['2d162303-78bf-599e-b197-93590ac3d315'],
+        'myPersons',
+        expect.anything(),
+        expect.anything(),
+        ['name', 'id'],
+      );
+    });
+
+    test('it should not fall back to query params when the header is invalid', async () => {
+      const { services, dataSource, options } = setupWithOneToManyRelation();
+      const route = new ListRelatedRoute(services, options, dataSource, 'books', 'myPersons');
+      const listRelationSpy = jest.spyOn(CollectionUtils, 'listRelation').mockResolvedValue([]);
+      listRelationSpy.mockClear();
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' },
+          query: { timezone: 'Europe/Paris', 'fields[persons]': 'id' },
+        },
+      });
+
+      await expect(route.handleListRelated(context)).rejects.toThrow(
+        'Invalid Forest-Projection header',
+      );
+      expect(listRelationSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('with special characters in names', () => {
     it('should register routes with escaped characters', () => {
       const services = factories.forestAdminHttpDriverServices.build();

--- a/packages/agent/test/routes/access/list.test.ts
+++ b/packages/agent/test/routes/access/list.test.ts
@@ -147,6 +147,120 @@ describe('ListRoute', () => {
     });
   });
 
+  describe('with the Forest-Projection header', () => {
+    const setupWithRelation = () => {
+      const dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'books',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              name: factories.columnSchema.build({ columnType: 'String' }),
+              author: factories.oneToOneSchema.build({
+                foreignCollection: 'persons',
+                originKey: 'bookId',
+                originKeyTarget: 'id',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'persons',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              bookId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            },
+          }),
+        }),
+      ]);
+      const options = factories.forestAdminHttpDriverOptions.build();
+      const services = factories.forestAdminHttpDriverServices.build();
+      services.serializer.serializeWithSearchMetadata = jest.fn().mockReturnValue('serialized');
+
+      return { dataSource, options, services };
+    };
+
+    test('it should read the projection from the Forest-Projection header', async () => {
+      const { dataSource, options, services } = setupWithRelation();
+      jest.spyOn(dataSource.getCollection('books'), 'list').mockResolvedValue([{ id: 1 }]);
+      const list = new List(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'name,author:id' },
+        customProperties: { query: { timezone: 'Europe/Paris' } },
+      });
+
+      await list.handleList(context);
+
+      expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['name', 'author:id', 'id'],
+      );
+    });
+
+    test('it should give precedence to the Forest-Projection header over query params', async () => {
+      const { dataSource, options, services } = setupWithRelation();
+      jest.spyOn(dataSource.getCollection('books'), 'list').mockResolvedValue([{ id: 1 }]);
+      const list = new List(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'author:id' },
+        customProperties: {
+          query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+        },
+      });
+
+      await list.handleList(context);
+
+      expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['author:id', 'id'],
+      );
+    });
+
+    test('it should not fall back to query params when the header is invalid', async () => {
+      const { dataSource, options, services } = setupWithRelation();
+      const listSpy = jest
+        .spyOn(dataSource.getCollection('books'), 'list')
+        .mockResolvedValue([{ id: 1 }]);
+      const list = new List(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: {
+          query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+        },
+      });
+
+      await expect(list.handleList(context)).rejects.toThrow('Invalid Forest-Projection header');
+      expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    test('it should fall back to query params when the header is empty', async () => {
+      const { dataSource, options, services } = setupWithRelation();
+      jest.spyOn(dataSource.getCollection('books'), 'list').mockResolvedValue([{ id: 1 }]);
+      const list = new List(services, options, dataSource, 'books');
+      const context = createMockContext({
+        state: { user: { email: 'john.doe@domain.com' } },
+        headers: { 'forest-projection': '' },
+        customProperties: {
+          query: { timezone: 'Europe/Paris', 'fields[books]': 'name' },
+        },
+      });
+
+      await list.handleList(context);
+
+      expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['name', 'id'],
+      );
+    });
+  });
+
   describe('with special characters in names', () => {
     it('should register routes with escaped characters', () => {
       const collection = factories.collection.build({

--- a/packages/agent/test/routes/capabilities.test.ts
+++ b/packages/agent/test/routes/capabilities.test.ts
@@ -78,6 +78,7 @@ describe('Capabilities', () => {
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
             canUseProjectionViaHeader: true,
+            canUseProjectionViaHeaderOnList: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -101,6 +102,7 @@ describe('Capabilities', () => {
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
             canUseProjectionViaHeader: true,
+            canUseProjectionViaHeaderOnList: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -122,6 +124,7 @@ describe('Capabilities', () => {
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
             canUseProjectionViaHeader: true,
+            canUseProjectionViaHeaderOnList: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [],
@@ -145,6 +148,7 @@ describe('Capabilities', () => {
           agentCapabilities: {
             canUseProjectionOnGetOne: true,
             canUseProjectionViaHeader: true,
+            canUseProjectionViaHeaderOnList: true,
             canUseMultipleFieldsProjectionOnRelation: true,
           },
           collections: [

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -418,6 +418,62 @@ describe('QueryStringParser', () => {
     });
   });
 
+  describe('parseProjectionFromHeaderOrQuery', () => {
+    test('should give precedence to the header over the query string', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': 'name' },
+        customProperties: { query: { 'fields[books]': 'id' } },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+        collectionSimple,
+        context,
+      );
+
+      expect(projection).toEqual(new Projection('name'));
+    });
+
+    test('should fallback to the query string when the header is missing', () => {
+      const context = createMockContext({
+        customProperties: { query: { 'fields[books]': 'name' } },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+        collectionSimple,
+        context,
+      );
+
+      expect(projection).toEqual(new Projection('name'));
+    });
+
+    test('should fallback to the query string when the header is empty', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': '' },
+        customProperties: { query: { 'fields[books]': 'name' } },
+      });
+
+      const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+        collectionSimple,
+        context,
+      );
+
+      expect(projection).toEqual(new Projection('name'));
+    });
+
+    test('should throw on an invalid header instead of falling back to the query string', () => {
+      const context = createMockContext({
+        headers: { 'forest-projection': 'field-that-do-not-exist' },
+        customProperties: { query: { 'fields[books]': 'name' } },
+      });
+
+      const fn = () =>
+        QueryStringParser.parseProjectionFromHeaderOrQuery(collectionSimple, context);
+
+      expect(fn).toThrow(ValidationError);
+      expect(fn).toThrow(/Invalid Forest-Projection header/);
+    });
+  });
+
   describe('parseSearch', () => {
     test('should return null when not provided', () => {
       const context = createMockContext({});

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -210,12 +210,12 @@ describe('QueryStringParser', () => {
           customProperties: { query: { 'fields[cars]': 'id,owner', 'fields[owner]': 'name' } },
         });
 
-        const projection = QueryStringParser.parseProjectionWithPks(
+        const projection = QueryStringParser.parseProjection(
           dataSource.getCollection('cars'),
           context,
         );
 
-        expect(projection).toEqual(new Projection('id', 'owner:name', 'owner:id'));
+        expect(projection).toEqual(new Projection('id', 'owner:name'));
       });
     });
   });
@@ -415,60 +415,6 @@ describe('QueryStringParser', () => {
       expect(fn).toThrow(
         "Invalid Forest-Projection header: The 'books.field-that-do-not-exist' field was not found. Available fields are: [id,name]. Please check if the field name is correct.",
       );
-    });
-  });
-
-  describe('parseProjectionWithPks', () => {
-    describe('when the request does not contain the primary keys', () => {
-      test('should return the requested project with the primary keys', () => {
-        const context = createMockContext({
-          customProperties: { query: { 'fields[books]': 'name' } },
-        });
-
-        const projection = QueryStringParser.parseProjectionWithPks(collectionSimple, context);
-
-        expect(projection).toEqual(new Projection('name', 'id'));
-      });
-    });
-
-    describe('on a collection with relationships', () => {
-      const dataSource = factories.dataSource.buildWithCollections([
-        factories.collection.build({
-          name: 'cars',
-          schema: factories.collectionSchema.build({
-            fields: {
-              id: factories.columnSchema.uuidPrimaryKey().build(),
-              name: factories.columnSchema.build(),
-              owner: factories.oneToOneSchema.build({
-                foreignCollection: 'owner',
-                originKey: 'id',
-              }),
-            },
-          }),
-        }),
-        factories.collection.build({
-          name: 'owner',
-          schema: factories.collectionSchema.build({
-            fields: {
-              id: factories.columnSchema.uuidPrimaryKey().build(),
-              name: factories.columnSchema.build(),
-            },
-          }),
-        }),
-      ]);
-
-      test('should convert the request to a valid projection', () => {
-        const context = createMockContext({
-          customProperties: { query: { 'fields[cars]': 'id,owner', 'fields[owner]': 'name' } },
-        });
-
-        const projection = QueryStringParser.parseProjectionWithPks(
-          dataSource.getCollection('cars'),
-          context,
-        );
-
-        expect(projection).toEqual(new Projection('id', 'owner:name', 'owner:id'));
-      });
     });
   });
 


### PR DESCRIPTION
## What

The following routes now read the projection from the `Forest-Projection` header (same format as get-one: `field,relation:subField`), taking precedence over the `fields[...]` query params:

- list (`GET /forest/:collection`)
- relationship list (`GET /forest/:collection/:id/relationships/:relation`)
- csv exports (the `.csv` variants of both)

The count variants accept and ignore the header — they never parse a projection — and tests lock that behavior in.

Relationship list/count URLs observed in production routinely approach the 2KB AWS WAF `SizeRestrictions_QUERYSTRING` default, and header-based projections are a prerequisite for projecting workspaces. Exports of the same wide views carry the same oversized query strings, hence the csv routes.

Unlike the other routes, csv keeps NOT adding pks to the projection, so the exported columns are exactly the requested ones.

## New capability

The agent announces `canUseProjectionViaHeaderOnList`, covering every record-listing route (list, relationship list, csv exports).

`canUseProjectionViaHeader` alone cannot be used to gate this: it is already released in 1.93.0–1.93.2, where the header only works on get-one. Without a second flag the frontend could not tell those versions apart from this one, and would have to keep `fields[...]` in the URL and switch to the header only above the WAF threshold — real logic on the front to work around a missing signal. `canUseMultipleFieldsProjectionOnRelation` and query-string parsing stay untouched, so frontend and agent deployments remain decoupled.

## Also fixed

On the csv routes, `CsvRouteContext.buildResponse` ran *before* the projection was parsed, so a request with an invalid projection returned a 400 wearing `Content-Disposition: attachment` — a browser-triggered export downloaded an error file instead of showing the error. It now runs once nothing can throw anymore. Pre-existing with an invalid `fields[...]` param; the header added one more trigger and these lines were being touched anyway.

## Notes

- CORS: nothing to do, the header is already allow-listed since #1813, and the agent's `@koa/cors` echoes `Access-Control-Request-Headers` on every route.
- `parseProjectionWithPks` lost its last two callers and is removed. It is not exported from the package's public surface.
- Out of scope: `agent-bff` and `agent-client` still serialize projections into `fields[...]` on their own hop to the agent, so a large projection can hit the same limit there.

fixes PRD-928