### PR TITLE
fix(mcp-server): blame the missing dependency, not the configured path

### DIFF
--- a/packages/mcp-server/src/utils/load-file-uploads.ts
+++ b/packages/mcp-server/src/utils/load-file-uploads.ts
@@ -36,9 +36,11 @@ export default async function loadFileUploads(
   } catch (error) {
     // "cannot find it" and "it ran and failed" send the operator to different places, and only the
     // first is about the path they configured.
+    // The quoted name, not the whole message: a module whose own dependency is missing reports
+    // MODULE_NOT_FOUND too, with the resolved path in the require stack rather than as the subject.
     const absent =
       (error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND' &&
-      String((error as Error)?.message).includes(resolved);
+      String((error as Error)?.message).includes(`'${resolved}'`);
 
     throw withCause(
       absent

--- a/packages/mcp-server/test/utils/load-file-uploads.test.ts
+++ b/packages/mcp-server/test/utils/load-file-uploads.test.ts
@@ -53,6 +53,16 @@ describe('loadFileUploads', () => {
     });
   });
 
+  it('blames the dependency, not the path, when the module requires something missing', async () => {
+    const file = writeModule(`require('@this/does-not-exist');`);
+
+    const error = (await loadFileUploads(file).catch((e: Error) => e)) as Error;
+
+    expect(error.message).toContain('failed while loading');
+    expect(error.message).toContain("Cannot find module '@this/does-not-exist'");
+    expect(error.message).not.toContain('was not found');
+  });
+
   it('names the module and the resolved path when it cannot be found', async () => {
     await expect(loadFileUploads('./does-not-exist.js')).rejects.toThrow(
       /"\.\/does-not-exist\.js" was not found \(resolved to .+\)/,


### PR DESCRIPTION
Found while writing the S3 storage example for a customer about to configure `FOREST_MCP_UPLOAD_STORAGE_MODULE`: the module was on disk and correct, and the server said it was not there.

```
FOREST_MCP_UPLOAD_STORAGE_MODULE "/app/forest-upload-storage.js" was not found (resolved to /app/forest-upload-storage.js).
```

The real cause was `@aws-sdk/client-s3` not being installed. Node raises `MODULE_NOT_FOUND` for that too, naming the *dependency* as the subject and carrying the module's own path in the require stack — so the old test, `message.includes(resolved)`, matched on the stack line and reported the wrong diagnosis.

Matching the quoted name separates the two cases:

| Situation | Node's message | Reported now |
|---|---|---|
| entry point missing | `Cannot find module '<resolved>'` | `was not found (resolved to …)` |
| its dependency missing | `Cannot find module '<dependency>'` | `failed while loading: Cannot find module '<dependency>'` |

Verified in plain node against the built `dist`, both directions — the Jest resolver rewrites this message, so a test alone would not have proven it. Pinned by `blames the dependency, not the path, when the module requires something missing`, alongside the existing test for a genuinely absent path.

`npm i @aws-sdk/client-s3` forgotten is the first thing anyone setting this variable will hit, and it was the one mistake the error actively mislabelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `loadFileUploads` to distinguish missing module from missing dependency in `MODULE_NOT_FOUND` errors
> When `require()` throws a `MODULE_NOT_FOUND` error, it can mean either the target module itself is absent or a dependency of that module is missing. Previously, the function treated both cases as 'module not found'. It now checks whether the error message contains the resolved path wrapped in single quotes; only that case is classified as 'not found', while missing-dependency errors are classified as 'failed while loading'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 701d045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->