### PR TITLE
feat(agent): resolve select-all selections for approval-required actions

### DIFF
--- a/packages/_example/src/forest/agent.ts
+++ b/packages/_example/src/forest/agent.ts
@@ -8,6 +8,7 @@ import { createSequelizeDataSource } from '@forestadmin/datasource-sequelize';
 import { createSqlDataSource } from '@forestadmin/datasource-sql';
 
 import customizeAccount from './customizations/account';
+import customizeAccountBill from './customizations/account-bill';
 import customizeCard from './customizations/card';
 import customizeComment from './customizations/comment';
 import customizeCustomer from './customizations/customer';
@@ -99,6 +100,7 @@ export default function makeAgent() {
 
     .customizeCollection('card', customizeCard)
     .customizeCollection('account', customizeAccount)
+    .customizeCollection('account_bills', customizeAccountBill)
     .customizeCollection('owner', customizeOwner)
     .customizeCollection('store', customizeStore)
     .customizeCollection('rental', customizeRental)

--- a/packages/_example/src/forest/agent.ts
+++ b/packages/_example/src/forest/agent.ts
@@ -8,7 +8,6 @@ import { createSequelizeDataSource } from '@forestadmin/datasource-sequelize';
 import { createSqlDataSource } from '@forestadmin/datasource-sql';
 
 import customizeAccount from './customizations/account';
-import customizeAccountBill from './customizations/account-bill';
 import customizeCard from './customizations/card';
 import customizeComment from './customizations/comment';
 import customizeCustomer from './customizations/customer';
@@ -100,7 +99,6 @@ export default function makeAgent() {
 
     .customizeCollection('card', customizeCard)
     .customizeCollection('account', customizeAccount)
-    .customizeCollection('account_bills', customizeAccountBill)
     .customizeCollection('owner', customizeOwner)
     .customizeCollection('store', customizeStore)
     .customizeCollection('rental', customizeRental)

--- a/packages/agent/src/routes/modification/action/action-authorization.ts
+++ b/packages/agent/src/routes/modification/action/action-authorization.ts
@@ -27,7 +27,13 @@ export default class ActionAuthorizationService {
     filterForCaller,
     filterForAllCaller,
     caller,
-  }: CanPerformCustomActionParams): Promise<void> {
+    resolveSelectAllRecordIds,
+  }: CanPerformCustomActionParams & {
+    // Set on a "select all" trigger: the frontend has no explicit id list to store in the approval
+    // request, so when approval turns out to be required, the resolved (capped) ids are handed back
+    // through the error. Resolution lives in the caller — it needs the http context.
+    resolveSelectAllRecordIds?: () => Promise<Array<string | number>>;
+  }): Promise<void> {
     const canTrigger = await this.canTriggerCustomAction(
       caller,
       customActionName,
@@ -54,7 +60,10 @@ export default class ActionAuthorizationService {
         filterForAllCaller,
       );
 
-      throw new CustomActionRequiresApprovalError(roleIdsAllowedToApprove);
+      throw new CustomActionRequiresApprovalError(
+        roleIdsAllowedToApprove,
+        await resolveSelectAllRecordIds?.(),
+      );
     }
   }
 

