### PR TITLE
feat(agent-bff): unfold the OpenAPI document per collection, relation and action

### DIFF
--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -25,6 +25,20 @@ forest-bff openapi --output                # writes ./openapi.json
 forest-bff openapi --output docs/api.json  # writes that path
 ```
 
+The document comes in two forms, and the command picks one from the environment:
+
+- **Unfolded** when `FOREST_SERVER_URL`, `FOREST_ENV_SECRET`, `FOREST_AUTH_SECRET` and `AGENT_URL`
+  are all set: one path per exposed collection, per to-many relation and per action, each carrying
+  the collection's real field set. This is the form to generate a client from. The command reads the
+  Forest schema and asks the agent for each collection's capabilities, signing its own short-lived
+  agent token with `FOREST_AUTH_SECRET`. A deployment configured this way but whose schema cannot be
+  read exits 1 rather than emitting the generic document, which would look like a complete answer.
+- **Generic** when that configuration is absent: the six runtime routes with `{collection}`,
+  `{relation}` and `{action}` as path parameters and no field enumerated. `info.description` says
+  which form the document is.
+
+Either way the runtime routes stay generic — only the document unfolds.
+
 `--output` takes the next argument as the destination unless it is empty or starts with
 `-`; the default `openapi.json` is written only when `--output` is the last argument, and
 a leftover token is rejected like any other extra. A missing parent directory is created,
@@ -58,7 +72,7 @@ yarn start:dev         # node --env-file=.env dist/cli.js
 | `HTTP_PORT`          | no       | Server port, integer 0–65535. Defaults to `3450`. `0` binds an OS-assigned ephemeral port. |
 | `BFF_ALLOWED_ORIGINS`| no       | Comma-separated CORS allow-list of exact origins (scheme + host + port). No wildcard. Empty ⇒ no cross-origin browser access. |
 | `BFF_DEFAULT_TIMEZONE`| no      | Fallback IANA timezone used when a request carries neither an `X-Forest-Timezone` header nor a body `timezone`. |
-| `BFF_OPENAPI_ENABLED` | no       | Serve `GET/HEAD /agent/openapi.json` (auth-gated) when `true`. Defaults to `true`. Set to `false` for customers who do not want the HTTP surface exposed: an authenticated `GET`/`HEAD` then gets `404 openapi_disabled`, other methods fall through to the agent routes exactly as they do when enabled, and `forest-bff openapi` keeps working either way. Accepted values: `true`/`false`. |
+| `BFF_OPENAPI_ENABLED` | no       | Serve `GET/HEAD /agent/openapi.json` (auth-gated) when `true`. Defaults to `true`. Set to `false` for customers who do not want the HTTP surface exposed: an authenticated `GET`/`HEAD` then gets `404 openapi_disabled`, other methods fall through to the agent routes exactly as they do when enabled, and `forest-bff openapi` keeps working either way. Accepted values: `true`/`false`. **The served document is unfolded and is not filtered per caller**: any authenticated caller, whatever their role, reads the name of every exposed collection, relation and field. Set this to `false` if that surface must not be reachable over HTTP. |
 
 ### Config validation
 

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -186,13 +186,16 @@ function resolveReadModelBundle(config: BFFConfig, logger: Logger): ReadModelBun
 }
 
 /**
- * What the OpenAPI document needs to unfold. It also needs the AGENT_URL the store does not: the
- * field set of a collection comes from the agent capabilities. Silent on purpose — the CLI and the
- * server report a missing configuration differently.
+ * When unfolding is possible, in ONE place: the document needs the AGENT_URL the store does not,
+ * because a collection's field set comes from the agent capabilities. The server passes the bundle it
+ * already built for the data routes; the CLI goes through `resolveUnfoldSource`. Silent on purpose —
+ * the two report a missing configuration differently.
  */
-export function resolveUnfoldSource(config: BFFConfig, logger: Logger): UnfoldSource | undefined {
-  const bundle = resolveReadModelBundle(config, logger);
-
+function toUnfoldSource(
+  bundle: ReadModelBundle | undefined,
+  config: BFFConfig,
+  logger: Logger,
+): UnfoldSource | undefined {
   if (!bundle || !config.agentUrl) return undefined;
 
   return {
@@ -201,6 +204,10 @@ export function resolveUnfoldSource(config: BFFConfig, logger: Logger): UnfoldSo
     timeoutMs: config.agentTimeoutMs,
     logger,
   };
+}
+
+export function resolveUnfoldSource(config: BFFConfig, logger: Logger): UnfoldSource | undefined {
+  return toUnfoldSource(resolveReadModelBundle(config, logger), config, logger);
 }
 
 // The data middleware falls through to the action middleware on a non-data path.
@@ -257,15 +264,7 @@ function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] 
   // One store for the whole edge. The document only unfolds when the agent is reachable too: with no
   // AGENT_URL every data path answers 501, so concrete paths would advertise a dead surface.
   const bundle = resolveReadModelBundle(config, logger);
-  const source =
-    bundle && config.agentUrl
-      ? {
-          store: bundle.store,
-          agentUrl: config.agentUrl,
-          timeoutMs: config.agentTimeoutMs,
-          logger,
-        }
-      : undefined;
+  const source = toUnfoldSource(bundle, config, logger);
 
   const chain: Middleware[] = [
     createAuthModeMiddleware({ authSecret: forestAuthSecret }),

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -1,6 +1,7 @@
 import type { BFFConfig } from './config/env-config';
 import type { UnfoldSource } from './openapi/unfolded-document';
 import type { Logger } from './ports/logger-port';
+import type { Metrics } from './ports/metrics-port';
 import type ReadModelStore from './read-model/read-model-store';
 import type { Middleware } from 'koa';
 
@@ -171,7 +172,11 @@ interface ReadModelBundle {
  * unfolding all share — one cache, one schema fetch. Needs no agent: the permissions endpoint and the
  * schema itself come from the SaaS.
  */
-function resolveReadModelBundle(config: BFFConfig, logger: Logger): ReadModelBundle | undefined {
+function resolveReadModelBundle(
+  config: BFFConfig,
+  logger: Logger,
+  metrics?: Metrics,
+): ReadModelBundle | undefined {
   const apiKeyConfig = resolveApiKeyConfig(config);
 
   if (!apiKeyConfig) return undefined;
@@ -180,6 +185,7 @@ function resolveReadModelBundle(config: BFFConfig, logger: Logger): ReadModelBun
     forestServerUrl: apiKeyConfig.forestServerUrl,
     envSecret: apiKeyConfig.forestEnvSecret,
     logger,
+    metrics,
   });
 
   return { store, apiKeyConfig };
@@ -206,8 +212,16 @@ function toUnfoldSource(
   };
 }
 
+/**
+ * Metrics are dropped rather than logged: without an explicit sink `createReadModel` builds a console
+ * one, which reports gauges at `Info`, and `createConsoleLogger` sends `Info` to `console.info` — the
+ * stdout the document is written to. The server keeps its metrics; the export has no sink for them
+ * anyway.
+ */
+const UNMEASURED: Metrics = { increment: () => undefined, gauge: () => undefined };
+
 export function resolveUnfoldSource(config: BFFConfig, logger: Logger): UnfoldSource | undefined {
-  return toUnfoldSource(resolveReadModelBundle(config, logger), config, logger);
+  return toUnfoldSource(resolveReadModelBundle(config, logger, UNMEASURED), config, logger);
 }
 
 // The data middleware falls through to the action middleware on a non-data path.

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -1,5 +1,7 @@
 import type { BFFConfig } from './config/env-config';
+import type { UnfoldSource } from './openapi/unfolded-document';
 import type { Logger } from './ports/logger-port';
+import type ReadModelStore from './read-model/read-model-store';
 import type { Middleware } from 'koa';
 
 import { bodyParser } from '@koa/bodyparser';
@@ -159,12 +161,55 @@ function buildApiKeyMiddleware(config: BFFConfig, logger: Logger): Middleware | 
   return createApiKeyMiddleware({ authenticator, logger });
 }
 
-// Data and action routes share one read-model store (a single cache, a single schema fetch). The
-// data middleware falls through to the action middleware on a non-data path.
-function buildAgentRouteMiddlewares(config: BFFConfig, logger: Logger): Middleware[] {
+interface ReadModelBundle {
+  store: ReadModelStore;
+  apiKeyConfig: ResolvedApiKeyConfig;
+}
+
+/**
+ * The read-model store the data routes, the action routes, the permissions endpoint and the OpenAPI
+ * unfolding all share — one cache, one schema fetch. Needs no agent: the permissions endpoint and the
+ * schema itself come from the SaaS.
+ */
+function resolveReadModelBundle(config: BFFConfig, logger: Logger): ReadModelBundle | undefined {
   const apiKeyConfig = resolveApiKeyConfig(config);
 
-  if (!apiKeyConfig) {
+  if (!apiKeyConfig) return undefined;
+
+  const { store } = createReadModel({
+    forestServerUrl: apiKeyConfig.forestServerUrl,
+    envSecret: apiKeyConfig.forestEnvSecret,
+    logger,
+  });
+
+  return { store, apiKeyConfig };
+}
+
+/**
+ * What the OpenAPI document needs to unfold. It also needs the AGENT_URL the store does not: the
+ * field set of a collection comes from the agent capabilities. Silent on purpose — the CLI and the
+ * server report a missing configuration differently.
+ */
+export function resolveUnfoldSource(config: BFFConfig, logger: Logger): UnfoldSource | undefined {
+  const bundle = resolveReadModelBundle(config, logger);
+
+  if (!bundle || !config.agentUrl) return undefined;
+
+  return {
+    store: bundle.store,
+    agentUrl: config.agentUrl,
+    timeoutMs: config.agentTimeoutMs,
+    logger,
+  };
+}
+
+// The data middleware falls through to the action middleware on a non-data path.
+function buildAgentRouteMiddlewares(
+  bundle: ReadModelBundle | undefined,
+  config: BFFConfig,
+  logger: Logger,
+): Middleware[] {
+  if (!bundle) {
     logger(
       'Warn',
       'Data, action and permissions endpoints disabled: FOREST_SERVER_URL, FOREST_ENV_SECRET or FOREST_AUTH_SECRET is missing',
@@ -173,11 +218,7 @@ function buildAgentRouteMiddlewares(config: BFFConfig, logger: Logger): Middlewa
     return [createAgentStubMiddleware()];
   }
 
-  const { store } = createReadModel({
-    forestServerUrl: apiKeyConfig.forestServerUrl,
-    envSecret: apiKeyConfig.forestEnvSecret,
-    logger,
-  });
+  const { store, apiKeyConfig } = bundle;
   const { agentUrl, agentTimeoutMs: timeoutMs } = config;
 
   const permissionsMiddleware = createPermissionsRoutesMiddleware({
@@ -213,14 +254,26 @@ function buildAgentMiddlewares(config: BFFConfig, logger: Logger): Middleware[] 
   }
 
   const apiKeyStep = buildApiKeyMiddleware(config, logger) ?? createApiKeyUnavailableGuard(logger);
+  // One store for the whole edge. The document only unfolds when the agent is reachable too: with no
+  // AGENT_URL every data path answers 501, so concrete paths would advertise a dead surface.
+  const bundle = resolveReadModelBundle(config, logger);
+  const source =
+    bundle && config.agentUrl
+      ? {
+          store: bundle.store,
+          agentUrl: config.agentUrl,
+          timeoutMs: config.agentTimeoutMs,
+          logger,
+        }
+      : undefined;
 
   const chain: Middleware[] = [
     createAuthModeMiddleware({ authSecret: forestAuthSecret }),
     apiKeyStep,
     createPerKeyOriginMiddleware(),
-    createOpenApiRoutes({ version, enabled: config.openapiEnabled }),
+    createOpenApiRoutes({ version, enabled: config.openapiEnabled, source }),
     createTimezoneMiddleware({ defaultTimezone }),
-    ...buildAgentRouteMiddlewares(config, logger),
+    ...buildAgentRouteMiddlewares(bundle, config, logger),
   ];
 
   return chain.map(agentScoped);

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -69,25 +69,23 @@ export async function renderOpenApi(env: NodeJS.ProcessEnv, logger: Logger): Pro
   // to do with (HTTP_PORT, the OAuth keys, the default timezone). A deployment that never asked for an
   // unfolded document must not see its export die on one of those, so the config is parsed only once
   // the four variables unfolding needs are all present — and from there a bad value is a real failure.
-  if (!authSecret || !wantsUnfolding(env)) {
+  const unfoldable =
+    authSecret && wantsUnfolding(env)
+      ? { source: resolveUnfoldSource(parseConfig(env), logger), authSecret }
+      : undefined;
+
+  if (!unfoldable?.source) {
     logger('Warn', `Emitting the generic OpenAPI document: ${NOTHING_TO_UNFOLD}`);
 
     return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
   }
 
-  const source = resolveUnfoldSource(parseConfig(env), logger);
-
-  if (!source) {
-    logger('Warn', `Emitting the generic OpenAPI document: ${NOTHING_TO_UNFOLD}`);
-
-    return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
-  }
-
+  const { source } = unfoldable;
   const readModel = await source.store.getReadModel();
   const { document, unfolding } = await buildUnfoldedDocument(
     source,
     readModel,
-    () => issueOpenApiAgentToken(authSecret),
+    () => issueOpenApiAgentToken(unfoldable.authSecret),
     version,
   );
 

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -42,6 +42,19 @@ export interface DispatchOutcome {
   server?: BFFHttpServer;
 }
 
+const UNFOLD_VARS = [
+  'FOREST_SERVER_URL',
+  'FOREST_ENV_SECRET',
+  'FOREST_AUTH_SECRET',
+  'AGENT_URL',
+] as const;
+
+const NOTHING_TO_UNFOLD = `${UNFOLD_VARS.join(', ')} must all be set to unfold it`;
+
+function wantsUnfolding(env: NodeJS.ProcessEnv): boolean {
+  return UNFOLD_VARS.every(name => (env[name] ?? '').trim() !== '');
+}
+
 /**
  * Unfolds when the deployment is configured to be inspected, and emits the generic document when it
  * is not configured at all — the command keeps working without configuration. A deployment that IS
@@ -49,27 +62,30 @@ export interface DispatchOutcome {
  * unfolded document, and a generic one would look like a complete answer.
  */
 export async function renderOpenApi(env: NodeJS.ProcessEnv, logger: Logger): Promise<string> {
-  const source = resolveUnfoldSource(parseConfig(env), logger);
   const authSecret = env.FOREST_AUTH_SECRET;
 
-  if (source && authSecret) {
-    const readModel = await source.store.getReadModel();
+  // `parseConfig` validates the WHOLE server configuration, including settings the export has nothing
+  // to do with (HTTP_PORT, the OAuth keys, the default timezone). A deployment that never asked for an
+  // unfolded document must not see its export die on one of those, so the config is parsed only once
+  // the four variables unfolding needs are all present — and from there a bad value is a real failure.
+  if (!authSecret || !wantsUnfolding(env)) {
+    logger('Warn', `Emitting the generic OpenAPI document: ${NOTHING_TO_UNFOLD}`);
 
-    return `${await buildUnfoldedDocument(
-      source,
-      readModel,
-      issueOpenApiAgentToken(authSecret),
-      version,
-    )}\n`;
+    return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
   }
 
-  logger(
-    'Warn',
-    'Emitting the generic OpenAPI document: FOREST_SERVER_URL, FOREST_ENV_SECRET, ' +
-      'FOREST_AUTH_SECRET or AGENT_URL is missing, so there is nothing to unfold against',
-  );
+  const source = resolveUnfoldSource(parseConfig(env), logger);
 
-  return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
+  if (!source) {
+    logger('Warn', `Emitting the generic OpenAPI document: ${NOTHING_TO_UNFOLD}`);
+
+    return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
+  }
+
+  const readModel = await source.store.getReadModel();
+  const token = issueOpenApiAgentToken(authSecret);
+
+  return `${await buildUnfoldedDocument(source, readModel, token, version)}\n`;
 }
 
 function rejectCli(reason: string): DispatchOutcome {

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -10,6 +10,7 @@ import { parseConfig } from './config/env-config';
 import { extractErrorMessage } from './errors';
 import { generateOpenApiDocument, serializeOpenApi } from './openapi/openapi-document';
 import buildUnfoldedDocument, { issueOpenApiAgentToken } from './openapi/unfolded-document';
+import { isFullyDegraded } from './openapi/unfolding';
 import version from './version';
 
 export const DEFAULT_OUTPUT_FILE = 'openapi.json';
@@ -83,9 +84,25 @@ export async function renderOpenApi(env: NodeJS.ProcessEnv, logger: Logger): Pro
   }
 
   const readModel = await source.store.getReadModel();
-  const token = issueOpenApiAgentToken(authSecret);
+  const { document, unfolding } = await buildUnfoldedDocument(
+    source,
+    readModel,
+    () => issueOpenApiAgentToken(authSecret),
+    version,
+  );
 
-  return `${await buildUnfoldedDocument(source, readModel, token, version)}\n`;
+  // Not one collection came back with its field set, so the agent was unreachable throughout. The
+  // paths are real but every field schema is free-form, which is not the document this command
+  // promises — a CI job regenerating it needs something to branch on, and the degraded notes buried
+  // in the descriptions are not it. One odd collection stays a warning, not a failure.
+  if (isFullyDegraded(unfolding)) {
+    throw new Error(
+      'No collection could be described: the agent answered no capabilities call, so every field ' +
+        'schema in the document would be free-form. Check AGENT_URL and the agent, then retry.',
+    );
+  }
+
+  return `${document}\n`;
 }
 
 function rejectCli(reason: string): DispatchOutcome {

--- a/packages/agent-bff/src/cli-dispatch.ts
+++ b/packages/agent-bff/src/cli-dispatch.ts
@@ -4,9 +4,12 @@ import type { Logger } from './ports/logger-port';
 import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
 
-import runCli from './cli-core';
+import createConsoleLogger from './adapters/console-logger';
+import runCli, { resolveUnfoldSource } from './cli-core';
+import { parseConfig } from './config/env-config';
 import { extractErrorMessage } from './errors';
 import { generateOpenApiDocument, serializeOpenApi } from './openapi/openapi-document';
+import buildUnfoldedDocument, { issueOpenApiAgentToken } from './openapi/unfolded-document';
 import version from './version';
 
 export const DEFAULT_OUTPUT_FILE = 'openapi.json';
@@ -17,7 +20,11 @@ export const USAGE = `Usage: forest-bff [command]
 
 Commands:
   (none)      Start the BFF server, configured from the environment.
-  openapi     Write the OpenAPI document to stdout. Needs no configuration.
+  openapi     Write the OpenAPI document to stdout. Needs no configuration, but
+              a deployment configured to reach its Forest schema and its agent
+              (FOREST_SERVER_URL, FOREST_ENV_SECRET, FOREST_AUTH_SECRET,
+              AGENT_URL) unfolds one path per collection, relation and action
+              instead of the generic ones.
               --output [file]  Write to a file instead of stdout, defaulting
                                to ${DEFAULT_OUTPUT_FILE} in the current directory.
 
@@ -35,7 +42,33 @@ export interface DispatchOutcome {
   server?: BFFHttpServer;
 }
 
-export function renderOpenApi(): string {
+/**
+ * Unfolds when the deployment is configured to be inspected, and emits the generic document when it
+ * is not configured at all — the command keeps working without configuration. A deployment that IS
+ * configured but whose schema cannot be read fails instead of quietly degrading: it asked for the
+ * unfolded document, and a generic one would look like a complete answer.
+ */
+export async function renderOpenApi(env: NodeJS.ProcessEnv, logger: Logger): Promise<string> {
+  const source = resolveUnfoldSource(parseConfig(env), logger);
+  const authSecret = env.FOREST_AUTH_SECRET;
+
+  if (source && authSecret) {
+    const readModel = await source.store.getReadModel();
+
+    return `${await buildUnfoldedDocument(
+      source,
+      readModel,
+      issueOpenApiAgentToken(authSecret),
+      version,
+    )}\n`;
+  }
+
+  logger(
+    'Warn',
+    'Emitting the generic OpenAPI document: FOREST_SERVER_URL, FOREST_ENV_SECRET, ' +
+      'FOREST_AUTH_SECRET or AGENT_URL is missing, so there is nothing to unfold against',
+  );
+
   return `${serializeOpenApi(generateOpenApiDocument(version))}\n`;
 }
 
@@ -64,7 +97,7 @@ function parseOutputOption(rest: string[]): OutputOption {
   };
 }
 
