### PR TITLE
feat(agent-bff): document the real operator set of each filterable field

### DIFF
--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -12,8 +12,6 @@ import type ReadModel from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
 import type { Operator } from '@forestadmin/datasource-toolkit';
 
-import { allOperators } from '@forestadmin/datasource-toolkit';
-
 import { extractErrorMessage } from '../errors';
 import { normalizeOperator, toCanonicalOperatorSet } from '../validation/operator-normalizer';
 
@@ -62,31 +60,35 @@ const UNTYPED = (degraded: CollectionFields['degraded']): CollectionFields => ({
 });
 
 /**
- * The operators to document for one field. An operator with no canonical mapping means the agent
- * runs a newer operator set than this package: the field then keeps the WHOLE operator set rather
- * than the mappable part of it. Documenting less than the runtime accepts would make a generated
- * client refuse a call the agent honours, and a raw snake_case operator must never reach the public
- * document — so the skew is surfaced in the log instead.
+ * The operators to document for one field, or null to leave the field out of the filterable set.
+ *
+ * An operator with no canonical mapping means the agent runs a newer operator set than this package.
+ * The field is dropped rather than widened, because `capabilities-validator` normalizes a field's
+ * WHOLE operator list before comparing the one that was sent: a skewed field answers 500
+ * `mapping_error` on ANY filter, even a plain `Equal`. Documenting it as filterable would promise a
+ * call the BFF never honours, and a raw snake_case operator must never reach the public document. The
+ * skew is surfaced in the log instead — dropping the field keeps the document truthful, so it stays
+ * cacheable.
  */
 function documentedOperators(
   collection: string,
   field: string,
   operators: string[],
   logger: Logger,
-): Operator[] {
+): Operator[] | null {
   const normalized: Operator[] = [];
 
   for (const operator of operators) {
     const canonical = normalizeOperator(operator);
 
     if (!canonical) {
-      logger('Warn', 'Documenting a field with every operator: one of its own has no mapping', {
+      logger('Warn', 'Documenting a field as not filterable: one of its operators has no mapping', {
         collection,
         field,
         operator,
       });
 
-      return [...allOperators];
+      return null;
     }
 
     normalized.push(canonical);
@@ -100,12 +102,18 @@ function collectFilterableFields(
   capabilities: CapabilitiesResult,
   logger: Logger,
 ): FilterableField[] {
-  return capabilities.fields
-    .filter(field => (field.operators?.length ?? 0) > 0)
-    .map(field => ({
-      name: field.name,
-      operators: documentedOperators(collection, field.name, field.operators as string[], logger),
-    }));
+  return capabilities.fields.flatMap(field => {
+    if ((field.operators?.length ?? 0) === 0) return [];
+
+    const operators = documentedOperators(
+      collection,
+      field.name,
+      field.operators as string[],
+      logger,
+    );
+
+    return operators === null ? [] : [{ name: field.name, operators }];
+  });
 }
 
 async function collectFields(

--- a/packages/agent-bff/src/openapi/collect-unfolding.ts
+++ b/packages/agent-bff/src/openapi/collect-unfolding.ts
@@ -1,16 +1,21 @@
 import type {
   CollectionFields,
+  FilterableField,
   UnfoldedAction,
   UnfoldedCollection,
   UnfoldedRelation,
   Unfolding,
 } from './unfolding';
 import type { Logger } from '../ports/logger-port';
-import type { CapabilitiesFetcher } from '../read-model/capabilities-cache';
+import type { CapabilitiesFetcher, CapabilitiesResult } from '../read-model/capabilities-cache';
 import type ReadModel from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
+import type { Operator } from '@forestadmin/datasource-toolkit';
+
+import { allOperators } from '@forestadmin/datasource-toolkit';
 
 import { extractErrorMessage } from '../errors';
+import { normalizeOperator, toCanonicalOperatorSet } from '../validation/operator-normalizer';
 
 // A cold document costs one capabilities call per collection. They are capped rather than fired all
 // at once so a 200-collection deployment cannot open 200 sockets to the agent at the same time; a
@@ -56,6 +61,53 @@ const UNTYPED = (degraded: CollectionFields['degraded']): CollectionFields => ({
   degraded,
 });
 
+/**
+ * The operators to document for one field. An operator with no canonical mapping means the agent
+ * runs a newer operator set than this package: the field then keeps the WHOLE operator set rather
+ * than the mappable part of it. Documenting less than the runtime accepts would make a generated
+ * client refuse a call the agent honours, and a raw snake_case operator must never reach the public
+ * document — so the skew is surfaced in the log instead.
+ */
+function documentedOperators(
+  collection: string,
+  field: string,
+  operators: string[],
+  logger: Logger,
+): Operator[] {
+  const normalized: Operator[] = [];
+
+  for (const operator of operators) {
+    const canonical = normalizeOperator(operator);
+
+    if (!canonical) {
+      logger('Warn', 'Documenting a field with every operator: one of its own has no mapping', {
+        collection,
+        field,
+        operator,
+      });
+
+      return [...allOperators];
+    }
+
+    normalized.push(canonical);
+  }
+
+  return toCanonicalOperatorSet(normalized);
+}
+
+function collectFilterableFields(
+  collection: string,
+  capabilities: CapabilitiesResult,
+  logger: Logger,
+): FilterableField[] {
+  return capabilities.fields
+    .filter(field => (field.operators?.length ?? 0) > 0)
+    .map(field => ({
+      name: field.name,
+      operators: documentedOperators(collection, field.name, field.operators as string[], logger),
+    }));
+}
+
 async function collectFields(
   collection: string,
   { store, capabilitiesFetcher, logger }: CollectUnfoldingOptions,
@@ -73,9 +125,7 @@ async function collectFields(
 
     return {
       projectable: capabilities.fields.map(field => field.name),
-      filterable: capabilities.fields
-        .filter(field => (field.operators?.length ?? 0) > 0)
-        .map(field => field.name),
+      filterable: collectFilterableFields(collection, capabilities, logger),
       degraded: null,
     };
   } catch (error) {

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -100,6 +100,11 @@ function groupByOperators(filterable: FilterableField[]): OperatorGroup[] {
   const groups = new Map<string, OperatorGroup>();
 
   filterable.forEach(field => {
+    // An empty set would emit `enum: []`, which forbids every value and makes the leaf unsatisfiable —
+    // the trap `fieldsEnum` guards above. `collectFilterableFields` cannot produce one, but `Unfolding`
+    // is hand-constructible plain data, so the generator holds the invariant rather than assume it.
+    if (field.operators.length === 0) return;
+
     // Safe as a key because the operators are normalized to one canonical order at collect time.
     const signature = field.operators.join(',');
     const group = groups.get(signature);
@@ -136,9 +141,9 @@ function leafShape(
 }
 
 /**
- * One leaf alternative per operator set. A field the agent reports without operators — a `ManyToOne`,
- * for instance — is in none of them: filtering on it answers 422 field_not_filterable, so it must not
- * be documented as filterable at all.
+ * One leaf alternative per operator set. A field absent from `filterable` is in none of them, which is
+ * the only honest way to document it: a `ManyToOne` answers 422 field_not_filterable, and a field the
+ * collector dropped for an unmappable operator answers 500 mapping_error on every filter.
  */
 function filterLeaves(pool: ComponentPool, plan: Pick<CollectionPlan, 'key' | 'collection'>) {
   const { name, fields } = plan.collection;
@@ -155,9 +160,16 @@ function filterLeaves(pool: ComponentPool, plan: Pick<CollectionPlan, 'key' | 'c
     ];
   }
 
+  // `-` rather than `_` before the index, and the difference is load-bearing: `sanitizeIdentifier` maps
+  // every character outside `[A-Za-z0-9_]` to `_`, so a collection key can end in `_<digit>` — either
+  // because the customer named a collection `Invoice 1`, or because `createNamer` suffixed a name that
+  // collapsed. With `_`, collection `Invoice 1` (no group, so the bare name below) and collection
+  // `Invoice` (first group) both claim `FilterLeaf_Invoice_1`, and `ComponentPool.add` settles it
+  // last-wins in silence — one collection would document the other's fields and operators. Sanitizing
+  // can never produce a `-`, so this separator makes the two namespaces disjoint by construction.
   return groups.map((group, index) =>
     pool.add(
-      `FilterLeaf_${plan.key}_${index + 1}`,
+      `FilterLeaf_${plan.key}-${index + 1}`,
       leafShape(
         { type: 'string', enum: group.fields },
         group.operators,

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -2,6 +2,7 @@ import type ComponentPool from './component-pool';
 import type { Namer } from './names';
 import type {
   CollectionFields,
+  FilterableField,
   UnfoldedAction,
   UnfoldedCollection,
   UnfoldedRelation,
@@ -82,40 +83,113 @@ function fieldsEnum(
   return pool.add(name, { type: 'string', enum: fields, description });
 }
 
-function filterSchema(
-  { pool }: Deps,
-  plan: Pick<CollectionPlan, 'key' | 'collection'>,
-  filterable: ReferenceObject | SchemaObject,
-): ReferenceObject {
-  const { name } = plan.collection;
-  const treeName = `Filter_${plan.key}`;
-  const treeRef = { $ref: `#/components/schemas/${treeName}` };
+interface OperatorGroup {
+  fields: string[];
+  operators: string[];
+}
 
-  // A node readable as BOTH a leaf and a branch is rejected with 400 (`agent-query.ts`
-  // `assertNoNodeReadableAsBothLeafAndBranch`), so each alternative excludes the other's
-  // discriminator. The exclusion carries the TYPE the runtime looks for — `isBranch` needs an ARRAY
-  // `conditions` and `isLeaf` a STRING `field` — because `{field, operator, conditions: "x"}` is a
-  // plain leaf the runtime accepts. Expressed as `not: { required }` rather than
-  // `additionalProperties: false`, which would also forbid an unknown extra key the runtime strips.
-  const leaf = pool.add(`FilterLeaf_${plan.key}`, {
+/**
+ * Groups the filterable fields by the operator set they share. One leaf per field would be as exact
+ * but would multiply the document by the field count; the number of distinct operator sets is bounded
+ * by the column types a collection really uses, and the cross product of a group is precisely the set
+ * of valid `(field, operator)` pairs. The grouping is derived from what capabilities reported — two
+ * fields of DIFFERENT types sharing an operator set land in one group, so nothing here is a type
+ * table.
+ */
+function groupByOperators(filterable: FilterableField[]): OperatorGroup[] {
+  const groups = new Map<string, OperatorGroup>();
+
+  filterable.forEach(field => {
+    // Safe as a key because the operators are normalized to one canonical order at collect time.
+    const signature = field.operators.join(',');
+    const group = groups.get(signature);
+
+    if (group) group.fields.push(field.name);
+    else groups.set(signature, { fields: [field.name], operators: [...field.operators] });
+  });
+
+  return [...groups.values()];
+}
+
+// A node readable as BOTH a leaf and a branch is rejected with 400 (`agent-query.ts`
+// `assertNoNodeReadableAsBothLeafAndBranch`), so each alternative excludes the other's discriminator.
+// The exclusion carries the TYPE the runtime looks for — `isBranch` needs an ARRAY `conditions` and
+// `isLeaf` a STRING `field` — because `{field, operator, conditions: "x"}` is a plain leaf the runtime
+// accepts. Expressed as `not: { required }` rather than `additionalProperties: false`, which would
+// also forbid an unknown extra key the runtime strips.
+function leafShape(
+  field: ReferenceObject | SchemaObject,
+  operators: string[],
+  description: string,
+): SchemaObject {
+  return {
     type: 'object',
-    description: `A single condition on ${quoted(name)}.`,
+    description,
     properties: {
-      field: filterable,
-      operator: { type: 'string', enum: OPERATORS },
+      field,
+      operator: { type: 'string', enum: operators },
       value: {},
     },
     required: ['field', 'operator'],
     not: { properties: { conditions: { type: 'array' } }, required: ['conditions'] },
-  });
+  };
+}
+
+/**
+ * One leaf alternative per operator set. A field the agent reports without operators — a `ManyToOne`,
+ * for instance — is in none of them: filtering on it answers 422 field_not_filterable, so it must not
+ * be documented as filterable at all.
+ */
+function filterLeaves(pool: ComponentPool, plan: Pick<CollectionPlan, 'key' | 'collection'>) {
+  const { name, fields } = plan.collection;
+  const groups = groupByOperators(fields.filterable);
+
+  // No known filterable field: the field stays free-form and every operator stays allowed, because a
+  // collection whose capabilities could not be read still accepts whatever it really exposes.
+  if (groups.length === 0) {
+    return [
+      pool.add(
+        `FilterLeaf_${plan.key}`,
+        leafShape({ type: 'string' }, OPERATORS, `A single condition on ${quoted(name)}.`),
+      ),
+    ];
+  }
+
+  return groups.map((group, index) =>
+    pool.add(
+      `FilterLeaf_${plan.key}_${index + 1}`,
+      leafShape(
+        { type: 'string', enum: group.fields },
+        group.operators,
+        `A single condition on ${quoted(name)}. These fields share one operator set, as the ` +
+          "collection's capabilities report it.",
+      ),
+    ),
+  );
+}
+
+function filterSchema(
+  { pool }: Deps,
+  plan: Pick<CollectionPlan, 'key' | 'collection'>,
+): ReferenceObject {
+  const { name, fields } = plan.collection;
+  const treeName = `Filter_${plan.key}`;
+  const treeRef = { $ref: `#/components/schemas/${treeName}` };
+  const leaves = filterLeaves(pool, plan);
+  const pairing =
+    fields.filterable.length > 0
+      ? ' There is one leaf alternative per operator set: a field accepts only the operators of ' +
+        'the alternative listing it, and an operator it does not support answers 400 ' +
+        'invalid_filter_operator.'
+      : '';
 
   return pool.add(treeName, {
     description:
       `A filter on ${quoted(name)}: either a leaf condition or a branch nesting more ` +
       'conditions. A branch must carry its aggregator. A node carrying both `field` and ' +
-      '`conditions` is rejected with 400, so the two shapes are mutually exclusive.',
+      `\`conditions\` is rejected with 400, so the two shapes are mutually exclusive.${pairing}`,
     anyOf: [
-      leaf,
+      ...leaves,
       {
         type: 'object',
         properties: {
@@ -146,18 +220,13 @@ function fieldRefs(deps: Deps, plan: Pick<CollectionPlan, 'key' | 'collection'>)
     `A field of ${quoted(name)}.`,
   );
 
-  // Filterable is a strict subset of projectable: the agent reports a ManyToOne without operators,
-  // so projecting or sorting on it works while filtering on it answers 422 field_not_filterable.
-  const filterable = fieldsEnum(
-    pool,
-    `FilterableFields_${plan.key}`,
-    fields.filterable,
-    `A filterable field of ${quoted(name)}.`,
-  );
-
+  // Filterable is a strict subset of projectable: the agent reports a ManyToOne without operators, so
+  // projecting or sorting on it works while filtering on it answers 422 field_not_filterable. Which is
+  // why the filterable fields are not enumerated here but inside the filter leaves, where each one
+  // sits next to the operators it actually supports.
   return {
     projectable,
-    filter: filterSchema(deps, plan, filterable),
+    filter: filterSchema(deps, plan),
     sort:
       fields.projectable.length === 0
         ? pool.reuse('SortClause', SortClauseSchema)

--- a/packages/agent-bff/src/openapi/unfolding.ts
+++ b/packages/agent-bff/src/openapi/unfolding.ts
@@ -1,5 +1,6 @@
 import type { FieldType } from '../read-model/capabilities-cache';
 import type { PrimaryKeyField } from '../read-model/read-model';
+import type { Operator } from '@forestadmin/datasource-toolkit';
 
 /**
  * The snapshot the OpenAPI generator unfolds. It is plain data on purpose: collecting it hits the
@@ -34,8 +35,19 @@ export interface UnfoldedRelation {
  */
 export interface CollectionFields {
   projectable: string[];
-  filterable: string[];
+  filterable: FilterableField[];
   degraded: DegradedReason | null;
+}
+
+/**
+ * A field the agent reports at least one operator for, with that operator set — the very set the
+ * runtime validates a filter leaf against. Normalized to canonical PascalCase and to the
+ * `allOperators` order at collect time, so the same capabilities answer always yields the same
+ * document whatever order the agent serialized the operators in.
+ */
+export interface FilterableField {
+  name: string;
+  operators: Operator[];
 }
 
 export type DegradedReason = 'capabilities_unavailable' | 'no_fields';

--- a/packages/agent-bff/src/validation/operator-normalizer.ts
+++ b/packages/agent-bff/src/validation/operator-normalizer.ts
@@ -26,3 +26,18 @@ const SNAKE_TO_PASCAL = new Map<string, Operator>(
 export function normalizeOperator(snakeCaseOperator: string): Operator | undefined {
   return SNAKE_TO_PASCAL.get(snakeCaseOperator);
 }
+
+const CANONICAL_ORDER = new Map<Operator, number>(
+  allOperators.map((operator, index) => [operator, index]),
+);
+
+/**
+ * Deduplicates and reorders an operator set to the `allOperators` order. The agent serializes a
+ * field's operators from a set, so their order is not contractual: putting them in a canonical order
+ * is what lets two fields sharing an operator set be recognized as sharing it.
+ */
+export function toCanonicalOperatorSet(operators: Operator[]): Operator[] {
+  return [...new Set(operators)].sort(
+    (left, right) => (CANONICAL_ORDER.get(left) as number) - (CANONICAL_ORDER.get(right) as number),
+  );
+}

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -5,8 +5,6 @@ import type {
 } from '../../src/read-model/capabilities-cache';
 import type ReadModelStore from '../../src/read-model/read-model-store';
 
-import { allOperators } from '@forestadmin/datasource-toolkit';
-
 import collectUnfolding from '../../src/openapi/collect-unfolding';
 import ReadModel from '../../src/read-model/read-model';
 import { action, collection, column, polymorphic, relation } from '../read-model/fixtures';
@@ -132,23 +130,49 @@ describe('collectUnfolding', () => {
       );
     });
 
-    it('should keep every operator on a field carrying one the BFF cannot map, and log the skew', async () => {
+    // The runtime answers 500 mapping_error on ANY filter on such a field, `Equal` included, because
+    // the validator normalizes the field's whole operator list before comparing the one that was sent.
+    it('should drop a field carrying an operator the BFF cannot map, and log the skew', async () => {
       const logger = jest.fn();
       const { collections } = await collect(readModel, {
         capabilities: async () => ({
-          fields: [{ name: 'id', type: 'String', operators: ['equal', 'teleports_to'] }],
+          fields: [
+            { name: 'id', type: 'String', operators: ['equal', 'teleports_to'] },
+            { name: 'email', type: 'String', operators: ['equal'] },
+          ],
         }),
         logger,
       });
 
-      expect(collections[0].fields.filterable).toEqual([
-        { name: 'id', operators: [...allOperators] },
-      ]);
+      expect(collections[0].fields.filterable).toEqual([{ name: 'email', operators: ['Equal'] }]);
       expect(logger).toHaveBeenCalledWith(
         'Warn',
-        'Documenting a field with every operator: one of its own has no mapping',
+        'Documenting a field as not filterable: one of its operators has no mapping',
         { collection: 'users', field: 'id', operator: 'teleports_to' },
       );
+    });
+
+    it('should keep a skewed field projectable, since only filtering on it fails', async () => {
+      const { collections } = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['equal', 'teleports_to'] }],
+        }),
+      });
+
+      expect(collections[0].fields.projectable).toEqual(['id']);
+      expect(collections[0].fields.filterable).toEqual([]);
+    });
+
+    it('should not degrade a collection whose only problem is a skewed field', async () => {
+      // `degraded` drives the memo guard and the degraded notes. Dropping the field keeps the document
+      // truthful, so there is nothing to un-cache and nothing to warn a reader about.
+      const { collections } = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['teleports_to'] }],
+        }),
+      });
+
+      expect(collections[0].fields.degraded).toBeNull();
     });
 
     it('should degrade a collection whose capabilities call fails, and say so in the log', async () => {

--- a/packages/agent-bff/test/openapi/collect-unfolding.test.ts
+++ b/packages/agent-bff/test/openapi/collect-unfolding.test.ts
@@ -5,6 +5,8 @@ import type {
 } from '../../src/read-model/capabilities-cache';
 import type ReadModelStore from '../../src/read-model/read-model-store';
 
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
 import collectUnfolding from '../../src/openapi/collect-unfolding';
 import ReadModel from '../../src/read-model/read-model';
 import { action, collection, column, polymorphic, relation } from '../read-model/fixtures';
@@ -93,9 +95,60 @@ describe('collectUnfolding', () => {
 
       expect(collections[0].fields).toEqual({
         projectable: ['id', 'author'],
-        filterable: ['id'],
+        filterable: [{ name: 'id', operators: ['Equal'] }],
         degraded: null,
       });
+    });
+
+    it('should normalize the capabilities operators to their canonical PascalCase form', async () => {
+      const { collections } = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['i_contains', 'not_equal'] }],
+        }),
+      });
+
+      expect(collections[0].fields.filterable).toEqual([
+        { name: 'id', operators: ['NotEqual', 'IContains'] },
+      ]);
+    });
+
+    it('should order the operators canonically, whatever order the agent listed them in', async () => {
+      const forward = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['equal', 'contains', 'in'] }],
+        }),
+      });
+      const backward = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['in', 'contains', 'equal'] }],
+        }),
+      });
+
+      expect(forward.collections[0].fields.filterable).toEqual([
+        { name: 'id', operators: ['Equal', 'In', 'Contains'] },
+      ]);
+      expect(backward.collections[0].fields.filterable).toEqual(
+        forward.collections[0].fields.filterable,
+      );
+    });
+
+    it('should keep every operator on a field carrying one the BFF cannot map, and log the skew', async () => {
+      const logger = jest.fn();
+      const { collections } = await collect(readModel, {
+        capabilities: async () => ({
+          fields: [{ name: 'id', type: 'String', operators: ['equal', 'teleports_to'] }],
+        }),
+        logger,
+      });
+
+      expect(collections[0].fields.filterable).toEqual([
+        { name: 'id', operators: [...allOperators] },
+      ]);
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        'Documenting a field with every operator: one of its own has no mapping',
+        { collection: 'users', field: 'id', operator: 'teleports_to' },
+      );
     });
 
     it('should degrade a collection whose capabilities call fails, and say so in the log', async () => {

--- a/packages/agent-bff/test/openapi/fixtures.ts
+++ b/packages/agent-bff/test/openapi/fixtures.ts
@@ -3,8 +3,9 @@ import type { Unfolding } from '../../src/openapi/unfolding';
 /**
  * One snapshot exercising every shape the unfolding has to survive: a name carrying a space, a
  * dotted name, an action name carrying a slash, two action names that collapse to the same
- * identifier, a ManyToOne that is projectable but not filterable, a composite key, a parent with no
- * key metadata, and a collection whose capabilities could not be read.
+ * identifier, a ManyToOne that is projectable but not filterable, two fields of DIFFERENT types
+ * sharing one operator set, a composite key, a parent with no key metadata, and a collection whose
+ * capabilities could not be read.
  */
 export default function unfoldingFixture(): Unfolding {
   return {
@@ -13,7 +14,11 @@ export default function unfoldingFixture(): Unfolding {
         name: 'My Coll',
         fields: {
           projectable: ['id', 'email', 'tags', 'author'],
-          filterable: ['id', 'email', 'tags'],
+          filterable: [
+            { name: 'id', operators: ['Equal', 'NotEqual', 'In'] },
+            { name: 'email', operators: ['Equal', 'NotEqual', 'In', 'Contains'] },
+            { name: 'tags', operators: ['Equal', 'NotEqual', 'In'] },
+          ],
           degraded: null,
         },
         primaryKeys: [{ name: 'id', type: 'Number' }],
@@ -43,7 +48,11 @@ export default function unfoldingFixture(): Unfolding {
       },
       {
         name: 'users.address',
-        fields: { projectable: ['street'], filterable: ['street'], degraded: null },
+        fields: {
+          projectable: ['street'],
+          filterable: [{ name: 'street', operators: ['Equal'] }],
+          degraded: null,
+        },
         primaryKeys: [],
         relations: [{ name: 'orders', foreignCollection: 'orders' }],
         actions: [],

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -1,3 +1,7 @@
+import type { UnfoldedCollection } from '../../src/openapi/unfolding';
+
+import { allOperators } from '@forestadmin/datasource-toolkit';
+
 import unfoldingFixture from './fixtures';
 import { ROUTE_PREFIX, generateOpenApiDocument } from '../../src/openapi/openapi-document';
 
@@ -19,6 +23,45 @@ function requestSchemaName(path: string): string {
 
 function requestSchema(path: string): Record<string, never> {
   return schemas[requestSchemaName(path)] as Record<string, never>;
+}
+
+function dereference(ref: string): Record<string, unknown> {
+  return schemas[ref.replace('#/components/schemas/', '')];
+}
+
+// The leaf alternatives of a filter tree are its `$ref` ones; the branch alternative is inlined.
+function leavesOf(treeName: string): { fields: string[]; operators: string[] }[] {
+  const { anyOf } = schemas[treeName] as unknown as { anyOf: { $ref?: string }[] };
+
+  return anyOf
+    .filter(alternative => alternative.$ref !== undefined)
+    .map(alternative => {
+      const { properties } = dereference(alternative.$ref as string) as unknown as {
+        properties: { field: { enum?: string[] }; operator: { enum: string[] } };
+      };
+
+      return { fields: properties.field.enum ?? [], operators: properties.operator.enum };
+    });
+}
+
+function filterableFieldsOf(treeName: string): string[] {
+  return leavesOf(treeName).flatMap(leaf => leaf.fields);
+}
+
+function branchOf(treeName: string): Record<string, never> {
+  const { anyOf } = schemas[treeName] as unknown as { anyOf: Record<string, never>[] };
+
+  return anyOf[anyOf.length - 1];
+}
+
+// A relation request composes the foreign collection request, so its filter sits one hop further.
+function relationFilterOf(path: string): string {
+  const { allOf } = requestSchema(path) as unknown as { allOf: [{ $ref: string }, unknown] };
+  const { properties } = dereference(allOf[0].$ref) as unknown as {
+    properties: { filter: { $ref: string } };
+  };
+
+  return properties.filter.$ref.replace('#/components/schemas/', '');
 }
 
 describe('the unfolded document', () => {
@@ -85,10 +128,31 @@ describe('the unfolded document', () => {
     );
   });
 
-  it('should leave a ManyToOne out of the filterable fields, which the runtime rejects', () => {
-    expect(schemas.FilterableFields_My_Coll).toEqual(
-      expect.objectContaining({ type: 'string', enum: ['id', 'email', 'tags'] }),
-    );
+  it('should leave a ManyToOne out of every filter leaf, which the runtime rejects', () => {
+    expect(filterableFieldsOf('Filter_My_Coll')).toEqual(['id', 'tags', 'email']);
+  });
+
+  it('should pair each field with the operators its capabilities report', () => {
+    expect(leavesOf('Filter_My_Coll')).toEqual([
+      { fields: ['id', 'tags'], operators: ['Equal', 'NotEqual', 'In'] },
+      { fields: ['email'], operators: ['Equal', 'NotEqual', 'In', 'Contains'] },
+    ]);
+  });
+
+  it('should group two fields of different types that share one operator set', () => {
+    const [first] = leavesOf('Filter_My_Coll');
+
+    expect(first.fields).toEqual(['id', 'tags']);
+  });
+
+  it('should order the operators canonically rather than alphabetically', () => {
+    const [, second] = leavesOf('Filter_My_Coll');
+
+    expect(second.operators.indexOf('In')).toBeLessThan(second.operators.indexOf('Contains'));
+  });
+
+  it('should no longer emit a filterable-field enum, now that each leaf carries its own', () => {
+    expect(Object.keys(schemas).filter(name => name.startsWith('FilterableFields'))).toEqual([]);
   });
 
   it('should point the filter, the projection and the sort at that collection own fields', () => {
@@ -101,32 +165,33 @@ describe('the unfolded document', () => {
     expect(request.properties.sort.items?.$ref).toBe('#/components/schemas/SortClause_My_Coll');
   });
 
-  it('should make the leaf and the branch mutually exclusive, which the runtime enforces', () => {
-    const leaf = schemas.FilterLeaf_My_Coll as unknown as { not: { required: string[] } };
-    const tree = schemas.Filter_My_Coll as unknown as {
-      anyOf: [unknown, { not: { required: string[] } }];
-    };
+  it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {
+    const branch = branchOf('Filter_My_Coll') as unknown as { not: { required: string[] } };
 
-    expect(leaf.not.required).toEqual(['conditions']);
-    expect(tree.anyOf[1].not.required).toEqual(['field']);
+    ['FilterLeaf_My_Coll_1', 'FilterLeaf_My_Coll_2'].forEach(name => {
+      const leaf = schemas[name] as unknown as { not: { required: string[] } };
+
+      expect(leaf.not.required).toEqual(['conditions']);
+    });
+    expect(branch.not.required).toEqual(['field']);
   });
 
   it('should exclude only the type the runtime reads as the other shape', () => {
     // `isBranch` needs an ARRAY `conditions` and `isLeaf` a STRING `field`, so a leaf carrying
     // `conditions: "x"` is a plain leaf the runtime accepts and the document must not refuse.
-    const leaf = schemas.FilterLeaf_My_Coll as unknown as {
+    const leaf = schemas.FilterLeaf_My_Coll_1 as unknown as {
       not: { properties: { conditions: { type: string } } };
     };
-    const tree = schemas.Filter_My_Coll as unknown as {
-      anyOf: [unknown, { not: { properties: { field: { type: string } } } }];
+    const branch = branchOf('Filter_My_Coll') as unknown as {
+      not: { properties: { field: { type: string } } };
     };
 
     expect(leaf.not.properties.conditions.type).toBe('array');
-    expect(tree.anyOf[1].not.properties.field.type).toBe('string');
+    expect(branch.not.properties.field.type).toBe('string');
   });
 
   it('should not forbid an unknown extra key on a filter node, which the runtime strips', () => {
-    const leaf = schemas.FilterLeaf_My_Coll as { additionalProperties?: unknown };
+    const leaf = schemas.FilterLeaf_My_Coll_1 as { additionalProperties?: unknown };
 
     expect(leaf.additionalProperties).toBeUndefined();
   });
@@ -187,6 +252,25 @@ describe('the unfolded document', () => {
     expect(request.properties.projection.items).toEqual({ type: 'string' });
     expect(request.description).toContain('NOT enumerated');
     expect(schemas.Fields_orders).toBeUndefined();
+  });
+
+  it('should keep every operator allowed on a collection whose capabilities failed', () => {
+    // Narrowing the operators there would forbid calls the runtime accepts: nothing is known about
+    // this collection fields, so nothing may be excluded.
+    expect(leavesOf('Filter_orders')).toEqual([{ fields: [], operators: [...allOperators] }]);
+  });
+
+  it('should carry the FOREIGN collection operators on a relation path, not the parent ones', () => {
+    expect(leavesOf(relationFilterOf('orders/relations/buyers/list'))).toEqual([
+      { fields: ['id', 'tags'], operators: ['Equal', 'NotEqual', 'In'] },
+      { fields: ['email'], operators: ['Equal', 'NotEqual', 'In', 'Contains'] },
+    ]);
+  });
+
+  it('should carry the foreign free-form leaf even when the parent has enumerated operators', () => {
+    // "My Coll".orders points at "orders", whose capabilities failed. The relation filter runs on the
+    // foreign collection, so this path must document its permissive leaf and NOT "My Coll" variants.
+    expect(filterableFieldsOf(relationFilterOf('My%20Coll/relations/orders/list'))).toEqual([]);
   });
 
   it('should type the action values from the static form fields, all optional', () => {
@@ -268,7 +352,11 @@ describe('an unfolding naming a collection it does not carry', () => {
       collections: [
         {
           name: 'users',
-          fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+          fields: {
+            projectable: ['id'],
+            filterable: [{ name: 'id', operators: ['Equal'] }],
+            degraded: null,
+          },
           primaryKeys: [{ name: 'id', type: 'Number' }],
           relations: [{ name: 'secrets', foreignCollection: 'secrets' }],
           actions: [],
@@ -287,9 +375,17 @@ describe('names that collide once sanitized', () => {
   // `_` is both what sanitizing produces and the separator between a collection and its child, so
   // deduplicating each segment on its own is not enough: `A_B` + `C` and `A` + `B_C` compose the same
   // identifier, and one action would silently get the other's request schema.
-  const collection = (name: string, actionName: string, relationName: string) => ({
+  const collection = (
+    name: string,
+    actionName: string,
+    relationName: string,
+  ): UnfoldedCollection => ({
     name,
-    fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+    fields: {
+      projectable: ['id'],
+      filterable: [{ name: 'id', operators: ['Equal'] }],
+      degraded: null,
+    },
     primaryKeys: [{ name: 'id', type: 'Number' }],
     relations: [{ name: relationName, foreignCollection: name }],
     actions: [{ name: actionName, fields: [] }],
@@ -332,7 +428,11 @@ describe('an unfolded document with no action', () => {
       collections: [
         {
           name: 'users',
-          fields: { projectable: ['id'], filterable: ['id'], degraded: null },
+          fields: {
+            projectable: ['id'],
+            filterable: [{ name: 'id', operators: ['Equal'] }],
+            degraded: null,
+          },
           primaryKeys: [{ name: 'id', type: 'Number' }],
           relations: [],
           actions: [],

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -1,4 +1,8 @@
-import type { UnfoldedCollection } from '../../src/openapi/unfolding';
+import type {
+  DegradedReason,
+  FilterableField,
+  UnfoldedCollection,
+} from '../../src/openapi/unfolding';
 
 import { allOperators } from '@forestadmin/datasource-toolkit';
 
@@ -52,6 +56,20 @@ function branchOf(treeName: string): Record<string, never> {
   const { anyOf } = schemas[treeName] as unknown as { anyOf: Record<string, never>[] };
 
   return anyOf[anyOf.length - 1];
+}
+
+function collectionOf(
+  name: string,
+  filterable: FilterableField[],
+  degraded: DegradedReason | null = null,
+): UnfoldedCollection {
+  return {
+    name,
+    fields: { projectable: filterable.map(field => field.name), filterable, degraded },
+    primaryKeys: [{ name: 'id', type: 'Number' }],
+    relations: [],
+    actions: [],
+  };
 }
 
 // A relation request composes the foreign collection request, so its filter sits one hop further.
@@ -168,7 +186,7 @@ describe('the unfolded document', () => {
   it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {
     const branch = branchOf('Filter_My_Coll') as unknown as { not: { required: string[] } };
 
-    ['FilterLeaf_My_Coll_1', 'FilterLeaf_My_Coll_2'].forEach(name => {
+    ['FilterLeaf_My_Coll-1', 'FilterLeaf_My_Coll-2'].forEach(name => {
       const leaf = schemas[name] as unknown as { not: { required: string[] } };
 
       expect(leaf.not.required).toEqual(['conditions']);
@@ -179,7 +197,7 @@ describe('the unfolded document', () => {
   it('should exclude only the type the runtime reads as the other shape', () => {
     // `isBranch` needs an ARRAY `conditions` and `isLeaf` a STRING `field`, so a leaf carrying
     // `conditions: "x"` is a plain leaf the runtime accepts and the document must not refuse.
-    const leaf = schemas.FilterLeaf_My_Coll_1 as unknown as {
+    const leaf = schemas['FilterLeaf_My_Coll-1'] as unknown as {
       not: { properties: { conditions: { type: string } } };
     };
     const branch = branchOf('Filter_My_Coll') as unknown as {
@@ -191,7 +209,7 @@ describe('the unfolded document', () => {
   });
 
   it('should not forbid an unknown extra key on a filter node, which the runtime strips', () => {
-    const leaf = schemas.FilterLeaf_My_Coll_1 as { additionalProperties?: unknown };
+    const leaf = schemas['FilterLeaf_My_Coll-1'] as { additionalProperties?: unknown };
 
     expect(leaf.additionalProperties).toBeUndefined();
   });
@@ -341,6 +359,57 @@ describe('the unfolded document', () => {
     const again = generateOpenApiDocument('9.9.9', unfoldingFixture());
 
     expect(JSON.stringify(again)).toBe(JSON.stringify(document));
+  });
+});
+
+describe('a collection whose key ends in an index-like suffix', () => {
+  // `sanitizeIdentifier` turns anything outside [A-Za-z0-9_] into `_`, and `createNamer` appends
+  // `_<n>` to a collapsed name, so a collection key can end in `_<digit>` on its own. A leaf namespace
+  // separated by `_` would let `Invoice 1` and `Invoice` claim the same component name, and
+  // `ComponentPool.add` settles a duplicate last-wins in silence.
+  const collision = generateOpenApiDocument('9.9.9', {
+    collections: [
+      collectionOf('Invoice 1', [], 'capabilities_unavailable'),
+      collectionOf('Invoice', [{ name: 'total', operators: ['Equal', 'GreaterThan'] }]),
+    ],
+  });
+  const collisionSchemas = collision.components?.schemas as Record<string, Record<string, never>>;
+
+  it('should give each collection its own filter leaf rather than share one', () => {
+    const leaves = Object.keys(collisionSchemas).filter(name => name.startsWith('FilterLeaf'));
+
+    expect(leaves).toHaveLength(2);
+    expect(new Set(leaves).size).toBe(2);
+  });
+
+  it('should not document one collection fields under the other name', () => {
+    const bare = collisionSchemas.FilterLeaf_Invoice_1 as unknown as {
+      description: string;
+      properties: { field: { enum?: string[] } };
+    };
+
+    expect(bare.description).toContain('"Invoice 1"');
+    expect(bare.properties.field.enum).toBeUndefined();
+  });
+});
+
+describe('an unfolding carrying a filterable field with no operator', () => {
+  it('should leave it out rather than emit an enum no value satisfies', () => {
+    // An empty enum forbids every value, so the leaf would be unsatisfiable. `collectFilterableFields`
+    // cannot produce one, but the generator takes hand-constructible plain data.
+    const empty = generateOpenApiDocument('9.9.9', {
+      collections: [collectionOf('E', [{ name: 'x', operators: [] }])],
+    });
+    const emptySchemas = empty.components?.schemas as Record<string, Record<string, never>>;
+    const leaf = emptySchemas.FilterLeaf_E as unknown as {
+      properties: { field: { enum?: string[] }; operator: { enum: string[] } };
+    };
+
+    expect(Object.keys(emptySchemas).filter(name => name.startsWith('FilterLeaf'))).toEqual([
+      'FilterLeaf_E',
+    ]);
+    expect(leaf.properties.field.enum).toBeUndefined();
+    expect(leaf.properties.operator.enum).toEqual([...allOperators]);
   });
 });
 

--- a/packages/agent-bff/test/validation/operator-normalizer.test.ts
+++ b/packages/agent-bff/test/validation/operator-normalizer.test.ts
@@ -1,6 +1,10 @@
 import { allOperators } from '@forestadmin/datasource-toolkit';
 
-import { normalizeOperator, toSnakeCaseOperator } from '../../src/validation/operator-normalizer';
+import {
+  normalizeOperator,
+  toCanonicalOperatorSet,
+  toSnakeCaseOperator,
+} from '../../src/validation/operator-normalizer';
 
 describe('operator-normalizer', () => {
   describe('normalizeOperator', () => {
@@ -39,5 +43,29 @@ describe('operator-normalizer', () => {
         expect(normalizeOperator(key)).toBeUndefined();
       },
     );
+  });
+
+  describe('toCanonicalOperatorSet', () => {
+    it('reorders an operator set to the canonical order', () => {
+      expect(toCanonicalOperatorSet(['Contains', 'In', 'Equal'])).toEqual([
+        'Equal',
+        'In',
+        'Contains',
+      ]);
+    });
+
+    it('gives two sets listing the same operators the same result', () => {
+      expect(toCanonicalOperatorSet(['Blank', 'Present'])).toEqual(
+        toCanonicalOperatorSet(['Present', 'Blank']),
+      );
+    });
+
+    it('drops a duplicate, which an enum must not carry twice', () => {
+      expect(toCanonicalOperatorSet(['Equal', 'Equal', 'In'])).toEqual(['Equal', 'In']);
+    });
+
+    it('keeps every canonical operator in the toolkit order', () => {
+      expect(toCanonicalOperatorSet([...allOperators].reverse())).toEqual([...allOperators]);
+    });
   });
 });


### PR DESCRIPTION
Fixes PRD-685

Stacked on #1823 — review that one first.

## Why

The unfolded document enumerated the filterable fields but offered every toolkit operator on all of them. A generated client, or the Zendesk filter UI, could not tell that `Contains` works on a String and not on a Boolean until the agent answered 400.

## What

Each filter leaf now pairs a field with the operators its capabilities report, as a JSON `enum` a codegen can read:

```json
"FilterLeaf_My_Coll_1": {
  "properties": {
    "field":    { "type": "string", "enum": ["id", "tags"] },
    "operator": { "type": "string", "enum": ["Equal", "NotEqual", "In"] },
    "value": {}
  }
}
```

Fields are grouped by the operator set they share rather than emitted one leaf each. One leaf per field would be as exact but would multiply the document by the field count; the number of distinct operator sets is bounded by the column types a collection really uses, and the cross product of a group is precisely the set of valid `(field, operator)` pairs. Two fields of **different** types sharing an operator set land in one group, so nothing here is a type table.

`FilterableFields_<key>` is gone: each leaf carries its own field subset, and their union is exactly the filterable set. A field the agent reports without operators — a `ManyToOne` — is in no leaf at all, which is what the runtime's 422 `field_not_filterable` means.

## Notable decisions

- **Operators are normalized and canonically ordered at collect time.** The agent serializes them from a set, so their order is not contractual; a canonical order is what lets two fields be recognized as sharing a set, and it keeps the document stable across the route's and the CLI's independent capabilities calls.
- **An unmappable operator keeps the whole operator set on that field, and logs the skew.** Documenting less than the runtime accepts would make a generated client refuse a call the agent honours; throwing like the runtime does would cost the entire document for one field. No raw snake_case ever reaches the public document.
- **A collection whose capabilities could not be read keeps its permissive leaf** — free-form field, every operator. Unchanged behavior.
- **Relations needed no wiring.** A relation request composes the foreign collection request, so the operators come from the foreign collection by construction. Covered by tests both ways: a rich parent pointing at a degraded foreign, and a degraded parent pointing at a rich foreign.

## Cost

No extra network call — the collector already had the operators in hand and threw them away.

## Tests

1073 pass, lint clean. New coverage: per-field operator enums, cross-type grouping, canonical ordering, the version-skew fallback and its log, the relation operator source in both directions, and the absence of `FilterableFields_*`. The existing route/CLI parity test and the redocly spec-validity test cover the new schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document per-field operator sets in filterable field schemas for agent-bff OpenAPI spec
> - The `filterable` field in `CollectionFields` changes from `string[]` to `FilterableField[]` (a `{ name, operators }` pair), giving each field its own canonical operator set.
> - Operators are normalized to PascalCase and deduplicated in canonical order via `toCanonicalOperatorSet`; unknown operators trigger a `Warn` log and fall back to the full `allOperators` set.
> - Filter leaf schemas in the OpenAPI output are now grouped by shared operator set, producing one leaf alternative per unique operator group instead of a single global leaf with a separate filterable-fields enum.
> - Collections with no known filterable fields get a permissive leaf (free-form field string + all operators); collections with known fields get scoped field enums paired with their operator enums.
> - Behavioral Change: `FilterableFields_*` schemas are removed from the OpenAPI output; filter schemas now use grouped leaf `$ref` alternatives.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1824 opened
>
> - Changed `documentedOperators` function to return `null` when encountering operators with no canonical mapping from `normalizeOperator`, instead of returning all operators from `@forestadmin/datasource-toolkit` [eae3def]
> - Updated `collectFilterableFields` to exclude fields with unmappable operators by filtering out entries where `documentedOperators` returns `null` [eae3def]
> - Added guard in `groupByOperators` to skip fields with empty operator lists, preventing creation of unsatisfiable filter leaf schemas with `enum: []` for operators [eae3def]
> - Changed filter leaf component naming scheme from `FilterLeaf_${plan.key}_${index + 1}` to `FilterLeaf_${plan.key}-${index + 1}` to prevent namespace collisions after identifier sanitization [eae3def]
> - Added test coverage verifying that fields with unmappable operators are dropped from filterable fields, log appropriate warnings, remain projectable, do not degrade collection quality, and that empty operator sets fall back to generic leaves [eae3def]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e4a8538. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->