--- a/packages/agent/src/routes/modification/action/action-authorization.ts
+++ b/packages/agent/src/routes/modification/action/action-authorization.ts
@@ -29,9 +29,7 @@ export default class ActionAuthorizationService {
     caller,
     resolveSelectAllRecordIds,
   }: CanPerformCustomActionParams & {
-    // Set on a "select all" trigger: the frontend has no explicit id list to store in the approval
-    // request, so when approval turns out to be required, the resolved (capped) ids are handed back
-    // through the error. Resolution lives in the caller — it needs the http context.
+    // Set on "select all": resolves the selection to the ids stored in the approval request.
     resolveSelectAllRecordIds?: () => Promise<Array<string | number>>;
   }): Promise<void> {
     const canTrigger = await this.canTriggerCustomAction(

--- a/packages/agent/src/routes/modification/action/action.ts
+++ b/packages/agent/src/routes/modification/action/action.ts
@@ -105,10 +105,13 @@ export default class ActionRoute extends CollectionRoute {
       await this.actionAuthorizationService.assertCanTriggerCustomAction({
         ...canPerformCustomActionParams,
         // Only a "select all" trigger needs its selection resolved (capped) for the approval
-        // request — a normal execute is never capped.
-        resolveSelectAllRecordIds: requestBody?.data?.attributes?.all_records
-          ? () => this.resolveApprovalRecordIds(context, caller, filterForCaller)
-          : undefined,
+        // request — a normal execute is never capped, and a global action targets no specific
+        // records (mirrors auditedRecordIds).
+        resolveSelectAllRecordIds:
+          requestBody?.data?.attributes?.all_records &&
+          this.collection.schema.actions[this.actionName].scope !== 'Global'
+            ? () => this.resolveApprovalRecordIds(context, caller, filterForCaller)
+            : undefined,
       });
     }
 

--- a/packages/agent/src/routes/modification/action/action.ts
+++ b/packages/agent/src/routes/modification/action/action.ts
@@ -21,6 +21,7 @@ import {
 } from '@forestadmin/datasource-toolkit';
 
 import ActionAuthorizationService from './action-authorization';
+import ApprovalSelectionTooLargeError from './errors/approval-selection-too-large-error';
 import {
   MAX_SNAPSHOT_RECORDS,
   buildRecorder,
@@ -101,9 +102,14 @@ export default class ActionRoute extends CollectionRoute {
         requesterId: requestBody.data.attributes.requester_id,
       });
     } else {
-      await this.actionAuthorizationService.assertCanTriggerCustomAction(
-        canPerformCustomActionParams,
-      );
+      await this.actionAuthorizationService.assertCanTriggerCustomAction({
+        ...canPerformCustomActionParams,
+        // Only a "select all" trigger needs its selection resolved (capped) for the approval
+        // request — a normal execute is never capped.
+        resolveSelectAllRecordIds: requestBody?.data?.attributes?.all_records
+          ? () => this.resolveApprovalRecordIds(context, caller, filterForCaller)
+          : undefined,
+      });
     }
 
     const rawData = requestBody.data.attributes.values;
@@ -292,6 +298,32 @@ export default class ActionRoute extends CollectionRoute {
     this.options.logger('Warn', message);
 
     return [];
+  }
+
+  // Resolve a "select all" selection to the concrete ids stored in the approval request. Capped at
+  // `maxRecordsForApproval`: above it we refuse the trigger rather than snapshot an unbounded id list
+  // (the Forest server enforces the same cap authoritatively when the request is created). Fetching
+  // cap+1 distinguishes "over the cap" from "exactly the cap". Runs the live-query segment handler
+  // for the same reason `auditedRecordIds` does.
+  private async resolveApprovalRecordIds(
+    context: Context,
+    caller: Caller,
+    filterForCaller: Filter,
+  ): Promise<Array<string | number>> {
+    const max = this.options.maxRecordsForApproval;
+    const paginatedFilter = await this.services.segmentQueryHandler.handleLiveQuerySegmentFilter(
+      context,
+      new PaginatedFilter({ ...filterForCaller, page: new Page(0, max + 1) }),
+    );
+    const records = await this.collection.list(
+      caller,
+      paginatedFilter,
+      new Projection(...SchemaUtils.getPrimaryKeys(this.collection.schema)),
+    );
+
+    if (records.length > max) throw new ApprovalSelectionTooLargeError(max);
+
+    return IdUtils.packIds(this.collection.schema, records);
   }
 
   private async handleHook(context: Context): Promise<void> {

--- a/packages/agent/src/routes/modification/action/action.ts
+++ b/packages/agent/src/routes/modification/action/action.ts
@@ -104,9 +104,7 @@ export default class ActionRoute extends CollectionRoute {
     } else {
       await this.actionAuthorizationService.assertCanTriggerCustomAction({
         ...canPerformCustomActionParams,
-        // Only a "select all" trigger needs its selection resolved (capped) for the approval
-        // request — a normal execute is never capped, and a global action targets no specific
-        // records (mirrors auditedRecordIds).
+        // Global actions target no specific records (mirrors auditedRecordIds).
         resolveSelectAllRecordIds:
           requestBody?.data?.attributes?.all_records &&
           this.collection.schema.actions[this.actionName].scope !== 'Global'
@@ -303,11 +301,7 @@ export default class ActionRoute extends CollectionRoute {
     return [];
   }
 
-  // Resolve a "select all" selection to the concrete ids stored in the approval request. Capped at
-  // `maxRecordsForApproval`: above it we refuse the trigger rather than snapshot an unbounded id list
-  // (the Forest server enforces the same cap authoritatively when the request is created). Fetching
-  // cap+1 distinguishes "over the cap" from "exactly the cap". Runs the live-query segment handler
-  // for the same reason `auditedRecordIds` does.
+  // Fetching cap+1 distinguishes "over the cap" from "exactly the cap".
   private async resolveApprovalRecordIds(
     context: Context,
     caller: Caller,

--- a/packages/agent/src/routes/modification/action/errors/approval-selection-too-large-error.ts
+++ b/packages/agent/src/routes/modification/action/errors/approval-selection-too-large-error.ts
@@ -1,0 +1,10 @@
+import { UnprocessableError } from '@forestadmin/datasource-toolkit';
+
+export default class ApprovalSelectionTooLargeError extends UnprocessableError {
+  constructor(max: number) {
+    super(
+      `This action requires approval and cannot be triggered on more than ${max} records at once. ` +
+        `Please refine your selection.`,
+    );
+  }
+}

--- a/packages/agent/src/routes/modification/action/errors/custom-action-requires-approval-error.ts
+++ b/packages/agent/src/routes/modification/action/errors/custom-action-requires-approval-error.ts
@@ -1,9 +1,6 @@
 import { ForbiddenError } from '@forestadmin/datasource-toolkit';
 
 export default class CustomActionRequiresApprovalError extends ForbiddenError {
-  // `recordIds` is only set for a "select all" trigger: the frontend has no explicit id list in
-  // that case, so the agent resolves the selection (capped) and hands the ids back to be stored in
-  // the approval request.
   constructor(roleIdsAllowedToApprove: number[], recordIds?: Array<string | number>) {
     super('This action requires to be approved.', {
       roleIdsAllowedToApprove,

--- a/packages/agent/src/routes/modification/action/errors/custom-action-requires-approval-error.ts
+++ b/packages/agent/src/routes/modification/action/errors/custom-action-requires-approval-error.ts
@@ -1,9 +1,13 @@
 import { ForbiddenError } from '@forestadmin/datasource-toolkit';
 
 export default class CustomActionRequiresApprovalError extends ForbiddenError {
-  constructor(roleIdsAllowedToApprove: number[]) {
+  // `recordIds` is only set for a "select all" trigger: the frontend has no explicit id list in
+  // that case, so the agent resolves the selection (capped) and hands the ids back to be stored in
+  // the approval request.
+  constructor(roleIdsAllowedToApprove: number[], recordIds?: Array<string | number>) {
     super('This action requires to be approved.', {
       roleIdsAllowedToApprove,
+      ...(recordIds ? { recordIds } : {}),
     });
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -75,6 +75,13 @@ export type AgentOptions = {
   ignoreMissingSchemaElementErrors?: boolean;
   useUnsafeActionEndpoint?: boolean;
   /**
+   * Max number of records an approval-required action may target when "select all" is used.
+   * Above this the trigger is rejected instead of storing a huge id snapshot in the approval.
+   * Must not exceed the Forest server's own cap (default 500), which is the authoritative gate.
+   * @default 500
+   */
+  maxRecordsForApproval?: number;
+  /**
    * Base URL of the workflow executor to proxy requests to.
    * When set, the agent forwards `/_internal/executor/*` to the executor verbatim,
    * benefiting from the agent's authentication layer.

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -75,9 +75,8 @@ export type AgentOptions = {
   ignoreMissingSchemaElementErrors?: boolean;
   useUnsafeActionEndpoint?: boolean;
   /**
-   * Max number of records an approval-required action may target when "select all" is used.
-   * Above this the trigger is rejected instead of storing a huge id snapshot in the approval.
-   * Must not exceed the Forest server's own cap (default 500), which is the authoritative gate.
+   * Max number of records a "select all" approval-required action may target.
+   * Must not exceed the Forest server's own cap (500).
    * @default 500
    */
   maxRecordsForApproval?: number;

--- a/packages/agent/src/utils/options-validator.ts
+++ b/packages/agent/src/utils/options-validator.ts
@@ -44,8 +44,7 @@ export default class OptionsValidator {
     copyOptions.instantCacheRefresh = copyOptions.instantCacheRefresh ?? true;
     copyOptions.workflowExecutorUrl = copyOptions.workflowExecutorUrl ?? null;
     copyOptions.auditTrail = copyOptions.auditTrail ?? null;
-    // Number.isFinite (not ??) so that NaN — e.g. Number() on an unset env var — also falls back
-    // to the default instead of silently disabling the cap (length > NaN is always false).
+    // Number.isFinite so NaN (e.g. Number() on an unset env var) also gets the default.
     copyOptions.maxRecordsForApproval = Number.isFinite(copyOptions.maxRecordsForApproval)
       ? copyOptions.maxRecordsForApproval
       : DEFAULT_MAX_RECORDS_FOR_APPROVAL;

--- a/packages/agent/src/utils/options-validator.ts
+++ b/packages/agent/src/utils/options-validator.ts
@@ -9,6 +9,8 @@ import { createSqlAuditStore } from '../audit-trail';
 const DEFAULT_MINIMUM_CACHE_DURATION = 60;
 // One year cache duration when using events
 const DEFAULT_CACHE_DURATION_WITH_EVENTS = 31560000;
+// Cross-service contract: the Forest server rejects approval requests above this many record ids.
+export const DEFAULT_MAX_RECORDS_FOR_APPROVAL = 500;
 
 export default class OptionsValidator {
   private static loggerPrefix = {
@@ -42,7 +44,11 @@ export default class OptionsValidator {
     copyOptions.instantCacheRefresh = copyOptions.instantCacheRefresh ?? true;
     copyOptions.workflowExecutorUrl = copyOptions.workflowExecutorUrl ?? null;
     copyOptions.auditTrail = copyOptions.auditTrail ?? null;
-    copyOptions.maxRecordsForApproval = copyOptions.maxRecordsForApproval ?? 500;
+    // Number.isFinite (not ??) so that NaN — e.g. Number() on an unset env var — also falls back
+    // to the default instead of silently disabling the cap (length > NaN is always false).
+    copyOptions.maxRecordsForApproval = Number.isFinite(copyOptions.maxRecordsForApproval)
+      ? copyOptions.maxRecordsForApproval
+      : DEFAULT_MAX_RECORDS_FOR_APPROVAL;
     copyOptions.maxBodySize = copyOptions.maxBodySize || '50mb';
     copyOptions.bodyParserOptions = copyOptions.bodyParserOptions || {
       jsonLimit: '50mb',

--- a/packages/agent/src/utils/options-validator.ts
+++ b/packages/agent/src/utils/options-validator.ts
@@ -42,6 +42,7 @@ export default class OptionsValidator {
     copyOptions.instantCacheRefresh = copyOptions.instantCacheRefresh ?? true;
     copyOptions.workflowExecutorUrl = copyOptions.workflowExecutorUrl ?? null;
     copyOptions.auditTrail = copyOptions.auditTrail ?? null;
+    copyOptions.maxRecordsForApproval = copyOptions.maxRecordsForApproval ?? 500;
     copyOptions.maxBodySize = copyOptions.maxBodySize || '50mb';
     copyOptions.bodyParserOptions = copyOptions.bodyParserOptions || {
       jsonLimit: '50mb',

--- a/packages/agent/test/__factories__/forest-admin-http-driver-options.ts
+++ b/packages/agent/test/__factories__/forest-admin-http-driver-options.ts
@@ -29,6 +29,7 @@ export default Factory.define<AgentOptionsWithDefaults>(() => ({
   },
   ignoreMissingSchemaElementErrors: false,
   useUnsafeActionEndpoint: false,
+  maxRecordsForApproval: 500,
   workflowExecutorUrl: null,
   auditTrail: null,
 }));

--- a/packages/agent/test/routes/modification/action/action.test.ts
+++ b/packages/agent/test/routes/modification/action/action.test.ts
@@ -808,6 +808,72 @@ describe('ActionRoute', () => {
       });
     });
 
+    test('accepts a selection of exactly the configured cap', async () => {
+      const cappedOptions = factories.forestAdminHttpDriverOptions.build({
+        maxRecordsForApproval: 2,
+      });
+      (
+        cappedOptions.forestAdminClient.permissionService.canTriggerCustomAction as jest.Mock
+      ).mockResolvedValue(true);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .doesTriggerCustomActionRequiresApproval as jest.Mock
+      ).mockResolvedValue(true);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .getRoleIdsAllowedToApproveWithoutConditions as jest.Mock
+      ).mockResolvedValue([7]);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .getConditionalApproveConditions as jest.Mock
+      ).mockResolvedValue(new Map());
+      (dataSource.getCollection('books').list as jest.Mock).mockResolvedValue([
+        { id: '123e4567-e89b-12d3-a456-426614174000' },
+        { id: '123e4567-e89b-12d3-a456-426614174001' },
+      ]);
+      route = new ActionRoute(services, cappedOptions, dataSource, 'books', 'MyBulkAction');
+
+      // @ts-expect-error: test private method
+      await expect(route.handleExecute(selectAllContext())).rejects.toMatchObject({
+        name: 'CustomActionRequiresApprovalError',
+        data: {
+          recordIds: [
+            '123e4567-e89b-12d3-a456-426614174000',
+            '123e4567-e89b-12d3-a456-426614174001',
+          ],
+        },
+      });
+      // cap+1 is requested so "exactly the cap" and "over the cap" are distinguishable
+      expect(dataSource.getCollection('books').list).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ page: expect.objectContaining({ skip: 0, limit: 3 }) }),
+        expect.anything(),
+      );
+    });
+
+    test('does not resolve ids on a global action (it targets no specific records)', async () => {
+      dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'books',
+          schema: {
+            actions: { MyGlobalAction: { scope: 'Global' } },
+            fields: { id: factories.columnSchema.uuidPrimaryKey().build() },
+          },
+          getForm: jest.fn().mockResolvedValue([]),
+          execute: jest.fn(),
+        }),
+      ]);
+      route = new ActionRoute(services, options, dataSource, 'books', 'MyGlobalAction');
+
+      // @ts-expect-error: test private method
+      const error = await route.handleExecute(selectAllContext()).catch(e => e);
+
+      expect(error).toMatchObject({ name: 'CustomActionRequiresApprovalError' });
+      expect(error.data.recordIds).toBeUndefined();
+      // No 422 above the cap, no id snapshot in the error.
+      expect(dataSource.getCollection('books').list).not.toHaveBeenCalled();
+    });
+
     test('does not resolve ids nor cap an explicit selection requiring approval', async () => {
       route = new ActionRoute(services, options, dataSource, 'books', 'MyBulkAction');
 

--- a/packages/agent/test/routes/modification/action/action.test.ts
+++ b/packages/agent/test/routes/modification/action/action.test.ts
@@ -713,6 +713,126 @@ describe('ActionRoute', () => {
     });
   });
 
+  describe('when an approval-required action is triggered on a select-all selection', () => {
+    beforeEach(() => {
+      dataSource = factories.dataSource.buildWithCollections([
+        factories.collection.build({
+          name: 'books',
+          schema: {
+            actions: { MyBulkAction: { scope: 'Bulk' } },
+            fields: { id: factories.columnSchema.uuidPrimaryKey().build() },
+          },
+          getForm: jest.fn().mockResolvedValue([]),
+          execute: jest.fn(),
+        }),
+      ]);
+      (
+        options.forestAdminClient.permissionService
+          .doesTriggerCustomActionRequiresApproval as jest.Mock
+      ).mockResolvedValue(true);
+      (
+        options.forestAdminClient.permissionService
+          .getRoleIdsAllowedToApproveWithoutConditions as jest.Mock
+      ).mockResolvedValue([7]);
+      (
+        options.forestAdminClient.permissionService.getConditionalApproveConditions as jest.Mock
+      ).mockResolvedValue(new Map());
+    });
+
+    const selectAllContext = () =>
+      createMockContext({
+        ...baseContext,
+        requestBody: {
+          data: {
+            attributes: {
+              ...baseContext.requestBody.data.attributes,
+              ids: [],
+              all_records: true,
+              all_records_ids_excluded: [],
+            },
+          },
+        },
+      });
+
+    test('resolves the selection to concrete ids and returns them in the approval error', async () => {
+      (dataSource.getCollection('books').list as jest.Mock).mockResolvedValue([
+        { id: '123e4567-e89b-12d3-a456-426614174000' },
+        { id: '123e4567-e89b-12d3-a456-426614174001' },
+      ]);
+      route = new ActionRoute(services, options, dataSource, 'books', 'MyBulkAction');
+
+      // @ts-expect-error: test private method
+      await expect(route.handleExecute(selectAllContext())).rejects.toMatchObject({
+        name: 'CustomActionRequiresApprovalError',
+        data: {
+          roleIdsAllowedToApprove: [7],
+          recordIds: [
+            '123e4567-e89b-12d3-a456-426614174000',
+            '123e4567-e89b-12d3-a456-426614174001',
+          ],
+        },
+      });
+    });
+
+    test('rejects with ApprovalSelectionTooLargeError above the configured cap', async () => {
+      const cappedOptions = factories.forestAdminHttpDriverOptions.build({
+        maxRecordsForApproval: 2,
+      });
+      (
+        cappedOptions.forestAdminClient.permissionService.canTriggerCustomAction as jest.Mock
+      ).mockResolvedValue(true);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .doesTriggerCustomActionRequiresApproval as jest.Mock
+      ).mockResolvedValue(true);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .getRoleIdsAllowedToApproveWithoutConditions as jest.Mock
+      ).mockResolvedValue([7]);
+      (
+        cappedOptions.forestAdminClient.permissionService
+          .getConditionalApproveConditions as jest.Mock
+      ).mockResolvedValue(new Map());
+      // cap+1 rows fetched => over the cap of 2
+      (dataSource.getCollection('books').list as jest.Mock).mockResolvedValue([
+        { id: '123e4567-e89b-12d3-a456-426614174000' },
+        { id: '123e4567-e89b-12d3-a456-426614174001' },
+        { id: '123e4567-e89b-12d3-a456-426614174002' },
+      ]);
+      route = new ActionRoute(services, cappedOptions, dataSource, 'books', 'MyBulkAction');
+
+      // @ts-expect-error: test private method
+      await expect(route.handleExecute(selectAllContext())).rejects.toMatchObject({
+        name: 'ApprovalSelectionTooLargeError',
+        message: expect.stringContaining('more than 2 records'),
+      });
+    });
+
+    test('does not resolve ids nor cap an explicit selection requiring approval', async () => {
+      route = new ActionRoute(services, options, dataSource, 'books', 'MyBulkAction');
+
+      const context = createMockContext({
+        ...baseContext,
+        requestBody: {
+          data: {
+            attributes: {
+              ...baseContext.requestBody.data.attributes,
+              ids: ['123e4567-e89b-12d3-a456-426614174000'],
+              all_records: false,
+            },
+          },
+        },
+      });
+
+      // @ts-expect-error: test private method
+      await expect(route.handleExecute(context)).rejects.toMatchObject({
+        name: 'CustomActionRequiresApprovalError',
+      });
+      // No select-all resolution => the id-listing query is never issued.
+      expect(dataSource.getCollection('books').list).not.toHaveBeenCalled();
+    });
+  });
+
   describe('with a global action used from list-view, detail-view & summary', () => {
     beforeEach(() => {
       dataSource = factories.dataSource.buildWithCollections([

--- a/packages/agent/test/utils/http-driver-options.test.ts
+++ b/packages/agent/test/utils/http-driver-options.test.ts
@@ -21,6 +21,32 @@ describe('OptionsValidator', () => {
       expect(options).toHaveProperty('skipSchemaUpdate', false);
     });
 
+    describe('maxRecordsForApproval', () => {
+      test('defaults to 500 when not configured', () => {
+        const options = OptionsValidator.withDefaults(mandatoryOptions);
+
+        expect(options).toHaveProperty('maxRecordsForApproval', 500);
+      });
+
+      test('defaults to 500 when NaN is passed (e.g. Number() on an unset env var)', () => {
+        const options = OptionsValidator.withDefaults({
+          ...mandatoryOptions,
+          maxRecordsForApproval: Number(process.env.SOME_UNSET_ENV_VAR),
+        });
+
+        expect(options).toHaveProperty('maxRecordsForApproval', 500);
+      });
+
+      test('keeps a configured value', () => {
+        const options = OptionsValidator.withDefaults({
+          ...mandatoryOptions,
+          maxRecordsForApproval: 100,
+        });
+
+        expect(options).toHaveProperty('maxRecordsForApproval', 100);
+      });
+    });
+
     test('logger should be callable', () => {
       jest.spyOn(console, 'error').mockReturnValue();
 

--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -19,7 +19,7 @@ function jsonApiDetail(body: unknown, text?: string): string | null {
 
 // Turn an agent RPC error into a human-readable message: the JSON:API detail with its HTTP status
 // when one can be extracted, else the raw message (which already carries the status).
-export default function parseAgentError(error: unknown): string | null {
+export default function parseAgentError(error: unknown, depth = 0): string | null {
   if (error instanceof AgentHttpError) {
     const detail = jsonApiDetail(error.body, error.responseText);
 
@@ -27,7 +27,17 @@ export default function parseAgentError(error: unknown): string | null {
   }
 
   if (error && typeof error === 'object' && 'message' in error) {
-    return (error as { message: string }).message || null;
+    const { message } = error as { message: string };
+    // Wrapper errors (e.g. ApprovalRequestCreationError) carry the actionable detail — like the
+    // Forest server's "limited to N records" 422 — in their cause: surface it alongside.
+    const causeDetail =
+      'cause' in error && depth < 3
+        ? parseAgentError((error as { cause: unknown }).cause, depth + 1)
+        : null;
+
+    if (message && causeDetail) return `${message} ${causeDetail}`;
+
+    return message || causeDetail;
   }
 
   return null;

--- a/packages/mcp-server/src/utils/error-parser.ts
+++ b/packages/mcp-server/src/utils/error-parser.ts
@@ -28,8 +28,7 @@ export default function parseAgentError(error: unknown, depth = 0): string | nul
 
   if (error && typeof error === 'object' && 'message' in error) {
     const { message } = error as { message: string };
-    // Wrapper errors (e.g. ApprovalRequestCreationError) carry the actionable detail — like the
-    // Forest server's "limited to N records" 422 — in their cause: surface it alongside.
+    // Wrapper errors (e.g. ApprovalRequestCreationError) carry the actionable detail in `cause`.
     const causeDetail =
       'cause' in error && depth < 3
         ? parseAgentError((error as { cause: unknown }).cause, depth + 1)

--- a/packages/mcp-server/test/utils/error-parser.test.ts
+++ b/packages/mcp-server/test/utils/error-parser.test.ts
@@ -47,6 +47,36 @@ describe('parseAgentError', () => {
     expect(parseAgentError({ unknownProperty: 'some value' })).toBeNull();
   });
 
+  it('appends the cause detail of a wrapper error (e.g. ApprovalRequestCreationError)', () => {
+    const error = new Error(
+      'The action requires an approval, but the approval request could not be created.',
+    ) as Error & { cause: unknown };
+    error.cause = new AgentHttpError(422, {
+      errors: [
+        { detail: 'Approval requests are limited to 500 records; please narrow your selection' },
+      ],
+    });
+
+    expect(parseAgentError(error)).toBe(
+      'The action requires an approval, but the approval request could not be created. ' +
+        'Approval requests are limited to 500 records; please narrow your selection (HTTP 422)',
+    );
+  });
+
+  it('ignores a cause without extractable detail', () => {
+    const error = new Error('Wrapper message') as Error & { cause: unknown };
+    error.cause = { foo: 'bar' };
+
+    expect(parseAgentError(error)).toBe('Wrapper message');
+  });
+
+  it('does not recurse forever on a cyclic cause chain', () => {
+    const error = new Error('Cyclic') as Error & { cause: unknown };
+    error.cause = error;
+
+    expect(parseAgentError(error)).toBe('Cyclic Cyclic Cyclic Cyclic');
+  });
+
   it('returns null for null/undefined', () => {
     expect(parseAgentError(null)).toBeNull();
     expect(parseAgentError(undefined)).toBeNull();


### PR DESCRIPTION
## Summary

Part of enabling bulk actions with approval on "select all" selections.

When an approval-required action is triggered with `all_records: true`, the frontend has no explicit id list to store in the approval request. The agent now:

- Resolves the select-all selection (filters + search + segment + scope, minus excluded ids) to concrete record ids and returns them in the `CustomActionRequiresApprovalError` payload (`data.recordIds`), so the frontend can store the full target set in the approval request.
- Caps the resolution with the new `maxRecordsForApproval` agent option (**default 500**, matching the Forest server's authoritative cap on `record_ids`). Above the cap, the trigger is rejected with `ApprovalSelectionTooLargeError` (422).
- Leaves normal (non-approval) executes untouched — they still run on the whole selection, uncapped.

## Related PRs

- agent-ruby: ForestAdmin/agent-ruby#374
- forest-express: ForestAdmin/forest-express#1064
- forest-rails: ForestAdmin/forest-rails#793

- Frontend: ForestAdmin/forestadmin#9924
- Server (authoritative 500 cap): ForestAdmin/forestadmin-server#8462

fixes PRD-934

## Test plan

- [x] Unit tests: select-all resolution returned in the approval error, over-cap rejection, explicit selections unaffected (44 action route tests + 15 authorization tests pass)
- [x] Manual test against a 120-record select-all approval flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve select-all record IDs for approval-required custom actions
> - When a select-all bulk action requires approval, `ActionRoute` now resolves the selection to concrete record IDs via `resolveApprovalRecordIds` and includes them in the `CustomActionRequiresApprovalError` payload; Global-scoped actions are exempt.
> - Adds `maxRecordsForApproval` option (default `500` via `DEFAULT_MAX_RECORDS_FOR_APPROVAL`) to `AgentOptions`; select-all selections exceeding this cap throw `ApprovalSelectionTooLargeError` (422).
> - `parseAgentError` in the MCP server now recursively extracts `cause` details (bounded to 3 levels) so nested error context surfaces to MCP clients.
> - Risk: `assertCanTriggerCustomAction` signature changed to accept an optional `resolveSelectAllRecordIds` callback — any out-of-tree callers of this method need to update. The new cap means select-all approval requests with more than `maxRecordsForApproval` records now return 422 instead of an approval prompt.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1847 opened
>
> - Removed customization for the `account_bills` collection from the `makeAgent` factory function [481aa92]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db92fb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->