### PR TITLE
fix(datasource-sequelize): keep parent records when a projected relation is scoped

### DIFF
--- a/packages/datasource-sequelize/package.json
+++ b/packages/datasource-sequelize/package.json
@@ -26,7 +26,8 @@
     "test": "jest"
   },
   "devDependencies": {
-    "sequelize": "^6.37.8"
+    "sequelize": "^6.37.8",
+    "sqlite3": "^5.1.7"
   },
   "peerDependencies": {
     "sequelize": ">= 6.12.0 < 7"

--- a/packages/datasource-sequelize/src/utils/query-converter.ts
+++ b/packages/datasource-sequelize/src/utils/query-converter.ts
@@ -291,6 +291,9 @@ export default class QueryConverter {
         association: name,
         attributes: relAttrProjection.columns,
         include: this.getIncludeFromProjection(relAttrProjection, relTableProjection),
+        // A `defaultScope` on the target makes sequelize mark the include as required, degrading
+        // the LEFT OUTER JOIN into an INNER JOIN and dropping parent records from lists and counts.
+        required: false,
       };
     });
   }

--- a/packages/datasource-sequelize/test/collection.test.ts
+++ b/packages/datasource-sequelize/test/collection.test.ts
@@ -616,6 +616,7 @@ describe('SequelizeDataSource > Collection', () => {
                   association: 'relations',
                   include: [],
                   attributes: [],
+                  required: false,
                 },
               ],
             }),

--- a/packages/datasource-sequelize/test/default-scope.test.ts
+++ b/packages/datasource-sequelize/test/default-scope.test.ts
@@ -1,0 +1,122 @@
+import type SequelizeCollection from '../src/collection';
+import type { Caller } from '@forestadmin/datasource-toolkit';
+
+import {
+  Aggregation,
+  ConditionTreeLeaf,
+  Filter,
+  PaginatedFilter,
+  Projection,
+} from '@forestadmin/datasource-toolkit';
+import { DataTypes, Sequelize } from 'sequelize';
+
+import { createSequelizeDataSource } from '../src/index';
+
+describe('Relation whose target declares a defaultScope', () => {
+  const caller: Caller = {} as Caller;
+
+  async function setupCars({ scoped }: { scoped: boolean }) {
+    const sequelize = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false });
+
+    const category = sequelize.define(
+      'Category',
+      { label: DataTypes.TEXT, archived: DataTypes.BOOLEAN },
+      scoped ? { defaultScope: { where: { archived: false } } } : {},
+    );
+    const car = sequelize.define('Car', { name: DataTypes.TEXT });
+
+    car.belongsTo(category, { as: 'category', foreignKey: 'categoryId' });
+
+    await sequelize.sync({ force: true });
+
+    await category.unscoped().bulkCreate([
+      { id: 1, label: 'LIVE', archived: false },
+      { id: 2, label: 'ARCHIVED', archived: true },
+    ]);
+    await car.bulkCreate([
+      { name: 'CAR-live', categoryId: 1 },
+      { name: 'CAR-archived', categoryId: 2 },
+      { name: 'CAR-orphan', categoryId: null },
+    ]);
+
+    const datasource = await createSequelizeDataSource(sequelize)(jest.fn(), jest.fn());
+
+    return {
+      sequelize,
+      collection: datasource.getCollection('Car') as SequelizeCollection,
+    };
+  }
+
+  describe('list', () => {
+    it('should keep every parent record when the relation is projected', async () => {
+      const { sequelize, collection } = await setupCars({ scoped: true });
+
+      const records = await collection.list(
+        caller,
+        new PaginatedFilter({}),
+        new Projection('name', 'category:label'),
+      );
+
+      expect(records).toEqual([
+        { name: 'CAR-live', category: { label: 'LIVE' } },
+        { name: 'CAR-archived', category: null },
+        { name: 'CAR-orphan', category: null },
+      ]);
+
+      await sequelize.close();
+    });
+
+    it('should return the related record when the target declares no defaultScope', async () => {
+      const { sequelize, collection } = await setupCars({ scoped: false });
+
+      const records = await collection.list(
+        caller,
+        new PaginatedFilter({}),
+        new Projection('name', 'category:label'),
+      );
+
+      expect(records).toEqual([
+        { name: 'CAR-live', category: { label: 'LIVE' } },
+        { name: 'CAR-archived', category: { label: 'ARCHIVED' } },
+        { name: 'CAR-orphan', category: null },
+      ]);
+
+      await sequelize.close();
+    });
+
+    it('should still filter on a scoped relation field', async () => {
+      const { sequelize, collection } = await setupCars({ scoped: true });
+
+      const records = await collection.list(
+        caller,
+        new PaginatedFilter({
+          conditionTree: new ConditionTreeLeaf('category:label', 'Equal', 'LIVE'),
+        }),
+        new Projection('name'),
+      );
+
+      expect(records).toEqual([{ name: 'CAR-live' }]);
+
+      await sequelize.close();
+    });
+  });
+
+  describe('aggregate', () => {
+    it('should count every parent record when the relation is projected', async () => {
+      const { sequelize, collection } = await setupCars({ scoped: true });
+
+      const results = await collection.aggregate(
+        caller,
+        new Filter({}),
+        new Aggregation({ operation: 'Count', groups: [{ field: 'category:label' }] }),
+      );
+
+      expect(results).toEqual([
+        { group: { 'category:label': null }, value: 2 },
+        { group: { 'category:label': 'LIVE' }, value: 1 },
+      ]);
+
+      await sequelize.close();
+    });
+  });
+});

