### PR TITLE
fix(datasource-customizer): reject malformed binary filter values instead of crashing

### DIFF
--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -20,7 +20,7 @@ import {
   CollectionDecorator,
   SchemaUtils,
   TypeGetter,
-  ValidationError,
+  parseDataUri,
 } from '@forestadmin/datasource-toolkit';
 import { filetypemime } from 'magic-bytes.js';
 
@@ -252,15 +252,7 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
 
       if (useHex) return Buffer.from(string, 'hex');
 
-      const payload = string.split(',')[1];
-
-      if (payload === undefined) {
-        throw new ValidationError(
-          `Expected a data uri of the form "data:<mime>;base64,<payload>", received "${string}"`,
-        );
-      }
-
-      return Buffer.from(payload, 'base64');
+      return parseDataUri(string).buffer;
     }
 
     const buffer = value as Buffer;

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -259,6 +259,8 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     value: unknown,
   ): Promise<unknown> {
     if (toBackend) {
+      if (Buffer.isBuffer(value)) return value;
+
       if (typeof value !== 'string') {
         throw new ValidationError(
           `Expected a string for a binary field, got ${typeof value}: ${JSON.stringify(value)}`,

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -25,6 +25,8 @@ import {
 } from '@forestadmin/datasource-toolkit';
 import { filetypemime } from 'magic-bytes.js';
 
+const HEX_BYTES = /^([0-9a-f]{2})+$/i;
+
 /**
  * As the transport layer between the forest admin agent and the frontend is JSON-API, binary data
  * is not supported.
@@ -244,7 +246,7 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
   }
 
   private parseHex(value: string): Buffer {
-    if (!/^([0-9a-f]{2})*$/i.test(value)) {
+    if (!HEX_BYTES.test(value)) {
       throw new ValidationError(
         `Expected an even-length hex string for a binary field, got "${value}"`,
       );
@@ -306,7 +308,7 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
       const maxLength = schema.validation?.find(v => v.operator === 'ShorterThan')?.value as number;
 
       if (this.shouldUseHex(name)) {
-        validation.push({ operator: 'Match', value: /^[0-9a-f]+$/ });
+        validation.push({ operator: 'Match', value: HEX_BYTES });
         if (minLength) validation.push({ operator: 'LongerThan', value: minLength * 2 + 1 });
         if (maxLength) validation.push({ operator: 'ShorterThan', value: maxLength * 2 - 1 });
       } else {

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -248,7 +248,7 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
   private parseHex(value: string): Buffer {
     if (!HEX_BYTES.test(value)) {
       throw new ValidationError(
-        `Expected an even-length hex string for a binary field, got "${value}"`,
+        `Expected a hex string of full bytes for a binary field, got "${value.slice(0, 32)}"`,
       );
     }
 
@@ -265,7 +265,9 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
 
       if (typeof value !== 'string') {
         throw new ValidationError(
-          `Expected a string for a binary field, got ${typeof value}: ${JSON.stringify(value)}`,
+          `Expected a string for a binary field, got ${typeof value}: ${JSON.stringify(
+            value,
+          )?.slice(0, 32)}`,
         );
       }
 

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -20,6 +20,7 @@ import {
   CollectionDecorator,
   SchemaUtils,
   TypeGetter,
+  ValidationError,
   parseDataUri,
 } from '@forestadmin/datasource-toolkit';
 import { filetypemime } from 'magic-bytes.js';
@@ -242,17 +243,31 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     return value;
   }
 
+  private parseHex(value: string): Buffer {
+    if (!/^([0-9a-f]{2})*$/i.test(value)) {
+      throw new ValidationError(
+        `Expected an even-length hex string for a binary field, got "${value}"`,
+      );
+    }
+
+    return Buffer.from(value, 'hex');
+  }
+
   private async convertScalar(
     toBackend: boolean,
     useHex: boolean,
     value: unknown,
   ): Promise<unknown> {
     if (toBackend) {
-      const string = value as string;
+      if (typeof value !== 'string') {
+        throw new ValidationError(
+          `Expected a string for a binary field, got ${typeof value}: ${JSON.stringify(value)}`,
+        );
+      }
 
-      if (useHex) return Buffer.from(string, 'hex');
+      if (useHex) return this.parseHex(value);
 
-      return parseDataUri(string).buffer;
+      return parseDataUri(value).buffer;
     }
 
     const buffer = value as Buffer;

--- a/packages/datasource-customizer/src/decorators/binary/collection.ts
+++ b/packages/datasource-customizer/src/decorators/binary/collection.ts
@@ -16,7 +16,12 @@ import type {
   RecordData,
 } from '@forestadmin/datasource-toolkit';
 
-import { CollectionDecorator, SchemaUtils, TypeGetter } from '@forestadmin/datasource-toolkit';
+import {
+  CollectionDecorator,
+  SchemaUtils,
+  TypeGetter,
+  ValidationError,
+} from '@forestadmin/datasource-toolkit';
 import { filetypemime } from 'magic-bytes.js';
 
 /**
@@ -245,7 +250,17 @@ export default class BinaryCollectionDecorator extends CollectionDecorator {
     if (toBackend) {
       const string = value as string;
 
-      return useHex ? Buffer.from(string, 'hex') : Buffer.from(string.split(',')[1], 'base64');
+      if (useHex) return Buffer.from(string, 'hex');
+
+      const payload = string.split(',')[1];
+
+      if (payload === undefined) {
+        throw new ValidationError(
+          `Expected a data uri of the form "data:<mime>;base64,<payload>", received "${string}"`,
+        );
+      }
+
+      return Buffer.from(payload, 'base64');
     }
 
     const buffer = value as Buffer;

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -8,6 +8,7 @@ import {
   Filter,
   PaginatedFilter,
   Projection,
+  ValidationError,
 } from '@forestadmin/datasource-toolkit';
 import * as factories from '@forestadmin/datasource-toolkit/dist/test/__factories__';
 
@@ -235,6 +236,20 @@ describe('BinaryCollectionDecorator', () => {
           },
         },
       ]);
+    });
+  });
+
+  describe('list filtering a binary column with a value that is not a data uri', () => {
+    it('should reject the filter instead of crashing on an undefined base64 payload', async () => {
+      const caller = factories.caller.build();
+      const filter = new PaginatedFilter({
+        conditionTree: new ConditionTreeLeaf('cover', 'Equal', 'Anthony'),
+      });
+
+      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
+        ValidationError,
+      );
+      expect(books.list).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -8,7 +8,6 @@ import {
   Filter,
   PaginatedFilter,
   Projection,
-  ValidationError,
 } from '@forestadmin/datasource-toolkit';
 import * as factories from '@forestadmin/datasource-toolkit/dist/test/__factories__';
 
@@ -239,54 +238,37 @@ describe('BinaryCollectionDecorator', () => {
     });
   });
 
-  describe('list filtering a binary column with a value that is not a data uri', () => {
-    it('should reject the filter instead of crashing on an undefined base64 payload', async () => {
+  describe('list filtering a binary column with a malformed value', () => {
+    it.each([
+      ['cover', 'Anthony', /must be a data uri/],
+      ['cover', 'data:text/plain,hello', /must be a data uri/],
+      ['id', 'Anthony', /hex string of full bytes/],
+      ['id', '303', /hex string of full bytes/],
+    ])(
+      'should reject %s = %p instead of querying the collection',
+      async (field, value, message) => {
+        const caller = factories.caller.build();
+        const filter = new PaginatedFilter({
+          conditionTree: new ConditionTreeLeaf(field, 'Equal', value),
+        });
+
+        await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
+          message,
+        );
+        expect(books.list).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should truncate a long value in the error message', async () => {
       const caller = factories.caller.build();
       const filter = new PaginatedFilter({
-        conditionTree: new ConditionTreeLeaf('cover', 'Equal', 'Anthony'),
+        conditionTree: new ConditionTreeLeaf('id', 'Equal', 'z'.repeat(5000)),
       });
 
       await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
-        ValidationError,
+        `Expected a hex string of full bytes for a binary field, got "${'z'.repeat(32)}"`,
       );
       expect(books.list).not.toHaveBeenCalled();
-    });
-
-    it('should reject a data uri that is not base64, rather than decode it to garbage', async () => {
-      const caller = factories.caller.build();
-      const filter = new PaginatedFilter({
-        conditionTree: new ConditionTreeLeaf('cover', 'Equal', 'data:text/plain,hello'),
-      });
-
-      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
-        /must be a data uri/,
-      );
-      expect(books.list).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('list filtering a hex binary column with a value that is not hex', () => {
-    it('should reject it rather than query for an empty buffer', async () => {
-      const caller = factories.caller.build();
-      const filter = new PaginatedFilter({
-        conditionTree: new ConditionTreeLeaf('id', 'Equal', 'Anthony'),
-      });
-
-      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
-        /even-length hex string/,
-      );
-      expect(books.list).not.toHaveBeenCalled();
-    });
-
-    it('should reject an odd-length hex string, which silently drops its last digit', async () => {
-      const caller = factories.caller.build();
-      const filter = new PaginatedFilter({
-        conditionTree: new ConditionTreeLeaf('id', 'Equal', '303'),
-      });
-
-      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
-        /even-length hex string/,
-      );
     });
   });
 
@@ -294,7 +276,9 @@ describe('BinaryCollectionDecorator', () => {
     it('should reject it with a validation error rather than an opaque TypeError', async () => {
       const caller = factories.caller.build();
 
-      await expect(decoratedBook.create(caller, [{ cover: 42 }])).rejects.toThrow(ValidationError);
+      await expect(decoratedBook.create(caller, [{ cover: 42 }])).rejects.toThrow(
+        'Expected a string for a binary field, got number: 42',
+      );
       expect(books.create).not.toHaveBeenCalled();
     });
 

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -259,9 +259,43 @@ describe('BinaryCollectionDecorator', () => {
       });
 
       await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
-        ValidationError,
+        /must be a data uri/,
       );
       expect(books.list).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list filtering a hex binary column with a value that is not hex', () => {
+    it('should reject it rather than query for an empty buffer', async () => {
+      const caller = factories.caller.build();
+      const filter = new PaginatedFilter({
+        conditionTree: new ConditionTreeLeaf('id', 'Equal', 'Anthony'),
+      });
+
+      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
+        /even-length hex string/,
+      );
+      expect(books.list).not.toHaveBeenCalled();
+    });
+
+    it('should reject an odd-length hex string, which silently drops its last digit', async () => {
+      const caller = factories.caller.build();
+      const filter = new PaginatedFilter({
+        conditionTree: new ConditionTreeLeaf('id', 'Equal', '303'),
+      });
+
+      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
+        /even-length hex string/,
+      );
+    });
+  });
+
+  describe('writing a non-string value into a binary column', () => {
+    it('should reject it with a validation error rather than an opaque TypeError', async () => {
+      const caller = factories.caller.build();
+
+      await expect(decoratedBook.create(caller, [{ cover: 42 }])).rejects.toThrow(ValidationError);
+      expect(books.create).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -110,7 +110,7 @@ describe('BinaryCollectionDecorator', () => {
           isPrimaryKey: true,
           columnType: 'String',
           validation: [
-            { operator: 'Match', value: /^[0-9a-f]+$/ },
+            { operator: 'Match', value: /^([0-9a-f]{2})+$/i },
             { operator: 'LongerThan', value: 31 },
             { operator: 'ShorterThan', value: 33 },
             { operator: 'Present' },
@@ -141,7 +141,7 @@ describe('BinaryCollectionDecorator', () => {
       expect(decoratedBook.schema.fields.cover).toEqual(
         expect.objectContaining({
           columnType: 'String',
-          validation: [{ operator: 'Match', value: /^[0-9a-f]+$/ }],
+          validation: [{ operator: 'Match', value: /^([0-9a-f]{2})+$/i }],
         }),
       );
     });

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -297,6 +297,16 @@ describe('BinaryCollectionDecorator', () => {
       await expect(decoratedBook.create(caller, [{ cover: 42 }])).rejects.toThrow(ValidationError);
       expect(books.create).not.toHaveBeenCalled();
     });
+
+    it('should let a buffer through, as it needs no conversion', async () => {
+      const caller = factories.caller.build();
+      const id = Buffer.from('0000', 'ascii');
+      (books.create as jest.Mock).mockResolvedValue([{ id }]);
+
+      await decoratedBook.create(caller, [{ id }]);
+
+      expect(books.create).toHaveBeenCalledWith(caller, [{ id }]);
+    });
   });
 
   describe('list with a more complex filter', () => {

--- a/packages/datasource-customizer/test/decorators/binary/collection.test.ts
+++ b/packages/datasource-customizer/test/decorators/binary/collection.test.ts
@@ -251,6 +251,18 @@ describe('BinaryCollectionDecorator', () => {
       );
       expect(books.list).not.toHaveBeenCalled();
     });
+
+    it('should reject a data uri that is not base64, rather than decode it to garbage', async () => {
+      const caller = factories.caller.build();
+      const filter = new PaginatedFilter({
+        conditionTree: new ConditionTreeLeaf('cover', 'Equal', 'data:text/plain,hello'),
+      });
+
+      await expect(decoratedBook.list(caller, filter, new Projection('id'))).rejects.toThrow(
+        ValidationError,
+      );
+      expect(books.list).not.toHaveBeenCalled();
+    });
   });
 
   describe('list with a more complex filter', () => {


### PR DESCRIPTION
## What

A `Binary` column filtered or written with a malformed value now raises `ValidationError` instead of crashing or converting the wrong bytes.

| Input | Before | After |
| --- | --- | --- |
| `'Anthony'` on a datauri column | `TypeError`, untyped → 500 | `ValidationError` |
| `'Anthony'` on a hex column (every Binary PK/FK) | **empty buffer, wrong results, no error** | `ValidationError` |
| `'data:text/plain,hello'` | decoded to garbage (`85e965`) | `ValidationError` |
| `42` | `TypeError`, untyped → 500 | `ValidationError` |

## Why

`convertScalar` assumed its input was always a well-formed datauri or hex string. It isn't: the value comes from a filter or a record patch, so anything can arrive.

`Buffer.from('Anthony'.split(',')[1], 'base64')` throws a raw `TypeError` — no HTTP status, so it surfaces as a generic 500 and the caller never learns what to send instead.

The hex branch was worse than the crash: `Buffer.from` never throws on bad hex, it stops at the first invalid character. `'Anthony'` yields an **empty buffer**, so a filter on a Binary primary key silently queried for an empty blob and returned wrong results with no error at all. `shouldUseHex` defaults to true for every primary and foreign key, so that was the common path.

## How

- a `Buffer` passes through untouched: it needs no conversion, and `Buffer.from(buf, 'hex')` already returned it verbatim
- any other non-string value rejected up front instead of being cast
- datauri branch delegates to the toolkit's `parseDataUri`, dropping a hand-rolled split that missed its hardening
- hex branch gets `HEX_BYTES` = `/^([0-9a-f]{2})+$/i` — odd lengths included, since `Buffer.from('303','hex')` silently drops a digit
- `replaceValidation` now advertises that same `HEX_BYTES`. It used to advertise `/^[0-9a-f]+$/`, which disagreed with the parser in both directions: `'303'` passed frontend validation then 400'd, and `'0F'` was blocked by the frontend though the backend accepts it
- rejected values are truncated to 32 characters in the message, like `parseDataUri` does — a `ValidationError` message is returned verbatim to the client

Tests assert the message (not just the class) and that the underlying collection was never called.

## Heads-up: writes are stricter too

`create`/`update` go through the same conversion. Three datauri forms that previously reached the database now raise: a raw comma in a `name=` media type, `data:base64,…` with no semicolon, and uppercase `BASE64` (`parseDataUri` is case-sensitive, RFC 2397 is not).

A raw `Buffer` is **not** affected: on a hex column it used to round-trip through `Buffer.from(buf, 'hex')`, and it still does. That is the `Buffer.isBuffer` passthrough above.

These rules come from `parseDataUri`, which already applies them to the S3 plugin's write path. If the uppercase form matters, fix it there for every caller rather than special-casing this decorator.

## Test

```bash
yarn workspace @forestadmin/datasource-customizer test -- test/decorators/binary/collection.test.ts
```

Also verified against a live agent: the same filter went from an opaque 500 to a 400 naming the expected format.

## Known limitation

`convertValueHelper` guards with `if (value)`, so `''`, `0` and `false` still bypass the conversion entirely and reach the connector unconverted. That predates this PR and is unchanged here; `Equal ''` on a Binary column can still produce the 500 class this PR narrows. Left out to keep the diff to the reported crash.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made

