### PR TITLE
fix(agent): serve only the columns of collections the caller may read

### DIFF
--- a/packages/agent/src/routes/access/chart.ts
+++ b/packages/agent/src/routes/access/chart.ts
@@ -1,5 +1,6 @@
 import type {
   Caller,
+  Collection,
   ConditionTreeBranch,
   DateOperation,
   Filter,
@@ -29,6 +30,7 @@ import { DateTime } from 'luxon';
 import { v1 as uuidv1 } from 'uuid';
 
 import ContextFilterFactory from '../../utils/context-filter-factory';
+import FieldPathUtils from '../../utils/field-path';
 import QueryStringParser from '../../utils/query-string';
 import CollectionRoute from '../collection-route';
 
@@ -66,6 +68,8 @@ export default class ChartRoute extends CollectionRoute {
       renderingId,
       chartRequest,
     });
+
+    await this.services.authorization.assertCanReadQueryFields(context, this.collection);
 
     switch (chartRequest.type) {
       case ChartType.Value:
@@ -120,6 +124,11 @@ export default class ChartRoute extends CollectionRoute {
       aggregateFieldName: aggregateField,
     } = <PieChart>context.request.body;
 
+    await this.assertCanReadAggregatedFields(context, this.collection, [
+      ['group a chart by', groupByField],
+      ['aggregate a chart on', aggregateField],
+    ]);
+
     const rows = await this.collection.aggregate(
       QueryStringParser.parseCaller(context),
       await this.getFilter(context),
@@ -143,6 +152,11 @@ export default class ChartRoute extends CollectionRoute {
       groupByFieldName: groupByDateField,
       timeRange,
     } = <LineChart>context.request.body;
+
+    await this.assertCanReadAggregatedFields(context, this.collection, [
+      ['group a chart by', groupByDateField],
+      ['aggregate a chart on', aggregateField],
+    ]);
 
     const filter = await this.getFilter(context);
     const filterOnlyWithValues = filter.override({
@@ -233,9 +247,25 @@ export default class ChartRoute extends CollectionRoute {
     }
 
     if (collection && filter && aggregation) {
-      const rows = await this.dataSource
-        .getCollection(collection)
-        .aggregate(QueryStringParser.parseCaller(context), filter, aggregation, Number(body.limit));
+      const aggregatedCollection = this.dataSource.getCollection(collection);
+
+      await this.assertCanReadAggregatedFields(context, aggregatedCollection, [
+        ['group a leaderboard by', aggregation.groups[0].field],
+        ['aggregate a leaderboard on', aggregation.field],
+      ]);
+
+      // A count exposes the cardinality of the relation, which `/relationships/<name>/count` puts
+      // behind `browse`.
+      if (!aggregation.field) {
+        await this.services.authorization.assertCanBrowse(context, field.foreignCollection);
+      }
+
+      const rows = await aggregatedCollection.aggregate(
+        QueryStringParser.parseCaller(context),
+        filter,
+        aggregation,
+        Number(body.limit),
+      );
 
       return rows.map(row => ({
         key: row.group[aggregation.groups[0].field] as string,
@@ -254,6 +284,10 @@ export default class ChartRoute extends CollectionRoute {
     );
     const aggregation = new Aggregation({ operation: aggregator, field: aggregateField });
 
+    await this.assertCanReadAggregatedFields(context, this.collection, [
+      ['aggregate a chart on', aggregateField],
+    ]);
+
     const rows = await this.collection.aggregate(
       QueryStringParser.parseCaller(context),
       filter,
@@ -261,6 +295,24 @@ export default class ChartRoute extends CollectionRoute {
     );
 
     return rows.length ? (rows[0].value as number) : 0;
+  }
+
+  private async assertCanReadAggregatedFields(
+    context: Context,
+    collection: Collection,
+    fields: Array<[action: string, path: string]>,
+  ): Promise<void> {
+    await this.services.authorization.assertCanReadUsages(
+      context,
+      this.collection.name,
+      fields
+        .filter(([, path]) => path)
+        .map(([action, path]) => ({
+          action,
+          path,
+          collectionName: FieldPathUtils.getLeafCollection(collection, path).name,
+        })),
+    );
   }
 
   private async getFilter(context: Context): Promise<Filter> {

--- a/packages/agent/src/routes/access/chart.ts
+++ b/packages/agent/src/routes/access/chart.ts
@@ -69,7 +69,10 @@ export default class ChartRoute extends CollectionRoute {
       chartRequest,
     });
 
-    await this.services.authorization.assertCanReadQueryFields(context, this.collection);
+    await this.services.authorization.assertCanReadQueryFields(context, this.collection, [
+      'filter',
+      'search',
+    ]);
 
     switch (chartRequest.type) {
       case ChartType.Value:

--- a/packages/agent/src/routes/access/chart.ts
+++ b/packages/agent/src/routes/access/chart.ts
@@ -299,7 +299,7 @@ export default class ChartRoute extends CollectionRoute {
 
   private async assertCanReadAggregatedFields(
     context: Context,
-    collection: Collection,
+    pathCollection: Collection,
     fields: Array<[action: string, path: string]>,
   ): Promise<void> {
     await this.services.authorization.assertCanReadUsages(
@@ -310,7 +310,7 @@ export default class ChartRoute extends CollectionRoute {
         .map(([action, path]) => ({
           action,
           path,
-          collectionName: FieldPathUtils.getLeafCollection(collection, path).name,
+          collectionName: FieldPathUtils.getLeafCollection(pathCollection, path).name,
         })),
     );
   }

--- a/packages/agent/src/routes/access/count-related.ts
+++ b/packages/agent/src/routes/access/count-related.ts
@@ -20,7 +20,10 @@ export default class CountRelatedRoute extends RelationRoute {
     await this.services.authorization.assertCanBrowse(context, this.foreignCollection.name);
 
     if (this.foreignCollection.schema.countable) {
-      await this.services.authorization.assertCanReadQueryFields(context, this.foreignCollection);
+      await this.services.authorization.assertCanReadQueryFields(context, this.foreignCollection, [
+        'filter',
+        'search',
+      ]);
 
       const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
       const scope = await this.services.authorization.getScope(this.foreignCollection, context);

--- a/packages/agent/src/routes/access/count-related.ts
+++ b/packages/agent/src/routes/access/count-related.ts
@@ -20,6 +20,8 @@ export default class CountRelatedRoute extends RelationRoute {
     await this.services.authorization.assertCanBrowse(context, this.foreignCollection.name);
 
     if (this.foreignCollection.schema.countable) {
+      await this.services.authorization.assertCanReadQueryFields(context, this.foreignCollection);
+
       const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
       const scope = await this.services.authorization.getScope(this.foreignCollection, context);
       const caller = QueryStringParser.parseCaller(context);

--- a/packages/agent/src/routes/access/count.ts
+++ b/packages/agent/src/routes/access/count.ts
@@ -16,7 +16,10 @@ export default class CountRoute extends CollectionRoute {
     await this.services.authorization.assertCanBrowse(context, this.collection.name);
 
     if (this.collection.schema.countable) {
-      await this.services.authorization.assertCanReadQueryFields(context, this.collection);
+      await this.services.authorization.assertCanReadQueryFields(context, this.collection, [
+        'filter',
+        'search',
+      ]);
 
       const scope = await this.services.authorization.getScope(this.collection, context);
       const caller = QueryStringParser.parseCaller(context);

--- a/packages/agent/src/routes/access/count.ts
+++ b/packages/agent/src/routes/access/count.ts
@@ -16,6 +16,8 @@ export default class CountRoute extends CollectionRoute {
     await this.services.authorization.assertCanBrowse(context, this.collection.name);
 
     if (this.collection.schema.countable) {
+      await this.services.authorization.assertCanReadQueryFields(context, this.collection);
+
       const scope = await this.services.authorization.getScope(this.collection, context);
       const caller = QueryStringParser.parseCaller(context);
       let filter = ContextFilterFactory.build(this.collection, context, scope);

--- a/packages/agent/src/routes/access/csv-related.ts
+++ b/packages/agent/src/routes/access/csv-related.ts
@@ -23,13 +23,20 @@ export default class CsvRelatedRoute extends RelationRoute {
   async handleRelatedCsv(context: Context): Promise<void> {
     await this.services.authorization.assertCanBrowse(context, this.foreignCollection.name);
     await this.services.authorization.assertCanExport(context, this.foreignCollection.name);
+    await this.services.authorization.assertCanReadQueryFields(context, this.foreignCollection);
 
-    const { header } = context.request.query as Record<string, string>;
+    const { header: requestedHeader } = context.request.query as Record<string, string>;
 
-    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
+    const requested = QueryStringParser.parseProjectionFromHeaderOrQuery(
       this.foreignCollection,
       context,
     );
+    const projection = await this.services.authorization.redactProjection(
+      context,
+      this.foreignCollection,
+      requested,
+    );
+    const header = CsvGenerator.filterHeader(requestedHeader, requested.projection, projection);
     const scope = await this.services.authorization.getScope(this.foreignCollection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.foreignCollection, context, scope);

--- a/packages/agent/src/routes/access/csv.ts
+++ b/packages/agent/src/routes/access/csv.ts
@@ -17,10 +17,17 @@ export default class CsvRoute extends CollectionRoute {
   async handleCsv(context: Context): Promise<void> {
     await this.services.authorization.assertCanBrowse(context, this.collection.name);
     await this.services.authorization.assertCanExport(context, this.collection.name);
+    await this.services.authorization.assertCanReadQueryFields(context, this.collection);
 
-    const { header } = context.request.query as Record<string, string>;
+    const { header: requestedHeader } = context.request.query as Record<string, string>;
 
-    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
+    const requested = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
+    const projection = await this.services.authorization.redactProjection(
+      context,
+      this.collection,
+      requested,
+    );
+    const header = CsvGenerator.filterHeader(requestedHeader, requested.projection, projection);
     const scope = await this.services.authorization.getScope(this.collection, context);
     const caller = QueryStringParser.parseCaller(context);
     const filter = ContextFilterFactory.buildPaginated(this.collection, context, scope);

--- a/packages/agent/src/routes/access/get.ts
+++ b/packages/agent/src/routes/access/get.ts
@@ -24,7 +24,11 @@ export default class GetRoute extends CollectionRoute {
       ),
     });
 
-    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
+    const projection = await this.services.authorization.redactProjection(
+      context,
+      this.collection,
+      QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context),
+    );
 
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),

--- a/packages/agent/src/routes/access/list-related.ts
+++ b/packages/agent/src/routes/access/list-related.ts
@@ -18,6 +18,7 @@ export default class ListRelatedRoute extends RelationRoute {
 
   public async handleListRelated(context: Context): Promise<void> {
     await this.services.authorization.assertCanBrowse(context, this.foreignCollection.name);
+    await this.services.authorization.assertCanReadQueryFields(context, this.foreignCollection);
 
     const parentId = IdUtils.unpackId(this.collection.schema, context.params.parentId);
     const scope = await this.services.authorization.getScope(this.foreignCollection, context);
@@ -27,9 +28,10 @@ export default class ListRelatedRoute extends RelationRoute {
       scope,
     );
 
-    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(
-      this.foreignCollection,
+    const projection = await this.services.authorization.redactProjection(
       context,
+      this.foreignCollection,
+      QueryStringParser.parseProjectionFromHeaderOrQuery(this.foreignCollection, context),
     );
 
     const records = await CollectionUtils.listRelation(

--- a/packages/agent/src/routes/access/list.ts
+++ b/packages/agent/src/routes/access/list.ts
@@ -12,6 +12,7 @@ export default class ListRoute extends CollectionRoute {
 
   public async handleList(context: Context) {
     await this.services.authorization.assertCanBrowse(context, this.collection.name);
+    await this.services.authorization.assertCanReadQueryFields(context, this.collection);
 
     const scope = await this.services.authorization.getScope(this.collection, context);
     let paginatedFilter = ContextFilterFactory.buildPaginated(this.collection, context, scope);
@@ -20,7 +21,11 @@ export default class ListRoute extends CollectionRoute {
       paginatedFilter,
     );
 
-    const projection = QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context);
+    const projection = await this.services.authorization.redactProjection(
+      context,
+      this.collection,
+      QueryStringParser.parseProjectionFromHeaderOrQuery(this.collection, context),
+    );
 
     const records = await this.collection.list(
       QueryStringParser.parseCaller(context),

--- a/packages/agent/src/routes/modification/update.ts
+++ b/packages/agent/src/routes/modification/update.ts
@@ -40,7 +40,10 @@ export default class UpdateRoute extends CollectionRoute {
     const [updateResult] = await this.collection.list(
       caller,
       new Filter({ conditionTree }),
-      ProjectionFactory.all(this.collection),
+      await this.services.authorization.redactProjection(context, this.collection, {
+        projection: ProjectionFactory.all(this.collection),
+        explicit: false,
+      }),
     );
 
     context.response.body = this.services.serializer.serialize(this.collection, updateResult);

--- a/packages/agent/src/routes/modification/update.ts
+++ b/packages/agent/src/routes/modification/update.ts
@@ -42,7 +42,7 @@ export default class UpdateRoute extends CollectionRoute {
       new Filter({ conditionTree }),
       await this.services.authorization.redactProjection(context, this.collection, {
         projection: ProjectionFactory.all(this.collection),
-        explicit: false,
+        namedByCaller: false,
       }),
     );
 

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -1,8 +1,9 @@
+import type { RequestedProjection } from '../../utils/query-string';
 import type { Collection, ConditionTree } from '@forestadmin/datasource-toolkit';
 import type { ForestAdminClient } from '@forestadmin/forestadmin-client';
 import type { Context } from 'koa';
 
-import { UnprocessableError } from '@forestadmin/datasource-toolkit';
+import { ForbiddenError, Projection, UnprocessableError } from '@forestadmin/datasource-toolkit';
 import {
   ChainedSQLQueryError,
   CollectionActionEvent,
@@ -12,6 +13,10 @@ import {
 
 import { HttpCode } from '../../types';
 import ConditionTreeParser from '../../utils/condition-tree-parser';
+import FieldPathUtils from '../../utils/field-path';
+import QueryStringParser from '../../utils/query-string';
+
+type FieldUsage = { action: string; path: string; collectionName: string };
 
 export default class AuthorizationService {
   constructor(private readonly forestAdminClient: ForestAdminClient) {}
@@ -38,6 +43,121 @@ export default class AuthorizationService {
 
   public async assertCanExport(context: Context, collectionName: string) {
     await this.assertCanOnCollection(CollectionActionEvent.Export, context, collectionName);
+  }
+
+  public async canRead(context: Context, collectionName: string): Promise<boolean> {
+    return this.forestAdminClient.permissionService.canOnCollection({
+      userId: context.state.user.id,
+      event: CollectionActionEvent.Read,
+      collectionName,
+    });
+  }
+
+  /**
+   * An unnamed field is redacted rather than refused: `ProjectionFactory.all` expands every column
+   * of every to-one relation when no `fields[]` is sent, so refusing would turn an ordinary
+   * listing into a 403.
+   */
+  public async redactProjection(
+    context: Context,
+    collection: Collection,
+    requested: RequestedProjection,
+  ): Promise<Projection> {
+    const { projection, explicit } = requested;
+    const owners = projection.map(path => FieldPathUtils.getLeafCollection(collection, path).name);
+    const permissions = await this.getReadPermissions(context, collection.name, owners);
+    const isReadable = (index: number) => permissions.get(owners[index]);
+
+    if (explicit) {
+      const denied = projection
+        .map((field, index) => ({ field, collection: owners[index] }))
+        .filter((_, index) => !isReadable(index));
+
+      if (denied.length) {
+        const fields = denied
+          .map(({ field, collection: name }) => `'${field}' from the '${name}' collection`)
+          .join(', ');
+
+        throw new ForbiddenError(`You are not allowed to read ${fields}.`);
+      }
+    }
+
+    return new Projection(...projection.filter((_, index) => isReadable(index)));
+  }
+
+  /**
+   * Refused rather than redacted: dropping a condition widens the result set and dropping a sort
+   * clause silently reorders it, while both leak the value they touch anyway — a `starts_with`
+   * filter answers one guess per request without returning a column of its own.
+   */
+  public async assertCanReadQueryFields(context: Context, collection: Collection): Promise<void> {
+    const usages: FieldUsage[] = [];
+    const push = (action: string, path: string) =>
+      usages.push({
+        action,
+        path,
+        collectionName: FieldPathUtils.getLeafCollection(collection, path).name,
+      });
+
+    QueryStringParser.parseConditionTree(collection, context)?.forEachLeaf(leaf =>
+      push('filter on', leaf.field),
+    );
+
+    for (const { field } of QueryStringParser.parseSort(collection, context)) {
+      push('sort on', field);
+    }
+
+    if (
+      QueryStringParser.parseSearch(collection, context) &&
+      QueryStringParser.parseSearchExtended(context)
+    ) {
+      for (const [name, field] of Object.entries(collection.schema.fields)) {
+        if (field.type === 'ManyToOne' || field.type === 'OneToOne') {
+          usages.push({
+            action: 'run an extended search through',
+            path: name,
+            collectionName: field.foreignCollection,
+          });
+        }
+      }
+    }
+
+    await this.assertCanReadUsages(context, collection.name, usages);
+  }
+
+  public async assertCanReadUsages(
+    context: Context,
+    rootCollectionName: string,
+    usages: FieldUsage[],
+  ): Promise<void> {
+    const permissions = await this.getReadPermissions(
+      context,
+      rootCollectionName,
+      usages.map(usage => usage.collectionName),
+    );
+    const denied = usages.find(usage => !permissions.get(usage.collectionName));
+
+    if (denied) {
+      throw new ForbiddenError(
+        `You cannot ${denied.action} '${denied.path}': you are not allowed to read the ` +
+          `'${denied.collectionName}' collection.`,
+      );
+    }
+  }
+
+  /** The root is skipped: its own route already asserts `browse` on a listing, `read` on a get. */
+  private async getReadPermissions(
+    context: Context,
+    rootCollectionName: string,
+    collectionNames: string[],
+  ): Promise<Map<string, boolean>> {
+    const toCheck = [...new Set(collectionNames)].filter(name => name !== rootCollectionName);
+    const allowed = await Promise.all(toCheck.map(name => this.canRead(context, name)));
+
+    return new Map<string, boolean>([
+      [rootCollectionName, true],
+      ...toCheck.map((name, index): [string, boolean] => [name, allowed[index]]),
+    ]);
   }
 
   private async assertCanOnCollection(

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -151,7 +151,7 @@ export default class AuthorizationService {
     }
   }
 
-  /** The root is skipped: its own route already asserts `browse` on a listing, `read` on a get. */
+  /** The root is skipped: `browse` gates a listing, `read` a get, and the signed hash a chart. */
   private async getReadPermissions(
     context: Context,
     rootCollectionName: string,

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -133,11 +133,21 @@ export default class AuthorizationService {
 
     if (search) {
       // Asked whatever the extended flag: `relation.column:term` is end-user syntax and reaches a
-      // relation without it. An unknown answer serves the request — the `replaceSearch` exemption.
-      const searched = (collection as CollectionDecorator).getSearchedFields?.(
-        search,
-        QueryStringParser.parseSearchExtended(context),
-      );
+      // relation without it.
+      const extended = QueryStringParser.parseSearchExtended(context);
+      const searched = (collection as CollectionDecorator).getSearchedFields?.(search, extended);
+
+      // An unknown footprint is a `replaceSearch` handler choosing its own fields. On a plain
+      // search the caller aimed at nothing, so it is served — the same category as a scope, and
+      // refusing would remove search from every customized collection. The extended flag is the
+      // caller's own, though: running one term both ways isolates the rows matched through a
+      // relation, a bit per term on collections no check covered. The exemption stops there.
+      if (!searched && extended) {
+        throw new ForbiddenError(
+          `You cannot run an extended search on the '${collection.name}' collection: the fields ` +
+            'it reaches cannot be determined, so they cannot be checked against your permissions.',
+        );
+      }
 
       for (const { path, collection: name } of searched ?? []) {
         usages.push({ action: 'search on', path, collectionName: name });

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -67,12 +67,12 @@ export default class AuthorizationService {
     collection: Collection,
     requested: RequestedProjection,
   ): Promise<Projection> {
-    const { projection, explicit } = requested;
+    const { projection, namedByCaller } = requested;
     const owners = projection.map(path => FieldPathUtils.getLeafCollection(collection, path).name);
     const permissions = await this.getReadPermissions(context, collection.name, owners);
     const isReadable = (index: number) => permissions.get(owners[index]);
 
-    if (explicit) {
+    if (namedByCaller) {
       const denied = projection
         .map((field, index) => ({ field, collection: owners[index] }))
         .filter((_, index) => !isReadable(index));
@@ -114,11 +114,8 @@ export default class AuthorizationService {
     const search = QueryStringParser.parseSearch(collection, context);
 
     if (search) {
-      // Asked of the stack rather than derived from the schema: `relation.column:term` is end-user
-      // syntax that needs no extended search, and the fields an extended one reaches are read below
-      // the publication and renaming layers. A `null` answer means the collection cannot say — a
-      // replaced search, where the customer's handler picks the fields and the caller only supplies
-      // the text.
+      // Asked whatever the extended flag: `relation.column:term` is end-user syntax and reaches a
+      // relation without it. An unknown answer serves the request — the `replaceSearch` exemption.
       const searched = (collection as CollectionDecorator).getSearchedFields?.(
         search,
         QueryStringParser.parseSearchExtended(context),

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -22,6 +22,10 @@ import QueryStringParser from '../../utils/query-string';
 
 type FieldUsage = { action: string; path: string; collectionName: string };
 
+export type QueryComponent = 'filter' | 'sort' | 'search';
+
+const ALL_QUERY_COMPONENTS: QueryComponent[] = ['filter', 'sort', 'search'];
+
 export default class AuthorizationService {
   constructor(private readonly forestAdminClient: ForestAdminClient) {}
 
@@ -93,8 +97,16 @@ export default class AuthorizationService {
    * Refused rather than redacted: dropping a condition widens the result set and dropping a sort
    * clause silently reorders it, while both leak the value they touch anyway — a `starts_with`
    * filter answers one guess per request without returning a column of its own.
+   *
+   * `consumes` names the query components the calling route applies to its filter. Checking one it
+   * drops would refuse a request the denied field cannot reach: `ContextFilterFactory.build` carries
+   * no sort, which only `buildPaginated` adds.
    */
-  public async assertCanReadQueryFields(context: Context, collection: Collection): Promise<void> {
+  public async assertCanReadQueryFields(
+    context: Context,
+    collection: Collection,
+    consumes: QueryComponent[] = ALL_QUERY_COMPONENTS,
+  ): Promise<void> {
     const usages: FieldUsage[] = [];
     const push = (action: string, path: string) =>
       usages.push({
@@ -103,15 +115,21 @@ export default class AuthorizationService {
         collectionName: FieldPathUtils.getLeafCollection(collection, path).name,
       });
 
-    QueryStringParser.parseConditionTree(collection, context)?.forEachLeaf(leaf =>
-      push('filter on', leaf.field),
-    );
-
-    for (const { field } of QueryStringParser.parseSort(collection, context)) {
-      push('sort on', field);
+    if (consumes.includes('filter')) {
+      QueryStringParser.parseConditionTree(collection, context)?.forEachLeaf(leaf =>
+        push('filter on', leaf.field),
+      );
     }
 
-    const search = QueryStringParser.parseSearch(collection, context);
+    if (consumes.includes('sort')) {
+      for (const { field } of QueryStringParser.parseSort(collection, context)) {
+        push('sort on', field);
+      }
+    }
+
+    const search = consumes.includes('search')
+      ? QueryStringParser.parseSearch(collection, context)
+      : null;
 
     if (search) {
       // Asked whatever the extended flag: `relation.column:term` is end-user syntax and reaches a

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -3,6 +3,7 @@ import type { Collection, ConditionTree } from '@forestadmin/datasource-toolkit'
 import type { ForestAdminClient } from '@forestadmin/forestadmin-client';
 import type { Context } from 'koa';
 
+import { getSearchedFieldPaths } from '@forestadmin/datasource-customizer';
 import { ForbiddenError, Projection, UnprocessableError } from '@forestadmin/datasource-toolkit';
 import {
   ChainedSQLQueryError,
@@ -107,17 +108,22 @@ export default class AuthorizationService {
       push('sort on', field);
     }
 
-    if (
-      QueryStringParser.parseSearch(collection, context) &&
-      QueryStringParser.parseSearchExtended(context)
-    ) {
-      for (const [name, field] of Object.entries(collection.schema.fields)) {
-        if (field.type === 'ManyToOne' || field.type === 'OneToOne') {
-          usages.push({
-            action: 'run an extended search through',
-            path: name,
-            collectionName: field.foreignCollection,
-          });
+    const search = QueryStringParser.parseSearch(collection, context);
+
+    if (search) {
+      // `relation.column:term` is end-user search syntax and works without extended search, so the
+      // paths it names are resolved by the search decorator's own resolver rather than guessed at.
+      for (const path of getSearchedFieldPaths(collection, search)) push('search on', path);
+
+      if (QueryStringParser.parseSearchExtended(context)) {
+        for (const [name, field] of Object.entries(collection.schema.fields)) {
+          if (field.type === 'ManyToOne' || field.type === 'OneToOne') {
+            usages.push({
+              action: 'run an extended search through',
+              path: name,
+              collectionName: field.foreignCollection,
+            });
+          }
         }
       }
     }

--- a/packages/agent/src/services/authorization/authorization.ts
+++ b/packages/agent/src/services/authorization/authorization.ts
@@ -1,9 +1,12 @@
 import type { RequestedProjection } from '../../utils/query-string';
-import type { Collection, ConditionTree } from '@forestadmin/datasource-toolkit';
+import type {
+  Collection,
+  CollectionDecorator,
+  ConditionTree,
+} from '@forestadmin/datasource-toolkit';
 import type { ForestAdminClient } from '@forestadmin/forestadmin-client';
 import type { Context } from 'koa';
 
-import { getSearchedFieldPaths } from '@forestadmin/datasource-customizer';
 import { ForbiddenError, Projection, UnprocessableError } from '@forestadmin/datasource-toolkit';
 import {
   ChainedSQLQueryError,
@@ -111,20 +114,18 @@ export default class AuthorizationService {
     const search = QueryStringParser.parseSearch(collection, context);
 
     if (search) {
-      // `relation.column:term` is end-user search syntax and works without extended search, so the
-      // paths it names are resolved by the search decorator's own resolver rather than guessed at.
-      for (const path of getSearchedFieldPaths(collection, search)) push('search on', path);
+      // Asked of the stack rather than derived from the schema: `relation.column:term` is end-user
+      // syntax that needs no extended search, and the fields an extended one reaches are read below
+      // the publication and renaming layers. A `null` answer means the collection cannot say — a
+      // replaced search, where the customer's handler picks the fields and the caller only supplies
+      // the text.
+      const searched = (collection as CollectionDecorator).getSearchedFields?.(
+        search,
+        QueryStringParser.parseSearchExtended(context),
+      );
 
-      if (QueryStringParser.parseSearchExtended(context)) {
-        for (const [name, field] of Object.entries(collection.schema.fields)) {
-          if (field.type === 'ManyToOne' || field.type === 'OneToOne') {
-            usages.push({
-              action: 'run an extended search through',
-              path: name,
-              collectionName: field.foreignCollection,
-            });
-          }
-        }
+      for (const { path, collection: name } of searched ?? []) {
+        usages.push({ action: 'search on', path, collectionName: name });
       }
     }
 

--- a/packages/agent/src/utils/csv-generator.ts
+++ b/packages/agent/src/utils/csv-generator.ts
@@ -52,6 +52,16 @@ export default class CsvGenerator {
     }
   }
 
+  /** Labels are positionally aligned with the requested projection; dropping one shifts the rest. */
+  static filterHeader(header: string, requested: Projection, kept: Projection): string {
+    if (!header || kept.length === requested.length) return header;
+
+    return header
+      .split(',')
+      .filter((_, index) => kept.includes(requested[index]))
+      .join(',');
+  }
+
   private static convert(records: RecordData[], projection: Projection): Promise<string> {
     return writeToString(
       records.map(record =>

--- a/packages/agent/src/utils/field-path.ts
+++ b/packages/agent/src/utils/field-path.ts
@@ -1,0 +1,22 @@
+import type { Collection } from '@forestadmin/datasource-toolkit';
+
+import { SchemaUtils } from '@forestadmin/datasource-toolkit';
+
+export default class FieldPathUtils {
+  static getLeafCollection(collection: Collection, path: string): Collection {
+    const index = path.indexOf(':');
+
+    if (index === -1) return collection;
+
+    const relation = SchemaUtils.getRelation(
+      collection.schema,
+      path.substring(0, index),
+      collection.name,
+    );
+
+    return FieldPathUtils.getLeafCollection(
+      collection.dataSource.getCollection(relation.foreignCollection),
+      path.substring(index + 1),
+    );
+  }
+}

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -21,6 +21,8 @@ import { getRequestId } from './correlation-id';
 const DEFAULT_ITEMS_PER_PAGE = 15;
 const DEFAULT_PAGE_TO_SKIP = 1;
 
+export type RequestedProjection = { projection: Projection; explicit: boolean };
+
 export default class QueryStringParser {
   private static VALID_TIMEZONES = new Set<string>();
 
@@ -86,11 +88,21 @@ export default class QueryStringParser {
     }
   }
 
-  static parseProjectionFromHeaderOrQuery(collection: Collection, context: Context): Projection {
-    return (
-      QueryStringParser.parseProjectionFromHeader(collection, context) ??
-      QueryStringParser.parseProjection(collection, context)
-    );
+  /** `explicit` is false when the projection is the default `ProjectionFactory.all` expansion. */
+  static parseProjectionFromHeaderOrQuery(
+    collection: Collection,
+    context: Context,
+  ): RequestedProjection {
+    const fromHeader = QueryStringParser.parseProjectionFromHeader(collection, context);
+
+    if (fromHeader) return { projection: fromHeader, explicit: true };
+
+    const fields = context.request.query[`fields[${collection.name}]`];
+
+    return {
+      projection: QueryStringParser.parseProjection(collection, context),
+      explicit: fields !== '' && fields !== undefined,
+    };
   }
 
   static parseSearch(collection: Collection, context: Context): string {

--- a/packages/agent/src/utils/query-string.ts
+++ b/packages/agent/src/utils/query-string.ts
@@ -21,7 +21,7 @@ import { getRequestId } from './correlation-id';
 const DEFAULT_ITEMS_PER_PAGE = 15;
 const DEFAULT_PAGE_TO_SKIP = 1;
 
-export type RequestedProjection = { projection: Projection; explicit: boolean };
+export type RequestedProjection = { projection: Projection; namedByCaller: boolean };
 
 export default class QueryStringParser {
   private static VALID_TIMEZONES = new Set<string>();
@@ -88,20 +88,19 @@ export default class QueryStringParser {
     }
   }
 
-  /** `explicit` is false when the projection is the default `ProjectionFactory.all` expansion. */
   static parseProjectionFromHeaderOrQuery(
     collection: Collection,
     context: Context,
   ): RequestedProjection {
     const fromHeader = QueryStringParser.parseProjectionFromHeader(collection, context);
 
-    if (fromHeader) return { projection: fromHeader, explicit: true };
+    if (fromHeader) return { projection: fromHeader, namedByCaller: true };
 
     const fields = context.request.query[`fields[${collection.name}]`];
 
     return {
       projection: QueryStringParser.parseProjection(collection, context),
-      explicit: fields !== '' && fields !== undefined,
+      namedByCaller: fields !== '' && fields !== undefined,
     };
   }
 

--- a/packages/agent/test/__factories__/authorization/authorization.ts
+++ b/packages/agent/test/__factories__/authorization/authorization.ts
@@ -15,6 +15,12 @@ export class AuthorizationsFactory extends Factory<AuthorizationService> {
       Authorizations.getScope = jest.fn();
       Authorizations.assertCanExecuteChart = jest.fn();
       Authorizations.invalidateScopeCache = jest.fn();
+      Authorizations.canRead = jest.fn().mockResolvedValue(true);
+      Authorizations.assertCanReadQueryFields = jest.fn();
+      Authorizations.assertCanReadUsages = jest.fn();
+      Authorizations.redactProjection = jest
+        .fn()
+        .mockImplementation(async (context, collection, requested) => requested.projection);
     });
   }
 }

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -281,6 +281,22 @@ describe('read permissions on related collections', () => {
   });
 
   describe('sort', () => {
+    // A count applies no sort — `ContextFilterFactory.build` carries none, only `buildPaginated`
+    // does — so refusing one would refuse a request the denied field cannot reach.
+    it('should ignore a sort on the count route, which never applies one', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const aggregate = jest
+        .spyOn(dataSource.getCollection('cards'), 'aggregate')
+        .mockResolvedValue([{ value: 3, group: {} }]);
+
+      await new Count(services, options, dataSource, 'cards').handleCount(
+        buildContext({ query: { sort: '-holder.nationalId' } }),
+      );
+
+      expect(aggregate).toHaveBeenCalled();
+    });
+
     it('should refuse a sort reading a collection the caller cannot read', async () => {
       const dataSource = buildDataSource();
       const services = buildServices();

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -293,6 +293,45 @@ describe('read permissions on related collections', () => {
       ).rejects.toThrow('you are not allowed to read the');
     });
 
+    it('should refuse a search naming a relation column through the dot syntax', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const aggregate = jest.spyOn(dataSource.getCollection('cards'), 'aggregate');
+
+      await expect(
+        new Count(services, options, dataSource, 'cards').handleCount(
+          buildContext({ query: { search: 'holder.nationalId:1850' } }),
+        ),
+      ).rejects.toThrow(
+        "You cannot search on 'holder:nationalId': you are not allowed to read the " +
+          "'holders' collection.",
+      );
+
+      expect(aggregate).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a search reaching a denied collection across a to-many relation', async () => {
+      const dataSource = buildDataSource();
+      const forestAdminClient = factories.forestAdminClient.build();
+      const services = factories.forestAdminHttpDriverServices.build();
+      services.authorization = new AuthorizationService(forestAdminClient);
+      services.serializer.serializeWithSearchMetadata = jest.fn();
+
+      // Searching from `holders`, so `cards` is the denied one here.
+      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockImplementation(
+        ({ collectionName }) => collectionName !== 'cards',
+      );
+
+      await expect(
+        new List(services, options, dataSource, 'holders').handleList(
+          buildContext({ query: { search: 'cards.panLast4:4242' } }),
+        ),
+      ).rejects.toThrow(
+        "You cannot search on 'cards:panLast4': you are not allowed to read the " +
+          "'cards' collection.",
+      );
+    });
+
     it('should accept a plain search, which never leaves the root collection', async () => {
       const dataSource = buildDataSource();
       const services = buildServices();

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -349,7 +349,10 @@ describe('read permissions on related collections', () => {
     it('should accept a plain search, which never leaves the root collection', async () => {
       const dataSource = buildDataSource();
       const services = buildServices();
-      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
+
+      cards.getSearchedFields = () => [{ path: 'panLast4', collection: 'cards' }];
 
       await new List(services, options, dataSource, 'cards').handleList(
         buildContext({ query: { search: 'martin' } }),
@@ -361,7 +364,14 @@ describe('read permissions on related collections', () => {
     it('should accept an extended search once every to-one relation is readable', async () => {
       const dataSource = buildDataSource();
       const services = buildServices(['holders', 'accounts']);
-      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
+
+      cards.getSearchedFields = () => [
+        { path: 'panLast4', collection: 'cards' },
+        { path: 'holder:fullName', collection: 'holders' },
+        { path: 'account:iban', collection: 'accounts' },
+      ];
 
       await new List(services, options, dataSource, 'cards').handleList(
         buildContext({ query: { search: 'martin', searchExtended: '1' } }),

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -180,8 +180,11 @@ describe('read permissions on related collections', () => {
         buildContext({}, { 'forest-projection': 'id,account:organization:name' }),
       );
 
-      // `withPks` re-adds `account:id`, which a ManyToOne already carries on the row as
-      // `cards.accountId`. A OneToOne intermediate would expose a key the row does not carry.
+      // `withPks` runs after the check and re-adds a key per surviving relation, so `account:id`
+      // comes back from a collection the caller cannot read. It carries nothing new only here,
+      // where the ManyToOne targets the primary key and the row already holds it as
+      // `cards.accountId`. A OneToOne, or a `foreignKeyTarget` that is not the primary key,
+      // exposes a key the row does not carry.
       expect([...list.mock.calls[0][2]].sort()).toEqual([
         'account:id',
         'account:organization:id',

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -1,0 +1,388 @@
+import type { DataSource } from '@forestadmin/datasource-toolkit';
+
+import { CollectionActionEvent } from '@forestadmin/forestadmin-client';
+import { createMockContext } from '@shopify/jest-koa-mocks';
+
+import Chart from '../../src/routes/access/chart';
+import Count from '../../src/routes/access/count';
+import Csv from '../../src/routes/access/csv';
+import Get from '../../src/routes/access/get';
+import List from '../../src/routes/access/list';
+import AuthorizationService from '../../src/services/authorization/authorization';
+import * as factories from '../__factories__';
+
+describe('read permissions on related collections', () => {
+  const options = factories.forestAdminHttpDriverOptions.build();
+
+  const buildDataSource = (): DataSource =>
+    factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        name: 'cards',
+        schema: factories.collectionSchema.build({
+          searchable: true,
+          countable: true,
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            panLast4: factories.columnSchema.build({ columnType: 'String' }),
+            accountId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            account: factories.manyToOneSchema.build({
+              foreignCollection: 'accounts',
+              foreignKey: 'accountId',
+            }),
+            holder: factories.manyToOneSchema.build({
+              foreignCollection: 'holders',
+              foreignKey: 'holderId',
+            }),
+          },
+        }),
+      }),
+      factories.collection.build({
+        name: 'accounts',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            iban: factories.columnSchema.build({ columnType: 'String' }),
+            balance: factories.columnSchema.build({ columnType: 'Number' }),
+            organizationId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            organization: factories.manyToOneSchema.build({
+              foreignCollection: 'organizations',
+              foreignKey: 'organizationId',
+            }),
+          },
+        }),
+      }),
+      factories.collection.build({
+        name: 'organizations',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            name: factories.columnSchema.build({ columnType: 'String' }),
+          },
+        }),
+      }),
+      factories.collection.build({
+        name: 'holders',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            fullName: factories.columnSchema.text().build(),
+            nationalId: factories.columnSchema.text().build(),
+            cards: factories.oneToManySchema.build({
+              foreignCollection: 'cards',
+              originKey: 'holderId',
+              originKeyTarget: 'id',
+            }),
+          },
+        }),
+      }),
+    ]);
+
+  const buildServices = (readableCollections: string[] = []) => {
+    const forestAdminClient = factories.forestAdminClient.build();
+
+    (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockImplementation(
+      ({ event, collectionName }) =>
+        collectionName === 'cards' ||
+        (event === CollectionActionEvent.Read && readableCollections.includes(collectionName)),
+    );
+
+    const services = factories.forestAdminHttpDriverServices.build();
+    services.authorization = new AuthorizationService(forestAdminClient);
+    services.serializer.serialize = jest.fn();
+    services.serializer.serializeWithSearchMetadata = jest.fn();
+
+    return services;
+  };
+
+  const buildContext = (
+    customProperties: Record<string, unknown>,
+    headers = {},
+    requestBody?: unknown,
+  ) =>
+    createMockContext({
+      headers,
+      requestBody,
+      state: { user: { id: 35, renderingId: 42, email: 'operator@domain.com' } },
+      customProperties: {
+        ...customProperties,
+        query: { timezone: 'Europe/Paris', ...(customProperties.query as object) },
+      },
+    });
+
+  describe('projection the caller named', () => {
+    it('should refuse the request and name every offending field at once', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({}, { 'forest-projection': 'id,holder:nationalId,account:iban' }),
+        ),
+      ).rejects.toThrow(
+        "You are not allowed to read 'holder:nationalId' from the 'holders' collection, " +
+          "'account:iban' from the 'accounts' collection.",
+      );
+
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a named field on a get-one too', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new Get(services, options, dataSource, 'cards').handleGet(
+          buildContext(
+            { params: { id: '2d162303-78bf-599e-b197-93590ac3d315' } },
+            { 'forest-projection': 'id,holder:fullName' },
+          ),
+        ),
+      ).rejects.toThrow("You are not allowed to read 'holder:fullName' from the 'holders'");
+    });
+
+    it('should refuse fields named through the fields[] query params', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({
+            query: { 'fields[cards]': 'id,holder', 'fields[holder]': 'nationalId' },
+          }),
+        ),
+      ).rejects.toThrow("You are not allowed to read 'holder:nationalId' from the 'holders'");
+    });
+
+    it('should serve a named field on a collection the caller can read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['holders']);
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({}, { 'forest-projection': 'id,holder:nationalId' }),
+      );
+
+      expect([...list.mock.calls[0][2]].sort()).toEqual(['holder:id', 'holder:nationalId', 'id']);
+    });
+
+    it('should traverse a collection it cannot read to reach a column it can', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['organizations']);
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({}, { 'forest-projection': 'id,account:organization:name' }),
+      );
+
+      // The `account:` primary keys `withPks` re-adds are already on the row as `cards.accountId`.
+      expect([...list.mock.calls[0][2]].sort()).toEqual([
+        'account:id',
+        'account:organization:id',
+        'account:organization:name',
+        'id',
+      ]);
+    });
+  });
+
+  describe('projection the caller never asked for', () => {
+    it('should redact rather than refuse, so an ordinary listing keeps working', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(buildContext({}));
+
+      expect(list.mock.calls[0][2].sort()).toEqual(['accountId', 'holderId', 'id', 'panLast4']);
+    });
+  });
+
+  describe('filter', () => {
+    const oracleFilter = JSON.stringify({
+      field: 'holder:nationalId',
+      operator: 'starts_with',
+      value: '1850',
+    });
+
+    it('should refuse a filter reading a collection the caller cannot read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { filters: oracleFilter } }),
+        ),
+      ).rejects.toThrow(
+        "You cannot filter on 'holder:nationalId': you are not allowed to read the " +
+          "'holders' collection.",
+      );
+
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should refuse the same filter on the count route', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const aggregate = jest.spyOn(dataSource.getCollection('cards'), 'aggregate');
+
+      await expect(
+        new Count(services, options, dataSource, 'cards').handleCount(
+          buildContext({ query: { filters: oracleFilter } }),
+        ),
+      ).rejects.toThrow("you are not allowed to read the 'holders' collection");
+
+      expect(aggregate).not.toHaveBeenCalled();
+    });
+
+    it('should accept a filter reading a collection the caller can read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['holders']);
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { filters: oracleFilter } }),
+      );
+
+      expect(list).toHaveBeenCalled();
+    });
+
+    it('should not check the scope, which the agent injects rather than the caller', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      jest
+        .spyOn(services.authorization, 'getScope')
+        .mockResolvedValue(
+          factories.conditionTreeLeaf.build({ field: 'holder:nationalId', value: '1850' }),
+        );
+
+      await new List(services, options, dataSource, 'cards').handleList(buildContext({}));
+
+      expect(list).toHaveBeenCalled();
+    });
+  });
+
+  describe('sort', () => {
+    it('should refuse a sort reading a collection the caller cannot read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { sort: '-account.balance' } }),
+        ),
+      ).rejects.toThrow(
+        "You cannot sort on 'account:balance': you are not allowed to read the " +
+          "'accounts' collection.",
+      );
+    });
+  });
+
+  describe('extended search', () => {
+    it('should refuse an extended search when a to-one relation cannot be read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        ),
+      ).rejects.toThrow('you are not allowed to read the');
+    });
+
+    it('should accept a plain search, which never leaves the root collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { search: 'martin' } }),
+      );
+
+      expect(list).toHaveBeenCalled();
+    });
+
+    it('should accept an extended search once every to-one relation is readable', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['holders', 'accounts']);
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+      );
+
+      expect(list).toHaveBeenCalled();
+    });
+  });
+
+  describe('csv export', () => {
+    it('should refuse an export naming a column of an unreadable collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      const context = buildContext({
+        query: {
+          header: 'Id,Holder national id',
+          'fields[cards]': 'id,holder',
+          'fields[holder]': 'nationalId',
+        },
+      });
+
+      await expect(
+        new Csv(services, options, dataSource, 'cards').handleCsv(context),
+      ).rejects.toThrow("You are not allowed to read 'holder:nationalId' from the 'holders'");
+    });
+  });
+
+  describe('chart', () => {
+    it('should refuse to group a chart by a column of an unreadable collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const body = {
+        type: 'Pie',
+        aggregator: 'Count',
+        groupByFieldName: 'holder:fullName',
+      };
+
+      (services.chartHandler.getChartWithContextInjected as jest.Mock).mockResolvedValue(body);
+
+      await expect(
+        new Chart(services, options, dataSource, 'cards').handleChart(buildContext({}, {}, body)),
+      ).rejects.toThrow(
+        "You cannot group a chart by 'holder:fullName': you are not allowed to read the " +
+          "'holders' collection.",
+      );
+    });
+
+    it('should assert browse on the collection a leaderboard counts, which no field names', async () => {
+      const dataSource = buildDataSource();
+      const forestAdminClient = factories.forestAdminClient.build();
+      const services = factories.forestAdminHttpDriverServices.build();
+      services.authorization = new AuthorizationService(forestAdminClient);
+      const body = {
+        type: 'Leaderboard',
+        aggregator: 'Count',
+        relationshipFieldName: 'cards',
+        labelFieldName: 'fullName',
+        limit: 5,
+      };
+
+      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockResolvedValue(true);
+      (services.chartHandler.getChartWithContextInjected as jest.Mock).mockResolvedValue(body);
+      jest.spyOn(dataSource.getCollection('cards'), 'aggregate').mockResolvedValue([]);
+
+      await new Chart(services, options, dataSource, 'holders').handleChart(
+        buildContext({}, {}, body),
+      );
+
+      expect(forestAdminClient.permissionService.canOnCollection).toHaveBeenCalledWith({
+        userId: 35,
+        event: CollectionActionEvent.Browse,
+        collectionName: 'cards',
+      });
+    });
+  });
+});

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -1,4 +1,4 @@
-import type { CollectionDecorator, DataSource } from '@forestadmin/datasource-toolkit';
+import type { CollectionDecorator, DataSource, RecordData } from '@forestadmin/datasource-toolkit';
 
 import { CollectionActionEvent } from '@forestadmin/forestadmin-client';
 import { createMockContext } from '@shopify/jest-koa-mocks';
@@ -13,6 +13,7 @@ import List from '../../src/routes/access/list';
 import ListRelated from '../../src/routes/access/list-related';
 import Update from '../../src/routes/modification/update';
 import AuthorizationService from '../../src/services/authorization/authorization';
+import Serializer from '../../src/services/serializer';
 import * as factories from '../__factories__';
 
 describe('read permissions on related collections', () => {
@@ -38,6 +39,11 @@ describe('read permissions on related collections', () => {
               foreignCollection: 'holders',
               foreignKey: 'holderId',
             }),
+            contract: factories.oneToOneSchema.build({
+              foreignCollection: 'contracts',
+              originKey: 'cardId',
+              originKeyTarget: 'id',
+            }),
           },
         }),
       }),
@@ -48,6 +54,21 @@ describe('read permissions on related collections', () => {
             id: factories.columnSchema.uuidPrimaryKey().build(),
             iban: factories.columnSchema.text().build(),
             balance: factories.columnSchema.build({ columnType: 'Number' }),
+            organizationId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            organization: factories.manyToOneSchema.build({
+              foreignCollection: 'organizations',
+              foreignKey: 'organizationId',
+            }),
+          },
+        }),
+      }),
+      factories.collection.build({
+        name: 'contracts',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            cardId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            reference: factories.columnSchema.text().build(),
             organizationId: factories.columnSchema.build({ columnType: 'Uuid' }),
             organization: factories.manyToOneSchema.build({
               foreignCollection: 'organizations',
@@ -180,17 +201,85 @@ describe('read permissions on related collections', () => {
         buildContext({}, { 'forest-projection': 'id,account:organization:name' }),
       );
 
-      // `withPks` runs after the check and re-adds a key per surviving relation, so `account:id`
-      // comes back from a collection the caller cannot read. It carries nothing new only here,
-      // where the ManyToOne targets the primary key and the row already holds it as
-      // `cards.accountId`. A OneToOne, or a `foreignKeyTarget` that is not the primary key,
-      // exposes a key the row does not carry.
+      // `account:id` comes back from a collection the caller cannot read, and has to: JSON:API
+      // renders a traversed relation as a resource of its own, so `accounts` needs an identity for
+      // `account:organization:name` to be served at all. `withPks` is what supplies it — dropping
+      // it would 500 rather than redact, see the serialization case below.
       expect([...list.mock.calls[0][2]].sort()).toEqual([
         'account:id',
         'account:organization:id',
         'account:organization:name',
         'id',
       ]);
+    });
+
+    it('should serve the key of a traversed OneToOne, which the root row does not carry', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['organizations']);
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({}, { 'forest-projection': 'id,contract:organization:name' }),
+      );
+
+      // The sharp end of the same rule: `contract` is a OneToOne, so `contracts.id` is not a
+      // foreign key the card row holds — the caller reads a value it has no other way to obtain.
+      // The alternative is refusing the traversal outright, which the leaf-only rule declines.
+      expect([...list.mock.calls[0][2]].sort()).toEqual([
+        'contract:id',
+        'contract:organization:id',
+        'contract:organization:name',
+        'id',
+      ]);
+    });
+
+    it('should expose that key and nothing else of the traversed collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['organizations']);
+      services.serializer = new Serializer();
+
+      const row = {
+        id: 'card-1',
+        panLast4: '4242',
+        contract: {
+          id: 'contract-1',
+          reference: 'C-1',
+          organization: { id: 'org-1', name: 'Acme' },
+        },
+      };
+
+      // Reprojected rather than returned whole, so the payload shows what the projection allowed:
+      // drop `contract:id` from it and the serializer throws on a relation with no identity.
+      jest
+        .spyOn(dataSource.getCollection('cards'), 'list')
+        .mockImplementation(async (caller, filter, projection) => projection.apply([row]));
+
+      const context = buildContext({}, { 'forest-projection': 'id,contract:organization:name' });
+
+      await new List(services, options, dataSource, 'cards').handleList(context);
+
+      const body = context.response.body as {
+        data: RecordData[];
+        included: RecordData[];
+      };
+
+      expect(body.data[0].relationships).toEqual({
+        contract: { data: { type: 'contracts', id: 'contract-1' } },
+      });
+
+      // The bound on what the residual costs: the traversed record carries its identity and no
+      // column of its own — `reference`, `cardId` and `organizationId` never reach the payload.
+      expect(body.included).toContainEqual({
+        type: 'contracts',
+        id: 'contract-1',
+        attributes: { id: 'contract-1' },
+        relationships: { organization: { data: { type: 'organizations', id: 'org-1' } } },
+      });
+      expect(body.included).toContainEqual({
+        type: 'organizations',
+        id: 'org-1',
+        attributes: { id: 'org-1', name: 'Acme' },
+      });
     });
   });
 

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -437,20 +437,61 @@ describe('read permissions on related collections', () => {
       expect(getSearchedFields).toHaveBeenCalledWith('martin', true);
     });
 
-    it('should serve the request when the stack cannot say what a search reaches', async () => {
+    it('should serve a plain search when the stack cannot say what it reaches', async () => {
       const dataSource = buildDataSource();
       const services = buildServices();
       const cards = dataSource.getCollection('cards') as CollectionDecorator;
       const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
 
-      // A replaced search: the handler picks the fields, the caller only supplies the text.
+      // A replaced search: the handler picks the fields, the caller only supplies the text. They
+      // aimed at nothing, and the footprint is the same for every role.
       cards.getSearchedFields = () => null;
 
       await new List(services, options, dataSource, 'cards').handleList(
-        buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        buildContext({ query: { search: 'martin' } }),
       );
 
-      expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: true });
+      expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: false });
+    });
+
+    it('should refuse the extended half of that same search', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
+
+      cards.getSearchedFields = () => null;
+
+      // The flag is the caller's: the same term with it off and on differs by exactly the rows
+      // matched through a relation, so an unverifiable traversal is refused where a plain search
+      // is served.
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        ),
+      ).rejects.toThrow(
+        "You cannot run an extended search on the 'cards' collection: the fields it reaches " +
+          'cannot be determined, so they cannot be checked against your permissions.',
+      );
+
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should read a stack that cannot answer at all as an unknown footprint too', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const cards = dataSource.getCollection('cards');
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
+
+      // No `getSearchedFields` on the collection rather than one answering `null`: silence is not
+      // an empty footprint either.
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        ),
+      ).rejects.toThrow("You cannot run an extended search on the 'cards' collection");
+
+      expect(list).not.toHaveBeenCalled();
     });
 
     it('should accept a plain search, which never leaves the root collection', async () => {

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -300,7 +300,6 @@ describe('read permissions on related collections', () => {
       const cards = dataSource.getCollection('cards') as CollectionDecorator;
       const aggregate = jest.spyOn(cards, 'aggregate');
 
-      // `relation.column:term` needs no extended search, and only the stack knows it resolves.
       cards.getSearchedFields = () => [{ path: 'holder:nationalId', collection: 'holders' }];
 
       await expect(

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -5,9 +5,12 @@ import { createMockContext } from '@shopify/jest-koa-mocks';
 
 import Chart from '../../src/routes/access/chart';
 import Count from '../../src/routes/access/count';
+import CountRelated from '../../src/routes/access/count-related';
 import Csv from '../../src/routes/access/csv';
+import CsvRelated from '../../src/routes/access/csv-related';
 import Get from '../../src/routes/access/get';
 import List from '../../src/routes/access/list';
+import ListRelated from '../../src/routes/access/list-related';
 import AuthorizationService from '../../src/services/authorization/authorization';
 import * as factories from '../__factories__';
 
@@ -42,7 +45,7 @@ describe('read permissions on related collections', () => {
         schema: factories.collectionSchema.build({
           fields: {
             id: factories.columnSchema.uuidPrimaryKey().build(),
-            iban: factories.columnSchema.build({ columnType: 'String' }),
+            iban: factories.columnSchema.text().build(),
             balance: factories.columnSchema.build({ columnType: 'Number' }),
             organizationId: factories.columnSchema.build({ columnType: 'Uuid' }),
             organization: factories.manyToOneSchema.build({
@@ -176,7 +179,8 @@ describe('read permissions on related collections', () => {
         buildContext({}, { 'forest-projection': 'id,account:organization:name' }),
       );
 
-      // The `account:` primary keys `withPks` re-adds are already on the row as `cards.accountId`.
+      // `withPks` re-adds `account:id`, which a ManyToOne already carries on the row as
+      // `cards.accountId`. A OneToOne intermediate would expose a key the row does not carry.
       expect([...list.mock.calls[0][2]].sort()).toEqual([
         'account:id',
         'account:organization:id',
@@ -245,7 +249,11 @@ describe('read permissions on related collections', () => {
         buildContext({ query: { filters: oracleFilter } }),
       );
 
-      expect(list).toHaveBeenCalled();
+      expect(list.mock.calls[0][1].conditionTree).toMatchObject({
+        field: 'holder:nationalId',
+        operator: 'StartsWith',
+        value: '1850',
+      });
     });
 
     it('should not check the scope, which the agent injects rather than the caller', async () => {
@@ -261,7 +269,10 @@ describe('read permissions on related collections', () => {
 
       await new List(services, options, dataSource, 'cards').handleList(buildContext({}));
 
-      expect(list).toHaveBeenCalled();
+      expect(list.mock.calls[0][1].conditionTree).toMatchObject({
+        field: 'holder:nationalId',
+        value: '1850',
+      });
     });
   });
 
@@ -341,7 +352,7 @@ describe('read permissions on related collections', () => {
         buildContext({ query: { search: 'martin' } }),
       );
 
-      expect(list).toHaveBeenCalled();
+      expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: false });
     });
 
     it('should accept an extended search once every to-one relation is readable', async () => {
@@ -353,7 +364,7 @@ describe('read permissions on related collections', () => {
         buildContext({ query: { search: 'martin', searchExtended: '1' } }),
       );
 
-      expect(list).toHaveBeenCalled();
+      expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: true });
     });
   });
 
@@ -376,6 +387,70 @@ describe('read permissions on related collections', () => {
     });
   });
 
+  // The related routes are the only sites resolving against `foreignCollection` rather than the
+  // route's own collection, so a swap between the two would otherwise go unnoticed.
+  describe('related routes', () => {
+    const holderCardsContext = () =>
+      buildContext({
+        params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' },
+        query: {
+          filters: JSON.stringify({
+            field: 'account:iban',
+            operator: 'equal',
+            value: 'FR76',
+          }),
+        },
+      });
+
+    it('should refuse a filter on a denied collection reached from the related list', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new ListRelated(services, options, dataSource, 'holders', 'cards').handleListRelated(
+          holderCardsContext(),
+        ),
+      ).rejects.toThrow(
+        "You cannot filter on 'account:iban': you are not allowed to read the " +
+          "'accounts' collection.",
+      );
+    });
+
+    it('should refuse the same filter on the related export', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new CsvRelated(services, options, dataSource, 'holders', 'cards').handleRelatedCsv(
+          holderCardsContext(),
+        ),
+      ).rejects.toThrow("you are not allowed to read the 'accounts' collection");
+    });
+
+    it('should refuse the same filter on the related count', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+
+      await expect(
+        new CountRelated(services, options, dataSource, 'holders', 'cards').handleCountRelated(
+          holderCardsContext(),
+        ),
+      ).rejects.toThrow("you are not allowed to read the 'accounts' collection");
+    });
+
+    it('should redact the related list projection rather than refuse it', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const list = jest.spyOn(dataSource.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new ListRelated(services, options, dataSource, 'holders', 'cards').handleListRelated(
+        buildContext({ params: { parentId: '2d162303-78bf-599e-b197-93590ac3d315' } }),
+      );
+
+      expect(list.mock.calls[0][2].sort()).toEqual(['accountId', 'holderId', 'id', 'panLast4']);
+    });
+  });
+
   describe('chart', () => {
     it('should refuse to group a chart by a column of an unreadable collection', async () => {
       const dataSource = buildDataSource();
@@ -393,6 +468,41 @@ describe('read permissions on related collections', () => {
       ).rejects.toThrow(
         "You cannot group a chart by 'holder:fullName': you are not allowed to read the " +
           "'holders' collection.",
+      );
+    });
+
+    it('should refuse a line chart grouped by a column of an unreadable collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const body = {
+        type: 'Line',
+        aggregator: 'Count',
+        groupByFieldName: 'holder:fullName',
+        timeRange: 'Day',
+      };
+
+      (services.chartHandler.getChartWithContextInjected as jest.Mock).mockResolvedValue(body);
+
+      await expect(
+        new Chart(services, options, dataSource, 'cards').handleChart(buildContext({}, {}, body)),
+      ).rejects.toThrow(
+        "You cannot group a chart by 'holder:fullName': you are not allowed to read the " +
+          "'holders' collection.",
+      );
+    });
+
+    it('should refuse a value chart aggregating a column of an unreadable collection', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const body = { type: 'Value', aggregator: 'Sum', aggregateFieldName: 'account:balance' };
+
+      (services.chartHandler.getChartWithContextInjected as jest.Mock).mockResolvedValue(body);
+
+      await expect(
+        new Chart(services, options, dataSource, 'cards').handleChart(buildContext({}, {}, body)),
+      ).rejects.toThrow(
+        "You cannot aggregate a chart on 'account:balance': you are not allowed to read the " +
+          "'accounts' collection.",
       );
     });
 

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -1,4 +1,4 @@
-import type { DataSource } from '@forestadmin/datasource-toolkit';
+import type { CollectionDecorator, DataSource } from '@forestadmin/datasource-toolkit';
 
 import { CollectionActionEvent } from '@forestadmin/forestadmin-client';
 import { createMockContext } from '@shopify/jest-koa-mocks';
@@ -293,21 +293,14 @@ describe('read permissions on related collections', () => {
   });
 
   describe('extended search', () => {
-    it('should refuse an extended search when a to-one relation cannot be read', async () => {
+    it('should refuse whatever the stack says the search will reach', async () => {
       const dataSource = buildDataSource();
       const services = buildServices();
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const aggregate = jest.spyOn(cards, 'aggregate');
 
-      await expect(
-        new List(services, options, dataSource, 'cards').handleList(
-          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
-        ),
-      ).rejects.toThrow('you are not allowed to read the');
-    });
-
-    it('should refuse a search naming a relation column through the dot syntax', async () => {
-      const dataSource = buildDataSource();
-      const services = buildServices();
-      const aggregate = jest.spyOn(dataSource.getCollection('cards'), 'aggregate');
+      // `relation.column:term` needs no extended search, and only the stack knows it resolves.
+      cards.getSearchedFields = () => [{ path: 'holder:nationalId', collection: 'holders' }];
 
       await expect(
         new Count(services, options, dataSource, 'cards').handleCount(
@@ -321,26 +314,35 @@ describe('read permissions on related collections', () => {
       expect(aggregate).not.toHaveBeenCalled();
     });
 
-    it('should refuse a search reaching a denied collection across a to-many relation', async () => {
+    it('should ask the stack with the extended flag the caller sent', async () => {
       const dataSource = buildDataSource();
-      const forestAdminClient = factories.forestAdminClient.build();
-      const services = factories.forestAdminHttpDriverServices.build();
-      services.authorization = new AuthorizationService(forestAdminClient);
-      services.serializer.serializeWithSearchMetadata = jest.fn();
+      const services = buildServices();
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const getSearchedFields = jest.fn().mockReturnValue([]);
+      cards.getSearchedFields = getSearchedFields;
+      jest.spyOn(cards, 'list').mockResolvedValue([]);
 
-      // Searching from `holders`, so `cards` is the denied one here.
-      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockImplementation(
-        ({ collectionName }) => collectionName !== 'cards',
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { search: 'martin', searchExtended: '1' } }),
       );
 
-      await expect(
-        new List(services, options, dataSource, 'holders').handleList(
-          buildContext({ query: { search: 'cards.panLast4:4242' } }),
-        ),
-      ).rejects.toThrow(
-        "You cannot search on 'cards:panLast4': you are not allowed to read the " +
-          "'cards' collection.",
+      expect(getSearchedFields).toHaveBeenCalledWith('martin', true);
+    });
+
+    it('should serve the request when the stack cannot say what a search reaches', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const cards = dataSource.getCollection('cards') as CollectionDecorator;
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([]);
+
+      // A replaced search: the handler picks the fields, the caller only supplies the text.
+      cards.getSearchedFields = () => null;
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { search: 'martin', searchExtended: '1' } }),
       );
+
+      expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: true });
     });
 
     it('should accept a plain search, which never leaves the root collection', async () => {

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -11,6 +11,7 @@ import CsvRelated from '../../src/routes/access/csv-related';
 import Get from '../../src/routes/access/get';
 import List from '../../src/routes/access/list';
 import ListRelated from '../../src/routes/access/list-related';
+import Update from '../../src/routes/modification/update';
 import AuthorizationService from '../../src/services/authorization/authorization';
 import * as factories from '../__factories__';
 
@@ -386,6 +387,59 @@ describe('read permissions on related collections', () => {
       await expect(
         new Csv(services, options, dataSource, 'cards').handleCsv(context),
       ).rejects.toThrow("You are not allowed to read 'holder:nationalId' from the 'holders'");
+    });
+  });
+
+  // `edit` is the entry point here, not `read`: the route re-lists the row it just wrote with a
+  // projection the caller never supplied, so the same disclosure is one HTTP verb away.
+  describe('update', () => {
+    const updateContext = () =>
+      buildContext(
+        { params: { id: '2d162303-78bf-599e-b197-93590ac3d315' } },
+        {},
+        {
+          data: {
+            id: '2d162303-78bf-599e-b197-93590ac3d315',
+            attributes: { panLast4: '4242' },
+          },
+        },
+      );
+
+    it('should redact the record it serializes back rather than refusing the write', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices();
+      const cards = dataSource.getCollection('cards');
+      cards.update = jest.fn();
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([{ id: 'a-card' }]);
+
+      await new Update(services, options, dataSource, 'cards').handleUpdate(updateContext());
+
+      expect([...list.mock.calls[0][2]].sort()).toEqual([
+        'accountId',
+        'holderId',
+        'id',
+        'panLast4',
+      ]);
+    });
+
+    it('should keep the columns of a collection the caller may read', async () => {
+      const dataSource = buildDataSource();
+      const services = buildServices(['holders']);
+      const cards = dataSource.getCollection('cards');
+      cards.update = jest.fn();
+      const list = jest.spyOn(cards, 'list').mockResolvedValue([{ id: 'a-card' }]);
+
+      await new Update(services, options, dataSource, 'cards').handleUpdate(updateContext());
+
+      expect([...list.mock.calls[0][2]].sort()).toEqual([
+        'accountId',
+        'holder:fullName',
+        'holder:id',
+        'holder:nationalId',
+        'holderId',
+        'id',
+        'panLast4',
+      ]);
     });
   });
 

--- a/packages/agent/test/services/authorization/authorization.test.ts
+++ b/packages/agent/test/services/authorization/authorization.test.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'koa';
 
+import { Projection } from '@forestadmin/datasource-toolkit';
 import {
   ChainedSQLQueryError,
   ChartType,
@@ -431,6 +432,111 @@ describe('AuthorizationService', () => {
       authorizationService.invalidateScopeCache(42);
 
       expect(forestAdminClient.markScopesAsUpdated).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe('keepReadableProjection', () => {
+    const buildDataSource = () =>
+      factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'cards',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              holder: factories.manyToOneSchema.build({
+                foreignCollection: 'holders',
+                foreignKey: 'holderId',
+              }),
+            },
+          }),
+        }),
+        factories.collection.build({
+          name: 'holders',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              fullName: factories.columnSchema.build(),
+              nationalId: factories.columnSchema.build(),
+            },
+          }),
+        }),
+      ]);
+
+    const context = {
+      state: { user: { id: 35, renderingId: 42 } },
+    } as unknown as Context;
+
+    it('should spend no permission check on the root collection', async () => {
+      const forestAdminClient = factories.forestAdminClient.build();
+      const authorizationService = new AuthorizationService(forestAdminClient);
+
+      const projection = await authorizationService.redactProjection(
+        context,
+        buildDataSource().getCollection('cards'),
+        { projection: new Projection('id', 'holderId'), explicit: true },
+      );
+
+      expect(projection).toEqual(['id', 'holderId']);
+      expect(forestAdminClient.permissionService.canOnCollection).not.toHaveBeenCalled();
+    });
+
+    it('should check a traversed collection once, whatever the number of paths', async () => {
+      const forestAdminClient = factories.forestAdminClient.build();
+      const authorizationService = new AuthorizationService(forestAdminClient);
+
+      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockResolvedValue(true);
+
+      await authorizationService.redactProjection(
+        context,
+        buildDataSource().getCollection('cards'),
+        {
+          projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
+          explicit: true,
+        },
+      );
+
+      expect(forestAdminClient.permissionService.canOnCollection).toHaveBeenCalledTimes(1);
+      expect(forestAdminClient.permissionService.canOnCollection).toHaveBeenCalledWith({
+        userId: 35,
+        event: CollectionActionEvent.Read,
+        collectionName: 'holders',
+      });
+    });
+
+    it('should drop every path reaching a denied collection', async () => {
+      const forestAdminClient = factories.forestAdminClient.build();
+      const authorizationService = new AuthorizationService(forestAdminClient);
+
+      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockResolvedValue(false);
+
+      const projection = await authorizationService.redactProjection(
+        context,
+        buildDataSource().getCollection('cards'),
+        {
+          projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
+          explicit: false,
+        },
+      );
+
+      expect(projection).toEqual(['id']);
+    });
+
+    it('should refuse instead of redacting when the caller named the fields', async () => {
+      const forestAdminClient = factories.forestAdminClient.build();
+      const authorizationService = new AuthorizationService(forestAdminClient);
+
+      (forestAdminClient.permissionService.canOnCollection as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        authorizationService.redactProjection(context, buildDataSource().getCollection('cards'), {
+          projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
+          explicit: true,
+        }),
+      ).rejects.toThrow(
+        "You are not allowed to read 'holder:fullName' from the 'holders' collection, " +
+          "'holder:nationalId' from the 'holders' collection.",
+      );
     });
   });
 });

