### PR TITLE
docs(agent-bff): describe the routes that shipped

### DIFF
--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -6,7 +6,28 @@ agent from a browser without learning MCP or JSON:API.
 It is a bootable Koa 3 server with a `/health` endpoint, a version header, env-driven config
 validation, OAuth (Mode 1) + API-key (Mode 2) auth, and a hardened request edge (timezone, CORS,
 auth-mode precedence, structured error contract), and it serves and exports its own OpenAPI
-document. The data-endpoint proxy lands in a later slice.
+document.
+
+## The routes it serves
+
+Everything the agent proxy exposes lives under `/agent/v1`. The data and action routes are `POST`
+— the filter, projection and paging all travel in the body, never in the query string:
+
+| Route | Method | What it does |
+| --- | --- | --- |
+| `/agent/v1/{collection}/list` · `/count` | `POST` | list or count records of a collection |
+| `/agent/v1/{collection}/relations/{relation}/list` · `/count` | `POST` | same, through a **to-many** relation — to-one relations are not listable and 404 by design |
+| `/agent/v1/{collection}/actions/{action}/form` · `/execute` | `POST` | load a Smart Action's form, then run it |
+| `/agent/v1/permissions` | `GET` | what the caller may see and do, **as display hints** for graying out UI — never an authorization decision |
+| `/agent/openapi.json` | `GET`/`HEAD` | the unfolded document, auth-gated, when `BFF_OPENAPI_ENABLED` is on |
+
+`/health` and `/oauth/*` sit outside the prefix and outside the auth edge.
+
+**The agent enforces permissions and scopes, not the BFF.** Each proxied call carries a
+short-lived agent token the BFF mints for the caller, so a request reaches the agent as that
+person and comes back filtered exactly as it would for them in Forest. A collection the current
+schema no longer exposes is re-checked on every call, so a schema refresh can never leave a
+dropped collection reachable.
 
 ## Usage
 
@@ -66,7 +87,7 @@ yarn start:dev         # node --env-file=.env dist/cli.js
 | `FOREST_AUTH_SECRET` | yes      | Agent JWT signing secret (never logged or echoed).                   |
 | `FOREST_ENV_SECRET`  | yes      | Forest SaaS environment secret (`forest-secret-key`), server-to-server. |
 | `FOREST_SERVER_URL`  | yes      | Forest SaaS API base URL.                                            |
-| `FOREST_APP_URL`     | yes      | Forest front base URL (OAuth front-channel, later slices).          |
+| `FOREST_APP_URL`     | yes      | Forest front base URL, used to build the OAuth front-channel redirect (`src/oauth/oauth-routes.ts`). |
 | `AGENT_URL`          | yes      | The customer agent base URL the BFF calls via agent-client.          |
 | `BFF_TOKEN_ENCRYPTION_KEY`| for OAuth | Base64-encoded 32-byte AES-256 key encrypting stored refresh tokens. Until it is set, the `/oauth/*` token-issuance routes are disabled and `/health` reports `degraded`; already-issued `bff_access` tokens still authenticate on `/agent/*` whenever `FOREST_AUTH_SECRET` is present. |
 | `HTTP_PORT`          | no       | Server port, integer 0–65535. Defaults to `3450`. `0` binds an OS-assigned ephemeral port. |
@@ -87,7 +108,7 @@ yarn start:dev         # node --env-file=.env dist/cli.js
 ## Request edge (`/agent/*`)
 
 Every agent call flows through a request edge that enforces three cross-cutting concerns before the
-(Slice-3) proxy runs. Errors use a structured, type-first contract — `{ error: { type, status,
+call is proxied to the agent. Errors use a structured, type-first contract — `{ error: { type, status,
 message, details? } }` — so consumers branch on `error.type`, never on message text.
 
 ### Auth-mode precedence


### PR DESCRIPTION
The README says **"The data-endpoint proxy lands in a later slice"** and refers to "the (Slice-3) proxy", while `list`, `count`, to-many relation `list`/`count`, action `form`/`execute`, the permissions endpoint and the OpenAPI route are all in place and tested (#1804, #1823, #1824, #1827). Someone reading it to decide whether this package can back their UI today concludes that it cannot — which is how I read it before checking the source.

## What changed

- **A route table with the real methods.** The data and action routes are `POST` (filter, projection and paging travel in the body); `/agent/v1/permissions` is a `GET`. Also states that only **to-many** relations are listable, since a to-one relation 404s by design.
- **The fact a caller most needs and the README never said**: permissions and scopes are enforced **by the agent**, because every proxied call carries a short-lived caller-scoped token the BFF mints — so `/agent/v1/permissions` returns display hints for graying out UI, never an authorization decision. Without that, a consumer can reasonably assume the BFF filters, and build on a wrong mental model.
- **`FOREST_APP_URL` is no longer "later slices"** — `src/oauth/oauth-routes.ts` consumes it to build the front-channel redirect.

Docs only, no behavior change. The pack that documents this plane is updated in parallel in ForestAdmin/claudine#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the shipped routes and configuration in `agent-bff` README
> Updates [README.md](https://github.com/ForestAdmin/agent-nodejs/pull/1846/files#diff-d28058d35a5af0e1a6e0b2e082c01d6da3dac1a1127d673782760a6a02af58f1) to replace the placeholder about a later data-endpoint slice with a full "The routes it serves" section covering `/agent/v1` list/count, relations, Smart Action form/execute, permissions, and the OpenAPI endpoint. Also clarifies that permissions and scopes are enforced by the agent, that the BFF mints short-lived agent tokens per request, and that `/health` and `/oauth/*` sit outside the auth edge. Refined the `FOREST_APP_URL` and `BFF_OPENAPI_ENABLED` descriptions in the Configuration table to match the implemented behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57c081e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->