### PR TITLE
chore(claude): register the forest plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,8 +25,7 @@
     "feature-dev@claude-code-plugins": true,
     "pr-review-toolkit@claude-code-plugins": true,
     "document-skills@anthropic-agent-skills": true,
-    "example-skills@anthropic-agent-skills": true,
-    "forest@forest": true
+    "example-skills@anthropic-agent-skills": true
   },
   "permissions": {
     "deny": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,12 @@
         "source": "github",
         "repo": "anthropics/skills"
       }
+    },
+    "forest": {
+      "source": {
+        "source": "github",
+        "repo": "ForestAdmin/claudine"
+      }
     }
   },
   "enabledPlugins": {
@@ -19,7 +25,8 @@
     "feature-dev@claude-code-plugins": true,
     "pr-review-toolkit@claude-code-plugins": true,
     "document-skills@anthropic-agent-skills": true,
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "forest@forest": true
   },
   "permissions": {
     "deny": [


### PR DESCRIPTION
Installing the Forest Claude Code toolkit in this repo currently takes two commands, the first of which nobody can guess:

```
/plugin marketplace add ForestAdmin/claudine
/plugin install forest@forest
```

This commits the marketplace source so only the second one is needed.

## What the entry does, and does not do

`.claude/settings.json` registers `ForestAdmin/claudine` as a marketplace named `forest`, and nothing else. It does not enable the plugin.

`extraKnownMarketplaces` is a declaration, not a fetch: a session never clones from it. Measured in a scratch project against an unreachable marketplace, and against a reachable one not yet on disk — in both cases the session started normally, wrote nothing to `installed_plugins.json` or `known_marketplaces.json`, cloned nothing, and printed no error even under `--debug`. So a developer who has not run `/plugin install forest@forest` has no plugin fetched, loaded or run for them, and someone without access to the private repo sees nothing at all rather than a failure.

The pre-enable key `"forest@forest": true` is deliberately absent, and not for the reason one might assume. Measured in the same harness, on a machine where the marketplace is *already* cloned, that key installs the plugin at project scope on session start with nobody running `/plugin install` — recorded in the ledger as `"scope": "project"` against the project path. That is what business rules 1 and 2 rule out: the entry must install nothing, and installing stays an explicit act by the developer. It has no bearing on people without access, who are unaffected either way.

Observed in print mode (`claude -p`); an interactive session may surface warnings print mode does not.

Access to the private `ForestAdmin/claudine` comes from the developer's own git credentials. There is no field for it here. Someone without access gets a resolution failure when they run `/plugin install` themselves — not before, since nothing here reaches for the marketplace unprompted.

Names come from the marketplace manifest rather than a guess: `ForestAdmin/claudine` → `.claude-plugin/marketplace.json` declares marketplace `"name": "forest"` with one plugin `"name": "forest"`, hence `forest@forest`.

## Scope

`.claude/settings.json` only, +6/-0, purely additive. The two `anthropics` marketplaces, the six already-enabled plugins and the `permissions.deny` block are byte-identical to `main` — `enabledPlugins` is no longer touched at all.

Refs: [PRD-713](https://linear.app/forestadmin/issue/PRD-713/install-the-toolkit-with-one-command-in-the-repos-we-work-in)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register the `forest` plugin source and enable `forest@forest` skill
> Adds a new GitHub-backed source named `forest` pointing to `ForestAdmin/claudine` in the Claude settings. Enables the `forest@forest` skill for use.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1841 opened
>
> - Removed `forest@forest` plugin registration from Claude settings configuration [86d446f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bc9ea1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