--- a/packages/agent/test/services/authorization/authorization.test.ts
+++ b/packages/agent/test/services/authorization/authorization.test.ts
@@ -435,7 +435,7 @@ describe('AuthorizationService', () => {
     });
   });
 
-  describe('keepReadableProjection', () => {
+  describe('redactProjection', () => {
     const buildDataSource = () =>
       factories.dataSource.buildWithCollections([
         factories.collection.build({

--- a/packages/agent/test/services/authorization/authorization.test.ts
+++ b/packages/agent/test/services/authorization/authorization.test.ts
@@ -474,7 +474,7 @@ describe('AuthorizationService', () => {
       const projection = await authorizationService.redactProjection(
         context,
         buildDataSource().getCollection('cards'),
-        { projection: new Projection('id', 'holderId'), explicit: true },
+        { projection: new Projection('id', 'holderId'), namedByCaller: true },
       );
 
       expect(projection).toEqual(['id', 'holderId']);
@@ -492,7 +492,7 @@ describe('AuthorizationService', () => {
         buildDataSource().getCollection('cards'),
         {
           projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
-          explicit: true,
+          namedByCaller: true,
         },
       );
 
@@ -515,7 +515,7 @@ describe('AuthorizationService', () => {
         buildDataSource().getCollection('cards'),
         {
           projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
-          explicit: false,
+          namedByCaller: false,
         },
       );
 
@@ -531,7 +531,7 @@ describe('AuthorizationService', () => {
       await expect(
         authorizationService.redactProjection(context, buildDataSource().getCollection('cards'), {
           projection: new Projection('id', 'holder:fullName', 'holder:nationalId'),
-          explicit: true,
+          namedByCaller: true,
         }),
       ).rejects.toThrow(
         "You are not allowed to read 'holder:fullName' from the 'holders' collection, " +

--- a/packages/agent/test/utils/csv-generator.test.ts
+++ b/packages/agent/test/utils/csv-generator.test.ts
@@ -409,4 +409,48 @@ describe('CsvGenerator', () => {
       });
     });
   });
+
+  describe('filterHeader', () => {
+    it('should drop the labels of the paths that were pruned', () => {
+      const header = CsvGenerator.filterHeader(
+        'Id,Pan,Holder national id',
+        new Projection('id', 'panLast4', 'holder:nationalId'),
+        new Projection('id', 'panLast4'),
+      );
+
+      expect(header).toEqual('Id,Pan');
+    });
+
+    it('should drop a label from the middle without shifting the others', () => {
+      const header = CsvGenerator.filterHeader(
+        'Id,Holder national id,Pan',
+        new Projection('id', 'holder:nationalId', 'panLast4'),
+        new Projection('id', 'panLast4'),
+      );
+
+      expect(header).toEqual('Id,Pan');
+    });
+
+    it('should return the header untouched when nothing was pruned', () => {
+      const projection = new Projection('id', 'panLast4');
+
+      expect(CsvGenerator.filterHeader('Id,Pan', projection, projection)).toEqual('Id,Pan');
+    });
+
+    it('should return an absent header as is', () => {
+      expect(
+        CsvGenerator.filterHeader(undefined, new Projection('id', 'x:y'), new Projection('id')),
+      ).toBeUndefined();
+    });
+
+    it('should drop every label when every path was pruned', () => {
+      const header = CsvGenerator.filterHeader(
+        'Holder national id',
+        new Projection('holder:nationalId'),
+        new Projection(),
+      );
+
+      expect(header).toEqual('');
+    });
+  });
 });

--- a/packages/agent/test/utils/field-path.test.ts
+++ b/packages/agent/test/utils/field-path.test.ts
@@ -1,0 +1,80 @@
+import FieldPathUtils from '../../src/utils/field-path';
+import * as factories from '../__factories__';
+
+describe('FieldPathUtils', () => {
+  const dataSource = factories.dataSource.buildWithCollections([
+    factories.collection.build({
+      name: 'cards',
+      schema: factories.collectionSchema.build({
+        fields: {
+          id: factories.columnSchema.uuidPrimaryKey().build(),
+          panLast4: factories.columnSchema.build({ columnType: 'String' }),
+          accountId: factories.columnSchema.build({ columnType: 'Uuid' }),
+          account: factories.manyToOneSchema.build({
+            foreignCollection: 'accounts',
+            foreignKey: 'accountId',
+          }),
+        },
+      }),
+    }),
+    factories.collection.build({
+      name: 'accounts',
+      schema: factories.collectionSchema.build({
+        fields: {
+          id: factories.columnSchema.uuidPrimaryKey().build(),
+          iban: factories.columnSchema.build({ columnType: 'String' }),
+          organizationId: factories.columnSchema.build({ columnType: 'Uuid' }),
+          organization: factories.manyToOneSchema.build({
+            foreignCollection: 'organizations',
+            foreignKey: 'organizationId',
+          }),
+        },
+      }),
+    }),
+    factories.collection.build({
+      name: 'organizations',
+      schema: factories.collectionSchema.build({
+        fields: {
+          id: factories.columnSchema.uuidPrimaryKey().build(),
+          name: factories.columnSchema.build({ columnType: 'String' }),
+        },
+      }),
+    }),
+  ]);
+
+  describe('getLeafCollection', () => {
+    it('should return the collection itself for a plain column', () => {
+      const owner = FieldPathUtils.getLeafCollection(dataSource.getCollection('cards'), 'panLast4');
+
+      expect(owner.name).toEqual('cards');
+    });
+
+    it('should return the collection the relation points to for a one hop path', () => {
+      const owner = FieldPathUtils.getLeafCollection(
+        dataSource.getCollection('cards'),
+        'account:iban',
+      );
+
+      expect(owner.name).toEqual('accounts');
+    });
+
+    it('should return the last collection of the path, not the ones crossed on the way', () => {
+      const owner = FieldPathUtils.getLeafCollection(
+        dataSource.getCollection('cards'),
+        'account:organization:name',
+      );
+
+      expect(owner.name).toEqual('organizations');
+    });
+
+    it('should return the root collection for a self referencing relation', () => {
+      const cards = dataSource.getCollection('cards');
+      cards.schema.fields.parent = factories.manyToOneSchema.build({
+        foreignCollection: 'cards',
+        foreignKey: 'id',
+      });
+
+      expect(FieldPathUtils.getLeafCollection(cards, 'parent:panLast4').name).toEqual('cards');
+    });
+  });
+});

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -430,7 +430,7 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual(new Projection('name'));
+      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
     });
 
     test('should fallback to the query string when the header is missing', () => {
@@ -443,7 +443,7 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual(new Projection('name'));
+      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
     });
 
     test('should fallback to the query string when the header is empty', () => {
@@ -457,7 +457,31 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual(new Projection('name'));
+      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
+    });
+
+    test('should report the default expansion as not explicit when no field is requested', () => {
+      const context = createMockContext({ customProperties: { query: {} } });
+
+      const { explicit } = QueryStringParser.parseProjectionFromHeaderOrQuery(
+        collectionSimple,
+        context,
+      );
+
+      expect(explicit).toBe(false);
+    });
+
+    test('should report an empty fields query param as not explicit', () => {
+      const context = createMockContext({
+        customProperties: { query: { 'fields[books]': '' } },
+      });
+
+      const { explicit } = QueryStringParser.parseProjectionFromHeaderOrQuery(
+        collectionSimple,
+        context,
+      );
+
+      expect(explicit).toBe(false);
     });
 
     test('should throw on an invalid header instead of falling back to the query string', () => {

--- a/packages/agent/test/utils/query-string.test.ts
+++ b/packages/agent/test/utils/query-string.test.ts
@@ -430,7 +430,7 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
+      expect(projection).toEqual({ projection: new Projection('name'), namedByCaller: true });
     });
 
     test('should fallback to the query string when the header is missing', () => {
@@ -443,7 +443,7 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
+      expect(projection).toEqual({ projection: new Projection('name'), namedByCaller: true });
     });
 
     test('should fallback to the query string when the header is empty', () => {
@@ -457,31 +457,31 @@ describe('QueryStringParser', () => {
         context,
       );
 
-      expect(projection).toEqual({ projection: new Projection('name'), explicit: true });
+      expect(projection).toEqual({ projection: new Projection('name'), namedByCaller: true });
     });
 
-    test('should report the default expansion as not explicit when no field is requested', () => {
+    test('should report the default expansion as not named by the caller', () => {
       const context = createMockContext({ customProperties: { query: {} } });
 
-      const { explicit } = QueryStringParser.parseProjectionFromHeaderOrQuery(
+      const { namedByCaller } = QueryStringParser.parseProjectionFromHeaderOrQuery(
         collectionSimple,
         context,
       );
 
-      expect(explicit).toBe(false);
+      expect(namedByCaller).toBe(false);
     });
 
-    test('should report an empty fields query param as not explicit', () => {
+    test('should report an empty fields query param as not named by the caller', () => {
       const context = createMockContext({
         customProperties: { query: { 'fields[books]': '' } },
       });
 
-      const { explicit } = QueryStringParser.parseProjectionFromHeaderOrQuery(
+      const { namedByCaller } = QueryStringParser.parseProjectionFromHeaderOrQuery(
         collectionSimple,
         context,
       );
 
-      expect(explicit).toBe(false);
+      expect(namedByCaller).toBe(false);
     });
 
     test('should throw on an invalid header instead of falling back to the query string', () => {

--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -596,6 +596,13 @@ export default class CollectionCustomizer<
 
   /**
    * Replace the behavior of the search bar
+   *
+   * On a plain search, the fields the handler reads are exempt from read permissions: the caller
+   * supplies the text and the handler picks the fields, so the agent cannot tell an intended one
+   * from one the role may not read. Point a handler at a column of a collection a role cannot read
+   * and that role can test values against it, reading each answer from whether rows come back.
+   * An extended search is refused rather than exempted, because the caller owns that flag and can
+   * compare the same term with it off and on.
    * @param definition handler to describe the new behavior
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/search Documentation Link}
    * @example

--- a/packages/datasource-customizer/src/decorators/search/collection.ts
+++ b/packages/datasource-customizer/src/decorators/search/collection.ts
@@ -9,12 +9,13 @@ import type {
   DataSourceDecorator,
   PaginatedFilter,
   PlainConditionTree,
+  SearchedField,
 } from '@forestadmin/datasource-toolkit';
 
 import { CollectionDecorator, ConditionTreeFactory } from '@forestadmin/datasource-toolkit';
 
 import CollectionSearchContext from './collection-search-context';
-import { lenientGetSchema } from './field-paths';
+import { getLeafCollectionName, getSearchedFieldPaths, lenientGetSchema } from './field-paths';
 import { extractSpecifiedFields, generateConditionTree, parseQuery } from './parse-query';
 
 export default class SearchCollectionDecorator extends CollectionDecorator {
@@ -118,6 +119,25 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
     return conditionTree?.toPlainObject();
   }
 
+  /**
+   * Answers against `childCollection`, which is what the search actually reads — a field hidden by
+   * the publication or renaming layers above is still searched. Returns `null` when a replacer is
+   * installed: the customer's handler chooses the fields, and the caller only supplies the text.
+   */
+  override getSearchedFields(search: string, extended: boolean): SearchedField[] | null {
+    if (this.replacer) return null;
+
+    const paths = [
+      ...getSearchedFieldPaths(this.childCollection, search),
+      ...this.getFields(this.childCollection, extended).map(([path]) => path),
+    ];
+
+    return paths.map(path => ({
+      path,
+      collection: getLeafCollectionName(this.childCollection, path),
+    }));
+  }
+
   private getFields(collection: Collection, extended: boolean): [string, ColumnSchema][] {
     const fields: [string, ColumnSchema][] = [];
 
@@ -135,5 +155,4 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
 
     return fields;
   }
-
 }

--- a/packages/datasource-customizer/src/decorators/search/collection.ts
+++ b/packages/datasource-customizer/src/decorators/search/collection.ts
@@ -14,7 +14,7 @@ import type {
 import { CollectionDecorator, ConditionTreeFactory } from '@forestadmin/datasource-toolkit';
 
 import CollectionSearchContext from './collection-search-context';
-import normalizeName from './normalize-name';
+import { lenientGetSchema } from './field-paths';
 import { extractSpecifiedFields, generateConditionTree, parseQuery } from './parse-query';
 
 export default class SearchCollectionDecorator extends CollectionDecorator {
@@ -91,7 +91,7 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
       [
         ...defaultFields,
         ...[...specifiedFields, ...(options?.onlyFields ?? []), ...(options?.includeFields ?? [])]
-          .map(name => this.lenientGetSchema(name))
+          .map(name => lenientGetSchema(this, name))
           .filter(Boolean)
           .map(schema => [schema.field, schema.schema] as [string, ColumnSchema]),
       ]
@@ -136,30 +136,4 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
     return fields;
   }
 
-  private lenientGetSchema(path: string): { field: string; schema: ColumnSchema } | null {
-    const [prefix, suffix] = path.split(/:(.*)/);
-    const fuzzyPrefix = normalizeName(prefix);
-
-    for (const [field, schema] of Object.entries(this.schema.fields)) {
-      const fuzzyFieldName = normalizeName(field);
-
-      if (fuzzyPrefix === fuzzyFieldName) {
-        if (!suffix && schema.type === 'Column') {
-          return { field, schema };
-        }
-
-        if (
-          suffix &&
-          (schema.type === 'OneToMany' || schema.type === 'ManyToOne' || schema.type === 'OneToOne')
-        ) {
-          const related = this.dataSource.getCollection(schema.foreignCollection);
-          const fuzzy = related.lenientGetSchema(suffix);
-
-          if (fuzzy) return { field: `${field}:${fuzzy.field}`, schema: fuzzy.schema };
-        }
-      }
-    }
-
-    return null;
-  }
 }

--- a/packages/datasource-customizer/src/decorators/search/field-paths.ts
+++ b/packages/datasource-customizer/src/decorators/search/field-paths.ts
@@ -40,3 +40,18 @@ export function getSearchedFieldPaths(collection: Collection, search: string): s
     .map(name => lenientGetSchema(collection, name)?.field)
     .filter(Boolean);
 }
+
+export function getLeafCollectionName(collection: Collection, path: string): string {
+  const index = path.indexOf(':');
+
+  if (index === -1) return collection.name;
+
+  const relation = collection.schema.fields[path.substring(0, index)];
+
+  if (!relation || relation.type === 'Column') return collection.name;
+
+  return getLeafCollectionName(
+    collection.dataSource.getCollection(relation.foreignCollection),
+    path.substring(index + 1),
+  );
+}

--- a/packages/datasource-customizer/src/decorators/search/field-paths.ts
+++ b/packages/datasource-customizer/src/decorators/search/field-paths.ts
@@ -1,0 +1,42 @@
+import type { Collection, ColumnSchema } from '@forestadmin/datasource-toolkit';
+
+import normalizeName from './normalize-name';
+import { extractSpecifiedFields, parseQuery } from './parse-query';
+
+export function lenientGetSchema(
+  collection: Collection,
+  path: string,
+): { field: string; schema: ColumnSchema } | null {
+  const [prefix, suffix] = path.split(/:(.*)/);
+  const fuzzyPrefix = normalizeName(prefix);
+
+  for (const [field, schema] of Object.entries(collection.schema.fields)) {
+    if (fuzzyPrefix === normalizeName(field)) {
+      if (!suffix && schema.type === 'Column') {
+        return { field, schema };
+      }
+
+      if (
+        suffix &&
+        (schema.type === 'OneToMany' || schema.type === 'ManyToOne' || schema.type === 'OneToOne')
+      ) {
+        const related = collection.dataSource.getCollection(schema.foreignCollection);
+        const fuzzy = lenientGetSchema(related, suffix);
+
+        if (fuzzy) return { field: `${field}:${fuzzy.field}`, schema: fuzzy.schema };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The field paths a search string reaches through the `relation.column:term` syntax, resolved the
+ * same way the search decorator resolves them — fuzzily, and across to-many relations too.
+ */
+export function getSearchedFieldPaths(collection: Collection, search: string): string[] {
+  return extractSpecifiedFields(parseQuery(search))
+    .map(name => lenientGetSchema(collection, name)?.field)
+    .filter(Boolean);
+}

--- a/packages/datasource-customizer/src/decorators/search/field-paths.ts
+++ b/packages/datasource-customizer/src/decorators/search/field-paths.ts
@@ -5,6 +5,8 @@ import type {
   RelationSchema,
 } from '@forestadmin/datasource-toolkit';
 
+import { SchemaUtils } from '@forestadmin/datasource-toolkit';
+
 import normalizeName from './normalize-name';
 import { extractSpecifiedFields, parseQuery } from './parse-query';
 
@@ -51,14 +53,21 @@ export function getSearchedFieldPaths(collection: Collection, search: string): s
     .filter(Boolean);
 }
 
+/**
+ * The collection a path's last column belongs to — the one a read permission applies to. A prefix
+ * that names no relation throws rather than falling back to `collection`, which the caller pins to
+ * readable: an unresolvable path must not read as an allowed one.
+ */
 export function getLeafCollectionName(collection: Collection, path: string): string {
   const index = path.indexOf(':');
 
   if (index === -1) return collection.name;
 
-  const relation = collection.schema.fields[path.substring(0, index)];
-
-  if (!relation || relation.type === 'Column') return collection.name;
+  const relation = SchemaUtils.getRelation(
+    collection.schema,
+    path.substring(0, index),
+    collection.name,
+  );
 
   return getLeafCollectionName(
     collection.dataSource.getCollection(relation.foreignCollection),

--- a/packages/datasource-customizer/src/decorators/search/field-paths.ts
+++ b/packages/datasource-customizer/src/decorators/search/field-paths.ts
@@ -1,7 +1,17 @@
-import type { Collection, ColumnSchema } from '@forestadmin/datasource-toolkit';
+import type {
+  Collection,
+  ColumnSchema,
+  FieldSchema,
+  RelationSchema,
+} from '@forestadmin/datasource-toolkit';
 
 import normalizeName from './normalize-name';
 import { extractSpecifiedFields, parseQuery } from './parse-query';
+
+const SEARCHABLE_THROUGH = ['OneToMany', 'ManyToOne', 'OneToOne'];
+
+const isSearchableThrough = (schema: FieldSchema): schema is RelationSchema =>
+  SEARCHABLE_THROUGH.includes(schema.type);
 
 export function lenientGetSchema(
   collection: Collection,
@@ -9,22 +19,22 @@ export function lenientGetSchema(
 ): { field: string; schema: ColumnSchema } | null {
   const [prefix, suffix] = path.split(/:(.*)/);
   const fuzzyPrefix = normalizeName(prefix);
+  const matches = Object.entries(collection.schema.fields).filter(
+    ([field]) => fuzzyPrefix === normalizeName(field),
+  );
 
-  for (const [field, schema] of Object.entries(collection.schema.fields)) {
-    if (fuzzyPrefix === normalizeName(field)) {
-      if (!suffix && schema.type === 'Column') {
-        return { field, schema };
-      }
+  if (!suffix) {
+    const column = matches.find(([, schema]) => schema.type === 'Column');
 
-      if (
-        suffix &&
-        (schema.type === 'OneToMany' || schema.type === 'ManyToOne' || schema.type === 'OneToOne')
-      ) {
-        const related = collection.dataSource.getCollection(schema.foreignCollection);
-        const fuzzy = lenientGetSchema(related, suffix);
+    return column ? { field: column[0], schema: column[1] as ColumnSchema } : null;
+  }
 
-        if (fuzzy) return { field: `${field}:${fuzzy.field}`, schema: fuzzy.schema };
-      }
+  for (const [field, schema] of matches) {
+    if (isSearchableThrough(schema)) {
+      const related = collection.dataSource.getCollection(schema.foreignCollection);
+      const fuzzy = lenientGetSchema(related, suffix);
+
+      if (fuzzy) return { field: `${field}:${fuzzy.field}`, schema: fuzzy.schema };
     }
   }
 

--- a/packages/datasource-customizer/src/index.ts
+++ b/packages/datasource-customizer/src/index.ts
@@ -13,6 +13,7 @@ export { default as CollectionChartContext } from './decorators/chart/context';
 export { ComputedDefinition } from './decorators/computed/types';
 export { OperatorDefinition } from './decorators/operators-emulate/types';
 export { RelationDefinition } from './decorators/relation/types';
+export { getSearchedFieldPaths } from './decorators/search/field-paths';
 export { SearchDefinition } from './decorators/search/types';
 export { SegmentDefinition } from './decorators/segment/types';
 export * from './decorators/write/write-replace/types';

--- a/packages/datasource-customizer/test/decorators/search/collections.test.ts
+++ b/packages/datasource-customizer/test/decorators/search/collections.test.ts
@@ -749,3 +749,56 @@ describe('SearchCollectionDecorator', () => {
     });
   });
 });
+
+describe('getSearchedFields', () => {
+  const buildCards = () =>
+    buildCollection(
+      {
+        fields: {
+          id: factories.columnSchema.uuidPrimaryKey().build(),
+          panLast4: factories.columnSchema.build({ columnType: 'String' }),
+          holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+          holder: factories.manyToOneSchema.build({
+            foreignCollection: 'holders',
+            foreignKey: 'holderId',
+          }),
+        },
+      },
+      [
+        factories.collection.build({
+          name: 'holders',
+          schema: factories.collectionSchema.build({
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              nationalId: factories.columnSchema.build({ columnType: 'String' }),
+            },
+          }),
+        }),
+      ],
+    );
+
+  test('it names the relation column the dot syntax reaches, without extended search', () => {
+    const searched = buildCards().getSearchedFields('holder.nationalId:1850', false);
+
+    expect(searched).toContainEqual({ path: 'holder:nationalId', collection: 'holders' });
+  });
+
+  test('it names every to-one column an extended search reaches', () => {
+    const searched = buildCards().getSearchedFields('martin', true);
+
+    expect(searched).toContainEqual({ path: 'holder:nationalId', collection: 'holders' });
+  });
+
+  test('it names none of them when the search is not extended', () => {
+    const searched = buildCards().getSearchedFields('martin', false);
+
+    expect(searched.every(({ collection }) => collection !== 'holders')).toBe(true);
+  });
+
+  test('it says it cannot tell when a replacer picks the fields', () => {
+    const decorator = buildCards();
+    decorator.replaceSearch(value => ({ field: 'id', operator: 'Equal', value }));
+
+    expect(decorator.getSearchedFields('martin', true)).toBeNull();
+  });
+});

--- a/packages/datasource-customizer/test/decorators/search/field-paths.test.ts
+++ b/packages/datasource-customizer/test/decorators/search/field-paths.test.ts
@@ -1,0 +1,60 @@
+import * as factories from '@forestadmin/datasource-toolkit/dist/test/__factories__';
+
+import { getLeafCollectionName } from '../../../src/decorators/search/field-paths';
+
+describe('getLeafCollectionName', () => {
+  const buildDataSource = () =>
+    factories.dataSource.buildWithCollections([
+      factories.collection.build({
+        name: 'cards',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            panLast4: factories.columnSchema.build({ columnType: 'String' }),
+            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            holder: factories.manyToOneSchema.build({
+              foreignCollection: 'holders',
+              foreignKey: 'holderId',
+            }),
+          },
+        }),
+      }),
+      factories.collection.build({
+        name: 'holders',
+        schema: factories.collectionSchema.build({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            nationalId: factories.columnSchema.text().build(),
+          },
+        }),
+      }),
+    ]);
+
+  it('should return the collection owning the last column of the path', () => {
+    const cards = buildDataSource().getCollection('cards');
+
+    expect(getLeafCollectionName(cards, 'holder:nationalId')).toBe('holders');
+  });
+
+  it('should return the collection itself for one of its own columns', () => {
+    const cards = buildDataSource().getCollection('cards');
+
+    expect(getLeafCollectionName(cards, 'panLast4')).toBe('cards');
+  });
+
+  // The caller pins the collection it asked about to readable, so answering `cards` here would
+  // turn "this path does not resolve" into "this path is allowed".
+  it('should throw rather than fall back to the collection it was asked about', () => {
+    const cards = buildDataSource().getCollection('cards');
+
+    expect(() => getLeafCollectionName(cards, 'panLast4:nationalId')).toThrow(
+      /relation.*panLast4|panLast4.*not/i,
+    );
+  });
+
+  it('should throw when the prefix names nothing at all', () => {
+    const cards = buildDataSource().getCollection('cards');
+
+    expect(() => getLeafCollectionName(cards, 'unknown:nationalId')).toThrow();
+  });
+});

--- a/packages/datasource-toolkit/src/decorators/collection-decorator.ts
+++ b/packages/datasource-toolkit/src/decorators/collection-decorator.ts
@@ -10,6 +10,8 @@ import type Projection from '../interfaces/query/projection';
 import type { CompositeId, RecordData } from '../interfaces/record';
 import type { CollectionSchema } from '../interfaces/schema';
 
+export type SearchedField = { path: string; collection: string };
+
 export default class CollectionDecorator implements Collection {
   readonly dataSource: DataSource;
   protected childCollection: Collection;
@@ -32,6 +34,16 @@ export default class CollectionDecorator implements Collection {
 
   get name(): string {
     return this.childCollection.name;
+  }
+
+  /**
+   * Which fields a search will actually reach, and where they live — `null` when the collection
+   * cannot say, which a caller must read as "unknown", never as "none".
+   */
+  getSearchedFields(search: string, extended: boolean): SearchedField[] | null {
+    return this.childCollection instanceof CollectionDecorator
+      ? this.childCollection.getSearchedFields(search, extended)
+      : null;
   }
 
   constructor(childCollection: Collection, dataSource: DataSource) {

--- a/packages/datasource-toolkit/src/index.ts
+++ b/packages/datasource-toolkit/src/index.ts
@@ -7,7 +7,7 @@ export { MAP_ALLOWED_OPERATORS_FOR_COLUMN_TYPE as allowedOperatorsForColumnType 
 export { default as BaseCollection } from './base-collection';
 export { default as BaseDataSource } from './base-datasource';
 export { default as DataSourceDecorator } from './decorators/datasource-decorator';
-export { default as CollectionDecorator } from './decorators/collection-decorator';
+export { default as CollectionDecorator, SearchedField } from './decorators/collection-decorator';
 
 // Query Interface
 export { default as Aggregation } from './interfaces/query/aggregation';


### PR DESCRIPTION
## Why

A read is permission-checked on the **root collection only**. Every column a projection, a filter or a sort reaches *through a relation path* is served with no check on the collection it comes from.

A role with `read` on `cards` and nothing at all on `holders` gets this in full:

```
GET /forest/cards
Forest-Projection: id,holder:nationalId,holder:dateOfBirth
```

The header is not even required — `GET /forest/cards` with no `fields[]` returns the same columns, because `ProjectionFactory.all` expands every column of every to-one relation.

The filter is the sharper half. It never returns the column, yet it answers one guess per request:

```
GET /forest/cards?filters={"field":"holder:nationalId","operator":"starts_with","value":"1850"}
```

One row back or zero rows back is one digit. Ten iterations per character recovers a national id in full, from a collection with zero granted permissions, without the value ever appearing in a response.

fixes PRD-900

## The rule

**Check the collection each path *ends* on.** Collections crossed on the way confer and require nothing — reaching one through a relation is a join, not a read — so `account:organization:name` needs `read` on `organizations` alone, and a ManyToMany through-collection stays out of it since it contributes no returned column.

What a denial does depends on **who asked for the field**:

| | |
|---|---|
| Named by the caller (`fields[]`, `Forest-Projection`) | **Refused**, listing every offending path in one message so a client drops them all and retries once |
| Never asked for (the `ProjectionFactory.all` default) | **Dropped from the projection** — refusing would turn an ordinary listing into a 403 |

Filters, sorts, extended searches and a chart's group-by or aggregated field are **always refused**. None has a prunable equivalent: dropping a condition widens the result set, dropping a sort clause silently reorders it, and a grouped-by key is chart output.

The check reads the caller's own query only. Scopes and segments are injected by the agent and may legitimately reference a collection the caller cannot read — a test locks that down.

## One case the rule does not describe

A leaderboard counting a relation has no aggregate field, so no path traces back to the collection being counted. What it exposes is that collection's cardinality, which is what `browse` already governs on `/forest/<collection>/count` and `/relationships/<name>/count` — so that is what gets asserted, on the foreign collection rather than on the through-collection a ManyToMany aggregates.

Found by an adversarial review pass on the first revision of this branch, not by the original implementation.

## Routes covered

`get`, `list`, `csv`, `list-related`, `csv-related`, `count`, `count-related`, the chart routes, and `update`.

`update` is a write, and in scope anyway. `PUT /forest/<collection>/:id` re-lists the row it just wrote with `ProjectionFactory.all` and serializes the result, so a role with `edit` on `cards` and no `read` on `holders` got `holder.nationalId` back from a no-op update — the same disclosure as `GET /forest/cards/:id`, and `edit` almost always comes with it. The projection there is entirely agent-chosen, so it is **redacted, never refused**: a write must not 403 because the row happens to carry a relation the caller cannot read.

The filter-shaped half on the destructive routes — `delete.ts:45` and `dissociate-delete-related.ts:122` accept the caller's `filters` on the same denied paths — is deliberately out of scope and split to PRD-1012. A delete answers `204` whatever it matched, so there is no response oracle and each probe destroys the rows it measures, while refusing would 403 any bulk delete filtered on a belongsTo sub-field, which the filter bar allows and no front change absorbs.

## Sequencing — the front has landed

The front used to ask for these columns on every list and detail view. It stopped in **ForestAdmin/forestadmin#9914**, which prunes projections by `canReadCollection` and renders a denied belongsTo as restricted — **merged into `main` on 2026-08-21** (`d050ef96`). That was the blocker on this PR: merging the agent first would have turned every list or detail view showing a belongsTo on a denied collection into a 403.

One path the front does not cover, by design: chart requests. See the dashboard leaderboard note under *Residual cost*.

## Residual cost

Roles that display a related label today without `read` on the target lose it until an admin grants it. One permission sweep per project, visible and diagnosable rather than silent.

**Dashboard leaderboards that count a relation break for existing roles.** A `Count` leaderboard on `holders` counting `cards`, for a role without `browse` on `cards`, now returns 403 where it returned counts — and the widget still renders, since dashboard chart visibility follows the chart's own collection, so it shows an error rather than disappearing. ForestAdmin/forestadmin#9914 prunes record, list and export projections and does not touch chart requests, so the sequencing note below does not cover this path. It needs the same permission sweep as the rest, on `browse` rather than `read`.

**A projected path that reaches through a collection the caller cannot read serves that collection's id.** The leaf-only rule grants `account:organization:name` on `read` of `organizations` alone, and JSON:API renders the traversed `accounts` record as a resource of its own — an identity in `relationships`, an entry in `included` — so the leaf column cannot be served without it. Its id and nothing more: no column of the traversed collection reaches the payload. Dropping the key instead is not an option, because `withPks` is what supplies the serializer's precondition — a relation with no identity raises `Missing one of expected fields` rather than redacting, a 500 where there was a 200. A OneToOne, or a `foreignKeyTarget` that is not the primary key, is the sharp end: the id is one the root row does not carry. Three cases in `test/security/related-read-permissions.test.ts` pin it, including the payload bound. Raised in review on this branch, where it was diagnosed in a comment and pinned by nothing.

**A `replaceSearch` handler is exempt on a plain search and refused on an extended one.** `getSearchedFields` answers `null` when a handler is installed, and the deciding question is whether the caller can aim. On a plain search they aimed at nothing — the footprint is the one the customer chose, identical for every role, so it is served, the same category as a scope, and refusing would remove search from every customized collection. The extended flag is theirs, though: the same term with it off and then on differs by exactly the rows matched through a relation, a bit per term over collections no check covered, so an unverifiable traversal is refused. Decided in PRD-1024, which applies to node unchanged. **The cost is a 403 where there was a 200** for a customer using `replaceSearch` on a collection where users tick extended search. The residual on the plain half is accepted and now stated in `replaceSearch`'s own JSDoc: a handler searching a column the role cannot read gives the caller the same rows-or-no-rows oracle a filter would, and the agent cannot tell that apart from what the customer intended.

Any client requesting relation fields its role may not read — a customer script, an `agent-client` integration, an MCP tool — starts getting a 403 where it got a 200. That is the fix working: only integrations running under a role that should never have had the data are affected, and the error names the field and the collection so they can be fixed rather than guessed at.

## Not in scope

- `browse` still stands in for a denied `read` when the front resolves a get-one through the list route — tracked in PRD-990.
- On `instantCacheRefresh: false`, each denied check clears and refetches the whole permission cache; denials are routine on the redaction path, so that is one permission fetch per read — tracked in PRD-1002, to be fixed in `forestadmin-client` rather than here.
- Nothing else known. The extended-search sweep no longer derives its own set: `getSearchedFields` walks down the stack and the search decorator answers from `childCollection`, so a field hidden by `.removeField` is still checked, and a replaced search — whose footprint the layer cannot state — is served plain and refused extended, see *Residual cost*.
- Whether a ManyToMany through-collection needs `read` of its own is left open, as PRD-900 states.

## Tests

`test/security/related-read-permissions.test.ts` builds the ticket's schema and role, and each case fails against the previous implementation — verified by reverting the guard, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce read permissions on query fields and projections across agent routes
> - Introduces `AuthorizationService.redactProjection` to drop or reject projection fields whose owning related collections the caller cannot read; implicit projections drop fields, explicit field lists return 403
> - Adds `AuthorizationService.assertCanReadQueryFields` to reject filter/sort/search terms that reference fields from unreadable related collections, applied to list, get, count, csv, chart, and related routes
> - Adds `FieldPathUtils.getLeafCollection` to resolve the owning collection of a colon-separated field path, and `SearchCollectionDecorator.getSearchedFields` to surface which fields an extended search will read
> - Updates `CsvGenerator.filterHeader` to keep CSV header labels aligned with redacted columns; `UpdateRoute.handleUpdate` now redacts unreadable fields from the post-update response
> - Risk: callers that previously received data from unreadable related collections via implicit projections or filters now get redacted results or 403s — check `redactProjection` in [authorization.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1840/files#diff-9103e7358427994d7727cf4f652032c5d2d47448022946adda46c493a403c686) and route handlers in [packages/agent/src/routes/access/](https://github.com/ForestAdmin/agent-nodejs/pull/1840/files#diff-9ff1c82c8599c82b6c6abae9421ab17e7978d93a5f0469cfe46ead771c137edf) for regressions in existing API consumers
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1840 opened
>
> - Renamed the `explicit` property to `namedByCaller` in the `RequestedProjection` type and updated all usages throughout `AuthorizationService.redactProjection`, `QueryStringParser.parseProjectionFromHeaderOrQuery`, `UpdateRoute.handleUpdate`, and associated tests [680ec65]
> - Updated an explanatory comment in the `related-read-permissions.test` test suite [aeb3c3c]
> - Extended `AuthorizationService.assertCanReadQueryFields` method to accept optional `consumes` parameter of type `QueryComponent[]` with default value `['filter','sort','search']`, and added exported `QueryComponent` type union and `ALL_QUERY_COMPONENTS` constant [9385592]
> - Updated `ChartRoute.makeChart`, `CountRelatedRoute.handleCountRelated`, and `CountRoute.handleCount` handlers to pass `['filter','search']` as third argument to `assertCanReadQueryFields` [9385592]
> - Added test case verifying count route ignores sort parameter on unreadable related fields [9385592]
> - Added test cases verifying that traversing a OneToOne relation on an unreadable collection correctly projects the relation key and serializes only the key and nested readable fields [e3e61ec]
> - Extended test data source schema with a OneToOne relation from `cards` to a new `contracts` collection and added the `contracts` collection with a ManyToOne relation to `organizations` [e3e61ec]
> - Added `RecordData` type import from `@forestadmin/datasource-toolkit` and `Serializer` import from local services [e3e61ec]
> - Updated test comments clarifying the requirement to include `account:id` in projection for serialization [e3e61ec]
> - Added extended search authorization check in `AuthorizationService.search` that throws `ForbiddenError` when searched fields cannot be determined [f3c2de6]
> - Added test coverage for extended search authorization with unknown field footprints [f3c2de6]
> - Expanded JSDoc documentation in `CollectionCustomizer.replaceSearch` to clarify security semantics of plain versus extended searches [f3c2de6]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e3e7b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->






