### PR TITLE
fix(workflow-executor): report invalid step definitions instead of dropping or coercing them

### DIFF
--- a/packages/workflow-executor/src/adapters/step-definition-mapper.ts
+++ b/packages/workflow-executor/src/adapters/step-definition-mapper.ts
@@ -4,6 +4,7 @@ import type {
   ServerWorkflowTask,
 } from './server-types';
 import type { ConditionStepDefinition, StepDefinition } from '../types/validated/step-definition';
+import type { z } from 'zod';
 
 import { ServerTaskTypeEnum } from './server-types';
 import { InvalidStepDefinitionError, UnsupportedStepTypeError } from '../errors';
@@ -18,41 +19,62 @@ import {
   UpdateRecordStepDefinitionSchema,
 } from '../types/validated/step-definition';
 
+// A bare ZodError escaping this mapper is logged-and-dropped by the port's getAvailableRuns
+// (only WorkflowExecutorError instances are reported as malformed), leaving the run silently
+// re-fetched on every poll — wrap parse failures so the run is reported to the orchestrator.
+function parseStepDefinition<Schema extends z.ZodType>(
+  schema: Schema,
+  input: unknown,
+): z.infer<Schema> {
+  const result = schema.safeParse(input);
+  if (result.success) return result.data;
+
+  const detail = result.error.issues
+    .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ');
+
+  throw new InvalidStepDefinitionError(detail);
+}
+
 function mapTask(task: ServerWorkflowTask): StepDefinition {
   // executionType is passed through as-is. Each schema applies its own `.default()` for a missing
-  // value; schemas that accept `manual` (guidance, load-related, trigger-action) drop `.catch` and
-  // reject an out-of-enum value rather than coercing it — server values are a 1:1 enum mapping today.
+  // value; schemas that accept `manual` (guidance, load-related, trigger-action) drop `.catch`
+  // and reject an out-of-enum value rather than coercing it — server values are a 1:1 enum
+  // mapping today.
   const base = { prompt: task.prompt, executionType: task.executionType, title: task.title };
 
   switch (task.taskType) {
     case ServerTaskTypeEnum.McpServer:
-      return McpStepDefinitionSchema.parse({
+      return parseStepDefinition(McpStepDefinitionSchema, {
         ...base,
         type: StepType.Mcp,
         mcpServerId: task.mcpServerId,
       });
     case ServerTaskTypeEnum.Guideline:
-      return GuidanceStepDefinitionSchema.parse({ ...base, type: StepType.Guidance });
+      return parseStepDefinition(GuidanceStepDefinitionSchema, {
+        ...base,
+        type: StepType.Guidance,
+      });
     case ServerTaskTypeEnum.GetData:
-      return ReadRecordStepDefinitionSchema.parse({
+      return parseStepDefinition(ReadRecordStepDefinitionSchema, {
         ...base,
         type: StepType.ReadRecord,
         preRecordedArgs: task.preRecordedArgs,
       });
     case ServerTaskTypeEnum.UpdateData:
-      return UpdateRecordStepDefinitionSchema.parse({
+      return parseStepDefinition(UpdateRecordStepDefinitionSchema, {
         ...base,
         type: StepType.UpdateRecord,
         preRecordedArgs: task.preRecordedArgs,
       });
     case ServerTaskTypeEnum.TriggerAction:
-      return TriggerActionStepDefinitionSchema.parse({
+      return parseStepDefinition(TriggerActionStepDefinitionSchema, {
         ...base,
         type: StepType.TriggerAction,
         preRecordedArgs: task.preRecordedArgs,
       });
     case ServerTaskTypeEnum.LoadRelatedRecord:
-      return LoadRelatedRecordStepDefinitionSchema.parse({
+      return parseStepDefinition(LoadRelatedRecordStepDefinitionSchema, {
         ...base,
         type: StepType.LoadRelatedRecord,
         preRecordedArgs: task.preRecordedArgs,
@@ -75,7 +97,7 @@ function mapCondition(condition: ServerWorkflowCondition): ConditionStepDefiniti
     );
   }
 
-  return ConditionStepDefinitionSchema.parse({
+  return parseStepDefinition(ConditionStepDefinitionSchema, {
     type: StepType.Condition,
     prompt: condition.prompt,
     executionType: condition.executionType,

--- a/packages/workflow-executor/src/types/validated/step-definition.ts
+++ b/packages/workflow-executor/src/types/validated/step-definition.ts
@@ -21,8 +21,9 @@ export enum StepExecutionMode {
 }
 
 // Shared fields across all step types. executionType is intentionally excluded —
-// each schema declares its own valid modes (most with .default().catch() for normalization;
-// guidance deliberately omits .catch to fail loud on an unknown mode).
+// each schema declares its own valid modes (read/update/mcp normalize with .default().catch();
+// condition, trigger-action, load-related-record and guidance deliberately omit .catch to fail
+// loud on an unknown mode).
 // The orchestrator serializes missing BPMN attributes as JSON null (DOM getAttribute), not as
 // absent keys — accept both and normalize to undefined.
 const optionalString = z
@@ -42,7 +43,10 @@ const { Manual, AutomatedWithConfirmation, FullyAutomated } = StepExecutionMode;
 export const ConditionStepDefinitionSchema = z.object({
   ...sharedFields,
   type: z.literal(StepType.Condition),
-  executionType: z.enum([Manual, FullyAutomated]).default(FullyAutomated).catch(FullyAutomated),
+  // NO `.catch` — coercing an unknown mode (e.g. a future `deterministic` from a newer
+  // orchestrator) to FullyAutomated would silently let the AI decide instead of the conditions
+  // the builder configured precisely because they don't trust the AI.
+  executionType: z.enum([Manual, FullyAutomated]).default(FullyAutomated),
   options: z.array(z.string()).min(2),
 });
 export type ConditionStepDefinition = z.infer<typeof ConditionStepDefinitionSchema>;

--- a/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
+++ b/packages/workflow-executor/test/adapters/step-definition-mapper.test.ts
@@ -146,7 +146,7 @@ describe('toStepDefinition', () => {
     it('rejects an mcp-server task missing mcpServerId at the zod boundary', () => {
       const task = makeTask({ taskType: ServerTaskTypeEnum.McpServer, prompt: 'run mcp' });
 
-      expect(() => toStepDefinition(task)).toThrow();
+      expect(() => toStepDefinition(task)).toThrow(InvalidStepDefinitionError);
     });
 
     it('should map task with guideline taskType to guidance', () => {
@@ -307,6 +307,22 @@ describe('toStepDefinition', () => {
       expect(toStepDefinition(condition)).toMatchObject({
         executionType: ServerStepExecutionTypeEnum.Manual,
       });
+    });
+
+    // A newer orchestrator may send a deterministic mode this executor version does not know.
+    // The `.catch(FullyAutomated)` that used to sit on the condition schema would have silently
+    // handed the decision to the AI; the mapper must reject the run as malformed instead.
+    it('should throw InvalidStepDefinitionError for an unknown executionType instead of coercing to Full AI', () => {
+      const condition = makeCondition(
+        [
+          { stepId: 's1', buttonText: null, answer: 'Yes' },
+          { stepId: 's2', buttonText: null, answer: 'No' },
+        ],
+        { executionType: 'deterministic' as ServerWorkflowCondition['executionType'] },
+      );
+
+      expect(() => toStepDefinition(condition)).toThrow(InvalidStepDefinitionError);
+      expect(() => toStepDefinition(condition)).toThrow(/executionType/);
     });
 
     it('should throw InvalidStepDefinitionError when fewer than 2 options', () => {

--- a/packages/workflow-executor/test/types/step-definition.test.ts
+++ b/packages/workflow-executor/test/types/step-definition.test.ts
@@ -1,9 +1,41 @@
 import {
+  ConditionStepDefinitionSchema,
   GuidanceStepDefinitionSchema,
   LoadRelatedRecordStepDefinitionSchema,
   StepExecutionMode,
   StepType,
 } from '../../src/types/validated/step-definition';
+
+describe('ConditionStepDefinitionSchema executionType', () => {
+  const base = { type: StepType.Condition as const, options: ['Yes', 'No'] };
+
+  it('parses each valid execution mode to its own value', () => {
+    expect(
+      ConditionStepDefinitionSchema.parse({ ...base, executionType: 'manual' }).executionType,
+    ).toBe(StepExecutionMode.Manual);
+    expect(
+      ConditionStepDefinitionSchema.parse({ ...base, executionType: 'fully-automated' })
+        .executionType,
+    ).toBe(StepExecutionMode.FullyAutomated);
+  });
+
+  it('defaults a missing executionType to FullyAutomated', () => {
+    expect(ConditionStepDefinitionSchema.parse(base).executionType).toBe(
+      StepExecutionMode.FullyAutomated,
+    );
+  });
+
+  // No `.catch` on the enum: an unknown value must be rejected, not silently coerced to
+  // FullyAutomated (which would let the AI decide in place of a future deterministic mode).
+  it('rejects an invalid executionType instead of coercing it', () => {
+    expect(
+      ConditionStepDefinitionSchema.safeParse({ ...base, executionType: 'deterministic' }).success,
+    ).toBe(false);
+    expect(
+      ConditionStepDefinitionSchema.safeParse({ ...base, executionType: 'not-a-mode' }).success,
+    ).toBe(false);
+  });
+});
 
 describe('LoadRelatedRecordStepDefinitionSchema executionType', () => {
   const base = { type: StepType.LoadRelatedRecord as const };


### PR DESCRIPTION
## Why

**Before** — an invalid step definition passed silently: either **coerced** (`.catch` turned an unknown `executionType` into Full AI, so the AI decided in the builder's place) or **dropped** (a bare `ZodError` was logged but never reported, so the run stayed pending and came back on every poll, forever).

**After** — both raise `InvalidStepDefinitionError`, which is reported to the orchestrator as a step error: the run stops with a message instead of continuing on a wrong decision or looping unseen.

Two ways an invalid step definition went unreported, and they have to be fixed together.

**Coerced.** A condition step whose `executionType` was outside the schema enum did not fail: the schema's `.catch(FullyAutomated)` substituted Full AI. No error, no log, the run completed — with the AI having taken a decision the builder configured precisely so the AI would not.

**Dropped.** Any other schema violation (missing `mcpServerId`, a condition with fewer than two options, an unknown operator, malformed `preRecordedArgs`) threw a bare `ZodError`. `getAvailableRuns` only reports `WorkflowExecutorError` as malformed, so a `ZodError` was logged and discarded — nothing reached the orchestrator, the run's state never changed, and it came back on every poll. One error line per poll, forever, with no terminal state.

They are a pair: dropping `.catch` on its own would have turned the silent AI decision into a silent poll loop. Wrapping the parses is what makes the throw actually get reported.

Motivated by PRD-472 (an outdated executor receiving `'deterministic'`), but it stands on its own — that value is no longer on the wire, and both bugs predate the feature.

## What

- `ConditionStepDefinitionSchema.executionType`: dropped `.catch(FullyAutomated)` (kept `.default` for missing values) — unknown values now reject loudly, matching the trigger-action/load-related/guidance no-`.catch` precedent.
- All step-definition mapper parses are wrapped in `InvalidStepDefinitionError`: a bare ZodError was only logged by `getAvailableRuns` and the run silently re-fetched every poll; it is now reported to the orchestrator as a malformed run.
- Tests: condition schema 3-test template (valid modes / default / rejects unknown incl. `'deterministic'`), mapper rejection test, and the mcp missing-`mcpServerId` assertion tightened to pin the mapTask wrapping.

Part of PRD-472. `'deterministic'` is intentionally NOT added to `StepExecutionMode`, and never will be: the mode was dropped from the wire contract, so a condition step is deterministic iff it carries `preRecordedArgs.optionConditions`. Rejecting the value stays the correct behaviour.

## Tests

Full workflow-executor suite: 1514 passed / 0 failed. Red-check: with src changes stashed, exactly the new behavioral tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unknown `executionType` values in condition step definitions instead of coercing to FullyAutomated
> - Removes `.catch(FullyAutomated)` from `ConditionStepDefinitionSchema` so that an unrecognized `executionType` now throws an error rather than silently coercing to `FullyAutomated`. Missing `executionType` still defaults to `FullyAutomated`.
> - Adds a `parseStepDefinition` helper in [step-definition-mapper.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1836/files#diff-b7de2aee7747c46286af27c1dac9169be8f2469b8a2bebe327065e1cc51efe02) that wraps `schema.safeParse` and converts Zod failures into `InvalidStepDefinitionError` with formatted issue details.
> - Replaces direct `.parse()` calls across all task and condition handlers with the new helper, so validation errors surface as `InvalidStepDefinitionError` instead of raw `ZodError`.
> - Behavioral Change: previously unknown `executionType` values were silently accepted; they now cause a hard failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 940a009.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->