### PR TITLE
test(agent-bff): pin the OpenAPI mount point under /agent and cover mode 2

### DIFF
--- a/packages/agent-bff/test/openapi/openapi-mount-invariant.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-mount-invariant.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+import * as publicApi from '../../src/index';
+import { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
+
+const SRC_DIR = path.join(__dirname, '..', '..', 'src');
+const OPENAPI_MODULE_PREFIX = 'openapi/';
+
+const ALLOWED_OPENAPI_IMPORTS: Record<string, string[]> = {
+  'cli-core.ts': ['openapi/openapi-routes', 'openapi/unfolded-document'],
+  'cli-dispatch.ts': ['openapi/openapi-document', 'openapi/unfolded-document', 'openapi/unfolding'],
+};
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC_DIR, { recursive: true, encoding: 'utf8' })
+    .map(entry => entry.split(path.sep).join('/'))
+    .filter(entry => entry.endsWith('.ts'));
+}
+
+function relativeImportsOf(file: string): string[] {
+  const source = readFileSync(path.join(SRC_DIR, file), 'utf8');
+
+  return [...source.matchAll(/from '(\.[^']*)'/g)].map(match =>
+    path.posix.normalize(path.posix.join(path.posix.dirname(file), match[1])),
+  );
+}
+
+function openapiImportsOutsideTheOpenapiDir(): Record<string, string[]> {
+  const byFile: Record<string, string[]> = {};
+  const outsiders = sourceFiles().filter(file => !file.startsWith(OPENAPI_MODULE_PREFIX));
+
+  for (const file of outsiders) {
+    const targets = [
+      ...new Set(
+        relativeImportsOf(file).filter(target => target.startsWith(OPENAPI_MODULE_PREFIX)),
+      ),
+    ].sort();
+
+    if (targets.length > 0) byFile[file] = targets;
+  }
+
+  return byFile;
+}
+
+describe('the OpenAPI document mount point', () => {
+  describe('when the served path is read', () => {
+    it('should sit under /agent, since that prefix is what the auth chain covers', () => {
+      expect(OPENAPI_PATH.startsWith('/agent/')).toBe(true);
+    });
+  });
+
+  describe('when a module outside src/openapi reaches into it', () => {
+    it('should only be the two known mount points, since any other one could serve the document off /agent', () => {
+      expect(openapiImportsOutsideTheOpenapiDir()).toEqual(ALLOWED_OPENAPI_IMPORTS);
+    });
+  });
+
+  describe('when the package public surface is read', () => {
+    it('should expose nothing OpenAPI-related, since a consumer could mount it off /agent', () => {
+      expect(Object.keys(publicApi).filter(name => /openapi/i.test(name))).toEqual([]);
+    });
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -55,6 +55,31 @@ const VALID_ENV = {
 
 const noopLogger: Logger = () => undefined;
 
+const API_KEY = `fbff_${'a'.repeat(16)}_${'b'.repeat(64)}`;
+
+const RESOLVED_IDENTITY = {
+  user: {
+    id: 42,
+    email: 'ada@example.com',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    team: 'Support',
+    tags: [],
+    permissionLevel: 'admin',
+  },
+  renderingId: 17,
+  allowedOrigins: [],
+};
+
+function mockApiKeyResolve(): void {
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'ok',
+    json: async () => RESOLVED_IDENTITY,
+  } as unknown as Response);
+}
+
 function sessionToken(): string {
   return issueBffAccessToken({
     sid: 'session-1',
@@ -159,6 +184,32 @@ describe('GET /agent/openapi.json', () => {
           .set('Authorization', `Bearer ${sessionToken()}`);
 
         expect(response.headers['cache-control']).toBe('no-store');
+      });
+    });
+  });
+
+  describe('when a valid api key is sent', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should serve the same unfolded document as a session caller, since the mode only changes the gate', async () => {
+      mockApiKeyResolve();
+
+      await withServer(VALID_ENV, async server => {
+        const withKey = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('X-Forest-Bff-Key', API_KEY);
+        const withSession = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('Authorization', `Bearer ${sessionToken()}`);
+
+        expect(withKey.status).toBe(200);
+        expect(withKey.body.openapi).toBe('3.1.0');
+        expect(Object.keys(withKey.body.paths)).toHaveLength(8);
+        expect(Object.keys(withKey.body.paths).sort()).toEqual(
+          Object.keys(withSession.body.paths).sort(),
+        );
       });
     });
   });
@@ -455,6 +506,24 @@ describe('GET /agent/openapi.json', () => {
 
   describe('when BFF_OPENAPI_ENABLED is false', () => {
     const disabledEnv = { ...VALID_ENV, BFF_OPENAPI_ENABLED: 'false' };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should answer 404 to an api key caller, exactly like a session caller', async () => {
+      mockApiKeyResolve();
+
+      await withServer(disabledEnv, async server => {
+        const response = await request(server.callback)
+          .get(OPENAPI_PATH)
+          .set('X-Forest-Bff-Key', API_KEY);
+
+        expect(response.status).toBe(404);
+        expect(response.body.error.type).toBe('openapi_disabled');
+        expect(response.text).not.toContain('"openapi"');
+      });
+    });
 
     it('should still reject an unauthenticated caller with 401', async () => {
       await withServer(disabledEnv, async server => {


### PR DESCRIPTION
## Why

The BFF has no deny-by-default gate: auth applies only to paths under `/agent`, and `/health` is a hardcoded public exact-match ahead of the chain. `GET /agent/openapi.json` is therefore gated by construction, not by a mechanism — which means the next route added elsewhere could serve the document unauthenticated, silently. An unauthenticated OpenAPI document hands over the full API surface (collections, fields, filter operators, actions) — OWASP API8:2023.

PRD-886 already covers 401-without-credential, 200-with-a-session-token and 404-at-the-root. This PR adds what unit tests did not yet pin: the invariant itself, and the Mode 2 path.

## What

`test/openapi/openapi-mount-invariant.test.ts` (static, no server boot):

- `OPENAPI_PATH` must start with `/agent/`.
- No file in `src/` outside `src/openapi/` may import `src/openapi/*`, except the known mount points: `cli-core.ts` -> `openapi-routes`, `unfolded-document`, and `cli-dispatch.ts` -> `openapi-document`, `unfolded-document`, `unfolding`. Asserted as an exact map, so any new importer fails — the first CI run on this branch demonstrated it by catching the importers PRD-684 added on `main`.
- `src/index.ts` exports nothing matching `/openapi/i`, so a package consumer cannot mount the document itself.

`test/openapi/openapi-routes.test.ts`: the missing Mode 2 coverage — a valid API key gets 200 and the very same unfolded document a session caller gets, and 404 `openapi_disabled` with a valid API key when `BFF_OPENAPI_ENABLED=false`.

Test-only. No production code touched.

## Verification

- `yarn workspace @forestadmin/agent-bff test` — 1084 tests green; lint clean.
- Mutation-tested: moving `OPENAPI_PATH` to the root, adding an `openapi-document` import in another module, and exporting `createOpenApiRoutes` from `index.ts` each fail the suite. The Mode 2 cases fail if key resolution fails, so the 200 does not pass for the wrong reason.
- Manual, local BFF against a real Forest server: no credential 401, Mode 1 session token 200, Mode 2 API key 200, root `/openapi.json` 404. Logged on the ticket.

## Out of scope

A generic deny-by-default gate for the whole BFF, and pinning its public HTTP surface. Recorded as still-open in a ticket comment.

Fixes PRD-686

🤖 Generated with [Claude Code](https://claude.com/claude-code)