-function writeOpenApiFile(file: string): DispatchOutcome {
+function writeOpenApiFile(file: string, document: string): DispatchOutcome {
   const asDirectory = file.endsWith('/') || file.endsWith(path.sep);
   const destination = path.resolve(
     process.cwd(),
@@ -73,7 +106,7 @@ function writeOpenApiFile(file: string): DispatchOutcome {
 
   try {
     mkdirSync(path.dirname(destination), { recursive: true });
-    writeFileSync(destination, renderOpenApi());
+    writeFileSync(destination, document);
   } catch (error) {
     process.stderr.write(`Cannot write ${destination}: ${extractErrorMessage(error)}\n`);
 
@@ -124,11 +157,13 @@ export default async function dispatchCli(
     );
   }
 
+  const document = await renderOpenApi(env, logger ?? createConsoleLogger());
+
   if (file !== undefined) {
-    return writeOpenApiFile(file);
+    return writeOpenApiFile(file, document);
   }
 
-  process.stdout.write(renderOpenApi());
+  process.stdout.write(document);
 
   return { exitCode: 0 };
 }

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -8,7 +8,7 @@ import type {
 import type { Logger } from '../ports/logger-port';
 import type { CapabilitiesResult } from '../read-model/capabilities-cache';
 import type ReadModel from '../read-model/read-model';
-import type { PrimaryKeyField, RelationTarget } from '../read-model/read-model';
+import type { PrimaryKeyField } from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
 import type { Context, Middleware } from 'koa';
 
@@ -40,15 +40,6 @@ import assertNoRelationFieldPaths from '../validation/relation-field-guard';
 
 const DATA_ROUTE = /^\/agent\/v1\/([^/]+)\/(list|count)$/;
 const RELATION_ROUTE = /^\/agent\/v1\/([^/]+)\/relations\/([^/]+)\/(list|count)$/;
-
-// Only to-many relations expose list/count on the agent; to-one relations get update-relation only.
-// A polymorphic relation carrying multiple targets is always the to-one (PolymorphicManyToOne) side.
-function resolveForeignCollection(target: RelationTarget | undefined): string | null {
-  if (!target || !('target' in target)) return null;
-  if (target.type !== 'HasMany' && target.type !== 'BelongsToMany') return null;
-
-  return target.target;
-}
 
 export interface DataRoutesMiddlewareOptions {
   store: ReadModelStore;
@@ -199,9 +190,7 @@ type RelationListHandlerDeps = RelationHandlerDeps & { primaryKeys: PrimaryKeyFi
 function assertRelationStillExposed(readModel: ReadModel, deps: RelationHandlerDeps): void {
   assertCollectionStillAllowed(readModel, deps.collection);
 
-  const stillTargets = resolveForeignCollection(
-    readModel.getRelationTarget(deps.collection, deps.relation),
-  );
+  const stillTargets = readModel.getListableRelationTarget(deps.collection, deps.relation);
 
   if (stillTargets !== deps.foreignCollection) {
     throw unknownRelation(`Unknown relation: ${deps.collection}.${deps.relation}`);
@@ -288,9 +277,7 @@ async function handleRelation(
 
   // The URL identity (does this listable relation exist?) is resolved before the body,
   // so a bad path 404s before its payload is inspected.
-  const foreignCollection = resolveForeignCollection(
-    readModel.getRelationTarget(deps.collection, relation),
-  );
+  const foreignCollection = readModel.getListableRelationTarget(deps.collection, relation);
 
   // TODO(PRD-672): the read-model's relation map is the allow-list, so an absent/to-one/polymorphic
   // relation cannot be told from a disallowed one — every non-listable relation maps to 404 here;

--- a/packages/agent-bff/src/data/pack-id.ts
+++ b/packages/agent-bff/src/data/pack-id.ts
@@ -2,7 +2,7 @@ import type { PrimaryKeyField } from '../read-model/read-model';
 
 import { mappingError } from '../http/bff-local-errors';
 
-const PACKED_ID_SEPARATOR = '|';
+export const PACKED_ID_SEPARATOR = '|';
 
 // The only column type unpacked to a number, mirroring the agent's `IdUtils.unpackId`.
 const NUMBER_COLUMN_TYPE = 'Number';

--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -1,0 +1,143 @@
+import type {
+  CollectionFields,
+  UnfoldedAction,
+  UnfoldedCollection,
+  UnfoldedRelation,
+  Unfolding,
+} from './unfolding';
+import type { Logger } from '../ports/logger-port';
+import type { CapabilitiesFetcher } from '../read-model/capabilities-cache';
+import type ReadModel from '../read-model/read-model';
+import type ReadModelStore from '../read-model/read-model-store';
+
+import { extractErrorMessage } from '../errors';
+
+// A cold document costs one capabilities call per collection. They are capped rather than fired all
+// at once so a 200-collection deployment cannot open 200 sockets to the agent at the same time; a
+// warm BFF pays nothing, the per-collection cache is shared with the data routes.
+export const CAPABILITIES_CONCURRENCY = 10;
+
+export interface CollectUnfoldingOptions {
+  readModel: ReadModel;
+  store: ReadModelStore;
+  capabilitiesFetcher: CapabilitiesFetcher;
+  logger: Logger;
+  concurrency?: number;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  // Recursive rather than a while loop: each worker takes the next item only once the previous one
+  // settled, which is what caps the concurrency.
+  const worker = async (): Promise<void> => {
+    if (cursor >= items.length) return;
+
+    const index = cursor;
+    cursor += 1;
+    results[index] = await run(items[index]);
+
+    await worker();
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+
+  return results;
+}
+
+const UNTYPED = (degraded: CollectionFields['degraded']): CollectionFields => ({
+  projectable: [],
+  filterable: [],
+  degraded,
+});
+
+async function collectFields(
+  collection: string,
+  { store, capabilitiesFetcher, logger }: CollectUnfoldingOptions,
+): Promise<CollectionFields> {
+  try {
+    const { capabilities } = await store.getCapabilities(collection, capabilitiesFetcher);
+
+    if (capabilities.fields.length === 0) {
+      logger('Warn', 'Documenting a collection without a field set: capabilities returned none', {
+        collection,
+      });
+
+      return UNTYPED('no_fields');
+    }
+
+    return {
+      projectable: capabilities.fields.map(field => field.name),
+      filterable: capabilities.fields
+        .filter(field => (field.operators?.length ?? 0) > 0)
+        .map(field => field.name),
+      degraded: null,
+    };
+  } catch (error) {
+    // A single unreachable collection must not cost the whole document: the collection keeps its
+    // paths, untyped. The alternative — dropping it — would hide a collection the runtime serves.
+    logger('Warn', 'Documenting a collection without a field set: capabilities are unavailable', {
+      collection,
+      error: extractErrorMessage(error),
+    });
+
+    return UNTYPED('capabilities_unavailable');
+  }
+}
+
+// A to-many relation pointing at a collection absent from the allow-list is dropped: the runtime
+// answers 404 on it (data-routes-middleware checks the foreign collection), so documenting it would
+// promise a dead path.
+function collectRelations(readModel: ReadModel, collection: string): UnfoldedRelation[] {
+  return readModel
+    .getListableRelations(collection)
+    .filter(relation => readModel.isCollectionAllowed(relation.foreignCollection))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function collectActions(readModel: ReadModel, collection: string): UnfoldedAction[] {
+  const byName = readModel.getActionEndpoints()[collection] ?? {};
+
+  return Object.keys(byName)
+    .sort()
+    .map(name => ({
+      name,
+      fields: (byName[name].fields ?? []).map(field => ({
+        name: field.field,
+        type: field.type,
+        isRequired: field.isRequired === true,
+        enums: field.enums ?? null,
+      })),
+    }));
+}
+
+/**
+ * Collects everything the document unfolds. Sorted at every level so two runs over one schema
+ * produce byte-identical documents — the route/CLI comparison depends on it.
+ *
+ * A schema refresh landing mid-collect can mix the new generation's field sets into this snapshot's
+ * structure. It is not guarded against: the caller memoizes per read-model identity, so the very
+ * next request rebuilds the whole document from one generation.
+ */
+export default async function collectUnfolding(
+  options: CollectUnfoldingOptions,
+): Promise<Unfolding> {
+  const { readModel, concurrency = CAPABILITIES_CONCURRENCY } = options;
+  const names = readModel.getAllowedCollections().sort();
+  const fields = await mapWithConcurrency(names, concurrency, name => collectFields(name, options));
+
+  const collections: UnfoldedCollection[] = names.map((name, index) => ({
+    name,
+    fields: fields[index],
+    primaryKeys: readModel.getPrimaryKeys(name),
+    relations: collectRelations(readModel, name),
+    actions: collectActions(readModel, name),
+  }));
+
+  return { collections };
+}

--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -94,10 +94,16 @@ async function collectFields(
 // answers 404 on it (data-routes-middleware checks the foreign collection), so documenting it would
 // promise a dead path.
 function collectRelations(readModel: ReadModel, collection: string): UnfoldedRelation[] {
-  return readModel
+  const listable = readModel
     .getListableRelations(collection)
-    .filter(relation => readModel.isCollectionAllowed(relation.foreignCollection))
-    .sort((left, right) => left.name.localeCompare(right.name));
+    .filter(relation => readModel.isCollectionAllowed(relation.foreignCollection));
+
+  // By name, in code-unit order like the collection and action levels — NOT `localeCompare`, which
+  // follows the process locale: the route and the CLI could then order one schema's relations
+  // differently and stop producing the same document.
+  return listable.sort((left, right) =>
+    left.name < right.name ? -1 : Number(left.name > right.name),
+  );
 }
 
 function collectActions(readModel: ReadModel, collection: string): UnfoldedAction[] {

--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -121,8 +121,8 @@ function collectActions(readModel: ReadModel, collection: string): UnfoldedActio
  * produce byte-identical documents — the route/CLI comparison depends on it.
  *
  * A schema refresh landing mid-collect can mix the new generation's field sets into this snapshot's
- * structure. It is not guarded against: the caller memoizes per read-model identity, so the very
- * next request rebuilds the whole document from one generation.
+ * structure. Detecting it belongs to the caller, which knows whether the read-model it passed is
+ * still the current one once this resolves.
  */
 export default async function collectUnfolding(
   options: CollectUnfoldingOptions,

--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -113,12 +113,17 @@ function collectActions(readModel: ReadModel, collection: string): UnfoldedActio
     .sort()
     .map(name => ({
       name,
-      fields: (byName[name].fields ?? []).map(field => ({
-        name: field.field,
-        type: field.type,
-        isRequired: field.isRequired === true,
-        enums: field.enums ?? null,
-      })),
+      // A form field with no usable name is dropped: the schema is cast from untyped JSON, and the
+      // read-model turns a malformed entry into `{}`, which would otherwise document a property
+      // literally called "undefined".
+      fields: (byName[name].fields ?? [])
+        .filter(field => typeof field?.field === 'string')
+        .map(field => ({
+          name: field.field,
+          type: field.type,
+          isRequired: field.isRequired === true,
+          enums: field.enums ?? null,
+        })),
     }));
 }
 

--- a/packages/agent-bff/src/openapi/component-pool.ts
+++ b/packages/agent-bff/src/openapi/component-pool.ts
@@ -1,0 +1,34 @@
+import type { z } from './zod-openapi';
+import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas31';
+
+const SCHEMA_PREFIX = '#/components/schemas/';
+
+/**
+ * Registers schema components on demand. Nothing is registered eagerly: a component no path
+ * references trips redocly's unused-component rule, and which shared pieces an unfolded document
+ * needs depends on the schema it was built from.
+ */
+export default class ComponentPool {
+  private readonly registry: OpenAPIRegistry;
+  private readonly shared = new Set<string>();
+
+  constructor(registry: OpenAPIRegistry) {
+    this.registry = registry;
+  }
+
+  /** A hand-written OpenAPI component. The caller owns name uniqueness. */
+  add(name: string, component: SchemaObject): ReferenceObject {
+    return this.registry.registerComponent('schemas', name, component).ref;
+  }
+
+  /** A zod schema shared by several paths, registered the first time it is referenced. */
+  reuse(name: string, schema: z.ZodType): ReferenceObject {
+    if (!this.shared.has(name)) {
+      this.registry.register(name, schema);
+      this.shared.add(name);
+    }
+
+    return { $ref: `${SCHEMA_PREFIX}${name}` };
+  }
+}

--- a/packages/agent-bff/src/openapi/field-schemas.ts
+++ b/packages/agent-bff/src/openapi/field-schemas.ts
@@ -31,14 +31,17 @@ export default function toFieldSchema(type: FieldType): SchemaObject {
     return { type: 'array', items: item === undefined ? {} : toFieldSchema(item) };
   }
 
-  // Null-checked because the capabilities payload is cast from untyped JSON, so nothing guarantees a
-  // column type is one of the three shapes the type declares.
+  // Null-checked, and its elements checked rather than trusted: the payload a column type comes from
+  // is cast from untyped JSON, so nothing guarantees the declared shape. A malformed entry is dropped
+  // instead of aborting the whole document — one bad field is not worth losing the spec over.
   if (typeof type === 'object' && type !== null && Array.isArray(type.fields)) {
+    const named = type.fields.filter(
+      field => typeof field === 'object' && field !== null && typeof field.field === 'string',
+    );
+
     return {
       type: 'object',
-      properties: Object.fromEntries(
-        type.fields.map(field => [field.field, toFieldSchema(field.type)]),
-      ),
+      properties: Object.fromEntries(named.map(field => [field.field, toFieldSchema(field.type)])),
     };
   }
 

--- a/packages/agent-bff/src/openapi/field-schemas.ts
+++ b/packages/agent-bff/src/openapi/field-schemas.ts
@@ -1,0 +1,44 @@
+import type { FieldType } from '../read-model/capabilities-cache';
+import type { SchemaObject } from 'openapi3-ts/oas31';
+
+// Forest primitives, mapped to the closest JSON Schema shape. `Json` maps to no constraint at all,
+// which is honest: any JSON value is accepted there.
+const PRIMITIVE_SCHEMAS: Record<string, SchemaObject> = {
+  Binary: { type: 'string' },
+  Boolean: { type: 'boolean' },
+  Date: { type: 'string', format: 'date-time' },
+  Dateonly: { type: 'string', format: 'date' },
+  Enum: { type: 'string' },
+  File: { type: 'string', description: 'A data URI.' },
+  Json: {},
+  Number: { type: 'number' },
+  Point: { type: 'string' },
+  String: { type: 'string' },
+  Time: { type: 'string' },
+  Timeonly: { type: 'string' },
+  Uuid: { type: 'string', format: 'uuid' },
+};
+
+/**
+ * Turns a Forest column type into a JSON Schema. Anything unrecognized — a relation marker such as
+ * `ManyToOne`, or a type a newer agent introduced — maps to an unconstrained schema rather than a
+ * guess, so the document never rejects a value the runtime accepts.
+ */
+export default function toFieldSchema(type: FieldType): SchemaObject {
+  if (Array.isArray(type)) {
+    const [item] = type;
+
+    return { type: 'array', items: item === undefined ? {} : toFieldSchema(item) };
+  }
+
+  if (typeof type === 'object' && Array.isArray(type.fields)) {
+    return {
+      type: 'object',
+      properties: Object.fromEntries(
+        type.fields.map(field => [field.field, toFieldSchema(field.type)]),
+      ),
+    };
+  }
+
+  return typeof type === 'string' ? PRIMITIVE_SCHEMAS[type] ?? {} : {};
+}

--- a/packages/agent-bff/src/openapi/field-schemas.ts
+++ b/packages/agent-bff/src/openapi/field-schemas.ts
@@ -31,7 +31,9 @@ export default function toFieldSchema(type: FieldType): SchemaObject {
     return { type: 'array', items: item === undefined ? {} : toFieldSchema(item) };
   }
 
-  if (typeof type === 'object' && Array.isArray(type.fields)) {
+  // Null-checked because the capabilities payload is cast from untyped JSON, so nothing guarantees a
+  // column type is one of the three shapes the type declares.
+  if (typeof type === 'object' && type !== null && Array.isArray(type.fields)) {
     return {
       type: 'object',
       properties: Object.fromEntries(

--- a/packages/agent-bff/src/openapi/names.ts
+++ b/packages/agent-bff/src/openapi/names.ts
@@ -1,0 +1,34 @@
+/**
+ * Collection, relation and action names are arbitrary customer strings: spaces, dots, slashes,
+ * accents. A path segment carries them URL-encoded, but an `operationId` cannot — redocly rejects a
+ * non-URL-safe one, and a codegen tool turns it into a method name. So identifiers are sanitized,
+ * and the exact name is carried in prose instead.
+ */
+export function sanitizeIdentifier(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9_]/g, '_') || '_';
+}
+
+/**
+ * Hands out unique sanitized identifiers. Sanitizing collapses distinct names (`Mark as paid` and
+ * `Mark-as-paid` both become `Mark_as_paid`), so the second one gets a numeric suffix. Callers must
+ * feed names in a stable order — the suffix depends on it, and two runs over one schema have to
+ * produce the same document.
+ */
+export default function createNamer(): (raw: string) => string {
+  const used = new Set<string>();
+
+  return (raw: string): string => {
+    const base = sanitizeIdentifier(raw);
+    let candidate = base;
+    let counter = 2;
+
+    while (used.has(candidate)) {
+      candidate = `${base}_${counter}`;
+      counter += 1;
+    }
+
+    used.add(candidate);
+
+    return candidate;
+  };
+}

--- a/packages/agent-bff/src/openapi/names.ts
+++ b/packages/agent-bff/src/openapi/names.ts
@@ -14,7 +14,9 @@ export function sanitizeIdentifier(raw: string): string {
  * feed names in a stable order — the suffix depends on it, and two runs over one schema have to
  * produce the same document.
  */
-export default function createNamer(): (raw: string) => string {
+export type Namer = (raw: string) => string;
+
+export default function createNamer(): Namer {
   const used = new Set<string>();
 
   return (raw: string): string => {

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -1,7 +1,9 @@
+import type { Unfolding } from './unfolding';
 import type { OpenAPIObject } from 'openapi3-ts/oas31';
 
 import { OpenAPIRegistry, OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
 
+import ComponentPool from './component-pool';
 import {
   ActionRequestSchema,
   CountRequestSchema,
@@ -13,6 +15,7 @@ import {
   RelationCountRequestSchema,
   RelationListRequestSchema,
 } from './schemas';
+import registerUnfoldedPaths from './unfolded-paths';
 import { z } from './zod-openapi';
 import BODY_LIMIT from '../http/body-limit';
 
@@ -43,46 +46,81 @@ const UNSUPPORTED_RESULT_DESCRIPTION =
   'Either the BFF runs without an agent configured, or the action returned a result shape the ' +
   'BFF cannot normalize. The second case carries no message field.';
 
-function errorResponses(statuses: string[], executeResults: boolean): Record<string, unknown> {
-  return Object.fromEntries(
-    statuses.map(status => {
-      const description = ERROR_STATUSES[status];
+const ERROR_RESPONSE_REF = '#/components/schemas/ErrorResponse';
+const MESSAGELESS_ERROR_RESPONSE_REF = '#/components/schemas/MessagelessErrorResponse';
 
-      if (!description) throw new Error(`No OpenAPI description for error status ${status}`);
+const UNSUPPORTED_ACTION_RESULT_COMPONENT = 'UnsupportedActionResult';
 
-      if (status === '501' && executeResults) {
-        return [
-          status,
-          {
-            description: UNSUPPORTED_RESULT_DESCRIPTION,
-            content: {
-              'application/json': {
-                schema: z.union([ErrorResponseSchema, MessagelessErrorResponseSchema]),
-              },
-            },
+const RETRY_AFTER_HEADER = {
+  'Retry-After': {
+    description: 'Seconds to wait before retrying. Set when the API key could not be resolved.',
+    required: false,
+    schema: { type: 'integer' as const },
+  },
+};
+
+type ResponseRef = { $ref: string };
+
+interface ErrorResponseRefs {
+  byStatus: Record<string, ResponseRef>;
+  unsupportedActionResult: ResponseRef;
+}
+
+// Every error body is identical across paths, and their descriptions are long: inlining them costs
+// ~2.8kB per path, which the unfolded document multiplies by every collection, relation and action.
+// Registering them once as components keeps a path's error block to a dozen refs.
+function registerErrorResponses(
+  registry: OpenAPIRegistry,
+  statuses: string[],
+  withActionResults: boolean,
+): ErrorResponseRefs {
+  registry.register('ErrorResponse', ErrorResponseSchema);
+
+  const byStatus: Record<string, ResponseRef> = {};
+
+  statuses.forEach(status => {
+    const description = ERROR_STATUSES[status];
+
+    if (!description) throw new Error(`No OpenAPI description for error status ${status}`);
+
+    byStatus[status] = registry.registerComponent('responses', `Error${status}`, {
+      description,
+      content: { 'application/json': { schema: { $ref: ERROR_RESPONSE_REF } } },
+      ...(status === '503' ? { headers: RETRY_AFTER_HEADER } : {}),
+    }).ref;
+  });
+
+  // A document with no action path must not carry this response, nor the messageless body it
+  // references: an unreferenced component trips redocly's unused-component rule.
+  if (!withActionResults) return { byStatus, unsupportedActionResult: byStatus['501'] };
+
+  registry.register('MessagelessErrorResponse', MessagelessErrorResponseSchema);
+
+  const unsupportedActionResult = registry.registerComponent(
+    'responses',
+    UNSUPPORTED_ACTION_RESULT_COMPONENT,
+    {
+      description: UNSUPPORTED_RESULT_DESCRIPTION,
+      content: {
+        'application/json': {
+          schema: {
+            anyOf: [{ $ref: ERROR_RESPONSE_REF }, { $ref: MESSAGELESS_ERROR_RESPONSE_REF }],
           },
-        ];
-      }
+        },
+      },
+    },
+  ).ref;
 
-      const response: Record<string, unknown> = {
-        description,
-        content: { 'application/json': { schema: ErrorResponseSchema } },
-      };
+  return { byStatus, unsupportedActionResult };
+}
 
-      if (status === '503') {
-        response.headers = {
-          'Retry-After': {
-            description:
-              'Seconds to wait before retrying. Set when the API key could not be resolved.',
-            required: false,
-            schema: { type: 'integer' },
-          },
-        };
-      }
-
-      return [status, response];
-    }),
-  );
+function errorResponses(
+  refs: ErrorResponseRefs,
+  executeResults: boolean,
+): Record<string, ResponseRef> {
+  return executeResults
+    ? { ...refs.byStatus, 501: refs.unsupportedActionResult }
+    : { ...refs.byStatus };
 }
 
 const DATA_ERRORS = [
@@ -188,19 +226,52 @@ function buildParams(names: string[]) {
   );
 }
 
-const TIMEZONE_HEADER_PARAM = z.object({
-  'X-Forest-Timezone': z
-    .string()
-    .optional()
-    .openapi({
-      description:
-        'An IANA timezone. Takes precedence over the `timezone` body field; the BFF default ' +
-        'applies when neither is sent.',
-    }),
-});
+// Registered as a parameter component rather than inlined: it is the same header on every path, and
+// its description costs a quarter of a path once the error responses are refs.
+const TIMEZONE_HEADER_COMPONENT = 'XForestTimezone';
 
-export function generateOpenApiDocument(version: string): OpenAPIObject {
+const TIMEZONE_HEADER = z
+  .string()
+  .optional()
+  .openapi({
+    param: { name: 'X-Forest-Timezone', in: 'header' },
+    description:
+      'An IANA timezone. Takes precedence over the `timezone` body field; the BFF default ' +
+      'applies when neither is sent.',
+  });
+
+const SHARED_DESCRIPTION =
+  'The timezone is resolved from the `X-Forest-Timezone` header first, then a `timezone` body ' +
+  'field, then the BFF default when one is configured. A deployment without a default rejects a ' +
+  'request carrying neither with 400 missing_timezone, so send one of the two to be safe. Sending ' +
+  'a content type other than application/json is not an error: a form-urlencoded body is parsed ' +
+  'like JSON, while any other content type is read as absent, which silently drops any filter, ' +
+  'sort, or page.';
+
+const GENERIC_DESCRIPTION =
+  'Paths are generic: one per operation, with the collection, relation and action passed as path ' +
+  'segments, and no field enumerated. This is the fallback form — a deployment configured to ' +
+  'reach its Forest schema and its agent unfolds one path per real collection, relation and ' +
+  'action instead, each carrying its own field set.';
+
+const UNFOLDED_DESCRIPTION =
+  'Paths are unfolded: one per exposed collection, to-many relation and action, each carrying the ' +
+  "collection's real field set. The RUNTIME routes stay generic — a path here is the generic " +
+  'route with its segments already filled in, so the collection, relation and action segments are ' +
+  'the exact schema names, URL-encoded. Every operationId is sanitized to stay usable as a ' +
+  'method name, so the exact name lives in the summary and description. A path whose fields are ' +
+  'not enumerated says so in its request description: the document was built without that ' +
+  "collection's capabilities. Only to-many relations appear; a to-one or polymorphic relation has " +
+  'no list or count route. This document describes the whole exposed schema regardless of the ' +
+  'caller: it is not filtered by the permissions of whoever fetched it.';
+
+export function generateOpenApiDocument(version: string, unfolding?: Unfolding): OpenAPIObject {
   const registry = new OpenAPIRegistry();
+  const hasActions =
+    unfolding === undefined ||
+    unfolding.collections.some(collection => collection.actions.length > 0);
+  const errorRefs = registerErrorResponses(registry, DATA_ERRORS, hasActions);
+  const timezoneHeader = [registry.registerParameter(TIMEZONE_HEADER_COMPONENT, TIMEZONE_HEADER)];
 
   registry.registerComponent('securitySchemes', SESSION_SCHEME, {
     type: 'http',
@@ -217,30 +288,44 @@ export function generateOpenApiDocument(version: string): OpenAPIObject {
     description: 'Mode 2: a BFF API key. Never send both this and an Authorization header.',
   });
 
-  ROUTES.forEach(route => {
-    registry.registerPath({
-      method: 'post',
-      path: `${ROUTE_PREFIX}${route.path}`,
-      operationId: route.operationId,
-      summary: route.summary,
-      security: SECURITY,
-      request: {
-        params: buildParams(route.params),
-        headers: TIMEZONE_HEADER_PARAM,
-        body: {
-          required: route.bodyRequired === true,
-          content: { 'application/json': { schema: route.request } },
-        },
+  if (unfolding) {
+    registerUnfoldedPaths(
+      {
+        registry,
+        pool: new ComponentPool(registry),
+        prefix: ROUTE_PREFIX,
+        security: SECURITY,
+        timezoneHeader,
+        errorResponses: executeResults => errorResponses(errorRefs, executeResults),
       },
-      responses: {
-        200: {
-          description: route.responseDescription,
-          content: { 'application/json': { schema: route.response } },
+      unfolding,
+    );
+  } else {
+    ROUTES.forEach(route => {
+      registry.registerPath({
+        method: 'post',
+        path: `${ROUTE_PREFIX}${route.path}`,
+        operationId: route.operationId,
+        summary: route.summary,
+        security: SECURITY,
+        request: {
+          params: buildParams(route.params),
+          headers: timezoneHeader,
+          body: {
+            required: route.bodyRequired === true,
+            content: { 'application/json': { schema: route.request } },
+          },
         },
-        ...errorResponses(DATA_ERRORS, route.executeResults === true),
-      },
+        responses: {
+          200: {
+            description: route.responseDescription,
+            content: { 'application/json': { schema: route.response } },
+          },
+          ...errorResponses(errorRefs, route.executeResults === true),
+        },
+      });
     });
-  });
+  }
 
   return new OpenApiGeneratorV31(registry.definitions).generateDocument({
     openapi: OPENAPI_VERSION,
@@ -248,15 +333,9 @@ export function generateOpenApiDocument(version: string): OpenAPIObject {
       title: 'Forest Admin BFF',
       version,
       license: { name: 'GPL-3.0', url: 'https://www.gnu.org/licenses/gpl-3.0.html' },
-      description:
-        'Runtime routes are generic: one path per operation, with the collection, relation and ' +
-        'action passed as path segments. The timezone is resolved from the `X-Forest-Timezone` ' +
-        'header first, then a `timezone` body field, then the BFF default when one is ' +
-        'configured. A deployment without a default rejects a request carrying neither with ' +
-        '400 missing_timezone, so send one of the two to be safe. Sending a content type other ' +
-        'than application/json is not an error: a form-urlencoded body is parsed like JSON, ' +
-        'while any other content type is read as absent, which silently drops any filter, ' +
-        'sort, or page.',
+      description: `${
+        unfolding ? UNFOLDED_DESCRIPTION : GENERIC_DESCRIPTION
+      } ${SHARED_DESCRIPTION}`,
     },
     servers: [{ url: '/' }],
   });

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -1,6 +1,10 @@
+import type { UnfoldSource } from './unfolded-document';
+import type ReadModel from '../read-model/read-model';
 import type { Middleware } from 'koa';
 
 import { generateOpenApiDocument, serializeOpenApi } from './openapi-document';
+import buildUnfoldedDocument from './unfolded-document';
+import { requireAgentToken, resolveReadModel } from '../http/agent-route-helpers';
 import { openapiDisabled } from '../http/bff-local-errors';
 
 export const OPENAPI_PATH = '/agent/openapi.json';
@@ -10,30 +14,52 @@ const READ_METHODS = new Set(['GET', 'HEAD']);
 export interface OpenApiRoutesOptions {
   version: string;
   enabled: boolean;
+  /** Absent (no agent or no read-model configuration) serves the generic document. */
+  source?: UnfoldSource;
 }
 
 export default function createOpenApiRoutes({
   version,
   enabled,
+  source,
 }: OpenApiRoutesOptions): Middleware {
-  const document = enabled ? serializeOpenApi(generateOpenApiDocument(version)) : undefined;
+  const generic =
+    enabled && !source ? serializeOpenApi(generateOpenApiDocument(version)) : undefined;
+
+  // Memoized on the read-model identity: the store builds a new one per schema generation, so the
+  // document is rebuilt exactly when the schema it describes changed.
+  let unfolded: { readModel: ReadModel; document: string } | undefined;
+
+  async function resolveDocument(ctx: Parameters<Middleware>[0]): Promise<string> {
+    if (!source) return generic as string;
+
+    // Before the schema is even read, so a caller with no agent credentials cannot make the BFF
+    // fetch anything: the unfolded document needs a token to ask the agent for capabilities.
+    const token = requireAgentToken(ctx);
+    const readModel = await resolveReadModel(source.store);
+
+    if (unfolded?.readModel !== readModel) {
+      unfolded = {
+        readModel,
+        document: await buildUnfoldedDocument(source, readModel, token, version),
+      };
+    }
+
+    return unfolded.document;
+  }
 
   return async function openApiRoutes(ctx, next) {
-    if (ctx.path !== OPENAPI_PATH) {
+    if (ctx.path !== OPENAPI_PATH || !READ_METHODS.has(ctx.method)) {
       await next();
 
       return;
     }
 
-    if (!READ_METHODS.has(ctx.method)) {
-      await next();
-
-      return;
-    }
-
-    if (document === undefined) {
+    if (!enabled) {
       throw openapiDisabled();
     }
+
+    const document = await resolveDocument(ctx);
 
     ctx.status = 200;
     ctx.type = 'application/json';

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -4,6 +4,7 @@ import type { Middleware } from 'koa';
 
 import { generateOpenApiDocument, serializeOpenApi } from './openapi-document';
 import buildUnfoldedDocument from './unfolded-document';
+import { hasDegradedCollection } from './unfolding';
 import { requireAgentToken, resolveReadModel } from '../http/agent-route-helpers';
 import { openapiDisabled } from '../http/bff-local-errors';
 
@@ -49,7 +50,7 @@ export default function createOpenApiRoutes({
 
     if (unfolded?.readModel === readModel) return unfolded.document;
 
-    const document = await buildUnfoldedDocument(source, readModel, token, version);
+    const { document, unfolding } = await buildUnfoldedDocument(source, readModel, token, version);
 
     // A schema refresh landing during the capabilities fan-out mixes the new generation's field sets
     // into this generation's collections, relations and actions. Such a document must not be served
@@ -59,7 +60,14 @@ export default function createOpenApiRoutes({
       return resolveDocument(ctx, attemptsLeft - 1);
     }
 
-    unfolded = { readModel, document };
+    // Only a complete document is memoized. The memo key is the schema generation, which moves on a
+    // 24h TTL, so caching a document built while the agent was briefly down would keep serving a
+    // field-less spec for a day — and longer still if a later schema refresh fails without bumping
+    // the revision. `CapabilitiesCache` deliberately caches successes only; this keeps that true
+    // end to end, at the cost of re-running the fan-out until the agent answers again.
+    if (!hasDegradedCollection(unfolding)) {
+      unfolded = { readModel, document };
+    }
 
     return document;
   }

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -11,6 +11,8 @@ export const OPENAPI_PATH = '/agent/openapi.json';
 
 const READ_METHODS = new Set(['GET', 'HEAD']);
 
+const MAX_GENERATION_RETRIES = 3;
+
 export interface OpenApiRoutesOptions {
   version: string;
   enabled: boolean;
@@ -30,22 +32,36 @@ export default function createOpenApiRoutes({
   // document is rebuilt exactly when the schema it describes changed.
   let unfolded: { readModel: ReadModel; document: string } | undefined;
 
-  async function resolveDocument(ctx: Parameters<Middleware>[0]): Promise<string> {
+  async function resolveDocument(
+    ctx: Parameters<Middleware>[0],
+    attemptsLeft = MAX_GENERATION_RETRIES,
+  ): Promise<string> {
     if (!source) return generic as string;
+
+    if (attemptsLeft <= 0) {
+      throw new Error('Schema generation kept changing while building the OpenAPI document');
+    }
 
     // Before the schema is even read, so a caller with no agent credentials cannot make the BFF
     // fetch anything: the unfolded document needs a token to ask the agent for capabilities.
     const token = requireAgentToken(ctx);
     const readModel = await resolveReadModel(source.store);
 
-    if (unfolded?.readModel !== readModel) {
-      unfolded = {
-        readModel,
-        document: await buildUnfoldedDocument(source, readModel, token, version),
-      };
+    if (unfolded?.readModel === readModel) return unfolded.document;
+
+    const document = await buildUnfoldedDocument(source, readModel, token, version);
+
+    // A schema refresh landing during the capabilities fan-out mixes the new generation's field sets
+    // into this generation's collections, relations and actions. Such a document must not be served
+    // nor cached — a consumer would generate a client from a self-contradictory schema. Bounded like
+    // `ReadModelStore.getCapabilities`, and driven by the 24h schema TTL rather than request volume.
+    if ((await resolveReadModel(source.store)) !== readModel) {
+      return resolveDocument(ctx, attemptsLeft - 1);
     }
 
-    return unfolded.document;
+    unfolded = { readModel, document };
+
+    return document;
   }
 
   return async function openApiRoutes(ctx, next) {

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -36,14 +36,14 @@ const ConditionTreeSchema: z.ZodType = z
       'collection capabilities; relation list and count forward the filter without either check.',
   });
 
-const SortClauseSchema = z
+export const SortClauseSchema = z
   .object({
     field: z.string(),
     direction: z.enum(['asc', 'desc']).optional(),
   })
   .openapi('SortClause', { description: 'Omitting `direction` sorts ascending.' });
 
-const PageSchema = z
+export const PageSchema = z
   .object({
     limit: z.number().int().positive(),
     offset: z.number().int().nonnegative(),
@@ -54,7 +54,7 @@ const PageSchema = z
       'Any other offset is rejected with 400 invalid_request.',
   });
 
-const TimezoneSchema = z.string().openapi({
+export const TimezoneSchema = z.string().openapi('Timezone', {
   description:
     'Used when the X-Forest-Timezone header is absent. The header wins when both are sent. A ' +
     'deployment with no configured default rejects a request carrying neither with 400 ' +
@@ -167,4 +167,4 @@ export const MessagelessErrorResponseSchema = z
       'The unsupported-action-result body, which carries no message field unlike every other error.',
   });
 
-export { ConditionTreeSchema, OPERATORS };
+export { ConditionTreeSchema, ParentIdSchema, OPERATORS };

--- a/packages/agent-bff/src/openapi/unfolded-document.ts
+++ b/packages/agent-bff/src/openapi/unfolded-document.ts
@@ -1,0 +1,60 @@
+import type { Logger } from '../ports/logger-port';
+import type ReadModel from '../read-model/read-model';
+import type ReadModelStore from '../read-model/read-model-store';
+
+import collectUnfolding from './collect-unfolding';
+import { generateOpenApiDocument, serializeOpenApi } from './openapi-document';
+import { issueAgentToken } from '../api-key/agent-token';
+import createAgentCapabilitiesFetcher from '../read-model/agent-capabilities-fetcher';
+
+/** Everything needed to unfold. Absent when the deployment cannot reach its schema or its agent. */
+export interface UnfoldSource {
+  store: ReadModelStore;
+  agentUrl: string;
+  timeoutMs?: number;
+  logger: Logger;
+}
+
+export default async function buildUnfoldedDocument(
+  source: UnfoldSource,
+  readModel: ReadModel,
+  token: string,
+  version: string,
+): Promise<string> {
+  const unfolding = await collectUnfolding({
+    readModel,
+    store: source.store,
+    capabilitiesFetcher: createAgentCapabilitiesFetcher({
+      agentUrl: source.agentUrl,
+      token,
+      timeoutMs: source.timeoutMs,
+    }),
+    logger: source.logger,
+  });
+
+  return serializeOpenApi(generateOpenApiDocument(version, unfolding));
+}
+
+/**
+ * The CLI has no caller to borrow an agent token from, so it signs its own with the deployment's
+ * auth secret — the only thing the agent verifies, and the capabilities route it calls runs no
+ * permission check. The identity is inert on purpose: it is never used to read or write records.
+ */
+export function issueOpenApiAgentToken(authSecret: string): string {
+  return issueAgentToken({
+    authSecret,
+    identity: {
+      renderingId: 0,
+      allowedOrigins: [],
+      user: {
+        id: 0,
+        email: 'openapi@agent-bff.forestadmin.com',
+        firstName: 'Forest',
+        lastName: 'BFF',
+        team: 'Operations',
+        tags: [],
+        permissionLevel: 'admin',
+      },
+    },
+  });
+}

--- a/packages/agent-bff/src/openapi/unfolded-document.ts
+++ b/packages/agent-bff/src/openapi/unfolded-document.ts
@@ -1,3 +1,4 @@
+import type { Unfolding } from './unfolding';
 import type { Logger } from '../ports/logger-port';
 import type ReadModel from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
@@ -15,12 +16,18 @@ export interface UnfoldSource {
   logger: Logger;
 }
 
+export interface UnfoldedDocument {
+  document: string;
+  /** Handed back so a caller can react to a collection that went out without its field set. */
+  unfolding: Unfolding;
+}
+
 export default async function buildUnfoldedDocument(
   source: UnfoldSource,
   readModel: ReadModel,
-  token: string,
+  token: string | (() => string),
   version: string,
-): Promise<string> {
+): Promise<UnfoldedDocument> {
   const unfolding = await collectUnfolding({
     readModel,
     store: source.store,
@@ -32,13 +39,17 @@ export default async function buildUnfoldedDocument(
     logger: source.logger,
   });
 
-  return serializeOpenApi(generateOpenApiDocument(version, unfolding));
+  return { document: serializeOpenApi(generateOpenApiDocument(version, unfolding)), unfolding };
 }
 
 /**
  * The CLI has no caller to borrow an agent token from, so it signs its own with the deployment's
  * auth secret — the only thing the agent verifies, and the capabilities route it calls runs no
  * permission check. The identity is inert on purpose: it is never used to read or write records.
+ *
+ * Minted per capabilities call rather than once: an agent token lives 5 minutes
+ * (`AGENT_TOKEN_EXPIRES_IN`) and a fan-out over hundreds of collections against a slow agent can
+ * outlive that, which would degrade the tail of the document for no reason.
  */
 export function issueOpenApiAgentToken(authSecret: string): string {
   return issueAgentToken({

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -209,10 +209,16 @@ function registerRequests(deps: Deps, plan: Omit<CollectionPlan, 'requests'>): R
   };
 }
 
+const PARENT_ID_SHAPE = {
+  anyOf: [{ type: 'string' as const, pattern: '\\S' }, { type: 'number' as const }],
+};
+
 /**
- * `parentId` is opaque on the wire, but the read-model knows the parent's key: only a `Number`
- * column comes back as a number, every other type stays a string, and a composite key travels as its
- * `|`-joined values (`unpackPrimaryKey` mirrors the agent's `IdUtils`).
+ * `parentId` is opaque on the wire: `parseParentId` takes a non-blank string or a finite number
+ * whatever the key's type is, and forwards it to the agent as a string. So the SHAPE stays that
+ * union — narrowing a numeric key to `number` would make a generated client reject `"123"`, which
+ * the endpoint accepts. What the read-model knows goes in the description: which column the id
+ * belongs to, and, for a composite key, the `|`-joined order `unpackPrimaryKey` expects.
  */
 function parentIdSchema(
   pool: ComponentPool,
@@ -223,7 +229,9 @@ function parentIdSchema(
 
   if (primaryKeys.length > 1) {
     return {
+      // A composite id only works as its packed string: a number could never carry the separator.
       type: 'string',
+      pattern: '\\S',
       description:
         `The composite id of the parent ${quoted(parent)} record: the values of ` +
         `${primaryKeys.map(key => key.name).join(', ')} joined by ` +
@@ -232,9 +240,13 @@ function parentIdSchema(
   }
 
   const [key] = primaryKeys;
-  const schema = key.type === 'Number' ? { type: 'number' as const } : { type: 'string' as const };
 
-  return { ...schema, description: `The parent ${quoted(parent)} record id (${key.name}).` };
+  return {
+    ...PARENT_ID_SHAPE,
+    description:
+      `The parent ${quoted(parent)} record id (${key.name}, ${key.type}). A number or its ` +
+      'string form are both accepted; the BFF forwards it to the agent as a string.',
+  };
 }
 
 function registerRelationRequests(

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -1,4 +1,5 @@
 import type ComponentPool from './component-pool';
+import type { Namer } from './names';
 import type {
   CollectionFields,
   UnfoldedAction,
@@ -256,11 +257,11 @@ function registerRelationRequests(
     'resolves which records are related.';
 
   return {
-    list: pool.add(`RelationListRequest_${plan.key}_${relationKey}`, {
+    list: pool.add(`RelationListRequest_${relationKey}`, {
       description,
       allOf: [foreign.requests.list, parentProperties],
     }),
-    count: pool.add(`RelationCountRequest_${plan.key}_${relationKey}`, {
+    count: pool.add(`RelationCountRequest_${relationKey}`, {
       description,
       allOf: [foreign.requests.count, parentProperties],
     }),
@@ -301,7 +302,7 @@ function registerActionRequest(
 ): ReferenceObject {
   const { pool } = deps;
 
-  return pool.add(`ActionRequest_${plan.key}_${actionKey}`, {
+  return pool.add(`ActionRequest_${actionKey}`, {
     type: 'object',
     description:
       `The body of action ${quoted(action.name)} on ${quoted(plan.collection.name)}. ` +
@@ -386,21 +387,21 @@ function registerRelationOperations(
   deps: Deps,
   plan: CollectionPlan,
   plansByName: Map<string, CollectionPlan>,
+  namer: Namer,
 ): void {
   const { pool } = deps;
-  const namer = createNamer();
 
   plan.collection.relations.forEach(relation => {
     const foreign = plansByName.get(relation.foreignCollection);
     if (!foreign) return;
 
-    const relationKey = namer(relation.name);
+    const relationKey = namer(`${plan.key}_${relation.name}`);
     const requests = registerRelationRequests(deps, plan, relation, relationKey, foreign);
     const parent = `${quoted(plan.collection.name)}.${quoted(relation.name)}`;
 
     registerOperation(deps, {
       path: `${segment(plan.collection.name)}/relations/${segment(relation.name)}/list`,
-      operationId: `listRelatedRecords_${plan.key}_${relationKey}`,
+      operationId: `listRelatedRecords_${relationKey}`,
       summary: `List ${relation.name} of ${plan.collection.name}`,
       description: `Lists the ${quoted(foreign.collection.name)} records related to a ${quoted(
         plan.collection.name,
@@ -413,7 +414,7 @@ function registerRelationOperations(
 
     registerOperation(deps, {
       path: `${segment(plan.collection.name)}/relations/${segment(relation.name)}/count`,
-      operationId: `countRelatedRecords_${plan.key}_${relationKey}`,
+      operationId: `countRelatedRecords_${relationKey}`,
       summary: `Count ${relation.name} of ${plan.collection.name}`,
       description: `Counts the ${quoted(
         foreign.collection.name,
@@ -426,11 +427,9 @@ function registerRelationOperations(
   });
 }
 
-function registerActionOperations(deps: Deps, plan: CollectionPlan): void {
-  const namer = createNamer();
-
+function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer): void {
   plan.collection.actions.forEach(action => {
-    const actionKey = namer(action.name);
+    const actionKey = namer(`${plan.key}_${action.name}`);
     const request = registerActionRequest(deps, plan, action, actionKey);
     // The path segment is the exact schema action name, URL-encoded — that is what the middleware
     // decodes and looks up. The operationId is sanitized, so the exact name lives in prose.
@@ -439,7 +438,7 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan): void {
 
     registerOperation(deps, {
       path: `${base}/form`,
-      operationId: `getActionForm_${plan.key}_${actionKey}`,
+      operationId: `getActionForm_${actionKey}`,
       summary: `Load the form of ${action.name} on ${plan.collection.name}`,
       description: `Loads the form of the custom action. ${identity} An unknown submitted field is skipped here, not rejected.`,
       request,
@@ -450,7 +449,7 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan): void {
 
     registerOperation(deps, {
       path: `${base}/execute`,
-      operationId: `executeAction_${plan.key}_${actionKey}`,
+      operationId: `executeAction_${actionKey}`,
       summary: `Execute ${action.name} on ${plan.collection.name}`,
       description: `Executes the custom action. ${identity} A submitted field the loaded form does not carry is rejected with 400.`,
       request,
@@ -467,9 +466,16 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan): void {
  * generic regexes — only the document unfolds.
  */
 export default function registerUnfoldedPaths(deps: Deps, unfolding: Unfolding): void {
-  const namer = createNamer();
+  // One namer per identifier family, fed the WHOLE composed name. Deduplicating each segment on its
+  // own would not be enough: sanitizing produces `_`, which is also the separator, so collection
+  // `A_B` with action `C` and collection `A` with action `B_C` both compose `A_B_C` — one action
+  // would then get the other's request schema.
+  const collections = createNamer();
+  const relations = createNamer();
+  const actions = createNamer();
+
   const plans = unfolding.collections.map(collection => {
-    const key = namer(collection.name);
+    const key = collections(collection.name);
 
     return { collection, key, requests: registerRequests(deps, { collection, key }) };
   });
@@ -477,7 +483,7 @@ export default function registerUnfoldedPaths(deps: Deps, unfolding: Unfolding):
 
   plans.forEach(plan => {
     registerCollectionOperations(deps, plan);
-    registerRelationOperations(deps, plan, plansByName);
-    registerActionOperations(deps, plan);
+    registerRelationOperations(deps, plan, plansByName, relations);
+    registerActionOperations(deps, plan, actions);
   });
 }

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -33,7 +33,8 @@ const DEGRADED_NOTE: Record<NonNullable<CollectionFields['degraded']>, string> =
     'exposes is still accepted.',
   no_fields:
     'The field names are NOT enumerated here: the agent reports no filterable or projectable ' +
-    'field on this collection.',
+    'field on this collection. Any field sent in `projection`, `sort` or `filter` is therefore ' +
+    'rejected with 422 unknown_field — call this path without them.',
 };
 
 interface RequestRefs {
@@ -89,6 +90,10 @@ function filterSchema(
   const treeName = `Filter_${plan.key}`;
   const treeRef = { $ref: `#/components/schemas/${treeName}` };
 
+  // A node readable as BOTH a leaf and a branch is rejected with 400 (`agent-query.ts`
+  // `assertNoNodeReadableAsBothLeafAndBranch`), so each alternative excludes the other's discriminator.
+  // Expressed as `not: { required }` rather than `additionalProperties: false`, which would also
+  // forbid an unknown extra key — one the runtime strips and accepts.
   const leaf = pool.add(`FilterLeaf_${plan.key}`, {
     type: 'object',
     description: `A single condition on ${quoted(name)}.`,
@@ -98,12 +103,14 @@ function filterSchema(
       value: {},
     },
     required: ['field', 'operator'],
+    not: { properties: { conditions: {} }, required: ['conditions'] },
   });
 
   return pool.add(treeName, {
     description:
       `A filter on ${quoted(name)}: either a leaf condition or a branch nesting more ` +
-      'conditions. A branch must carry its aggregator.',
+      'conditions. A branch must carry its aggregator. A node carrying both `field` and ' +
+      '`conditions` is rejected with 400, so the two shapes are mutually exclusive.',
     anyOf: [
       leaf,
       {
@@ -113,6 +120,7 @@ function filterSchema(
           conditions: { type: 'array', items: treeRef },
         },
         required: ['aggregator', 'conditions'],
+        not: { properties: { field: {} }, required: ['field'] },
       },
     ],
   });

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -1,0 +1,475 @@
+import type ComponentPool from './component-pool';
+import type {
+  CollectionFields,
+  UnfoldedAction,
+  UnfoldedCollection,
+  UnfoldedRelation,
+  Unfolding,
+} from './unfolding';
+import type { z } from './zod-openapi';
+import type { PrimaryKeyField } from '../read-model/read-model';
+import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas31';
+
+import toFieldSchema from './field-schemas';
+import createNamer from './names';
+import {
+  CountResponseSchema,
+  ListResponseSchema,
+  OPERATORS,
+  PageSchema,
+  ParentIdSchema,
+  SortClauseSchema,
+  TimezoneSchema,
+} from './schemas';
+import { PACKED_ID_SEPARATOR } from '../data/pack-id';
+
+const AGGREGATORS = ['And', 'Or'];
+
+const DEGRADED_NOTE: Record<NonNullable<CollectionFields['degraded']>, string> = {
+  capabilities_unavailable:
+    'The field names are NOT enumerated here: the agent could not be asked for this ' +
+    "collection's capabilities when the document was built. Any field the collection really " +
+    'exposes is still accepted.',
+  no_fields:
+    'The field names are NOT enumerated here: the agent reports no filterable or projectable ' +
+    'field on this collection.',
+};
+
+interface RequestRefs {
+  list: ReferenceObject;
+  count: ReferenceObject;
+}
+
+interface CollectionPlan {
+  collection: UnfoldedCollection;
+  key: string;
+  requests: RequestRefs;
+}
+
+interface Deps {
+  registry: OpenAPIRegistry;
+  pool: ComponentPool;
+  prefix: string;
+  security: Record<string, string[]>[];
+  timezoneHeader: z.ZodType[];
+  errorResponses: (executeResults: boolean) => Record<string, ReferenceObject>;
+}
+
+function quoted(name: string): string {
+  return JSON.stringify(name);
+}
+
+// A name reaches the runtime through decodeURIComponent, so the document must carry it encoded —
+// including the separators that would otherwise change the route, such as a slash inside an action
+// name (`a/b` is reachable only as `a%2Fb`).
+function segment(name: string): string {
+  return encodeURIComponent(name);
+}
+
+function fieldsEnum(
+  pool: ComponentPool,
+  name: string,
+  fields: string[],
+  description: string,
+): SchemaObject | ReferenceObject {
+  // An empty enum would forbid every value, so a collection with no known field set keeps a plain
+  // string — the runtime is the one that rejects an unknown field, and it says which.
+  if (fields.length === 0) return { type: 'string' };
+
+  return pool.add(name, { type: 'string', enum: fields, description });
+}
+
+function filterSchema(
+  { pool }: Deps,
+  plan: Pick<CollectionPlan, 'key' | 'collection'>,
+  filterable: ReferenceObject | SchemaObject,
+): ReferenceObject {
+  const { name } = plan.collection;
+  const treeName = `Filter_${plan.key}`;
+  const treeRef = { $ref: `#/components/schemas/${treeName}` };
+
+  const leaf = pool.add(`FilterLeaf_${plan.key}`, {
+    type: 'object',
+    description: `A single condition on ${quoted(name)}.`,
+    properties: {
+      field: filterable,
+      operator: { type: 'string', enum: OPERATORS },
+      value: {},
+    },
+    required: ['field', 'operator'],
+  });
+
+  return pool.add(treeName, {
+    description:
+      `A filter on ${quoted(name)}: either a leaf condition or a branch nesting more ` +
+      'conditions. A branch must carry its aggregator.',
+    anyOf: [
+      leaf,
+      {
+        type: 'object',
+        properties: {
+          aggregator: { type: 'string', enum: AGGREGATORS },
+          conditions: { type: 'array', items: treeRef },
+        },
+        required: ['aggregator', 'conditions'],
+      },
+    ],
+  });
+}
+
+interface FieldRefs {
+  projectable: ReferenceObject | SchemaObject;
+  filter: ReferenceObject;
+  sort: ReferenceObject | SchemaObject;
+}
+
+function fieldRefs(deps: Deps, plan: Pick<CollectionPlan, 'key' | 'collection'>): FieldRefs {
+  const { pool } = deps;
+  const { name, fields } = plan.collection;
+
+  const projectable = fieldsEnum(
+    pool,
+    `Fields_${plan.key}`,
+    fields.projectable,
+    `A field of ${quoted(name)}.`,
+  );
+
+  // Filterable is a strict subset of projectable: the agent reports a ManyToOne without operators,
+  // so projecting or sorting on it works while filtering on it answers 400 field_not_filterable.
+  const filterable = fieldsEnum(
+    pool,
+    `FilterableFields_${plan.key}`,
+    fields.filterable,
+    `A filterable field of ${quoted(name)}.`,
+  );
+
+  return {
+    projectable,
+    filter: filterSchema(deps, plan, filterable),
+    sort:
+      fields.projectable.length === 0
+        ? pool.reuse('SortClause', SortClauseSchema)
+        : pool.add(`SortClause_${plan.key}`, {
+            type: 'object',
+            description: 'Omitting `direction` sorts ascending.',
+            properties: {
+              field: projectable,
+              direction: { type: 'string', enum: ['asc', 'desc'] },
+            },
+            required: ['field'],
+          }),
+  };
+}
+
+function requestDescription(collection: UnfoldedCollection, subject: string): string {
+  const note = collection.fields.degraded ? ` ${DEGRADED_NOTE[collection.fields.degraded]}` : '';
+
+  return `${subject}${note}`;
+}
+
+function registerRequests(deps: Deps, plan: Omit<CollectionPlan, 'requests'>): RequestRefs {
+  const { pool } = deps;
+  const { collection, key } = plan;
+  const refs = fieldRefs(deps, plan);
+  const timezone = pool.reuse('Timezone', TimezoneSchema);
+
+  return {
+    list: pool.add(`ListRequest_${key}`, {
+      type: 'object',
+      description: requestDescription(
+        collection,
+        `Filter, sort and project records of ${quoted(collection.name)}.`,
+      ),
+      properties: {
+        filter: refs.filter,
+        projection: { type: 'array', items: refs.projectable },
+        sort: { type: 'array', items: refs.sort },
+        page: pool.reuse('Page', PageSchema),
+        timezone,
+      },
+    }),
+    count: pool.add(`CountRequest_${key}`, {
+      type: 'object',
+      description: requestDescription(
+        collection,
+        `Count records of ${quoted(collection.name)} matching a filter.`,
+      ),
+      properties: { filter: refs.filter, timezone },
+    }),
+  };
+}
+
+/**
+ * `parentId` is opaque on the wire, but the read-model knows the parent's key: only a `Number`
+ * column comes back as a number, every other type stays a string, and a composite key travels as its
+ * `|`-joined values (`unpackPrimaryKey` mirrors the agent's `IdUtils`).
+ */
+function parentIdSchema(
+  pool: ComponentPool,
+  parent: string,
+  primaryKeys: PrimaryKeyField[],
+): ReferenceObject | SchemaObject {
+  if (primaryKeys.length === 0) return pool.reuse('ParentId', ParentIdSchema);
+
+  if (primaryKeys.length > 1) {
+    return {
+      type: 'string',
+      description:
+        `The composite id of the parent ${quoted(parent)} record: the values of ` +
+        `${primaryKeys.map(key => key.name).join(', ')} joined by ` +
+        `${quoted(PACKED_ID_SEPARATOR)}, in that order.`,
+    };
+  }
+
+  const [key] = primaryKeys;
+  const schema = key.type === 'Number' ? { type: 'number' as const } : { type: 'string' as const };
+
+  return { ...schema, description: `The parent ${quoted(parent)} record id (${key.name}).` };
+}
+
+function registerRelationRequests(
+  deps: Deps,
+  plan: CollectionPlan,
+  relation: UnfoldedRelation,
+  relationKey: string,
+  foreign: CollectionPlan,
+): RequestRefs {
+  const { pool } = deps;
+  const parentId = parentIdSchema(pool, plan.collection.name, plan.collection.primaryKeys);
+  const parentProperties = {
+    type: 'object' as const,
+    properties: { parentId },
+    required: ['parentId'],
+  };
+  const description =
+    `Filter, sort and projection apply to ${quoted(foreign.collection.name)}, the foreign ` +
+    `collection of ${quoted(plan.collection.name)}.${quoted(relation.name)}; the parent only ` +
+    'resolves which records are related.';
+
+  return {
+    list: pool.add(`RelationListRequest_${plan.key}_${relationKey}`, {
+      description,
+      allOf: [foreign.requests.list, parentProperties],
+    }),
+    count: pool.add(`RelationCountRequest_${plan.key}_${relationKey}`, {
+      description,
+      allOf: [foreign.requests.count, parentProperties],
+    }),
+  };
+}
+
+function actionFieldSchema(field: UnfoldedAction['fields'][number]): SchemaObject {
+  const base = field.enums
+    ? { type: 'string' as const, enum: field.enums }
+    : toFieldSchema(field.type);
+
+  return field.isRequired
+    ? { ...base, description: 'The agent declares this field required on the static form.' }
+    : base;
+}
+
+function actionValuesSchema(action: UnfoldedAction): SchemaObject {
+  return {
+    type: 'object',
+    // No property is required and no additional one is forbidden on purpose: a load or change hook
+    // rebuilds the form at call time, so the schema's static fields are an indication, not the
+    // contract — and the read-model cannot tell a hookless action from a legacy schema that simply
+    // omitted its hooks, so "static" is never certain.
+    description:
+      'The submitted action fields. These are the fields the schema declares statically; a load ' +
+      'or change hook can add, drop or require others at call time.',
+    properties: Object.fromEntries(
+      action.fields.map(field => [field.name, actionFieldSchema(field)]),
+    ),
+  };
+}
+
+function registerActionRequest(
+  deps: Deps,
+  plan: CollectionPlan,
+  action: UnfoldedAction,
+  actionKey: string,
+): ReferenceObject {
+  const { pool } = deps;
+
+  return pool.add(`ActionRequest_${plan.key}_${actionKey}`, {
+    type: 'object',
+    description:
+      `The body of action ${quoted(action.name)} on ${quoted(plan.collection.name)}. ` +
+      '`recordIds` is required even on a global action: send an empty array when the action ' +
+      'targets no record.',
+    properties: {
+      recordIds: { type: 'array', items: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
+      values: actionValuesSchema(action),
+      timezone: pool.reuse('Timezone', TimezoneSchema),
+    },
+    required: ['recordIds'],
+  });
+}
+
+interface OperationOptions {
+  path: string;
+  operationId: string;
+  summary: string;
+  description: string;
+  request: ReferenceObject;
+  response: ReferenceObject | SchemaObject;
+  responseDescription: string;
+  bodyRequired: boolean;
+  executeResults?: boolean;
+}
+
+function registerOperation(deps: Deps, options: OperationOptions): void {
+  deps.registry.registerPath({
+    method: 'post',
+    path: `${deps.prefix}/${options.path}`,
+    operationId: options.operationId,
+    summary: options.summary,
+    description: options.description,
+    security: deps.security,
+    request: {
+      headers: deps.timezoneHeader,
+      body: {
+        required: options.bodyRequired,
+        content: { 'application/json': { schema: options.request } },
+      },
+    },
+    responses: {
+      200: {
+        description: options.responseDescription,
+        content: { 'application/json': { schema: options.response } },
+      },
+      ...deps.errorResponses(options.executeResults === true),
+    },
+  });
+}
+
+function registerCollectionOperations(deps: Deps, plan: CollectionPlan): void {
+  const { pool } = deps;
+  const { name } = plan.collection;
+  const listResponse = pool.reuse('ListResponse', ListResponseSchema);
+  const countResponse = pool.reuse('CountResponse', CountResponseSchema);
+
+  registerOperation(deps, {
+    path: `${segment(name)}/list`,
+    operationId: `listRecords_${plan.key}`,
+    summary: `List records of ${name}`,
+    description: `Lists records of the ${quoted(name)} collection.`,
+    request: plan.requests.list,
+    response: listResponse,
+    responseDescription: `A page of ${quoted(name)} records`,
+    bodyRequired: false,
+  });
+
+  registerOperation(deps, {
+    path: `${segment(name)}/count`,
+    operationId: `countRecords_${plan.key}`,
+    summary: `Count records of ${name}`,
+    description: `Counts records of the ${quoted(name)} collection.`,
+    request: plan.requests.count,
+    response: countResponse,
+    responseDescription: `The matching ${quoted(name)} record count`,
+    bodyRequired: false,
+  });
+}
+
+function registerRelationOperations(
+  deps: Deps,
+  plan: CollectionPlan,
+  plansByName: Map<string, CollectionPlan>,
+): void {
+  const { pool } = deps;
+  const namer = createNamer();
+
+  plan.collection.relations.forEach(relation => {
+    const foreign = plansByName.get(relation.foreignCollection);
+    if (!foreign) return;
+
+    const relationKey = namer(relation.name);
+    const requests = registerRelationRequests(deps, plan, relation, relationKey, foreign);
+    const parent = `${quoted(plan.collection.name)}.${quoted(relation.name)}`;
+
+    registerOperation(deps, {
+      path: `${segment(plan.collection.name)}/relations/${segment(relation.name)}/list`,
+      operationId: `listRelatedRecords_${plan.key}_${relationKey}`,
+      summary: `List ${relation.name} of ${plan.collection.name}`,
+      description: `Lists the ${quoted(foreign.collection.name)} records related to a ${quoted(
+        plan.collection.name,
+      )} record through ${parent}.`,
+      request: requests.list,
+      response: pool.reuse('ListResponse', ListResponseSchema),
+      responseDescription: `A page of related ${quoted(foreign.collection.name)} records`,
+      bodyRequired: true,
+    });
+
+    registerOperation(deps, {
+      path: `${segment(plan.collection.name)}/relations/${segment(relation.name)}/count`,
+      operationId: `countRelatedRecords_${plan.key}_${relationKey}`,
+      summary: `Count ${relation.name} of ${plan.collection.name}`,
+      description: `Counts the ${quoted(
+        foreign.collection.name,
+      )} records related through ${parent}.`,
+      request: requests.count,
+      response: pool.reuse('CountResponse', CountResponseSchema),
+      responseDescription: `The matching related ${quoted(foreign.collection.name)} record count`,
+      bodyRequired: true,
+    });
+  });
+}
+
+function registerActionOperations(deps: Deps, plan: CollectionPlan): void {
+  const namer = createNamer();
+
+  plan.collection.actions.forEach(action => {
+    const actionKey = namer(action.name);
+    const request = registerActionRequest(deps, plan, action, actionKey);
+    // The path segment is the exact schema action name, URL-encoded — that is what the middleware
+    // decodes and looks up. The operationId is sanitized, so the exact name lives in prose.
+    const identity = `The action name is exactly ${quoted(action.name)}.`;
+    const base = `${segment(plan.collection.name)}/actions/${segment(action.name)}`;
+
+    registerOperation(deps, {
+      path: `${base}/form`,
+      operationId: `getActionForm_${plan.key}_${actionKey}`,
+      summary: `Load the form of ${action.name} on ${plan.collection.name}`,
+      description: `Loads the form of the custom action. ${identity} An unknown submitted field is skipped here, not rejected.`,
+      request,
+      response: {},
+      responseDescription: 'The action form fields',
+      bodyRequired: true,
+    });
+
+    registerOperation(deps, {
+      path: `${base}/execute`,
+      operationId: `executeAction_${plan.key}_${actionKey}`,
+      summary: `Execute ${action.name} on ${plan.collection.name}`,
+      description: `Executes the custom action. ${identity} A submitted field the loaded form does not carry is rejected with 400.`,
+      request,
+      response: {},
+      responseDescription: 'The normalized action result',
+      bodyRequired: true,
+      executeResults: true,
+    });
+  });
+}
+
+/**
+ * Emits one path per exposed collection, to-many relation and action. The runtime routes stay the
+ * generic regexes — only the document unfolds.
+ */
+export default function registerUnfoldedPaths(deps: Deps, unfolding: Unfolding): void {
+  const namer = createNamer();
+  const plans = unfolding.collections.map(collection => {
+    const key = namer(collection.name);
+
+    return { collection, key, requests: registerRequests(deps, { collection, key }) };
+  });
+  const plansByName = new Map(plans.map(plan => [plan.collection.name, plan]));
+
+  plans.forEach(plan => {
+    registerCollectionOperations(deps, plan);
+    registerRelationOperations(deps, plan, plansByName);
+    registerActionOperations(deps, plan);
+  });
+}

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -92,9 +92,11 @@ function filterSchema(
   const treeRef = { $ref: `#/components/schemas/${treeName}` };
 
   // A node readable as BOTH a leaf and a branch is rejected with 400 (`agent-query.ts`
-  // `assertNoNodeReadableAsBothLeafAndBranch`), so each alternative excludes the other's discriminator.
-  // Expressed as `not: { required }` rather than `additionalProperties: false`, which would also
-  // forbid an unknown extra key — one the runtime strips and accepts.
+  // `assertNoNodeReadableAsBothLeafAndBranch`), so each alternative excludes the other's
+  // discriminator. The exclusion carries the TYPE the runtime looks for — `isBranch` needs an ARRAY
+  // `conditions` and `isLeaf` a STRING `field` — because `{field, operator, conditions: "x"}` is a
+  // plain leaf the runtime accepts. Expressed as `not: { required }` rather than
+  // `additionalProperties: false`, which would also forbid an unknown extra key the runtime strips.
   const leaf = pool.add(`FilterLeaf_${plan.key}`, {
     type: 'object',
     description: `A single condition on ${quoted(name)}.`,
@@ -104,7 +106,7 @@ function filterSchema(
       value: {},
     },
     required: ['field', 'operator'],
-    not: { properties: { conditions: {} }, required: ['conditions'] },
+    not: { properties: { conditions: { type: 'array' } }, required: ['conditions'] },
   });
 
   return pool.add(treeName, {
@@ -121,7 +123,7 @@ function filterSchema(
           conditions: { type: 'array', items: treeRef },
         },
         required: ['aggregator', 'conditions'],
-        not: { properties: { field: {} }, required: ['field'] },
+        not: { properties: { field: { type: 'string' } }, required: ['field'] },
       },
     ],
   });
@@ -145,7 +147,7 @@ function fieldRefs(deps: Deps, plan: Pick<CollectionPlan, 'key' | 'collection'>)
   );
 
   // Filterable is a strict subset of projectable: the agent reports a ManyToOne without operators,
-  // so projecting or sorting on it works while filtering on it answers 400 field_not_filterable.
+  // so projecting or sorting on it works while filtering on it answers 422 field_not_filterable.
   const filterable = fieldsEnum(
     pool,
     `FilterableFields_${plan.key}`,

--- a/packages/agent-bff/src/openapi/unfolding.ts
+++ b/packages/agent-bff/src/openapi/unfolding.ts
@@ -27,7 +27,7 @@ export interface UnfoldedRelation {
 /**
  * `projectable` is every capability field; `filterable` is the subset carrying operators. They
  * differ: a `ManyToOne` is reported by the agent without operators, so projecting or sorting on it
- * works while filtering on it answers 400 field_not_filterable.
+ * works while filtering on it answers 422 field_not_filterable.
  *
  * `degraded` is set when the field set could not be established. The collection keeps its paths, but
  * their field schemas stay free-form strings — an empty enum would forbid every valid call.
@@ -39,6 +39,22 @@ export interface CollectionFields {
 }
 
 export type DegradedReason = 'capabilities_unavailable' | 'no_fields';
+
+/** True when at least one collection went out without its field set. */
+export function hasDegradedCollection(unfolding: Unfolding): boolean {
+  return unfolding.collections.some(collection => collection.fields.degraded !== null);
+}
+
+/**
+ * True when NO collection got its field set — the signature of an unreachable agent rather than of
+ * one odd collection. An empty schema is not degraded: there was nothing to enumerate.
+ */
+export function isFullyDegraded(unfolding: Unfolding): boolean {
+  return (
+    unfolding.collections.length > 0 &&
+    unfolding.collections.every(collection => collection.fields.degraded !== null)
+  );
+}
 
 export interface UnfoldedAction {
   name: string;

--- a/packages/agent-bff/src/openapi/unfolding.ts
+++ b/packages/agent-bff/src/openapi/unfolding.ts
@@ -1,0 +1,55 @@
+import type { FieldType } from '../read-model/capabilities-cache';
+import type { PrimaryKeyField } from '../read-model/read-model';
+
+/**
+ * The snapshot the OpenAPI generator unfolds. It is plain data on purpose: collecting it hits the
+ * network (schema + capabilities per collection), generating from it does not, so the route and the
+ * CLI can be proven to emit the same document by feeding them one snapshot.
+ */
+export interface Unfolding {
+  collections: UnfoldedCollection[];
+}
+
+export interface UnfoldedCollection {
+  name: string;
+  fields: CollectionFields;
+  primaryKeys: PrimaryKeyField[];
+  /** To-many relations whose foreign collection is exposed too — the only ones with a route. */
+  relations: UnfoldedRelation[];
+  actions: UnfoldedAction[];
+}
+
+export interface UnfoldedRelation {
+  name: string;
+  foreignCollection: string;
+}
+
+/**
+ * `projectable` is every capability field; `filterable` is the subset carrying operators. They
+ * differ: a `ManyToOne` is reported by the agent without operators, so projecting or sorting on it
+ * works while filtering on it answers 400 field_not_filterable.
+ *
+ * `degraded` is set when the field set could not be established. The collection keeps its paths, but
+ * their field schemas stay free-form strings — an empty enum would forbid every valid call.
+ */
+export interface CollectionFields {
+  projectable: string[];
+  filterable: string[];
+  degraded: DegradedReason | null;
+}
+
+export type DegradedReason = 'capabilities_unavailable' | 'no_fields';
+
+export interface UnfoldedAction {
+  name: string;
+  fields: UnfoldedActionField[];
+}
+
+export interface UnfoldedActionField {
+  name: string;
+  type: FieldType;
+  isRequired: boolean;
+  enums: string[] | null;
+}
+
+export type { FieldType };

--- a/packages/agent-bff/src/read-model/agent-capabilities-fetcher.ts
+++ b/packages/agent-bff/src/read-model/agent-capabilities-fetcher.ts
@@ -6,24 +6,36 @@ import createAgentHttpRequester from '../agent/create-agent-http-requester';
 
 export interface AgentCapabilitiesFetcherOptions {
   agentUrl: string;
-  token: string;
+  /** A borrowed request token, or a factory when the caller can mint one per fetch. */
+  token: string | (() => string);
   timeoutMs?: number;
 }
 
 /**
- * Builds a capabilities fetcher bound to a request's agent token. The cache calls it only on a
- * miss, so the token of whichever request first populates a collection is the one used.
+ * Builds a capabilities fetcher bound to an agent token. The cache calls it only on a miss, so the
+ * token of whichever request first populates a collection is the one used.
+ *
+ * A factory exists for the token because an agent token lives 5 minutes: a caller fanning out over
+ * hundreds of collections can outlive a single one, and the tail of that fan-out would fail on an
+ * expired token. A request can only borrow its caller's, so it passes the string.
  */
 export default function createAgentCapabilitiesFetcher({
   agentUrl,
   token,
   timeoutMs,
 }: AgentCapabilitiesFetcherOptions): CapabilitiesFetcher {
-  const client = createRemoteAgentClient({
-    url: agentUrl,
-    token,
-    httpRequester: createAgentHttpRequester(token, agentUrl, timeoutMs),
-  });
+  const clientFor = (bearer: string) =>
+    createRemoteAgentClient({
+      url: agentUrl,
+      token: bearer,
+      httpRequester: createAgentHttpRequester(bearer, agentUrl, timeoutMs),
+    });
 
-  return collection => client.collection(collection).capabilities();
+  if (typeof token === 'string') {
+    const client = clientFor(token);
+
+    return collection => client.collection(collection).capabilities();
+  }
+
+  return collection => clientFor(token()).collection(collection).capabilities();
 }

--- a/packages/agent-bff/src/read-model/capabilities-cache.ts
+++ b/packages/agent-bff/src/read-model/capabilities-cache.ts
@@ -1,7 +1,15 @@
 import { ONE_DAY_MS } from './schema-cache';
 
+/**
+ * A Forest column type: a primitive name, a one-element array wrapping another type, a composite
+ * `{ fields }`, or a relation marker like `ManyToOne`.
+ */
+export type FieldType = string | FieldType[] | { fields: { field: string; type: FieldType }[] };
+
 export interface CapabilitiesResult {
-  fields: { name: string; type: string; operators?: string[] }[];
+  // `type` is the agent's raw `columnType`, so it is not always a plain name: an array-of-primitive
+  // column arrives as `['String']`, and a relation entry arrives as the marker `ManyToOne`.
+  fields: { name: string; type: FieldType; operators?: string[] }[];
 }
 
 export type CapabilitiesFetcher = (collection: string) => Promise<CapabilitiesResult>;

--- a/packages/agent-bff/src/read-model/read-model.ts
+++ b/packages/agent-bff/src/read-model/read-model.ts
@@ -9,6 +9,19 @@ export type RelationTarget =
 
 export type PrimaryKeyField = { name: string; type: string };
 
+export type ListableRelation = { name: string; foreignCollection: string };
+
+// Only to-many relations expose list/count on the agent; to-one relations get update-relation only.
+// A polymorphic relation carrying multiple targets is always the to-one (PolymorphicManyToOne) side.
+// The data routes and the OpenAPI unfolding both resolve listability here, so a relation can never be
+// documented as listable while the runtime 404s it, or the reverse.
+function toListableTarget(target: RelationTarget): string | null {
+  if (!('target' in target)) return null;
+  if (target.type !== 'HasMany' && target.type !== 'BelongsToMany') return null;
+
+  return target.target;
+}
+
 function toRelationTarget(field: ForestSchemaField): RelationTarget | null {
   if (!field.relationship) return null;
 
@@ -45,12 +58,14 @@ function deepFreeze<T>(value: T): T {
 export default class ReadModel {
   private readonly collections: Set<string>;
   private readonly relations: Map<string, Map<string, RelationTarget>>;
+  private readonly listableRelations: Map<string, Map<string, string>>;
   private readonly actionEndpoints: ActionEndpointsByCollection;
   private readonly primaryKeys: Map<string, PrimaryKeyField[]>;
 
   constructor(collections: ForestSchemaCollection[]) {
     this.collections = new Set();
     this.relations = new Map();
+    this.listableRelations = new Map();
     // Null-prototype so an action/collection named like an Object.prototype member
     // (`toString`, `constructor`, `__proto__`, …) can't falsely pass the allow-list.
     this.actionEndpoints = Object.create(null) as ActionEndpointsByCollection;
@@ -71,13 +86,20 @@ export default class ReadModel {
 
   private buildRelations(collection: ForestSchemaCollection): void {
     const relations = new Map<string, RelationTarget>();
+    const listable = new Map<string, string>();
 
     for (const field of collection.fields ?? []) {
       const target = toRelationTarget(field);
-      if (target) relations.set(field.field, target);
+
+      if (target) {
+        relations.set(field.field, target);
+        const foreignCollection = toListableTarget(target);
+        if (foreignCollection) listable.set(field.field, foreignCollection);
+      }
     }
 
     this.relations.set(collection.name, relations);
+    this.listableRelations.set(collection.name, listable);
   }
 
   private buildActionEndpoints(collection: ForestSchemaCollection): void {
@@ -116,8 +138,26 @@ export default class ReadModel {
     return this.collections.has(collection);
   }
 
+  /** A fresh copy per call, so a consumer cannot mutate the shared cached read-model. */
   getAllowedCollections(): string[] {
     return [...this.collections];
+  }
+
+  /**
+   * The to-many, non-polymorphic relations of a collection — the only ones with a list/count route.
+   * The foreign collection is NOT checked against the allow-list here: the data routes must keep
+   * telling a non-listable relation (404 unknown_relation) from a listable one pointing at a hidden
+   * collection (404 unknown_collection), so that filter belongs to each caller.
+   */
+  getListableRelations(collection: string): ListableRelation[] {
+    const listable = this.listableRelations.get(collection);
+    if (!listable) return [];
+
+    return [...listable].map(([name, foreignCollection]) => ({ name, foreignCollection }));
+  }
+
+  getListableRelationTarget(collection: string, relation: string): string | undefined {
+    return this.listableRelations.get(collection)?.get(relation);
   }
 
   isRelationAllowed(collection: string, relation: string): boolean {

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -171,6 +171,27 @@ describe('collectUnfolding', () => {
   });
 
   describe('determinism', () => {
+    it('should order relations by code unit, not by the process locale', async () => {
+      // `localeCompare` would put `ärenden` first under en-US and last under code units, so the CLI
+      // and the route could order one schema differently and stop producing the same document.
+      const readModel = new ReadModel([
+        collection('users', [
+          relation('zulu', 'HasMany', 'target.id'),
+          relation('ärenden', 'HasMany', 'target.id'),
+          relation('orders', 'HasMany', 'target.id'),
+        ]),
+        collection('target', [column('id')]),
+      ]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[1].relations.map(entry => entry.name)).toEqual([
+        'orders',
+        'zulu',
+        'ärenden',
+      ]);
+    });
+
     it('should sort collections, relations and actions by name', async () => {
       const readModel = new ReadModel([
         collection(

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -1,0 +1,218 @@
+import type { Logger } from '../../src/ports/logger-port';
+import type {
+  CapabilitiesFetcher,
+  CapabilitiesResult,
+} from '../../src/read-model/capabilities-cache';
+import type ReadModelStore from '../../src/read-model/read-model-store';
+
+import collectUnfolding from '../../src/openapi/collect-unfolding';
+import ReadModel from '../../src/read-model/read-model';
+import { action, collection, column, polymorphic, relation } from '../read-model/fixtures';
+
+const noopLogger: Logger = () => undefined;
+
+function storeOf(readModel: ReadModel): ReadModelStore {
+  return {
+    getReadModel: async () => readModel,
+    getCapabilities: async (name: string, fetcher: CapabilitiesFetcher) => ({
+      capabilities: await fetcher(name),
+      readModel,
+    }),
+  } as unknown as ReadModelStore;
+}
+
+const CAPABILITIES: CapabilitiesResult = {
+  fields: [
+    { name: 'id', type: 'Number', operators: ['equal'] },
+    { name: 'author', type: 'ManyToOne' },
+  ],
+};
+
+function collect(
+  readModel: ReadModel,
+  {
+    capabilities = async () => CAPABILITIES,
+    logger = noopLogger,
+    concurrency,
+  }: {
+    capabilities?: CapabilitiesFetcher;
+    logger?: Logger;
+    concurrency?: number;
+  } = {},
+) {
+  return collectUnfolding({
+    readModel,
+    store: storeOf(readModel),
+    capabilitiesFetcher: capabilities,
+    logger,
+    concurrency,
+  });
+}
+
+describe('collectUnfolding', () => {
+  describe('relations', () => {
+    const readModel = new ReadModel([
+      collection('users', [
+        column('id'),
+        relation('orders', 'HasMany', 'orders.userId'),
+        relation('roles', 'BelongsToMany', 'roles.id'),
+        relation('company', 'BelongsTo', 'companies.id'),
+        relation('profile', 'HasOne', 'profiles.userId'),
+        polymorphic('owner', ['orders', 'roles']),
+        relation('secrets', 'HasMany', 'secrets.userId'),
+      ]),
+      collection('orders', [column('id')]),
+      collection('roles', [column('id')]),
+      collection('companies', [column('id')]),
+      collection('profiles', [column('id')]),
+    ]);
+
+    it('should keep only the to-many relations whose foreign collection is exposed', async () => {
+      const { collections } = await collect(readModel);
+      const users = collections.find(entry => entry.name === 'users');
+
+      expect(users?.relations).toEqual([
+        { name: 'orders', foreignCollection: 'orders' },
+        { name: 'roles', foreignCollection: 'roles' },
+      ]);
+    });
+
+    it('should drop a to-many relation pointing at a collection the BFF does not expose', async () => {
+      const { collections } = await collect(readModel);
+      const users = collections.find(entry => entry.name === 'users');
+
+      expect(users?.relations.map(entry => entry.name)).not.toContain('secrets');
+    });
+  });
+
+  describe('fields', () => {
+    const readModel = new ReadModel([collection('users', [column('id')])]);
+
+    it('should split projectable from filterable, since a ManyToOne carries no operator', async () => {
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].fields).toEqual({
+        projectable: ['id', 'author'],
+        filterable: ['id'],
+        degraded: null,
+      });
+    });
+
+    it('should degrade a collection whose capabilities call fails, and say so in the log', async () => {
+      const logger = jest.fn();
+      const { collections } = await collect(readModel, {
+        capabilities: async () => {
+          throw new Error('agent is down');
+        },
+        logger,
+      });
+
+      expect(collections[0].fields).toEqual({
+        projectable: [],
+        filterable: [],
+        degraded: 'capabilities_unavailable',
+      });
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        'Documenting a collection without a field set: capabilities are unavailable',
+        { collection: 'users', error: 'agent is down' },
+      );
+    });
+
+    it('should degrade a collection the agent reports no field for', async () => {
+      const logger = jest.fn();
+      const { collections } = await collect(readModel, {
+        capabilities: async () => ({ fields: [] }),
+        logger,
+      });
+
+      expect(collections[0].fields.degraded).toBe('no_fields');
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        'Documenting a collection without a field set: capabilities returned none',
+        { collection: 'users' },
+      );
+    });
+  });
+
+  describe('actions', () => {
+    it('should map the static form fields of every action with an endpoint', async () => {
+      const withFields = action('Ban', '/forest/users/actions/ban');
+      withFields.fields = [
+        {
+          field: 'reason',
+          type: 'String',
+          isRequired: true,
+          enums: ['spam', 'abuse'],
+        } as (typeof withFields.fields)[number],
+      ];
+      const readModel = new ReadModel([collection('users', [column('id')], [withFields])]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].actions).toEqual([
+        {
+          name: 'Ban',
+          fields: [{ name: 'reason', type: 'String', isRequired: true, enums: ['spam', 'abuse'] }],
+        },
+      ]);
+    });
+
+    it('should leave out an action with no endpoint, which the BFF does not expose', async () => {
+      const endpointless = { ...action('Ban', ''), endpoint: undefined } as unknown as ReturnType<
+        typeof action
+      >;
+      const readModel = new ReadModel([collection('users', [column('id')], [endpointless])]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].actions).toEqual([]);
+    });
+  });
+
+  describe('determinism', () => {
+    it('should sort collections, relations and actions by name', async () => {
+      const readModel = new ReadModel([
+        collection(
+          'zulu',
+          [relation('beta', 'HasMany', 'alpha.id'), relation('alpha', 'HasMany', 'alpha.id')],
+          [action('zeta', '/z'), action('alpha', '/a')],
+        ),
+        collection('alpha', [column('id')]),
+      ]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections.map(entry => entry.name)).toEqual(['alpha', 'zulu']);
+      expect(collections[1].relations.map(entry => entry.name)).toEqual(['alpha', 'beta']);
+      expect(collections[1].actions.map(entry => entry.name)).toEqual(['alpha', 'zeta']);
+    });
+  });
+
+  describe('concurrency', () => {
+    it('should never have more capabilities calls in flight than the cap', async () => {
+      const readModel = new ReadModel(
+        Array.from({ length: 12 }, (_, index) => collection(`c${index}`, [column('id')])),
+      );
+      let inFlight = 0;
+      let peak = 0;
+
+      const { collections } = await collect(readModel, {
+        concurrency: 3,
+        capabilities: async () => {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await new Promise(resolve => {
+            setImmediate(resolve);
+          });
+          inFlight -= 1;
+
+          return CAPABILITIES;
+        },
+      });
+
+      expect(collections).toHaveLength(12);
+      expect(peak).toBe(3);
+    });
+  });
+});

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -170,6 +170,19 @@ describe('collectUnfolding', () => {
       ]);
     });
 
+    it('should drop a form field with no usable name, which would document "undefined"', async () => {
+      const malformed = action('Ban', '/forest/users/actions/ban');
+      malformed.fields = [
+        null,
+        { field: 'reason', type: 'String' },
+      ] as unknown as typeof malformed.fields;
+      const readModel = new ReadModel([collection('users', [column('id')], [malformed])]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].actions[0].fields.map(field => field.name)).toEqual(['reason']);
+    });
+
     it('should treat an action with no fields key as a form with no field', async () => {
       const fieldless = action('Ban', '/forest/users/actions/ban');
       delete (fieldless as { fields?: unknown }).fields;

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -158,6 +158,28 @@ describe('collectUnfolding', () => {
       ]);
     });
 
+    it('should default a form field that declares neither isRequired nor enums', async () => {
+      const bare = action('Ban', '/forest/users/actions/ban');
+      bare.fields = [{ field: 'reason', type: 'String' } as (typeof bare.fields)[number]];
+      const readModel = new ReadModel([collection('users', [column('id')], [bare])]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].actions[0].fields).toEqual([
+        { name: 'reason', type: 'String', isRequired: false, enums: null },
+      ]);
+    });
+
+    it('should treat an action with no fields key as a form with no field', async () => {
+      const fieldless = action('Ban', '/forest/users/actions/ban');
+      delete (fieldless as { fields?: unknown }).fields;
+      const readModel = new ReadModel([collection('users', [column('id')], [fieldless])]);
+
+      const { collections } = await collect(readModel);
+
+      expect(collections[0].actions).toEqual([{ name: 'Ban', fields: [] }]);
+    });
+
     it('should leave out an action with no endpoint, which the BFF does not expose', async () => {
       const endpointless = { ...action('Ban', ''), endpoint: undefined } as unknown as ReturnType<
         typeof action

--- a/packages/agent-bff/test/openapi/field-schemas.test.ts
+++ b/packages/agent-bff/test/openapi/field-schemas.test.ts
@@ -1,0 +1,67 @@
+import toFieldSchema from '../../src/openapi/field-schemas';
+
+describe('toFieldSchema', () => {
+  it.each([
+    ['String', { type: 'string' }],
+    ['Boolean', { type: 'boolean' }],
+    ['Number', { type: 'number' }],
+    ['Date', { type: 'string', format: 'date-time' }],
+    ['Dateonly', { type: 'string', format: 'date' }],
+    ['Uuid', { type: 'string', format: 'uuid' }],
+    ['Enum', { type: 'string' }],
+  ])('should map the %s column type', (type, expected) => {
+    expect(toFieldSchema(type)).toEqual(expected);
+  });
+
+  it('should leave a Json column unconstrained, since any JSON value is accepted there', () => {
+    expect(toFieldSchema('Json')).toEqual({});
+  });
+
+  it('should describe a File as a data URI, which is how an action receives one', () => {
+    expect(toFieldSchema('File')).toEqual({ type: 'string', description: 'A data URI.' });
+  });
+
+  it('should wrap an array type around its item type', () => {
+    expect(toFieldSchema(['Number'])).toEqual({ type: 'array', items: { type: 'number' } });
+  });
+
+  it('should map a composite type to an object, one property per nested field', () => {
+    expect(
+      toFieldSchema({
+        fields: [
+          { field: 'street', type: 'String' },
+          { field: 'zip', type: 'Number' },
+        ],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { street: { type: 'string' }, zip: { type: 'number' } },
+    });
+  });
+
+  it('should nest a composite inside an array, which a nested list column produces', () => {
+    expect(toFieldSchema([{ fields: [{ field: 'street', type: 'String' }] }])).toEqual({
+      type: 'array',
+      items: { type: 'object', properties: { street: { type: 'string' } } },
+    });
+  });
+
+  it('should not constrain an empty array type, which carries no item to describe', () => {
+    expect(toFieldSchema([])).toEqual({ type: 'array', items: {} });
+  });
+
+  it.each([
+    ['a relation marker', 'ManyToOne'],
+    ['a type a newer agent introduced', 'Vector'],
+  ])('should leave %s unconstrained rather than guess', (_, type) => {
+    expect(toFieldSchema(type)).toEqual({});
+  });
+
+  it.each([
+    ['a malformed composite', { fields: 'not-an-array' }],
+    ['a value that is not a type at all', 42],
+    ['null', null],
+  ])('should leave %s unconstrained, since the schema is cast from untyped data', (_, type) => {
+    expect(toFieldSchema(type as never)).toEqual({});
+  });
+});

--- a/packages/agent-bff/test/openapi/field-schemas.test.ts
+++ b/packages/agent-bff/test/openapi/field-schemas.test.ts
@@ -64,4 +64,17 @@ describe('toFieldSchema', () => {
   ])('should leave %s unconstrained, since the schema is cast from untyped data', (_, type) => {
     expect(toFieldSchema(type as never)).toEqual({});
   });
+
+  it.each([
+    ['a null entry', null],
+    ['an entry with no name', {}],
+    ['an entry whose name is not a string', { field: 42, type: 'String' }],
+  ])('should drop %s from a composite rather than abort the document', (_, field) => {
+    expect(
+      toFieldSchema({ fields: [field, { field: 'street', type: 'String' }] } as never),
+    ).toEqual({
+      type: 'object',
+      properties: { street: { type: 'string' } },
+    });
+  });
 });

--- a/packages/agent-bff/test/openapi/fixtures.ts
+++ b/packages/agent-bff/test/openapi/fixtures.ts
@@ -1,0 +1,53 @@
+import type { Unfolding } from '../../src/openapi/unfolding';
+
+/**
+ * One snapshot exercising every shape the unfolding has to survive: a name carrying a space, a
+ * dotted name, an action name carrying a slash, two action names that collapse to the same
+ * identifier, a ManyToOne that is projectable but not filterable, a composite key, a parent with no
+ * key metadata, and a collection whose capabilities could not be read.
+ */
+export default function unfoldingFixture(): Unfolding {
+  return {
+    collections: [
+      {
+        name: 'My Coll',
+        fields: {
+          projectable: ['id', 'email', 'tags', 'author'],
+          filterable: ['id', 'email', 'tags'],
+          degraded: null,
+        },
+        primaryKeys: [{ name: 'id', type: 'Number' }],
+        relations: [{ name: 'orders', foreignCollection: 'orders' }],
+        actions: [
+          {
+            name: 'Mark as paid/done',
+            fields: [
+              { name: 'reason', type: 'String', isRequired: true, enums: null },
+              { name: 'kind', type: 'Enum', isRequired: false, enums: ['refund', 'gift'] },
+              { name: 'files', type: ['File'], isRequired: false, enums: null },
+              { name: 'payload', type: 'Json', isRequired: false, enums: null },
+            ],
+          },
+          { name: 'Mark-as-paid/done', fields: [] },
+        ],
+      },
+      {
+        name: 'orders',
+        fields: { projectable: [], filterable: [], degraded: 'capabilities_unavailable' },
+        primaryKeys: [
+          { name: 'shop', type: 'String' },
+          { name: 'number', type: 'Number' },
+        ],
+        relations: [{ name: 'buyers', foreignCollection: 'My Coll' }],
+        actions: [],
+      },
+      {
+        name: 'users.address',
+        fields: { projectable: ['street'], filterable: ['street'], degraded: null },
+        primaryKeys: [],
+        relations: [{ name: 'orders', foreignCollection: 'orders' }],
+        actions: [],
+      },
+    ],
+  };
+}

--- a/packages/agent-bff/test/openapi/names.test.ts
+++ b/packages/agent-bff/test/openapi/names.test.ts
@@ -1,0 +1,42 @@
+import createNamer, { sanitizeIdentifier } from '../../src/openapi/names';
+
+describe('sanitizeIdentifier', () => {
+  it.each([
+    ['Mark as paid', 'Mark_as_paid'],
+    ['Mark as paid/done', 'Mark_as_paid_done'],
+    ['User.address', 'User_address'],
+    ['clôturé', 'cl_tur_'],
+  ])('should turn %s into a URL-safe identifier', (raw, expected) => {
+    expect(sanitizeIdentifier(raw)).toBe(expected);
+  });
+
+  it('should never return an empty identifier, which is not a usable method name', () => {
+    expect(sanitizeIdentifier('')).toBe('_');
+    expect(sanitizeIdentifier('///')).toBe('___');
+  });
+});
+
+describe('createNamer', () => {
+  it('should hand out the sanitized name when nothing claimed it', () => {
+    const namer = createNamer();
+
+    expect(namer('users')).toBe('users');
+    expect(namer('orders')).toBe('orders');
+  });
+
+  it('should suffix the names that collapse onto an already claimed one', () => {
+    const namer = createNamer();
+
+    expect(namer('Mark as paid')).toBe('Mark_as_paid');
+    expect(namer('Mark-as-paid')).toBe('Mark_as_paid_2');
+    expect(namer('Mark.as.paid')).toBe('Mark_as_paid_3');
+  });
+
+  it('should keep two namers independent, so one family cannot rename another', () => {
+    const collections = createNamer();
+    const actions = createNamer();
+
+    expect(collections('users')).toBe('users');
+    expect(actions('users')).toBe('users');
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -95,6 +95,18 @@ describe('renderOpenApi', () => {
 
     await expect(renderOpenApi(VALID_ENV, noopLogger)).rejects.toThrow();
   });
+
+  it('should ignore a broken server-only setting, which the export does not use', async () => {
+    const document = JSON.parse(await renderOpenApi({ HTTP_PORT: 'nope' }, noopLogger));
+
+    expect(Object.keys(document.paths)).toHaveLength(6);
+  });
+
+  it('should still reject a broken setting once the deployment asks to be unfolded', async () => {
+    await expect(renderOpenApi({ ...VALID_ENV, HTTP_PORT: 'nope' }, noopLogger)).rejects.toThrow(
+      /HTTP_PORT/,
+    );
+  });
 });
 
 describe('dispatchCli', () => {

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from '../../src/ports/logger-port';
 
 import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import http from 'http';
+import jsonwebtoken from 'jsonwebtoken';
 import { tmpdir } from 'os';
 import path from 'path';
 import request from 'supertest';
@@ -31,6 +32,7 @@ const CAPABILITIES = { fields: [{ name: 'id', type: 'Number', operators: ['equal
 
 const fetchSchema = jest.fn().mockResolvedValue(SCHEMA);
 const fetchCapabilities = jest.fn().mockResolvedValue(CAPABILITIES);
+const mintedTokens: string[] = [];
 
 jest.mock('../../src/read-model/forest-schema-client', () => ({
   __esModule: true,
@@ -42,9 +44,15 @@ jest.mock('../../src/read-model/forest-schema-client', () => ({
   },
 }));
 
+// The token is resolved here rather than ignored, because the CLI is expected to hand over a factory
+// that signs one per fetch — a single 5-minute token cannot cover a long fan-out.
 jest.mock('../../src/read-model/agent-capabilities-fetcher', () => ({
   __esModule: true,
-  default: () => fetchCapabilities,
+  default: ({ token }: { token: string | (() => string) }) => {
+    mintedTokens.push(typeof token === 'function' ? token() : token);
+
+    return fetchCapabilities;
+  },
 }));
 
 const VALID_ENV = {
@@ -62,6 +70,16 @@ describe('renderOpenApi', () => {
   beforeEach(() => {
     fetchSchema.mockReset().mockResolvedValue(SCHEMA);
     fetchCapabilities.mockReset().mockResolvedValue(CAPABILITIES);
+    mintedTokens.length = 0;
+  });
+
+  it('should sign its own agent token, since a CLI has no caller to borrow one from', async () => {
+    await renderOpenApi(VALID_ENV, noopLogger);
+
+    expect(mintedTokens).toHaveLength(1);
+    expect(jsonwebtoken.verify(mintedTokens[0], VALID_ENV.FOREST_AUTH_SECRET)).toEqual(
+      expect.objectContaining({ email: 'openapi@agent-bff.forestadmin.com' }),
+    );
   });
 
   it('should return a parseable OpenAPI 3.1 document', async () => {
@@ -122,6 +140,15 @@ describe('renderOpenApi', () => {
     expect(document.components.schemas.Fields_users).toBeDefined();
   });
 
+  it('should stay generic when the auth secret is there but the agent url is not', async () => {
+    const document = JSON.parse(
+      await renderOpenApi({ ...VALID_ENV, AGENT_URL: undefined }, noopLogger),
+    );
+
+    expect(Object.keys(document.paths)).toHaveLength(6);
+    expect(fetchSchema).not.toHaveBeenCalled();
+  });
+
   it('should ignore a broken server-only setting, which the export does not use', async () => {
     const document = JSON.parse(await renderOpenApi({ HTTP_PORT: 'nope' }, noopLogger));
 
@@ -150,6 +177,21 @@ describe('dispatchCli', () => {
       } finally {
         listen.mockRestore();
         stdout.mockRestore();
+      }
+    });
+
+    it('should fall back to the console logger when the caller passes none, as the bin does', async () => {
+      const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi'], {});
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(JSON.parse(stdout.mock.calls[0][0] as string).openapi).toBe('3.1.0');
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
       }
     });
 

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -27,10 +27,10 @@ const SCHEMA = [
   collection('orders', [column('id')]),
 ];
 
+const CAPABILITIES = { fields: [{ name: 'id', type: 'Number', operators: ['equal'] }] };
+
 const fetchSchema = jest.fn().mockResolvedValue(SCHEMA);
-const fetchCapabilities = jest
-  .fn()
-  .mockResolvedValue({ fields: [{ name: 'id', type: 'Number', operators: ['equal'] }] });
+const fetchCapabilities = jest.fn().mockResolvedValue(CAPABILITIES);
 
 jest.mock('../../src/read-model/forest-schema-client', () => ({
   __esModule: true,
@@ -59,6 +59,11 @@ const VALID_ENV = {
 const noopLogger: Logger = () => undefined;
 
 describe('renderOpenApi', () => {
+  beforeEach(() => {
+    fetchSchema.mockReset().mockResolvedValue(SCHEMA);
+    fetchCapabilities.mockReset().mockResolvedValue(CAPABILITIES);
+  });
+
   it('should return a parseable OpenAPI 3.1 document', async () => {
     expect(JSON.parse(await renderOpenApi({}, noopLogger)).openapi).toBe('3.1.0');
   });
@@ -94,6 +99,27 @@ describe('renderOpenApi', () => {
     fetchSchema.mockRejectedValueOnce(new Error('forest server is down'));
 
     await expect(renderOpenApi(VALID_ENV, noopLogger)).rejects.toThrow();
+  });
+
+  it('should fail when not one collection could be described, since CI has nothing to branch on', async () => {
+    fetchCapabilities.mockRejectedValue(new Error('agent is down'));
+
+    await expect(renderOpenApi(VALID_ENV, noopLogger)).rejects.toThrow(
+      /No collection could be described/,
+    );
+  });
+
+  it('should still emit the document when only one collection is degraded', async () => {
+    fetchCapabilities.mockImplementation(async (name: string) => {
+      if (name === 'orders') throw new Error('agent is down');
+
+      return { fields: [{ name: 'id', type: 'Number', operators: ['equal'] }] };
+    });
+
+    const document = JSON.parse(await renderOpenApi(VALID_ENV, noopLogger));
+
+    expect(Object.keys(document.paths)).toContain('/agent/v1/orders/list');
+    expect(document.components.schemas.Fields_users).toBeDefined();
   });
 
   it('should ignore a broken server-only setting, which the export does not use', async () => {

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -183,12 +183,39 @@ describe('dispatchCli', () => {
     it('should fall back to the console logger when the caller passes none, as the bin does', async () => {
       const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
       const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      // Silenced because jest buffers console output and flushes it to process.stdout, which the spy
+      // would otherwise pick up ahead of the document.
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
       try {
         const outcome = await dispatchCli(['openapi'], {});
 
         expect(outcome).toEqual({ exitCode: 0 });
         expect(JSON.parse(stdout.mock.calls[0][0] as string).openapi).toBe('3.1.0');
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+        stderr.mockRestore();
+        warn.mockRestore();
+      }
+    });
+
+    // The redirected form is the one that breaks: `console.info` writes to the same stream as the
+    // document, so a single Info log makes `> openapi.json` produce a file JSON.parse rejects. Runs
+    // with the REAL console logger on purpose — passing a noop one is what hid this.
+    it('should leave stdout parseable when unfolding, whatever it logs on the way', async () => {
+      const written: string[] = [];
+      const stdout = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(chunk => written.push(String(chunk)) > 0);
+      const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      try {
+        const outcome = await dispatchCli(['openapi'], VALID_ENV);
+
+        expect(outcome).toEqual({ exitCode: 0 });
+        expect(() => JSON.parse(written.join(''))).not.toThrow();
+        expect(JSON.parse(written.join('')).info.description).toContain('Paths are unfolded');
       } finally {
         stdout.mockRestore();
         stderr.mockRestore();

--- a/packages/agent-bff/test/openapi/openapi-cli.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-cli.test.ts
@@ -16,6 +16,36 @@ import dispatchCli, {
 import { issueBffAccessToken } from '../../src/oauth/bff-token';
 import { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
 import version from '../../src/version';
+import { action, collection, column, relation } from '../read-model/fixtures';
+
+const SCHEMA = [
+  collection(
+    'users',
+    [column('id'), column('email'), relation('orders', 'HasMany', 'orders.userId')],
+    [action('Mark as paid', '/forest/users/actions/mark-as-paid')],
+  ),
+  collection('orders', [column('id')]),
+];
+
+const fetchSchema = jest.fn().mockResolvedValue(SCHEMA);
+const fetchCapabilities = jest
+  .fn()
+  .mockResolvedValue({ fields: [{ name: 'id', type: 'Number', operators: ['equal'] }] });
+
+jest.mock('../../src/read-model/forest-schema-client', () => ({
+  __esModule: true,
+  default: class {
+    // eslint-disable-next-line class-methods-use-this
+    fetchSchema() {
+      return fetchSchema();
+    }
+  },
+}));
+
+jest.mock('../../src/read-model/agent-capabilities-fetcher', () => ({
+  __esModule: true,
+  default: () => fetchCapabilities,
+}));
 
 const VALID_ENV = {
   FOREST_AUTH_SECRET: 'auth-secret',
@@ -29,12 +59,41 @@ const VALID_ENV = {
 const noopLogger: Logger = () => undefined;
 
 describe('renderOpenApi', () => {
-  it('should return a parseable OpenAPI 3.1 document', () => {
-    expect(JSON.parse(renderOpenApi()).openapi).toBe('3.1.0');
+  it('should return a parseable OpenAPI 3.1 document', async () => {
+    expect(JSON.parse(await renderOpenApi({}, noopLogger)).openapi).toBe('3.1.0');
   });
 
-  it('should end with a newline, so the output pipes cleanly', () => {
-    expect(renderOpenApi().endsWith('\n')).toBe(true);
+  it('should end with a newline, so the output pipes cleanly', async () => {
+    expect((await renderOpenApi({}, noopLogger)).endsWith('\n')).toBe(true);
+  });
+
+  it('should emit the generic document when nothing is configured to unfold against', async () => {
+    const document = JSON.parse(await renderOpenApi({}, noopLogger));
+
+    expect(Object.keys(document.paths)).toHaveLength(6);
+    expect(document.info.description).toContain('Paths are generic');
+  });
+
+  it('should unfold when the deployment is configured, without borrowing a caller token', async () => {
+    const document = JSON.parse(await renderOpenApi(VALID_ENV, noopLogger));
+
+    expect(Object.keys(document.paths).sort()).toEqual([
+      '/agent/v1/orders/count',
+      '/agent/v1/orders/list',
+      '/agent/v1/users/actions/Mark%20as%20paid/execute',
+      '/agent/v1/users/actions/Mark%20as%20paid/form',
+      '/agent/v1/users/count',
+      '/agent/v1/users/list',
+      '/agent/v1/users/relations/orders/count',
+      '/agent/v1/users/relations/orders/list',
+    ]);
+    expect(document.info.description).toContain('Paths are unfolded');
+  });
+
+  it('should fail rather than degrade when a configured deployment cannot be read', async () => {
+    fetchSchema.mockRejectedValueOnce(new Error('forest server is down'));
+
+    await expect(renderOpenApi(VALID_ENV, noopLogger)).rejects.toThrow();
   });
 });
 
@@ -277,8 +336,8 @@ describe('dispatchCli --output', () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  function expectedDocument(): string {
-    return renderOpenApi();
+  function expectedDocument(): Promise<string> {
+    return renderOpenApi({}, noopLogger);
   }
 
   async function exportQuietly(argv: string[]) {
@@ -301,7 +360,7 @@ describe('dispatchCli --output', () => {
 
         expect(outcome).toEqual({ exitCode: 0 });
         expect(readFileSync(path.join(directory, DEFAULT_OUTPUT_FILE), 'utf8')).toBe(
-          expectedDocument(),
+          await expectedDocument(),
         );
         expect(stdout).not.toHaveBeenCalled();
       } finally {
@@ -335,7 +394,7 @@ describe('dispatchCli --output', () => {
       const outcome = await dispatchCli(['openapi', '--output', target], {}, noopLogger);
 
       expect(outcome).toEqual({ exitCode: 0 });
-      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+      expect(readFileSync(target, 'utf8')).toBe(await expectedDocument());
     });
 
     it(`should treat a trailing slash as a directory and write ${DEFAULT_OUTPUT_FILE} inside it`, async () => {
@@ -343,7 +402,7 @@ describe('dispatchCli --output', () => {
 
       expect(outcome).toEqual({ exitCode: 0 });
       expect(readFileSync(path.join(directory, 'build', DEFAULT_OUTPUT_FILE), 'utf8')).toBe(
-        expectedDocument(),
+        await expectedDocument(),
       );
     });
 
@@ -353,14 +412,16 @@ describe('dispatchCli --output', () => {
       const outcome = await exportQuietly(['openapi', '--output', target]);
 
       expect(outcome).toEqual({ exitCode: 0 });
-      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+      expect(readFileSync(target, 'utf8')).toBe(await expectedDocument());
     });
 
     it('should resolve a relative path against the current directory', async () => {
       const outcome = await exportQuietly(['openapi', '--output', 'relative.json']);
 
       expect(outcome).toEqual({ exitCode: 0 });
-      expect(readFileSync(path.join(directory, 'relative.json'), 'utf8')).toBe(expectedDocument());
+      expect(readFileSync(path.join(directory, 'relative.json'), 'utf8')).toBe(
+        await expectedDocument(),
+      );
     });
   });
 
@@ -372,7 +433,7 @@ describe('dispatchCli --output', () => {
       const outcome = await exportQuietly(['openapi', '--output', target]);
 
       expect(outcome).toEqual({ exitCode: 0 });
-      expect(readFileSync(target, 'utf8')).toBe(expectedDocument());
+      expect(readFileSync(target, 'utf8')).toBe(await expectedDocument());
     });
   });
 
@@ -471,7 +532,7 @@ describe('dispatchCli --output', () => {
 
 describe('the CLI export and the HTTP route', () => {
   it('should produce the same document, since both use one generator', async () => {
-    const exported = renderOpenApi();
+    const exported = await renderOpenApi(VALID_ENV, noopLogger);
 
     const outcome = await dispatchCli([], VALID_ENV, noopLogger);
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -10,6 +10,37 @@ import {
 const document = generateOpenApiDocument('9.9.9');
 const schemas = document.components?.schemas as Record<string, Record<string, unknown>>;
 
+type ResolvedResponse = {
+  description: string;
+  headers?: Record<string, unknown>;
+  content?: Record<string, { schema: Record<string, unknown> }>;
+};
+
+const responseComponents = (document.components?.responses ?? {}) as unknown as Record<
+  string,
+  ResolvedResponse
+>;
+
+function responsesOf(path: string): Record<string, ResolvedResponse> {
+  const { responses } = (document.paths?.[path] as { post: { responses: Record<string, unknown> } })
+    .post;
+
+  return Object.fromEntries(
+    Object.entries(responses).map(([status, response]) => {
+      const ref = (response as { $ref?: string }).$ref;
+      const resolved = ref
+        ? responseComponents[ref.replace('#/components/responses/', '')]
+        : (response as ResolvedResponse);
+
+      return [status, resolved];
+    }),
+  );
+}
+
+function listResponses(): Record<string, ResolvedResponse> {
+  return responsesOf(`${ROUTE_PREFIX}/{collection}/list`);
+}
+
 function leafOperators(): string[] {
   const leaf = schemas.ConditionTreeLeaf as {
     properties: { operator: { enum: string[] } };
@@ -202,13 +233,9 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('should allow a messageless 501 body on execute, which the result mapper returns', () => {
-    const execute = document.paths?.[`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`] as {
-      post: {
-        responses: Record<string, { content: Record<string, { schema: { anyOf: unknown[] } }> }>;
-      };
-    };
+    const execute = responsesOf(`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`);
 
-    expect(execute.post.responses['501'].content['application/json'].schema.anyOf).toEqual([
+    expect(execute['501'].content?.['application/json'].schema.anyOf).toEqual([
       { $ref: '#/components/schemas/ErrorResponse' },
       { $ref: '#/components/schemas/MessagelessErrorResponse' },
     ]);
@@ -221,62 +248,85 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('should keep a plain error body for the 501 the agent stub returns on other routes', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: {
-        responses: Record<string, { content: Record<string, { schema: { $ref: string } }> }>;
-      };
-    };
-
-    expect(list.post.responses['501'].content['application/json'].schema.$ref).toBe(
+    expect(listResponses()['501'].content?.['application/json'].schema.$ref).toBe(
       '#/components/schemas/ErrorResponse',
     );
   });
 
-  it('should declare the timezone header as a parameter, not only in prose', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { parameters: { name: string; in: string; required?: boolean }[] };
-    };
-    const header = list.post.parameters.find(parameter => parameter.in === 'header');
+  it('should share one response component per error status instead of inlining it per path', () => {
+    const errors = Object.values(document.paths ?? {}).flatMap(path =>
+      Object.entries(
+        (path as { post: { responses: Record<string, unknown> } }).post.responses,
+      ).filter(([status]) => status !== '200'),
+    );
 
-    expect(header).toEqual(expect.objectContaining({ name: 'X-Forest-Timezone', in: 'header' }));
-    expect(header?.required).not.toBe(true);
+    expect(errors).toHaveLength(72);
+    errors.forEach(([, response]) => {
+      expect(response).toEqual({ $ref: expect.stringContaining('#/components/responses/') });
+    });
+    expect(Object.keys(responseComponents).sort()).toEqual([
+      'Error400',
+      'Error401',
+      'Error403',
+      'Error404',
+      'Error413',
+      'Error415',
+      'Error422',
+      'Error429',
+      'Error500',
+      'Error501',
+      'Error502',
+      'Error503',
+      'UnsupportedActionResult',
+    ]);
+  });
+
+  it('should declare the timezone header as a parameter, not only in prose', () => {
+    const header = (
+      document.components?.parameters as Record<
+        string,
+        { name: string; in: string; required?: boolean }
+      >
+    ).XForestTimezone;
+
+    expect(header).toEqual(
+      expect.objectContaining({ name: 'X-Forest-Timezone', in: 'header', required: false }),
+    );
+  });
+
+  it('should share the timezone header as one parameter component instead of per path', () => {
+    const parameters = Object.values(document.paths ?? {}).flatMap(
+      path => (path as { post: { parameters: unknown[] } }).post.parameters,
+    );
+
+    expect(parameters).toContainEqual({ $ref: '#/components/parameters/XForestTimezone' });
   });
 
   it('should describe an invalid filter operator under 400, the status it actually returns', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { description: string }> };
-    };
+    const list = listResponses();
 
-    expect(list.post.responses['400'].description).toContain('invalid filter operator');
-    expect(list.post.responses['422'].description).not.toContain('operator');
+    expect(list['400'].description).toContain('invalid filter operator');
+    expect(list['422'].description).not.toContain('operator');
   });
 
   it('should distinguish a form body, which is parsed, from other non-JSON bodies, which drop', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { description: string }> };
-    };
+    const list = listResponses();
 
-    expect(list.post.responses['415'].description).toContain('NOT rejected');
-    expect(list.post.responses['415'].description).toContain('form-urlencoded');
+    expect(list['415'].description).toContain('NOT rejected');
+    expect(list['415'].description).toContain('form-urlencoded');
     expect(document.info.description).toContain('form-urlencoded');
     expect(document.info.description).toContain('silently');
   });
 
   it('should name the 403s the BFF itself emits, not only the agent passthrough', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { description: string }> };
-    };
+    const list = listResponses();
 
-    expect(list.post.responses['403'].description).toContain('needs approval');
-    expect(list.post.responses['403'].description).toContain('Forest identity');
+    expect(list['403'].description).toContain('needs approval');
+    expect(list['403'].description).toContain('Forest identity');
   });
 
   it('should warn that a missing timezone is a 400 when no default is configured', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { description: string }> };
-    };
-
-    expect(list.post.responses['400'].description).toContain('missing or invalid timezone');
+    expect(listResponses()['400'].description).toContain('missing or invalid timezone');
     expect(document.info.description).toContain('missing_timezone');
   });
 
@@ -285,27 +335,19 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('should declare Retry-After on 503, the only status that sets it', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { headers?: Record<string, unknown> }> };
-    };
+    const list = listResponses();
 
-    expect(Object.keys(list.post.responses['503'].headers ?? {})).toEqual(['Retry-After']);
-    expect(list.post.responses['429'].headers).toBeUndefined();
+    expect(Object.keys(list['503'].headers ?? {})).toEqual(['Retry-After']);
+    expect(list['429'].headers).toBeUndefined();
   });
 
   it('should not promise a Retry-After on 429, where no code path sets one', () => {
-    const list = document.paths?.[`${ROUTE_PREFIX}/{collection}/list`] as {
-      post: { responses: Record<string, { description: string }> };
-    };
-
-    expect(list.post.responses['429'].description).not.toContain('Retry-After');
+    expect(listResponses()['429'].description).not.toContain('Retry-After');
   });
 
   it('should give every response a description, which the OpenAPI struct rule requires', () => {
-    const responses = Object.values(document.paths ?? {}).flatMap(path =>
-      Object.values(
-        (path as { post: { responses: Record<string, { description?: string }> } }).post.responses,
-      ),
+    const responses = Object.keys(document.paths ?? {}).flatMap(path =>
+      Object.values(responsesOf(path)),
     );
 
     expect(responses.length).toBeGreaterThan(0);

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '../../src/ports/logger-port';
+import type ReadModelStore from '../../src/read-model/read-model-store';
 import type { Middleware } from 'koa';
 
 import request from 'supertest';
@@ -6,6 +7,7 @@ import request from 'supertest';
 import runCli from '../../src/cli-core';
 import { issueBffAccessToken } from '../../src/oauth/bff-token';
 import createOpenApiRoutes, { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
+import ReadModel from '../../src/read-model/read-model';
 import { action, collection, column, relation } from '../read-model/fixtures';
 
 const SCHEMA = [
@@ -251,6 +253,77 @@ describe('GET /agent/openapi.json', () => {
         expect(first.text).toBe(second.text);
         expect(fetchCapabilities).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  describe('when the schema refreshes while the document is being built', () => {
+    function readContext() {
+      return {
+        path: OPENAPI_PATH,
+        method: 'GET',
+        state: { agentToken: 'agent-jwt' },
+        status: 404,
+        body: undefined as unknown,
+        type: undefined,
+        set: () => undefined,
+      } as unknown as Parameters<Middleware>[0];
+    }
+
+    function storeOf(generations: ReadModel[]) {
+      const last = generations[generations.length - 1];
+
+      return {
+        getReadModel: jest.fn(async () => generations.shift() ?? last),
+        getCapabilities: async (
+          name: string,
+          fetcher: (collection: string) => Promise<unknown>,
+        ) => ({
+          capabilities: await fetcher(name),
+          readModel: last,
+        }),
+      } as unknown as ReadModelStore;
+    }
+
+    function routesFor(store: ReadModelStore): Middleware {
+      return createOpenApiRoutes({
+        version: '1.2.3',
+        enabled: true,
+        source: { store, agentUrl: 'https://agent.example.com', logger: noopLogger },
+      });
+    }
+
+    const oldGeneration = new ReadModel([collection('users', [column('id')])]);
+    const newGeneration = new ReadModel([collection('orders', [column('id')])]);
+
+    it('should serve the new generation rather than a document mixing the two', async () => {
+      // Read once before the build, once after: the second read observes the refresh, so the
+      // document built from the old collections with the new field sets is thrown away.
+      const store = storeOf([oldGeneration, newGeneration, newGeneration, newGeneration]);
+      const ctx = readContext();
+
+      await routesFor(store)(ctx, async () => undefined);
+
+      expect(Object.keys(JSON.parse(ctx.body as string).paths)).toEqual([
+        '/agent/v1/orders/list',
+        '/agent/v1/orders/count',
+      ]);
+    });
+
+    it('should give up rather than loop when the schema keeps changing under it', async () => {
+      const store = {
+        getReadModel: async () => new ReadModel([collection('users', [column('id')])]),
+        getCapabilities: async (
+          name: string,
+          fetcher: (collection: string) => Promise<unknown>,
+        ) => ({
+          capabilities: await fetcher(name),
+          readModel: newGeneration,
+        }),
+      } as unknown as ReadModelStore;
+
+      await expect(routesFor(store)(readContext(), async () => undefined)).rejects.toThrow(
+        /kept changing/,
+      );
     });
   });
 

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -6,6 +6,41 @@ import request from 'supertest';
 import runCli from '../../src/cli-core';
 import { issueBffAccessToken } from '../../src/oauth/bff-token';
 import createOpenApiRoutes, { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
+import { action, collection, column, relation } from '../read-model/fixtures';
+
+const SCHEMA = [
+  collection(
+    'users',
+    [column('id'), column('email'), relation('orders', 'HasMany', 'orders.userId')],
+    [action('Mark as paid', '/forest/users/actions/mark-as-paid')],
+  ),
+  collection('orders', [column('id'), column('label')]),
+];
+
+const CAPABILITIES = {
+  fields: [
+    { name: 'id', type: 'Number', operators: ['equal'] },
+    { name: 'email', type: 'String', operators: ['equal', 'like'] },
+  ],
+};
+
+const fetchSchema = jest.fn().mockResolvedValue(SCHEMA);
+const fetchCapabilities = jest.fn().mockResolvedValue(CAPABILITIES);
+
+jest.mock('../../src/read-model/forest-schema-client', () => ({
+  __esModule: true,
+  default: class {
+    // eslint-disable-next-line class-methods-use-this
+    fetchSchema() {
+      return fetchSchema();
+    }
+  },
+}));
+
+jest.mock('../../src/read-model/agent-capabilities-fetcher', () => ({
+  __esModule: true,
+  default: () => fetchCapabilities,
+}));
 
 const VALID_ENV = {
   FOREST_AUTH_SECRET: 'auth-secret',
@@ -52,6 +87,11 @@ async function withServer(
 }
 
 describe('GET /agent/openapi.json', () => {
+  beforeEach(() => {
+    fetchSchema.mockClear().mockResolvedValue(SCHEMA);
+    fetchCapabilities.mockClear().mockResolvedValue(CAPABILITIES);
+  });
+
   describe('when no credentials are sent', () => {
     it('should return 401 and never the document, since the route sits behind the agent gate', async () => {
       await withServer(VALID_ENV, async server => {
@@ -67,7 +107,7 @@ describe('GET /agent/openapi.json', () => {
   });
 
   describe('when a valid session token is sent', () => {
-    it('should serve the OpenAPI document', async () => {
+    it('should serve a document unfolded from the deployment schema', async () => {
       await withServer(VALID_ENV, async server => {
         const response = await request(server.callback)
           .get(OPENAPI_PATH)
@@ -75,7 +115,38 @@ describe('GET /agent/openapi.json', () => {
 
         expect(response.status).toBe(200);
         expect(response.body.openapi).toBe('3.1.0');
-        expect(Object.keys(response.body.paths)).toHaveLength(6);
+        expect(Object.keys(response.body.paths).sort()).toEqual([
+          '/agent/v1/orders/count',
+          '/agent/v1/orders/list',
+          '/agent/v1/users/actions/Mark%20as%20paid/execute',
+          '/agent/v1/users/actions/Mark%20as%20paid/form',
+          '/agent/v1/users/count',
+          '/agent/v1/users/list',
+          '/agent/v1/users/relations/orders/count',
+          '/agent/v1/users/relations/orders/list',
+        ]);
+      });
+    });
+
+    it('should enumerate the collection fields, which is what the unfolding is for', async () => {
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.body.components.schemas.Fields_users).toEqual(
+          expect.objectContaining({ type: 'string', enum: ['id', 'email'] }),
+        );
+      });
+    });
+
+    it('should ask the agent for capabilities once per collection, not once per path', async () => {
+      await withServer(VALID_ENV, async server => {
+        await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(fetchCapabilities.mock.calls).toEqual([['orders'], ['users']]);
       });
     });
 
@@ -102,14 +173,55 @@ describe('GET /agent/openapi.json', () => {
   });
 
   describe('when the agent url is absent, so data endpoints fall back to the stub', () => {
-    it('should still serve the document, since it never calls the agent', async () => {
+    it('should serve the generic document, since there is nothing to unfold against', async () => {
       await withServer({ ...VALID_ENV, AGENT_URL: undefined }, async server => {
         const response = await request(server.callback)
           .get(OPENAPI_PATH)
           .set('Authorization', `Bearer ${sessionToken()}`);
 
         expect(response.status).toBe(200);
-        expect(response.body.openapi).toBe('3.1.0');
+        expect(Object.keys(response.body.paths)).toHaveLength(6);
+        expect(response.body.info.description).toContain('Paths are generic');
+        expect(fetchSchema).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the schema cannot be read', () => {
+    it('should answer 503 rather than a generic document that looks complete', async () => {
+      fetchSchema.mockRejectedValue(new Error('forest server is down'));
+
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.status).toBe(503);
+        expect(response.body.error.type).toBe('schema_unavailable');
+      });
+    });
+  });
+
+  describe('when a collection has no capabilities', () => {
+    it('should keep its paths with free-form field schemas instead of dropping it', async () => {
+      fetchCapabilities.mockImplementation(async (name: string) => {
+        if (name === 'orders') throw new Error('agent is down');
+
+        return CAPABILITIES;
+      });
+
+      await withServer(VALID_ENV, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(response.status).toBe(200);
+        expect(Object.keys(response.body.paths)).toContain('/agent/v1/orders/list');
+        expect(response.body.components.schemas.Fields_orders).toBeUndefined();
+        expect(response.body.components.schemas.ListRequest_orders.properties.projection).toEqual({
+          type: 'array',
+          items: { type: 'string' },
+        });
       });
     });
   });
@@ -126,7 +238,7 @@ describe('GET /agent/openapi.json', () => {
   });
 
   describe('when the document is requested twice', () => {
-    it('should return the byte-identical document, since it is built once at boot', async () => {
+    it('should return the byte-identical document, built once per schema generation', async () => {
       await withServer(VALID_ENV, async server => {
         const token = sessionToken();
         const first = await request(server.callback)
@@ -137,6 +249,7 @@ describe('GET /agent/openapi.json', () => {
           .set('Authorization', `Bearer ${token}`);
 
         expect(first.text).toBe(second.text);
+        expect(fetchCapabilities).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -256,6 +256,43 @@ describe('GET /agent/openapi.json', () => {
     });
   });
 
+  describe('when the agent was down while the document was built', () => {
+    it('should not memoize the degraded document, which would outlive the outage by a day', async () => {
+      fetchCapabilities.mockRejectedValue(new Error('agent is down'));
+
+      await withServer(VALID_ENV, async server => {
+        const token = sessionToken();
+        const get = () =>
+          request(server.callback).get(OPENAPI_PATH).set('Authorization', `Bearer ${token}`);
+
+        await get();
+        await get();
+
+        // Two collections, two requests: the fan-out ran again instead of serving the memo.
+        expect(fetchCapabilities).toHaveBeenCalledTimes(4);
+      });
+    });
+
+    it('should serve the enumerated fields as soon as the agent answers again', async () => {
+      fetchCapabilities.mockRejectedValueOnce(new Error('agent is down'));
+      fetchCapabilities.mockRejectedValueOnce(new Error('agent is down'));
+
+      await withServer(VALID_ENV, async server => {
+        const token = sessionToken();
+        const get = () =>
+          request(server.callback).get(OPENAPI_PATH).set('Authorization', `Bearer ${token}`);
+
+        const degraded = await get();
+        const recovered = await get();
+
+        expect(degraded.body.components.schemas.Fields_users).toBeUndefined();
+        expect(recovered.body.components.schemas.Fields_users).toEqual(
+          expect.objectContaining({ enum: ['id', 'email'] }),
+        );
+      });
+    });
+  });
+
   describe('when the schema refreshes while the document is being built', () => {
     function readContext() {
       return {

--- a/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-spec-validity.test.ts
@@ -1,8 +1,11 @@
+import type { OpenAPIObject } from 'openapi3-ts/oas31';
+
 import { spawnSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 
+import unfoldingFixture from './fixtures';
 import { generateOpenApiDocument, serializeOpenApi } from '../../src/openapi/openapi-document';
 
 const REDOCLY_BIN = path.join(
@@ -10,15 +13,18 @@ const REDOCLY_BIN = path.join(
   'bin/cli.js',
 );
 
-describe('the generated OpenAPI document', () => {
+describe.each([
+  ['generic', () => generateOpenApiDocument('1.0.0')],
+  ['unfolded', () => generateOpenApiDocument('1.0.0', unfoldingFixture())],
+])('the %s OpenAPI document', (name, build: () => OpenAPIObject) => {
   let directory: string;
   let status: number | null;
   let output: string;
 
   beforeAll(() => {
     directory = mkdtempSync(path.join(tmpdir(), 'bff-openapi-'));
-    const file = path.join(directory, 'openapi.json');
-    writeFileSync(file, serializeOpenApi(generateOpenApiDocument('1.0.0')));
+    const file = path.join(directory, `${name}.json`);
+    writeFileSync(file, serializeOpenApi(build()));
 
     const result = spawnSync(process.execPath, [REDOCLY_BIN, 'lint', file], { encoding: 'utf8' });
     status = result.status;

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -101,6 +101,22 @@ describe('the unfolded document', () => {
     expect(request.properties.sort.items?.$ref).toBe('#/components/schemas/SortClause_My_Coll');
   });
 
+  it('should make the leaf and the branch mutually exclusive, which the runtime enforces', () => {
+    const leaf = schemas.FilterLeaf_My_Coll as unknown as { not: { required: string[] } };
+    const tree = schemas.Filter_My_Coll as unknown as {
+      anyOf: [unknown, { not: { required: string[] } }];
+    };
+
+    expect(leaf.not.required).toEqual(['conditions']);
+    expect(tree.anyOf[1].not.required).toEqual(['field']);
+  });
+
+  it('should not forbid an unknown extra key on a filter node, which the runtime strips', () => {
+    const leaf = schemas.FilterLeaf_My_Coll as { additionalProperties?: unknown };
+
+    expect(leaf.additionalProperties).toBeUndefined();
+  });
+
   it('should describe a relation request with the FOREIGN collection fields, not the parent ones', () => {
     const request = requestSchema('My%20Coll/relations/orders/list') as unknown as {
       allOf: [{ $ref: string }, Record<string, unknown>];

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -260,6 +260,29 @@ describe('the unfolded document', () => {
   });
 });
 
+describe('an unfolding naming a collection it does not carry', () => {
+  it('should skip that relation rather than reference a schema it never registered', () => {
+    // `collectUnfolding` filters those out, but the generator takes plain data: a hand-built
+    // snapshot must not be able to emit a path whose request schema does not exist.
+    const orphaned = generateOpenApiDocument('9.9.9', {
+      collections: [
+        {
+          name: 'users',
+          fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+          primaryKeys: [{ name: 'id', type: 'Number' }],
+          relations: [{ name: 'secrets', foreignCollection: 'secrets' }],
+          actions: [],
+        },
+      ],
+    });
+
+    expect(Object.keys(orphaned.paths ?? {})).toEqual([
+      '/agent/v1/users/list',
+      '/agent/v1/users/count',
+    ]);
+  });
+});
+
 describe('names that collide once sanitized', () => {
   // `_` is both what sanitizing produces and the separator between a collection and its child, so
   // deduplicating each segment on its own is not enough: `A_B` + `C` and `A` + `B_C` compose the same

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -235,6 +235,49 @@ describe('the unfolded document', () => {
   });
 });
 
+describe('names that collide once sanitized', () => {
+  // `_` is both what sanitizing produces and the separator between a collection and its child, so
+  // deduplicating each segment on its own is not enough: `A_B` + `C` and `A` + `B_C` compose the same
+  // identifier, and one action would silently get the other's request schema.
+  const collection = (name: string, actionName: string, relationName: string) => ({
+    name,
+    fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+    primaryKeys: [{ name: 'id', type: 'Number' }],
+    relations: [{ name: relationName, foreignCollection: name }],
+    actions: [{ name: actionName, fields: [] }],
+  });
+
+  const colliding = generateOpenApiDocument('9.9.9', {
+    collections: [collection('A_B', 'C', 'R'), collection('A', 'B_C', 'B_R')],
+  });
+  const operationIds = Object.values(
+    colliding.paths as Record<string, { post: { operationId: string } }>,
+  ).map(item => item.post.operationId);
+
+  it('should keep every operationId unique, which codegen tools require', () => {
+    expect(new Set(operationIds).size).toBe(operationIds.length);
+  });
+
+  it('should suffix the second composed identifier rather than reuse it', () => {
+    expect(operationIds).toContain('executeAction_A_B_C');
+    expect(operationIds).toContain('executeAction_A_B_C_2');
+    expect(operationIds).toContain('listRelatedRecords_A_B_R');
+    expect(operationIds).toContain('listRelatedRecords_A_B_R_2');
+  });
+
+  it('should give each action its own request schema, not the other one', () => {
+    const collidingPaths = colliding.paths as Record<
+      string,
+      { post: { requestBody: { content: Record<string, { schema: { $ref: string } }> } } }
+    >;
+    const refs = Object.entries(collidingPaths)
+      .filter(([path]) => path.includes('/actions/'))
+      .map(([, item]) => item.post.requestBody.content['application/json'].schema.$ref);
+
+    expect(new Set(refs).size).toBe(2);
+  });
+});
+
 describe('an unfolded document with no action', () => {
   it('should not carry the action-result response, which nothing would reference', () => {
     const withoutActions = generateOpenApiDocument('9.9.9', {

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -1,0 +1,243 @@
+import unfoldingFixture from './fixtures';
+import { ROUTE_PREFIX, generateOpenApiDocument } from '../../src/openapi/openapi-document';
+
+const document = generateOpenApiDocument('9.9.9', unfoldingFixture());
+const paths = document.paths as Record<string, { post: Record<string, unknown> }>;
+const schemas = document.components?.schemas as Record<string, Record<string, unknown>>;
+
+function operation(path: string): Record<string, unknown> {
+  return paths[`${ROUTE_PREFIX}/${path}`]?.post;
+}
+
+function requestSchemaName(path: string): string {
+  const { content } = operation(path).requestBody as {
+    content: Record<string, { schema: { $ref: string } }>;
+  };
+
+  return content['application/json'].schema.$ref.replace('#/components/schemas/', '');
+}
+
+function requestSchema(path: string): Record<string, never> {
+  return schemas[requestSchemaName(path)] as Record<string, never>;
+}
+
+describe('the unfolded document', () => {
+  it('should emit one path per collection, to-many relation and action', () => {
+    expect(Object.keys(paths).sort()).toEqual([
+      `${ROUTE_PREFIX}/My%20Coll/actions/Mark%20as%20paid%2Fdone/execute`,
+      `${ROUTE_PREFIX}/My%20Coll/actions/Mark%20as%20paid%2Fdone/form`,
+      `${ROUTE_PREFIX}/My%20Coll/actions/Mark-as-paid%2Fdone/execute`,
+      `${ROUTE_PREFIX}/My%20Coll/actions/Mark-as-paid%2Fdone/form`,
+      `${ROUTE_PREFIX}/My%20Coll/count`,
+      `${ROUTE_PREFIX}/My%20Coll/list`,
+      `${ROUTE_PREFIX}/My%20Coll/relations/orders/count`,
+      `${ROUTE_PREFIX}/My%20Coll/relations/orders/list`,
+      `${ROUTE_PREFIX}/orders/count`,
+      `${ROUTE_PREFIX}/orders/list`,
+      `${ROUTE_PREFIX}/orders/relations/buyers/count`,
+      `${ROUTE_PREFIX}/orders/relations/buyers/list`,
+      `${ROUTE_PREFIX}/users.address/count`,
+      `${ROUTE_PREFIX}/users.address/list`,
+      `${ROUTE_PREFIX}/users.address/relations/orders/count`,
+      `${ROUTE_PREFIX}/users.address/relations/orders/list`,
+    ]);
+  });
+
+  it('should keep every path under the /agent/v1 prefix', () => {
+    expect(Object.keys(paths).every(path => path.startsWith(`${ROUTE_PREFIX}/`))).toBe(true);
+  });
+
+  it('should give a collection absent from the read-model no path at all', () => {
+    expect(Object.keys(paths).some(path => path.includes('secrets'))).toBe(false);
+  });
+
+  it('should carry the exact action name in the path, URL-encoded, slash included', () => {
+    expect(
+      paths[`${ROUTE_PREFIX}/My%20Coll/actions/Mark%20as%20paid%2Fdone/execute`],
+    ).toBeDefined();
+  });
+
+  it('should sanitize the operationId, which redocly rejects with a space or a slash', () => {
+    const operationIds = Object.values(paths).map(path => path.post.operationId as string);
+
+    expect(operationIds).toContain('executeAction_My_Coll_Mark_as_paid_done');
+    operationIds.forEach(operationId => expect(operationId).toMatch(/^[A-Za-z0-9_]+$/));
+  });
+
+  it('should suffix the second of two action names that collapse when sanitized', () => {
+    expect(operation('My%20Coll/actions/Mark-as-paid%2Fdone/execute').operationId).toBe(
+      'executeAction_My_Coll_Mark_as_paid_done_2',
+    );
+  });
+
+  it('should name the exact action in prose, since the operationId cannot carry it', () => {
+    expect(operation('My%20Coll/actions/Mark%20as%20paid%2Fdone/form').description).toContain(
+      'exactly "Mark as paid/done"',
+    );
+    expect(operation('My%20Coll/actions/Mark%20as%20paid%2Fdone/form').summary).toContain(
+      'Mark as paid/done',
+    );
+  });
+
+  it('should enumerate the projectable fields of the collection', () => {
+    expect(schemas.Fields_My_Coll).toEqual(
+      expect.objectContaining({ type: 'string', enum: ['id', 'email', 'tags', 'author'] }),
+    );
+  });
+
+  it('should leave a ManyToOne out of the filterable fields, which the runtime rejects', () => {
+    expect(schemas.FilterableFields_My_Coll).toEqual(
+      expect.objectContaining({ type: 'string', enum: ['id', 'email', 'tags'] }),
+    );
+  });
+
+  it('should point the filter, the projection and the sort at that collection own fields', () => {
+    const request = requestSchema('My%20Coll/list') as unknown as {
+      properties: Record<string, { $ref?: string; items?: { $ref: string } }>;
+    };
+
+    expect(request.properties.filter.$ref).toBe('#/components/schemas/Filter_My_Coll');
+    expect(request.properties.projection.items?.$ref).toBe('#/components/schemas/Fields_My_Coll');
+    expect(request.properties.sort.items?.$ref).toBe('#/components/schemas/SortClause_My_Coll');
+  });
+
+  it('should describe a relation request with the FOREIGN collection fields, not the parent ones', () => {
+    const request = requestSchema('My%20Coll/relations/orders/list') as unknown as {
+      allOf: [{ $ref: string }, Record<string, unknown>];
+    };
+
+    expect(request.allOf[0].$ref).toBe('#/components/schemas/ListRequest_orders');
+  });
+
+  it('should require parentId on a relation request and type it from the parent key', () => {
+    const request = requestSchema('My%20Coll/relations/orders/list') as unknown as {
+      allOf: [unknown, { properties: { parentId: { type: string } }; required: string[] }];
+    };
+
+    expect(request.allOf[1].required).toEqual(['parentId']);
+    expect(request.allOf[1].properties.parentId.type).toBe('number');
+  });
+
+  it('should document a composite parent key as its packed string form', () => {
+    const request = requestSchema('orders/relations/buyers/list') as unknown as {
+      allOf: [unknown, { properties: { parentId: { type: string; description: string } } }];
+    };
+
+    expect(request.allOf[1].properties.parentId.type).toBe('string');
+    expect(request.allOf[1].properties.parentId.description).toContain(
+      'shop, number joined by "|"',
+    );
+  });
+
+  it('should fall back to the opaque parent id when the parent exposes no key metadata', () => {
+    const request = requestSchema('users.address/relations/orders/list') as unknown as {
+      allOf: [unknown, { properties: { parentId: { $ref?: string } } }];
+    };
+
+    expect(request.allOf[1].properties.parentId.$ref).toBe('#/components/schemas/ParentId');
+  });
+
+  it('should keep the paths of a collection whose capabilities failed, with free-form fields', () => {
+    const request = requestSchema('orders/list') as unknown as {
+      description: string;
+      properties: { projection: { items: { type: string } } };
+    };
+
+    expect(request.properties.projection.items).toEqual({ type: 'string' });
+    expect(request.description).toContain('NOT enumerated');
+    expect(schemas.Fields_orders).toBeUndefined();
+  });
+
+  it('should type the action values from the static form fields, all optional', () => {
+    const request = requestSchema(
+      'My%20Coll/actions/Mark%20as%20paid%2Fdone/execute',
+    ) as unknown as {
+      properties: { values: { properties: Record<string, unknown>; required?: string[] } };
+      required: string[];
+    };
+
+    expect(request.properties.values.properties).toEqual({
+      reason: {
+        type: 'string',
+        description: 'The agent declares this field required on the static form.',
+      },
+      kind: { type: 'string', enum: ['refund', 'gift'] },
+      files: { type: 'array', items: { type: 'string', description: 'A data URI.' } },
+      payload: {},
+    });
+    expect(request.properties.values.required).toBeUndefined();
+    expect(request.required).toEqual(['recordIds']);
+  });
+
+  it('should share one response component per error status across every unfolded path', () => {
+    const errors = Object.values(paths).flatMap(path =>
+      Object.entries(path.post.responses as Record<string, unknown>).filter(
+        ([status]) => status !== '200',
+      ),
+    );
+
+    expect(errors).toHaveLength(16 * 12);
+    errors.forEach(([, response]) => {
+      expect(response).toEqual({ $ref: expect.stringContaining('#/components/responses/') });
+    });
+  });
+
+  it('should say in the description that the runtime routes stay generic', () => {
+    expect(document.info.description).toContain('RUNTIME routes stay generic');
+  });
+
+  it('should warn that the document is not filtered by the caller permissions', () => {
+    expect(document.info.description).toContain('not filtered by the permissions');
+  });
+
+  it('should reuse the timezone header parameter instead of inlining it per path', () => {
+    Object.values(paths).forEach(path => {
+      expect(path.post.parameters).toEqual([{ $ref: '#/components/parameters/XForestTimezone' }]);
+    });
+  });
+
+  it('should not require a body on list and count, which accept an absent one', () => {
+    const requiredByPath = Object.fromEntries(
+      Object.entries(paths).map(([path, item]) => [
+        path,
+        (item.post.requestBody as { required?: boolean }).required === true,
+      ]),
+    );
+
+    expect(requiredByPath[`${ROUTE_PREFIX}/My%20Coll/list`]).toBe(false);
+    expect(requiredByPath[`${ROUTE_PREFIX}/My%20Coll/count`]).toBe(false);
+    expect(requiredByPath[`${ROUTE_PREFIX}/My%20Coll/relations/orders/list`]).toBe(true);
+    expect(requiredByPath[`${ROUTE_PREFIX}/My%20Coll/actions/Mark%20as%20paid%2Fdone/form`]).toBe(
+      true,
+    );
+  });
+
+  it('should build a byte-identical document from the same snapshot', () => {
+    const again = generateOpenApiDocument('9.9.9', unfoldingFixture());
+
+    expect(JSON.stringify(again)).toBe(JSON.stringify(document));
+  });
+});
+
+describe('an unfolded document with no action', () => {
+  it('should not carry the action-result response, which nothing would reference', () => {
+    const withoutActions = generateOpenApiDocument('9.9.9', {
+      collections: [
+        {
+          name: 'users',
+          fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+          primaryKeys: [{ name: 'id', type: 'Number' }],
+          relations: [],
+          actions: [],
+        },
+      ],
+    });
+
+    expect(Object.keys(withoutActions.components?.responses ?? {})).not.toContain(
+      'UnsupportedActionResult',
+    );
+    expect(Object.keys(withoutActions.components?.schemas ?? {})).not.toContain(
+      'MessagelessErrorResponse',
+    );
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -111,6 +111,20 @@ describe('the unfolded document', () => {
     expect(tree.anyOf[1].not.required).toEqual(['field']);
   });
 
+  it('should exclude only the type the runtime reads as the other shape', () => {
+    // `isBranch` needs an ARRAY `conditions` and `isLeaf` a STRING `field`, so a leaf carrying
+    // `conditions: "x"` is a plain leaf the runtime accepts and the document must not refuse.
+    const leaf = schemas.FilterLeaf_My_Coll as unknown as {
+      not: { properties: { conditions: { type: string } } };
+    };
+    const tree = schemas.Filter_My_Coll as unknown as {
+      anyOf: [unknown, { not: { properties: { field: { type: string } } } }];
+    };
+
+    expect(leaf.not.properties.conditions.type).toBe('array');
+    expect(tree.anyOf[1].not.properties.field.type).toBe('string');
+  });
+
   it('should not forbid an unknown extra key on a filter node, which the runtime strips', () => {
     const leaf = schemas.FilterLeaf_My_Coll as { additionalProperties?: unknown };
 

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -125,13 +125,24 @@ describe('the unfolded document', () => {
     expect(request.allOf[0].$ref).toBe('#/components/schemas/ListRequest_orders');
   });
 
-  it('should require parentId on a relation request and type it from the parent key', () => {
+  it('should require parentId on a relation request and name the parent key it belongs to', () => {
     const request = requestSchema('My%20Coll/relations/orders/list') as unknown as {
-      allOf: [unknown, { properties: { parentId: { type: string } }; required: string[] }];
+      allOf: [unknown, { properties: { parentId: { description: string } }; required: string[] }];
     };
 
     expect(request.allOf[1].required).toEqual(['parentId']);
-    expect(request.allOf[1].properties.parentId.type).toBe('number');
+    expect(request.allOf[1].properties.parentId.description).toContain('(id, Number)');
+  });
+
+  it('should accept a numeric parent id as a number or its string form, like the runtime', () => {
+    const request = requestSchema('My%20Coll/relations/orders/list') as unknown as {
+      allOf: [unknown, { properties: { parentId: { anyOf: unknown[] } } }];
+    };
+
+    expect(request.allOf[1].properties.parentId.anyOf).toEqual([
+      { type: 'string', pattern: '\\S' },
+      { type: 'number' },
+    ]);
   });
 
   it('should document a composite parent key as its packed string form', () => {

--- a/packages/agent-bff/test/openapi/unfolded-document.test.ts
+++ b/packages/agent-bff/test/openapi/unfolded-document.test.ts
@@ -1,0 +1,50 @@
+import jsonwebtoken from 'jsonwebtoken';
+
+import { issueOpenApiAgentToken } from '../../src/openapi/unfolded-document';
+
+describe('issueOpenApiAgentToken', () => {
+  const AUTH_SECRET = 'auth-secret';
+
+  function decode(token: string): Record<string, unknown> {
+    return jsonwebtoken.verify(token, AUTH_SECRET) as Record<string, unknown>;
+  }
+
+  it('should sign a token the agent accepts, since the signature is all it verifies', () => {
+    expect(() => decode(issueOpenApiAgentToken(AUTH_SECRET))).not.toThrow();
+  });
+
+  it('should reject verification under another secret, so the token is not portable', () => {
+    expect(() => jsonwebtoken.verify(issueOpenApiAgentToken(AUTH_SECRET), 'other')).toThrow();
+  });
+
+  it('should carry an inert identity, since it never reads or writes a record', () => {
+    expect(decode(issueOpenApiAgentToken(AUTH_SECRET))).toEqual(
+      expect.objectContaining({
+        id: 0,
+        email: 'openapi@agent-bff.forestadmin.com',
+        renderingId: 0,
+        team: 'Operations',
+      }),
+    );
+  });
+
+  it('should carry the snake_case aliases the Ruby and Python agents read', () => {
+    expect(decode(issueOpenApiAgentToken(AUTH_SECRET))).toEqual(
+      expect.objectContaining({
+        first_name: 'Forest',
+        last_name: 'BFF',
+        rendering_id: 0,
+        permission_level: 'admin',
+      }),
+    );
+  });
+
+  it('should expire, so a leaked export token is not a lasting credential', () => {
+    const { exp, iat } = decode(issueOpenApiAgentToken(AUTH_SECRET)) as {
+      exp: number;
+      iat: number;
+    };
+
+    expect(exp - iat).toBe(5 * 60);
+  });
+});

--- a/packages/agent-bff/test/read-model/agent-capabilities-fetcher.test.ts
+++ b/packages/agent-bff/test/read-model/agent-capabilities-fetcher.test.ts
@@ -37,6 +37,44 @@ describe('createAgentCapabilitiesFetcher', () => {
     expect(result).toEqual({ fields: [{ name: 'email' }] });
   });
 
+  it('should reuse one client for a borrowed token, which cannot be renewed', async () => {
+    const collection = jest
+      .fn()
+      .mockReturnValue({ capabilities: jest.fn().mockResolvedValue({ fields: [] }) });
+    createRemoteAgentClientMock.mockReturnValue({ collection });
+
+    const fetcher = createAgentCapabilitiesFetcher({ agentUrl: 'https://agent', token: 'tok' });
+    await fetcher('users');
+    await fetcher('orders');
+
+    expect(createRemoteAgentClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should sign a fresh token per fetch when given a factory, so a long fan-out cannot expire', async () => {
+    const collection = jest
+      .fn()
+      .mockReturnValue({ capabilities: jest.fn().mockResolvedValue({ fields: [] }) });
+    createRemoteAgentClientMock.mockReturnValue({ collection });
+    let minted = 0;
+
+    const fetcher = createAgentCapabilitiesFetcher({
+      agentUrl: 'https://agent',
+      token: () => {
+        minted += 1;
+
+        return `tok-${minted}`;
+      },
+    });
+    await fetcher('users');
+    await fetcher('orders');
+
+    expect(minted).toBe(2);
+    expect(createRemoteAgentClientMock.mock.calls.map(call => call[0].token)).toEqual([
+      'tok-1',
+      'tok-2',
+    ]);
+  });
+
   it('should inject an HttpRequester that applies the configured timeout', async () => {
     createRemoteAgentClientMock.mockReturnValue({
       collection: jest

--- a/packages/agent-bff/test/read-model/read-model.test.ts
+++ b/packages/agent-bff/test/read-model/read-model.test.ts
@@ -94,6 +94,73 @@ describe('ReadModel', () => {
     });
   });
 
+  describe('collection enumeration', () => {
+    it('should enumerate the schema collections in schema order', () => {
+      const model = new ReadModel([
+        collection('users', [column('id')]),
+        collection('orders', [column('id')]),
+      ]);
+
+      expect(model.getAllowedCollections()).toEqual(['users', 'orders']);
+    });
+
+    it('should hand out a fresh array, so a mutating consumer cannot shrink the allow-list', () => {
+      const model = new ReadModel([collection('users', [column('id')])]);
+
+      model.getAllowedCollections().push('secrets');
+
+      expect(model.getAllowedCollections()).toEqual(['users']);
+      expect(model.isCollectionAllowed('secrets')).toBe(false);
+    });
+  });
+
+  describe('listable relations', () => {
+    const model = new ReadModel([
+      collection('users', [
+        relation('orders', 'HasMany', 'orders.userId'),
+        relation('roles', 'BelongsToMany', 'roles.id'),
+        relation('company', 'BelongsTo', 'companies.id'),
+        relation('profile', 'HasOne', 'profiles.userId'),
+        polymorphic('owner', ['posts', 'videos']),
+      ]),
+    ]);
+
+    it('should enumerate only the to-many relations, which are the ones with a list route', () => {
+      expect(model.getListableRelations('users')).toEqual([
+        { name: 'orders', foreignCollection: 'orders' },
+        { name: 'roles', foreignCollection: 'roles' },
+      ]);
+    });
+
+    it('should resolve a to-many relation to its foreign collection', () => {
+      expect(model.getListableRelationTarget('users', 'orders')).toBe('orders');
+      expect(model.getListableRelationTarget('users', 'roles')).toBe('roles');
+    });
+
+    it.each(['company', 'profile', 'owner'])(
+      'should not resolve %s, which has no list route',
+      relationName => {
+        expect(model.getListableRelationTarget('users', relationName)).toBeUndefined();
+      },
+    );
+
+    it('should still enumerate a to-many relation pointing at a collection outside the schema', () => {
+      const withHiddenTarget = new ReadModel([
+        collection('users', [relation('secrets', 'HasMany', 'secrets.userId')]),
+      ]);
+
+      expect(withHiddenTarget.getListableRelations('users')).toEqual([
+        { name: 'secrets', foreignCollection: 'secrets' },
+      ]);
+      expect(withHiddenTarget.isCollectionAllowed('secrets')).toBe(false);
+    });
+
+    it('should return nothing for an unknown collection', () => {
+      expect(model.getListableRelations('ghosts')).toEqual([]);
+      expect(model.getListableRelationTarget('ghosts', 'orders')).toBeUndefined();
+    });
+  });
+
   describe('collection-scoped keying', () => {
     it('should keep same-named relations on different collections distinct', () => {
       const model = new ReadModel([


### PR DESCRIPTION
Fixes PRD-684

## What

The document used to describe six generic paths with `{collection}`, `{relation}` and `{action}` as path parameters, so a codegen tool produced six methods where everything is a `string`. It now emits **one path per exposed collection, to-many relation and action**, each carrying that collection's real field set.

The **runtime routes are untouched** — they stay the generic regexes. A documented path is the generic route with its segments already filled in.

```
POST /agent/v1/customers/list
POST /agent/v1/customers/relations/orders/list      # fields of `orders`, the foreign side
POST /agent/v1/customers/actions/Mark%20as%20paid/execute
```

## Decisions

**Field names come from `capabilities()`, not from the schema fields.** The schema carries every column, but `capabilities-validator.ts` answers 422 for any projection/sort/filter field absent from capabilities — a document built from schema fields would advertise JSON columns and to-many relations the runtime rejects. Cost: one capabilities call per collection, through the existing 24h per-collection cache shared with the data routes, capped at 10 in flight.

**Two field enums per collection, not one.** The agent reports a `ManyToOne` without operators, so it is projectable and sortable but not filterable (422 `field_not_filterable`).

**The generic paths are replaced, not kept alongside.** Coexistence is lint-clean (checked), but a document describing each route twice, once typed and once as `string`, is not the concrete surface this is for.

**`operationId` is sanitized; the exact name lives in prose.** `redocly lint` errors on `operation-operationId-url-safe` for any operationId containing a space or a slash, so "the operationId carries the exact action name" and "redocly lint green" cannot both hold for an action named `Mark as paid`. Non-`[A-Za-z0-9_]` becomes `_`, collisions get a deterministic numeric suffix, and the **path segment** keeps the exact name URL-encoded — which is what the middleware decodes. `%2F` and `%20` in a path key are lint-clean (checked).

**Action `values` is typed but indicative.** Properties come from the schema's static form fields, all optional, additional properties allowed. `read-model.ts` defaults `hooks`/`fields`, which destroys the absent-vs-empty distinction `agent-client` documents as load-bearing (`domains/action.ts:101-107`) — so `hooks.load === false` cannot be trusted to mean "static form", and strict typing would reject valid calls on a legacy schema.

**`parentId` is typed from the parent's key.** `Number` → number, anything else → string, composite → the `|`-packed string, falling back to the opaque union when the parent exposes no key metadata.

**A collection whose `capabilities()` fails keeps its paths, untyped.** Free-form `string` field schemas plus the reason in the request description and a `Warn` log — never an empty enum, which would forbid every valid call. Dropping the collection would hide something the runtime serves.

**The listable-relation rule moved into the read-model.** It used to live privately in `data-routes-middleware.ts` (twice, after #1801); the unfolding needs the same predicate, and copies are how the document and the runtime drift apart. The foreign-collection allow-list check **stays** in the middleware: moving it would collapse `unknown_collection` into `unknown_relation`.

**A relation request describes the foreign collection's fields**, and since #1801 the runtime validates them against exactly that collection's capabilities — so the enum and the 422 now agree instead of the document being stricter than the runtime.

**With no `AGENT_URL`, the document stays generic**, even though the store can still read the schema (#1804 made that state real: the permissions endpoint needs the store without the agent). Concrete paths would be enumerable, but every data path answers 501 in that configuration, so unfolding would advertise a dead surface.

**Collect and generate are separate.** All I/O and the fan-out live in `collect-unfolding.ts`; `generateOpenApiDocument(version, unfolding?)` stays pure and synchronous. That is what makes the route/CLI comparison one snapshot fed through two call sites rather than two stubbed network chains.

## `forest-bff openapi` is now hybrid

- Configured to be inspected (`FOREST_SERVER_URL`, `FOREST_ENV_SECRET`, `FOREST_AUTH_SECRET`, `AGENT_URL`) → unfolded. It signs its own short-lived agent token: the agent verifies only the signature, and the capabilities route runs no permission check.
- Not configured → the generic document, so the command keeps working with no configuration at all, as documented.
- Configured but the schema cannot be read → **exits 1**, rather than a generic document that would look like a complete answer. The route answers 503 in the same situation, like the data routes.
- Configured, schema readable, but **not one** collection could be described → **exits 1** too: the paths would be real with every field schema free-form, which is not the document this command advertises. One degraded collection out of many stays a warning.

Each capabilities call signs its own agent token: one token lives 5 minutes, and a fan-out over hundreds of collections against a slow agent can outlive that.

`info.description` states which of the two forms the document is.

## Size

Unfolding multiplies the per-path cost, so it was measured first. The 12 error responses were inlined on every path — 2 847 of the ~3 800 bytes of a path. They are now `components/responses` refs, and the timezone header is a shared `components/parameters` ref.

| | before | after |
| -- | -- | -- |
| Generic document | 54 KB | **36 KB** |
| Per path | 3 775 B | **1 394 B** |

Measured on the unfolded document itself, 5 fields per collection and no relation or action, so the per-path figure above is not the whole story — each collection also registers its own `Fields_*`, `FilterableFields_*`, `Filter_*`, `FilterLeaf_*`, `SortClause_*`, `ListRequest_*` and `CountRequest_*` components:

| Collections | Paths | Document |
| -- | -- | -- |
| 10 | 20 | 100 KB |
| 100 | 200 | 899 KB |
| 200 | 400 | 1.79 MB |

So ~600 paths lands near 2.6 MB, not the ~1.4 MB a naive per-path multiplication suggests (thanks @Tonours for catching that). Without the error-response and header factoring the same document would be several times that. No arbitrary cap on the number of paths: a measured case would have to overrun this first.

## Security

The document is **not filtered per caller** — the allow-list is schema-derived and the agent's capabilities route runs no permission check, so any authenticated caller reads the name of every exposed collection, relation and field. That is stated in `info.description` and in the README next to `BFF_OPENAPI_ENABLED`, which already exists to close that surface. Per-role documents were rejected on purpose: a generated client would then depend on who ran the command. The route still requires an agent token before it reads anything, so an unauthenticated caller cannot make the BFF fetch a schema.

## Scope

Untouched: the data routes' behaviour, the action routes' behaviour, the agent, the MCP server, the OAuth flow. No SaaS or DB write. Per-field operator metadata is PRD-685, verifying a generated client is PRD-687.

Two additive changes outside `src/openapi/`:
- `ReadModel` gains `getAllowedCollections()`, `getListableRelations()` and `getListableRelationTarget()`.
- `CapabilitiesResult.type` is widened from `string` to the real column type: the agent returns the raw `columnType`, so an array-of-primitive column arrives as `['String']` and the old declaration was wrong. Nothing read it before.

**Stop condition #2 is resolved.** This branch was written before #1804 landed and added `getAllowedCollections()` with the same signature on purpose, so the rebase conflict was textual — both bodies were identical. Rebased onto `main` at `788ae0f3c`; the only other resolution was `cli-core.ts`, where #1804 split the store's lifetime from the agent's.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test   # 1018 tests
yarn workspace @forestadmin/agent-bff lint
```

`redocly lint` runs inside the suite, on the generic **and** the unfolded document, and both must come out with the single deliberate warning (the unused session scheme).

Against a real deployment:

```bash
cd packages/agent-bff && yarn build
node --env-file=.env dist/cli.js openapi --output /tmp/openapi.json
jq -r '.paths | keys[]' /tmp/openapi.json
env -u AGENT_URL node dist/cli.js openapi | jq -r '.info.description'   # the generic form
```

The fixture used by the tests covers a collection name with a space, a dotted name, an action name with a slash, two action names that collapse when sanitized, a `ManyToOne`, a composite key, a parent with no key metadata, and a collection whose capabilities failed. To-one, polymorphic and hidden-target relations are covered on the collect side, where they are filtered out.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Fixes PRD-684
>
> ## What
>
> The document used to describe six generic paths with `{collection}`, `{relation}` and `{action}` as path parameters, so a codegen tool produced six methods where everything is a `string`. It now emits **one path per exposed collection, to-many relation and action**, each carrying that collection's real field set.
>
> The **runtime routes are untouched** — they stay the generic regexes. A documented path is the generic route with its segments already filled in.
>
> ```
> POST /agent/v1/customers/list
> POST /agent/v1/customers/relations/orders/list      # fields of `orders`, the foreign side
> POST /agent/v1/customers/actions/Mark%20as%20paid/execute
> ```
>
> ## Decisions
>
> **Field names come from `capabilities()`, not from the schema fields.** The schema carries every column, but `capabilities-validator.ts` answers 422 for any projection/sort/filter field absent from capabilities — a document built from schema fields would advertise JSON columns and to-many relations the runtime rejects. Cost: one capabilities call per collection, through the existing 24h per-collection cache shared with the data routes, capped at 10 in flight.
>
> **Two field enums per collection, not one.** The agent reports a `ManyToOne` without operators, so it is projectable and sortable but not filterable (422 `field_not_filterable`).
>
> **The generic paths are replaced, not kept alongside.** Coexistence is lint-clean (checked), but a document describing each route twice, once typed and once as `string`, is not the concrete surface this is for.
>
> **`operationId` is sanitized; the exact name lives in prose.** `redocly lint` errors on `operation-operationId-url-safe` for any operationId containing a space or a slash, so "the operationId carries the exact action name" and "redocly lint green" cannot both hold for an action named `Mark as paid`. Non-`[A-Za-z0-9_]` becomes `_`, collisions get a deterministic numeric suffix, and the **path segment** keeps the exact name URL-encoded — which is what the middleware decodes. `%2F` and `%20` in a path key are lint-clean (checked).
>
> **Action `values` is typed but indicative.** Properties come from the schema's static form fields, all optional, additional properties allowed. `read-model.ts` defaults `hooks`/`fields`, which destroys the absent-vs-empty distinction `agent-client` documents as load-bearing (`domains/action.ts:101-107`) — so `hooks.load === false` cannot be trusted to mean "static form", and strict typing would reject valid calls on a legacy schema.
>
> **`parentId` is typed from the parent's key.** `Number` → number, anything else → string, composite → the `|`-packed string, falling back to the opaque union when the parent exposes no key metadata.
>
> **A collection whose `capabilities()` fails keeps its paths, untyped.** Free-form `string` field schemas plus the reason in the request description and a `Warn` log — never an empty enum, which would forbid every valid call. Dropping the collection would hide something the runtime serves.
>
> **The listable-relation rule moved into the read-model.** It used to live privately in `data-routes-middleware.ts` (twice, after #1801); the unfolding needs the same predicate, and copies are how the document and the runtime drift apart. The foreign-collection allow-list check **stays** in the middleware: moving it would collapse `unknown_collection` into `unknown_relation`.
>
> **A relation request describes the foreign collection's fields**, and since #1801 the runtime validates them against exactly that collection's capabilities — so the enum and the 422 now agree instead of the document being stricter than the runtime.
>
> **With no `AGENT_URL`, the document stays generic**, even though the store can still read the schema (#1804 made that state real: the permissions endpoint needs the store without the agent). Concrete paths would be enumerable, but every data path answers 501 in that configuration, so unfolding would advertise a dead surface.
>
> **Collect and generate are separate.** All I/O and the fan-out live in `collect-unfolding.ts`; `generateOpenApiDocument(version, unfolding?)` stays pure and synchronous. That is what makes the route/CLI comparison one snapshot fed through two call sites rather than two stubbed network chains.
>
> ## `forest-bff openapi` is now hybrid
>
> - Configured to be inspected (`FOREST_SERVER_URL`, `FOREST_ENV_SECRET`, `FOREST_AUTH_SECRET`, `AGENT_URL`) → unfolded. It signs its own short-lived agent token: the agent verifies only the signature, and the capabilities route runs no permission check.
> - Not configured → the generic document, so the command keeps working with no configuration at all, as documented.
> - Configured but the schema cannot be read → **exits 1**, rather than a generic document that would look like a complete answer. The route answers 503 in the same situation, like the data routes.
> - Configured, schema readable, but **not one** collection could be described → **exits 1** too: the paths would be real with every field schema free-form, which is not the document this command advertises. One degraded collection out of many stays a warning.
>
> Each capabilities call signs its own agent token: one token lives 5 minutes, and a fan-out over hundreds of collections against a slow agent can outlive that.
>
> `info.description` states which of the two forms the document is.
>
> ## Size
>
> Unfolding multiplies the per-path cost, so it was measured first. The 12 error responses were inlined on every path — 2 847 of the ~3 800 bytes of a path. They are now `components/responses` refs, and the timezone header is a shared `components/parameters` ref.
>
> | | before | after |
> | -- | -- | -- |
> | Generic document | 54 KB | **36 KB** |
> | Per path | 3 775 B | **1 394 B** |
>
> Measured on the unfolded document itself, 5 fields per collection and no relation or action, so the per-path figure above is not the whole story — each collection also registers its own `Fields_*`, `FilterableFields_*`, `Filter_*`, `FilterLeaf_*`, `SortClause_*`, `ListRequest_*` and `CountRequest_*` components:
>
> | Collections | Paths | Document |
> | -- | -- | -- |
> | 10 | 20 | 100 KB |
> | 100 | 200 | 899 KB |
> | 200 | 400 | 1.79 MB |
>
> So ~600 paths lands near 2.6 MB, not the ~1.4 MB a naive per-path multiplication suggests (thanks @Tonours for catching that). Without the error-response and header factoring the same document would be several times that. No arbitrary cap on the number of paths: a measured case would have to overrun this first.
>
> ## Security
>
> The document is **not filtered per caller** — the allow-list is schema-derived and the agent's capabilities route runs no permission check, so any authenticated caller reads the name of every exposed collection, relation and field. That is stated in `info.description` and in the README next to `BFF_OPENAPI_ENABLED`, which already exists to close that surface. Per-role documents were rejected on purpose: a generated client would then depend on who ran the command. The route still requires an agent token before it reads anything, so an unauthenticated caller cannot make the BFF fetch a schema.
>
> ## Scope
>
> Untouched: the data routes' behaviour, the action routes' behaviour, the agent, the MCP server, the OAuth flow. No SaaS or DB write. Per-field operator metadata is PRD-685, verifying a generated client is PRD-687.
>
> Two additive changes outside `src/openapi/`:
> - `ReadModel` gains `getAllowedCollections()`, `getListableRelations()` and `getListableRelationTarget()`.
> - `CapabilitiesResult.type` is widened from `string` to the real column type: the agent returns the raw `columnType`, so an array-of-primitive column arrives as `['String']` and the old declaration was wrong. Nothing read it before.
>
> **Stop condition #2 is resolved.** This branch was written before #1804 landed and added `getAllowedCollections()` with the same signature on purpose, so the rebase conflict was textual — both bodies were identical. Rebased onto `main` at `788ae0f3c`; the only other resolution was `cli-core.ts`, where #1804 split the store's lifetime from the agent's.
>
> ## How to test
>
> ```bash
> yarn workspace @forestadmin/agent-bff test   # 1018 tests
> yarn workspace @forestadmin/agent-bff lint
> ```
>
> `redocly lint` runs inside the suite, on the generic **and** the unfolded document, and both must come out with the single deliberate warning (the unused session scheme).
>
> Against a real deployment:
>
> ```bash
> cd packages/agent-bff && yarn build
> node --env-file=.env dist/cli.js openapi --output /tmp/openapi.json
> jq -r '.paths | keys[]' /tmp/openapi.json
> env -u AGENT_URL node dist/cli.js openapi | jq -r '.info.description'   # the generic form
> ```
>
> The fixture used by the tests covers a collection name with a space, a dotted name, an action name with a slash, two action names that collapse when sanitized, a `ManyToOne`, a composite key, a parent with no key metadata, and a collection whose capabilities failed. To-one, polymorphic and hidden-target relations are covered on the collect side, where they are filtered out.
>
> ## Definition of Done
>
> ### General
>
> - [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
> - [ ] Test manually the implemented changes
> - [x] Validate the code quality (indentation, syntax, style, simplicity, readability)
>
> ### Security
>
> - [x] Consider the security impact of the changes made
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1823 opened
>
> - Modified `buildUnfoldedDocument`, `createAgentCapabilitiesFetcher`, and CLI `renderOpenApi` command to accept token as either a string or factory function, enabling fresh token generation per capabilities fetch to avoid token expiration during long fan-outs [0e05324]
> - Modified `createOpenApiRoutes` middleware and `renderOpenApi` CLI command to detect degraded unfold results and handle them differently: middleware no longer memoizes documents with any degraded collection, and CLI aborts with error when no collections were successfully described [0e05324]
> - Adjusted `filterSchema` utility to specify types in mutual exclusion `not` clauses for leaf and branch filter discriminators, permitting leaf nodes with non-array `conditions` and branch nodes with non-string `field` properties [0e05324]
> - Changed `collectRelations` utility to sort relation names by code-unit comparison instead of locale-aware `localeCompare`, ensuring deterministic ordering [0e05324]
> - Introduced `toUnfoldSource` helper function to construct `UnfoldSource` from `ReadModelBundle`, config, and logger, replacing inline construction in `resolveUnfoldSource` and `buildAgentMiddlewares` [0e05324]
> - Modified `renderOpenApi` function in `agent-bff` to conditionally compute an unfoldable OpenAPI document only when `FOREST_AUTH_SECRET` is present and the environment requests unfolding, deferring config parsing and source resolution into a guarded branch with optional chaining fallback to the generic document [f578bbb]
> - Implemented `issueOpenApiAgentToken` function in `agent-bff` to generate signed JWT tokens for agent authentication with 5-minute expiry and identity claims including snake_case aliases [f578bbb]
> - Added null safety check in `toFieldSchema` function to prevent accessing `fields` property on null or malformed composite type values [f578bbb]
> - Added test coverage for OpenAPI unfolding defaulting behavior, field schema mappings, identifier sanitization, CLI token signing, and non-registered collection handling [f578bbb]
> - Added validation and filtering to drop malformed field entries lacking valid string field names from OpenAPI schema generation [64149d6]
> - Introduced a no-op `Metrics` implementation (`UNMEASURED`) and threaded an optional `metrics` parameter through `resolveReadModelBundle` to `createReadModel`, with `resolveUnfoldSource` passing `UNMEASURED` to suppress metric emissions during CLI openapi export [ca2540f]
> - Added test coverage to verify that `console.warn` is invoked when no logger is provided to the CLI and that stdout remains valid JSON during the openapi command with unfolding enabled [ca2540f]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->