--- a/packages/datasource-sequelize/test/utils/query-converter.unit.test.ts
+++ b/packages/datasource-sequelize/test/utils/query-converter.unit.test.ts
@@ -543,7 +543,7 @@ describe('Utils > QueryConverter', () => {
         const queryConverter = new QueryConverter(model);
 
         expect(queryConverter.getIncludeFromProjection(projection)).toEqual([
-          { association: 'model', include: [], attributes: ['another_field'] },
+          { association: 'model', include: [], attributes: ['another_field'], required: false },
         ]);
       });
 
@@ -555,8 +555,16 @@ describe('Utils > QueryConverter', () => {
         expect(queryConverter.getIncludeFromProjection(projection)).toEqual([
           {
             association: 'model',
-            include: [{ association: 'another_model', include: [], attributes: ['a_field'] }],
+            include: [
+              {
+                association: 'another_model',
+                include: [],
+                attributes: ['a_field'],
+                required: false,
+              },
+            ],
             attributes: [],
+            required: false,
           },
         ]);
       });
@@ -567,7 +575,7 @@ describe('Utils > QueryConverter', () => {
         const queryConverter = new QueryConverter(model);
 
         expect(queryConverter.getIncludeFromProjection(new Projection(), projection)).toEqual([
-          { association: 'model', include: [], attributes: [] },
+          { association: 'model', include: [], attributes: [], required: false },
         ]);
       });
 
@@ -579,8 +587,11 @@ describe('Utils > QueryConverter', () => {
         expect(queryConverter.getIncludeFromProjection(new Projection(), projection)).toEqual([
           {
             association: 'model',
-            include: [{ association: 'another_model', include: [], attributes: [] }],
+            include: [
+              { association: 'another_model', include: [], attributes: [], required: false },
+            ],
             attributes: [],
+            required: false,
           },
         ]);
       });


### PR DESCRIPTION
fixes PRD-950

## Problem

`QueryConverter#getIncludeFromProjection` built its includes without `required`. When the target model declares a `defaultScope` carrying a `where`, Sequelize injects that condition into the include and implicitly makes it required, turning the `LEFT OUTER JOIN` into an `INNER JOIN`.

Parent records then disappeared from lists and counts merely because a projected relation was scoped out — **and so did parent records whose foreign key is simply null**, which have no scoped-out relation at all.

Since the frontend projects `relation:displayField` for every belongsTo it displays, showing a column silently changed the row set and the total. `aggregate` builds its includes with the same helper, so a count of 3 records returned 1.

## Fix

`required: false` on every include built from the projection. The scope condition stays in the `ON` clause, the join goes back to `LEFT OUTER`, the relation resolves to `null` and the parent record stays — the scope hides the *related record*, not its parent.

Measured on sqlite, 3 cars, projection `category:label`, `Category` declaring `defaultScope: { where: { archived: false } }`:

| Scenario | Rows | Join |
| -- | -- | -- |
| no defaultScope (control) | 3/3 | LEFT OUTER |
| defaultScope, before | **1/3** | INNER |
| defaultScope, after | 3/3 — scoped-out relation is `null` | LEFT OUTER |
| no defaultScope + fix | 3/3, relation intact | LEFT OUTER |

Count goes from 1 to 3 the same way.

**The change is a no-op when no scope is involved**: with no `where` in the include, Sequelize already emitted a `LEFT OUTER JOIN`. Only the broken case changes.

**Filters spanning relations are unaffected**: they live in the top-level `WHERE` as `$relation.field$`, not in the `ON` clause. Verified in a test.

## Parity with the ruby agent

This aligns the two agents on the same observable behaviour. The ActiveRecord datasource already guards against this case — `joinable_target` returns nil when the target model carries a `default_scope` (`query.rb`, `return if target.nil? || !target.model.default_scopes.empty?`) and the hop falls back to preload.

Ran the equivalent scenario against agent-ruby to confirm the outcome rather than infer it from the guard. Its dummy `Car` declares `default_scope { where('id > ?', 10) }`, so a car with `id <= 10` is the analogue of the scoped-out case:

```
--- ruby agent, projection ['id', 'first_name', 'car:reference'] ---
rows: 2/2
  has-visible-car    -> {"reference"=>"CAR-in-scope"}
  has-scoped-out-car -> nil
```

Parent row kept, relation `nil` — identical to what this PR produces. (The null-foreign-key case is not representable there, `users.car_id` is NOT NULL in the dummy schema; it is moot anyway since preload puts no join at all on the parent query.)

## Tests

New `test/default-scope.test.ts`, functional on in-memory sqlite and going through the real `createSequelizeDataSource` → `collection.list` / `collection.aggregate` path — the ticket's original measurement replayed Sequelize by hand, so this confirms it against the agent itself.

- list returns 3/3 with the scoped-out and orphan relations as `null` — **fails without the fix**
- count returns 3 — **fails without the fix**
- control with no `defaultScope`: relation comes back in full — regression guard
- filter on a scoped relation field still returns 1 row — regression guard

Both guards were checked against the unfixed code to confirm the first two bite and the last two hold.

`sqlite3` added to devDependencies: the test needs it and it was only available through hoisting.

## Verified

Green on CI, which starts the docker-compose containers for this package and runs the whole suite:

- `datasource-sequelize`: 260 tests / 14 suites, including `filter.integration` and `count.integration` against postgres 16, MySQL 8, MariaDB 11 and MSSQL 2022
- `datasource-sql`: 1140 tests (also on containers)
- `datasource-replica`: 56 tests, exercises this collection on sqlite

🤖 Generated with [Claude Code](https://claude.com/claude-code)