### PR TITLE
feat(agent-bff): bundle opentelemetry apm in the docker image

### DIFF
--- a/packages/agent-bff/Dockerfile
+++ b/packages/agent-bff/Dockerfile
@@ -109,4 +109,8 @@ LABEL org.opencontainers.image.title="forestadmin-agent-bff" \
 # Exec form, no wrapper script: the CLI takes positional subcommands (`openapi`),
 # so a "is the first argument a flag?" wrapper would misread them as a command to
 # exec. Use `--entrypoint` to run anything else in the image.
-ENTRYPOINT ["node", "/app/packages/agent-bff/dist/cli.js"]
+#
+# tracing-preload runs before cli.js so the OTel auto-instrumentation patches land
+# before the app imports anything. It is inert until OTEL_EXPORTER_OTLP_ENDPOINT is
+# set, so this costs an install that never opted into APM nothing but the require.
+ENTRYPOINT ["node", "--require", "/app/packages/agent-bff/dist/tracing-preload.js", "/app/packages/agent-bff/dist/cli.js"]

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -90,8 +90,10 @@ The Docker image ships with [OpenTelemetry](https://opentelemetry.io/) APM built
 any OTLP-compatible backend (Datadog, Grafana Tempo, Jaeger, Honeycomb, etc.). It is **off by
 default** and turns on as soon as you point it at an OTLP receiver — no code changes or extra
 installs required. Tracing is set up before the app starts (auto-instrumentation for HTTP and the
-outbound calls to the agent and the Forest SaaS), and buffered spans are flushed on `SIGTERM` /
-`SIGINT`, alongside the graceful shutdown described above.
+outbound calls to the agent and the Forest SaaS). The graceful shutdown described above waits for
+the buffered spans to be exported before it exits, but gives that its own 2 second deadline rather
+than the 10 seconds in-flight requests get: an unreachable collector costs you the last spans, never
+the ability to stop. Worst case it adds ~3 seconds to a shutdown.
 
 Configure it entirely through the standard OTel environment variables:
 

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -84,6 +84,41 @@ so under load it would SIGKILL exactly when the shutdown is doing its job. Hence
 above and `stop_grace_period: 15s` in the Compose file; on Kubernetes the default
 `terminationGracePeriodSeconds` of 30 already covers it.
 
+### Observability (OpenTelemetry)
+
+The Docker image ships with [OpenTelemetry](https://opentelemetry.io/) APM built in, and works with
+any OTLP-compatible backend (Datadog, Grafana Tempo, Jaeger, Honeycomb, etc.). It is **off by
+default** and turns on as soon as you point it at an OTLP receiver — no code changes or extra
+installs required. Tracing is set up before the app starts (auto-instrumentation for HTTP and the
+outbound calls to the agent and the Forest SaaS), and buffered spans are flushed on `SIGTERM` /
+`SIGINT` before the process exits.
+
+Configure it entirely through the standard OTel environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP receiver URL (e.g. `http://collector:4318`). **Tracing stays disabled until this is set.** |
+| `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-agent-bff`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. |
+| `OTEL_SDK_DISABLED` | Set to `true` to force-disable tracing even when an endpoint is configured. |
+
+```bash
+docker run -d \
+  -p 3450:3450 \
+  -e FOREST_AUTH_SECRET="..." \
+  -e FOREST_ENV_SECRET="..." \
+  -e FOREST_SERVER_URL="https://api.forestadmin.com" \
+  -e FOREST_APP_URL="https://app.forestadmin.com" \
+  -e AGENT_URL="http://host.docker.internal:3351" \
+  -e BFF_TOKEN_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT="http://collector:4318" \
+  ghcr.io/forestadmin/agent-bff:latest
+```
+
+> **Note:** OpenTelemetry is bundled only in the Docker image. It is not shipped with the npm
+> package — with an endpoint set but the packages absent, the BFF logs a warning and starts
+> untraced rather than failing.
+
 ### Without Docker
 
 Packaged / production — run the bin:

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -100,7 +100,7 @@ Configure it entirely through the standard OTel environment variables:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP receiver URL (e.g. `http://collector:4318`). **Tracing stays disabled until this is set.** |
 | `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-agent-bff`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. |
-| `OTEL_SDK_DISABLED` | Set to `true` to force-disable tracing even when an endpoint is configured. |
+| `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing even when an endpoint is configured. |
 
 ```bash
 docker run -d \
@@ -116,9 +116,10 @@ docker run -d \
   ghcr.io/forestadmin/agent-bff:latest
 ```
 
-> **Note:** OpenTelemetry is bundled only in the Docker image. It is not shipped with the npm
-> package — with an endpoint set but the packages absent, the BFF logs a warning and starts
-> untraced rather than failing.
+> **Note:** These variables only do anything in the Docker image. The image's entry point loads
+> the tracing preload before the CLI; the npm `forest-bff` bin runs the CLI on its own, and the
+> OpenTelemetry packages are not npm dependencies — so outside Docker an `OTEL_*` variable is
+> read by nothing and the process starts untraced, silently.
 
 ### Without Docker
 

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -103,11 +103,12 @@ Configure it entirely through the standard OTel environment variables:
 | `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-agent-bff`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. |
 | `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing even when an endpoint is configured. |
-| `OTEL_TRACES_EXPORTER` | Set to `none` to stop exporting while keeping instrumentation on, so trace context still propagates to the agent and the Forest SaaS. Any other value exports over OTLP. |
+| `OTEL_TRACES_EXPORTER` | Unset (or `otlp`) exports over OTLP to the endpoint above. Any other value — `none`, `console`, a list — is left to the SDK to configure from the environment, and only the OTLP exporter ships in the image. Instrumentation stays on either way, so trace context keeps propagating to the agent and the Forest SaaS. |
 
 ```bash
 docker run -d \
   -p 3450:3450 \
+  --stop-timeout 15 \
   --add-host host.docker.internal:host-gateway \
   -e FOREST_AUTH_SECRET="..." \
   -e FOREST_ENV_SECRET="..." \

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -104,7 +104,9 @@ Configure it entirely through the standard OTel environment variables:
 | `OTEL_SERVICE_NAME` | Service name reported in traces. Falls back to `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, then to `forestadmin-agent-bff`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. A `service.name` here is honoured when `OTEL_SERVICE_NAME` is unset. |
 | `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing whatever else is configured. |
-| `OTEL_TRACES_EXPORTER` | Unset (or `otlp`) exports over OTLP to the endpoint above. Any other value — `none`, `console`, a list — is left to the SDK to configure from the environment; only the OTLP and console exporters ship in the image. Setting it alone turns tracing on without an OTLP endpoint, which is what makes `console` usable for debugging. Instrumentation stays on either way, so trace context keeps propagating to the agent and the Forest SaaS. |
+| `OTEL_TRACES_EXPORTER` | Which exporter the SDK builds: `otlp` (the default), `console`, `zipkin`, `none`, or a list. Setting it alone turns tracing on without an OTLP endpoint, which is what makes `console` usable for debugging. `none` keeps instrumentation running with nothing exported, so trace context still propagates to the agent and the Forest SaaS. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal endpoint, taking precedence over the generic one above. Setting either turns tracing on. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` (the default), `http/json` or `grpc`, with `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` for traces alone. |
 
 ```bash
 docker run -d \

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -89,7 +89,8 @@ above and `stop_grace_period: 15s` in the Compose file; on Kubernetes the defaul
 The Docker image ships with [OpenTelemetry](https://opentelemetry.io/) APM built in, and works with
 any OTLP-compatible backend (Datadog, Grafana Tempo, Jaeger, Honeycomb, etc.). It is **off by
 default** and turns on as soon as you point it at an OTLP receiver — no code changes or extra
-installs required. Tracing is set up before the app starts (auto-instrumentation for HTTP and the
+installs required. A setup that cannot start logs a warning and runs untraced rather than taking
+the process down with it. Tracing is set up before the app starts (auto-instrumentation for HTTP and the
 outbound calls to the agent and the Forest SaaS). The graceful shutdown described above waits for
 the buffered spans to be exported before it exits, but gives that its own 2 second deadline rather
 than the 10 seconds in-flight requests get: an unreachable collector costs you the last spans, never
@@ -99,11 +100,11 @@ Configure it entirely through the standard OTel environment variables:
 
 | Variable | Description |
 | --- | --- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP receiver URL (e.g. `http://collector:4318`). **Tracing stays disabled until this is set.** |
-| `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-agent-bff`. |
-| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. |
-| `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing even when an endpoint is configured. |
-| `OTEL_TRACES_EXPORTER` | Unset (or `otlp`) exports over OTLP to the endpoint above. Any other value — `none`, `console`, a list — is left to the SDK to configure from the environment, and only the OTLP exporter ships in the image. Instrumentation stays on either way, so trace context keeps propagating to the agent and the Forest SaaS. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP receiver URL (e.g. `http://collector:4318`). **Tracing stays off until this or `OTEL_TRACES_EXPORTER` is set.** |
+| `OTEL_SERVICE_NAME` | Service name reported in traces. Falls back to `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, then to `forestadmin-agent-bff`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. A `service.name` here is honoured when `OTEL_SERVICE_NAME` is unset. |
+| `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing whatever else is configured. |
+| `OTEL_TRACES_EXPORTER` | Unset (or `otlp`) exports over OTLP to the endpoint above. Any other value — `none`, `console`, a list — is left to the SDK to configure from the environment; only the OTLP and console exporters ship in the image. Setting it alone turns tracing on without an OTLP endpoint, which is what makes `console` usable for debugging. Instrumentation stays on either way, so trace context keeps propagating to the agent and the Forest SaaS. |
 
 ```bash
 docker run -d \

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -105,6 +105,7 @@ Configure it entirely through the standard OTel environment variables:
 ```bash
 docker run -d \
   -p 3450:3450 \
+  --add-host host.docker.internal:host-gateway \
   -e FOREST_AUTH_SECRET="..." \
   -e FOREST_ENV_SECRET="..." \
   -e FOREST_SERVER_URL="https://api.forestadmin.com" \

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -103,6 +103,7 @@ Configure it entirely through the standard OTel environment variables:
 | `OTEL_SERVICE_NAME` | Service name reported in traces. Default: `forestadmin-agent-bff`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, e.g. `deployment.environment=production`. |
 | `OTEL_SDK_DISABLED` | Set to `true` (case-insensitive) to force-disable tracing even when an endpoint is configured. |
+| `OTEL_TRACES_EXPORTER` | Set to `none` to stop exporting while keeping instrumentation on, so trace context still propagates to the agent and the Forest SaaS. Any other value exports over OTLP. |
 
 ```bash
 docker run -d \

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -91,7 +91,7 @@ any OTLP-compatible backend (Datadog, Grafana Tempo, Jaeger, Honeycomb, etc.). I
 default** and turns on as soon as you point it at an OTLP receiver — no code changes or extra
 installs required. Tracing is set up before the app starts (auto-instrumentation for HTTP and the
 outbound calls to the agent and the Forest SaaS), and buffered spans are flushed on `SIGTERM` /
-`SIGINT` before the process exits.
+`SIGINT`, alongside the graceful shutdown described above.
 
 Configure it entirely through the standard OTel environment variables:
 

--- a/packages/agent-bff/docker/README.md
+++ b/packages/agent-bff/docker/README.md
@@ -8,7 +8,7 @@ keeps the image small while staying reproducible.
 
 - [`build-deps-manifest.js`](./build-deps-manifest.js) merges the external
   (non-`@forestadmin`) runtime dependencies of the BFF and its 4 workspace
-  dependencies into a single `package.json`.
+  dependencies, plus the OpenTelemetry packages, into a single `package.json`.
 - [`deps/yarn.lock`](./deps/) pins every transitive version.
 - The Docker build regenerates the manifest from the live `package.json` files
   and runs `yarn install --frozen-lockfile`. If a workspace dependency changes
@@ -37,7 +37,8 @@ runners; on a slim box python3 is the one likely to be missing.
 Only `deps/yarn.lock` is committed — the manifest is generated on demand (the
 Docker build regenerates it too), so there is no stale `package.json` to drift.
 Run this whenever a runtime dependency of one of the 5 workspace packages
-changes (the build will fail with `--frozen-lockfile` until you do):
+changes **or when the `OTEL_DEPENDENCIES` versions in `build-deps-manifest.js`
+are bumped** (the build will fail with `--frozen-lockfile` until you do):
 
 The generated manifest carries the repo's pinned `packageManager`
 (`yarn@1.22.19`), so with Corepack enabled (`corepack enable`) the refresh uses

--- a/packages/agent-bff/docker/README.md
+++ b/packages/agent-bff/docker/README.md
@@ -9,6 +9,10 @@ keeps the image small while staying reproducible.
 - [`build-deps-manifest.js`](./build-deps-manifest.js) merges the external
   (non-`@forestadmin`) runtime dependencies of the BFF and its 4 workspace
   dependencies, plus the OpenTelemetry packages, into a single `package.json`.
+  Three OTel packages are named there; `sdk-node` drags in every OTLP exporter
+  and the Zipkin one behind them, which is what lets the image honour
+  `OTEL_TRACES_EXPORTER` and `OTEL_EXPORTER_OTLP_PROTOCOL` without the app ever
+  choosing an exporter.
 - [`deps/yarn.lock`](./deps/) pins every transitive version.
 - The Docker build regenerates the manifest from the live `package.json` files
   and runs `yarn install --frozen-lockfile`. If a workspace dependency changes

--- a/packages/agent-bff/docker/build-deps-manifest.js
+++ b/packages/agent-bff/docker/build-deps-manifest.js
@@ -24,7 +24,11 @@ const WORKSPACE_PACKAGES = [
   'forestadmin-client',
 ];
 
-// Pinned to exact versions — OTel ships only in the Docker image.
+// Pinned to exact versions — OTel ships only in the Docker image, so nothing else bumps them.
+// A fixable CRITICAL/HIGH in this tree blocks every publish of this image until someone raises a
+// pin here and refreshes deps/yarn.lock (see the propagator-jaeger resolution below for the shape
+// of that fix). Renovate does not watch this file — it is a plain object, not a manifest — so an
+// unrelated release will stall on it unless someone is looking.
 const OTEL_DEPENDENCIES = {
   '@opentelemetry/sdk-node': '0.219.0',
   '@opentelemetry/auto-instrumentations-node': '0.77.0',
@@ -114,4 +118,4 @@ if (require.main === module) {
   generate(packagesDir, outFile);
 }
 
-module.exports = { WORKSPACE_PACKAGES, OTEL_DEPENDENCIES, generate };
+module.exports = { WORKSPACE_PACKAGES, generate };

--- a/packages/agent-bff/docker/build-deps-manifest.js
+++ b/packages/agent-bff/docker/build-deps-manifest.js
@@ -1,7 +1,8 @@
 // Generates the package.json for the Docker image's isolated runtime deps.
 //
 // It merges the external (non-@forestadmin) runtime dependencies of the BFF and
-// its 4 workspace dependencies into a single manifest.
+// its 4 workspace dependencies into a single manifest, plus the OpenTelemetry
+// packages used for APM (Docker-only; not shipped to npm consumers of the CLI).
 //
 // The output is deterministic (sorted keys). A committed yarn.lock sits next to
 // the generated manifest; the Docker build regenerates the manifest and runs
@@ -23,6 +24,13 @@ const WORKSPACE_PACKAGES = [
   'forestadmin-client',
 ];
 
+// Pinned to exact versions — OTel ships only in the Docker image.
+const OTEL_DEPENDENCIES = {
+  '@opentelemetry/sdk-node': '0.219.0',
+  '@opentelemetry/auto-instrumentations-node': '0.77.0',
+  '@opentelemetry/exporter-trace-otlp-http': '0.219.0',
+};
+
 // Security pins for transitive deps whose parents never ship a patched range.
 // They mirror the monorepo root's `resolutions` for the packages that actually
 // appear in this closure — the isolated install does not inherit the root ones.
@@ -31,6 +39,8 @@ const RESOLUTIONS = {
   '**/qs': '>=6.15.2',
   // jsonapi-serializer pins lodash ^4.17.x.
   '**/lodash': '^4.18.0',
+  // auto-instrumentations-node pins propagator-jaeger 2.8.0 (CVE-2026-59892, fixed in 2.9.0).
+  '**/@opentelemetry/propagator-jaeger': '2.9.0',
 };
 
 function generate(packagesDir, outFile) {
@@ -59,6 +69,8 @@ function generate(packagesDir, outFile) {
       declaredBy[name] = pkg;
     }
   }
+
+  Object.assign(deps, OTEL_DEPENDENCIES);
 
   const sorted = Object.fromEntries(Object.keys(deps).sort().map(key => [key, deps[key]]));
 
@@ -102,4 +114,4 @@ if (require.main === module) {
   generate(packagesDir, outFile);
 }
 
-module.exports = { WORKSPACE_PACKAGES, generate };
+module.exports = { WORKSPACE_PACKAGES, OTEL_DEPENDENCIES, generate };

--- a/packages/agent-bff/docker/build-deps-manifest.js
+++ b/packages/agent-bff/docker/build-deps-manifest.js
@@ -25,6 +25,8 @@ const WORKSPACE_PACKAGES = [
 ];
 
 // Pinned to exact versions — OTel ships only in the Docker image, so nothing else bumps them.
+// sdk-node drags in every OTLP exporter plus the Zipkin one, which is why the image can honour
+// OTEL_TRACES_EXPORTER and OTEL_EXPORTER_OTLP_PROTOCOL without naming an exporter here.
 // A fixable CRITICAL/HIGH in this tree blocks every publish of this image until someone raises a
 // pin here and refreshes deps/yarn.lock (see the propagator-jaeger resolution below for the shape
 // of that fix). Renovate does not watch this file — it is a plain object, not a manifest — so an

--- a/packages/agent-bff/docker/deps/yarn.lock
+++ b/packages/agent-bff/docker/deps/yarn.lock
@@ -9,10 +9,45 @@
   dependencies:
     openapi3-ts "^4.1.2"
 
+"@grpc/grpc-js@^1.14.3":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
+    yargs "^17.7.2"
+
 "@hapi/bourne@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-3.0.0.tgz#f11fdf7dda62fe8e336fa7c6642d9041f30356d7"
   integrity sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@koa/bodyparser@^6.1.0":
   version "6.1.0"
@@ -29,12 +64,858 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
+"@opentelemetry/api-logs@0.219.0", "@opentelemetry/api-logs@^0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz#3303f10f43e6ff1741f8f6019e43a92723781630"
+  integrity sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/auto-instrumentations-node@0.77.0":
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.77.0.tgz#cc5df74ff122b9c506a1ebf78aed95ee9a4aff71"
+  integrity sha512-LkF930Cs+v+ZO/qV6LolbocvFkJJ812BBDyRNjQpwllBA+rFvGtP/voXPuh24QV3JKl5/3c3GulLHvMn8spqkQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/instrumentation-amqplib" "^0.66.0"
+    "@opentelemetry/instrumentation-aws-lambda" "^0.71.0"
+    "@opentelemetry/instrumentation-aws-sdk" "^0.74.0"
+    "@opentelemetry/instrumentation-bunyan" "^0.64.0"
+    "@opentelemetry/instrumentation-cassandra-driver" "^0.64.0"
+    "@opentelemetry/instrumentation-connect" "^0.62.0"
+    "@opentelemetry/instrumentation-cucumber" "^0.35.0"
+    "@opentelemetry/instrumentation-dataloader" "^0.36.0"
+    "@opentelemetry/instrumentation-dns" "^0.62.0"
+    "@opentelemetry/instrumentation-express" "^0.67.0"
+    "@opentelemetry/instrumentation-fs" "^0.38.0"
+    "@opentelemetry/instrumentation-generic-pool" "^0.62.0"
+    "@opentelemetry/instrumentation-graphql" "^0.67.0"
+    "@opentelemetry/instrumentation-grpc" "^0.219.0"
+    "@opentelemetry/instrumentation-hapi" "^0.65.0"
+    "@opentelemetry/instrumentation-host-metrics" "^0.2.0"
+    "@opentelemetry/instrumentation-http" "^0.219.0"
+    "@opentelemetry/instrumentation-ioredis" "^0.67.0"
+    "@opentelemetry/instrumentation-kafkajs" "^0.28.0"
+    "@opentelemetry/instrumentation-knex" "^0.63.0"
+    "@opentelemetry/instrumentation-koa" "^0.67.0"
+    "@opentelemetry/instrumentation-lru-memoizer" "^0.63.0"
+    "@opentelemetry/instrumentation-memcached" "^0.62.0"
+    "@opentelemetry/instrumentation-mongodb" "^0.72.0"
+    "@opentelemetry/instrumentation-mongoose" "^0.65.0"
+    "@opentelemetry/instrumentation-mysql" "^0.65.0"
+    "@opentelemetry/instrumentation-mysql2" "^0.65.0"
+    "@opentelemetry/instrumentation-nestjs-core" "^0.65.0"
+    "@opentelemetry/instrumentation-net" "^0.63.0"
+    "@opentelemetry/instrumentation-openai" "^0.17.0"
+    "@opentelemetry/instrumentation-oracledb" "^0.44.0"
+    "@opentelemetry/instrumentation-pg" "^0.71.0"
+    "@opentelemetry/instrumentation-pino" "^0.65.0"
+    "@opentelemetry/instrumentation-redis" "^0.67.0"
+    "@opentelemetry/instrumentation-restify" "^0.64.0"
+    "@opentelemetry/instrumentation-router" "^0.63.0"
+    "@opentelemetry/instrumentation-runtime-node" "^0.32.0"
+    "@opentelemetry/instrumentation-socket.io" "^0.66.0"
+    "@opentelemetry/instrumentation-tedious" "^0.38.0"
+    "@opentelemetry/instrumentation-undici" "^0.29.0"
+    "@opentelemetry/instrumentation-winston" "^0.63.0"
+    "@opentelemetry/resource-detector-alibaba-cloud" "^0.34.0"
+    "@opentelemetry/resource-detector-aws" "^2.19.0"
+    "@opentelemetry/resource-detector-azure" "^0.27.0"
+    "@opentelemetry/resource-detector-container" "^0.8.10"
+    "@opentelemetry/resource-detector-gcp" "^0.54.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/sdk-node" "^0.219.0"
+
+"@opentelemetry/configuration@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/configuration/-/configuration-0.219.0.tgz#cb950aaa77bdb921a3fd636dc792f8beb712be17"
+  integrity sha512-wXZUYv4ngu43nA4WEhuXNacm46LW+17LRM8nKyIhBzroRA24PBYjMnakwzR/w777nFUB5xlgsYTTeuXxumZM1Q==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    yaml "^2.0.0"
+
+"@opentelemetry/context-async-hooks@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz#24381ef388bc28d53fa8dad72dfd1429acc82016"
+  integrity sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==
+
+"@opentelemetry/core@2.10.0", "@opentelemetry/core@^2.0.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.10.0.tgz#aa77f7138e74ba5399d5f3bb0deade0c168f00b2"
+  integrity sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/core@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz#f6e86de3688bdb54a6ca8f4935363a5b588ae91c"
+  integrity sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/core@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.9.0.tgz#49de86106f86255b471b2ff035ef1003a851b252"
+  integrity sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-logs-otlp-grpc@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.219.0.tgz#d828e7495d05c54fd51a6495094eaf9e485805c1"
+  integrity sha512-7SvzDCIclHWAcCwZ1MTOLcwn4BVNPGI3QxS/DJraPNe1TTL+4TvUBq5zeQV8tsnYvtDN7wKW2qocVmaCP2l7sQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+
+"@opentelemetry/exporter-logs-otlp-http@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.219.0.tgz#3a4764ec408efdf9c573cfc3e4ffc41392694d3b"
+  integrity sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+
+"@opentelemetry/exporter-logs-otlp-proto@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.219.0.tgz#de0431c17a944928471ffab1dcea9e02e70271ac"
+  integrity sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/exporter-metrics-otlp-grpc@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.219.0.tgz#b9d1ede26f45adfbcbf087dd7d4065dfc1268121"
+  integrity sha512-6LaaSrPxK5L55bXevWajvOMxGOpNm0n12tG53TeZaUeNzXwLPg6d2KCC1zAlGsojan+xRG71mA4Qqs9K2VVrKQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.219.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+
+"@opentelemetry/exporter-metrics-otlp-http@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.219.0.tgz#aed2238678486434cff020cbdfef07b24f1370b6"
+  integrity sha512-6CaDRbMVHZSDWzNXwrR8y/H4B/Z1eMNnkHiPQlTx3Ojz2OHY4X/aff/UC4P/3pHUQSuTfi3oh2UsPPZppw+Vrg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+
+"@opentelemetry/exporter-metrics-otlp-proto@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.219.0.tgz#7a7a20dba913f00c115fb48901502680c41e23dc"
+  integrity sha512-DUS7XyIiEnoeccQUvuKy0G2/YqeKhpN8FVIrGbrLNIVMj10yeIFLRzRv0tibCI2kXXvlTTABVexGAk78wHk2ug==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.219.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+
+"@opentelemetry/exporter-prometheus@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.219.0.tgz#8ea911269156f3cd4f08a1e8e5727df3f316b687"
+  integrity sha512-TxOnJ85eWJY5JyOJsNMXiRTYlkDcOv0u3KbXEzWCc+tUS9sjL/BC6BcdxZ0B9r2OFVqsrZFXUzSD2sZUy42Ucw==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-trace-otlp-grpc@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.219.0.tgz#ef421636a3e360b4e8e1d26a2cae0d6f49c5187a"
+  integrity sha512-BkDNv1UD6BscW19MxbAxVmSYSSFuyeqR6buV2/HTYqA7GrR0EbTFzqG6h86T3PtXmpdbsWjMGLDdjG2rikG27Q==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/exporter-trace-otlp-http@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz#37ad13bd871fe5d983754bb2ad2e2ac2f3e167ec"
+  integrity sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/exporter-trace-otlp-proto@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.219.0.tgz#cec3c1da46bb3ac5774461830634d6509b797bf1"
+  integrity sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/exporter-zipkin@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.8.0.tgz#03f5ca641f611fc15b9530d2a2ec6238a167bda1"
+  integrity sha512-Mj84UkEa17BK2o903VTXW3wM8CrSZexGs4tRGVZVIMM9ni1T6TuGx5IrRfoWKAbshx42D5/kc7YV+axypLPYyA==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation-amqplib@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.66.0.tgz#c29676ad8740d982edcef5353726cf30cefc786d"
+  integrity sha512-lyJgobzP0Ce+tRGOkdnrb60apfqU89xB9FeMTmo1TJU007KTMLiLFd4iCfTiBEXzBsVplx7kwrVN4FqGBUcD2Q==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-aws-lambda@^0.71.0":
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.71.0.tgz#7d9082a15e2a01aa3b8666b6fefe27c0b4aef4b6"
+  integrity sha512-9Sv6flQDeNNF6ZbiLgn+NYJa220yRZdDSIdgDZsqNubpDnYAPF33OHcQDlE8mFiaOq14mngoPS48JnYc8JT+Ug==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/propagator-aws-xray" "^2.1.4"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@types/aws-lambda" "^8.10.155"
+
+"@opentelemetry/instrumentation-aws-sdk@^0.74.0":
+  version "0.74.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.74.0.tgz#8a05691ef0eeede0cc0271b3f350233fd18cd731"
+  integrity sha512-EMLUGgx2wJSXdwMEFdwd3IaW+mkUF8PENdzDFQ1FRdztzMG1d1XN76ORIjAMsXcKQISlRRcz93AWPQeBPn4EKA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+
+"@opentelemetry/instrumentation-bunyan@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.64.0.tgz#c133310306aa6d5eed712b6d59c89f2d4b257430"
+  integrity sha512-jrRNFvpREutmpoWhk1T8n9q/RYdxbViXwSUPHN8yQR1bzgtwfOl/y8G/p8Xfudlky9GGsqw5WRc6q6QrfgF3pw==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.219.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@types/bunyan" "1.8.11"
+
+"@opentelemetry/instrumentation-cassandra-driver@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.64.0.tgz#8861b78fbd359e2cea8b5eb47367a33e7a2d0526"
+  integrity sha512-KN+iOsmPI0nkX2lfgNgHBrHNaDuxDwIbwFrlvyrZ4bAT8bTKcCOXhne70O9qihM8+T1F4tjvPXpCfhKZbmsYiw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.37.0"
+
+"@opentelemetry/instrumentation-connect@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.62.0.tgz#db1d0dd394f020cd3b903761ccd838ab36571142"
+  integrity sha512-ZGV2sOyeffqMiqoh4RpsPTs/TUI5cCS+cEWvC9wUfvaEekR5omR6P/ClG+QDwasGBlKx2zfFPjSYPpzUo81XAw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@types/connect" "3.4.38"
+
+"@opentelemetry/instrumentation-cucumber@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.35.0.tgz#6037bf6e6d0eef058d4f5ec233f3913dfea6b20b"
+  integrity sha512-H9NsbcFiVOFOcOu40+VOOjxdTeonu0VHI3mte5ie5ka/bazzIPGncQoHpL6su53C3/sgMdKjE6ZuwsB7Y8gQpA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-dataloader@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.36.0.tgz#64c2316acd7e4a35bdd24d69fc11ebb3d26f8451"
+  integrity sha512-gE0mTk+EnVaBN0mPRM1V6FqzQ9VckTp6ZFIssU5hxy+e3sqspYILBhV/0IHZ33qxGa3B9buLVZnuzVjUISfyoQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-dns@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.62.0.tgz#514d8fc16f91884353493a2e627e121a8fde5096"
+  integrity sha512-6v0X8wEqhIyv2b7MXhmipyCitJfm0vnF5mLBTWXojovoHp7P1EpN5sb12LgdhVlozhGwRZdzb6OvKUVsxKMD8g==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-express@^0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.67.0.tgz#0a63c4900db27b7203b7b7d01a61a6d88b97eeea"
+  integrity sha512-1WTWX2YNZIV+jPmEqdf/Vd1gHMT92TKA/0pf/iIItWhV6+RhzhnUUW4kSWQn8L3qVcgWEzQ860/ZOwaIwayi8A==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-fs@^0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.38.0.tgz#b4a951dadb085efd1a04dbc100c9974e280a33f4"
+  integrity sha512-6OBofWODg0RcPkl3bA+7yPf0e4Vi3O7ZxlFGY5QHPMMLxWVMnjWPEXQ2NlLBk19Sr8LcvEyyZOStdLJrT5o2dQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-generic-pool@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.62.0.tgz#7cedf3c9c2431c829856e92fa1ebc0212a1d3282"
+  integrity sha512-IhO2y/MaK1oZ4EbUgdkSVT+XViPq86IAz4lwPe9jaba00M2yDWs8+f9xjcH3tK5IC3dZuAxXmifGmfvuJp92jw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-graphql@^0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.67.0.tgz#e01e077c254b42317a053898d245ce9a3509596d"
+  integrity sha512-NMUmuhtYvv3AwkK4zsHQbTCXS81QS63hbNZRKfXc7W8f4KbWeKLmqKqvnfjUcqZoGS0eAw2kNKNYcbtbQ7baAg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-grpc@^0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.219.0.tgz#dcb8a4ef9ba26b9c8e8eee19a5546b34a6e2e852"
+  integrity sha512-GyW1Kfbf7uiJXeBZovB/uXPUdkaZYWzB2ZPCdY2CU7+6V207u8wlCM+zVd3UwhEjOBrMbZAGq+m38aBEI/EVtA==
+  dependencies:
+    "@opentelemetry/instrumentation" "0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation-hapi@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.65.0.tgz#3cdeb5c1424c5929589ba10cf846ed4996ff5b31"
+  integrity sha512-Whhas9iU0SfK/7XBcgCwfW5c9AaxjxtZpzW21t3Ml8XZ6Irc3hF36JDolMmFa7nUjML9n9bSUAZjwCgrK+2UdQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-host-metrics@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-host-metrics/-/instrumentation-host-metrics-0.2.0.tgz#20cea70fb5620a41b0b30fedc3d52751801f9b3c"
+  integrity sha512-NIttCEOLdg1ebbDiJpCf0Ly1OGIa10isesik+K2dnXy2P99q4muUFjpaLtTnhkENrt9SmR0Zrxzq7B+W/VNWyw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    systeminformation "^5.31.6"
+
+"@opentelemetry/instrumentation-http@^0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.219.0.tgz#8dac2a15e9b9247fb8514a5525ecc0b86f2d67bb"
+  integrity sha512-nNt1fqpyah/OKjNHdEOu8xLwISppRU2qJuF8aR+fCcftVwdFkPgtworBLA+TI1HU2iF508jcQBF2gerWczJAXg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/instrumentation" "0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+    forwarded-parse "2.1.2"
+
+"@opentelemetry/instrumentation-ioredis@^0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.67.0.tgz#a87a1f0389b1c997b00842ca9255d61ed814c9b0"
+  integrity sha512-dv64vQ4aXbJvRMMAFrMUSzDeJrNv/uQMLjfaav4LHAOar7Xn08W3pkoYoYEnzq/n2+fGgG96rp9S0gQ+VnLDiw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/redis-common" "^0.38.3"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-kafkajs@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.28.0.tgz#fbbfa3a1942e74f05945a581f44a5362de1e1fba"
+  integrity sha512-dztkg70nJds3Uc0Xo3NFlRqL5iYgGYWh8myuuGfRC6NnXJchY0Kw9QnBjTZxBSldXU+P6nv2snDVMmlxuy6fEw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.30.0"
+
+"@opentelemetry/instrumentation-knex@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.63.0.tgz#9dc7e96097bc55f1a59f59bb0eebf8a15635bb7b"
+  integrity sha512-XrpRahI/9vTrfSUfkhy8jGX8KMRKecQIPU9GyEZ8gkR030iJwQYsMmKGO5TK9R80cQGUopXwDvV55zmVNEkcPg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.1"
+
+"@opentelemetry/instrumentation-koa@^0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.67.0.tgz#ca60e192f2deb5b22173654fbe36ef8704d9f862"
+  integrity sha512-QOGY4mjqvF85LDcrzwrQXMcsu1wMTALeL1OHyTkLpN/7cnoDtv0W/qMBjHVq4IKYK6yDH4ZDNdwlonJPhwCGcw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.36.0"
+
+"@opentelemetry/instrumentation-lru-memoizer@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.63.0.tgz#3ae4808df4635ab384feee59e76566290d02e201"
+  integrity sha512-DlZRNXfiosmREoLbEGbYuxF70cYXjrYqoaO1sJE167i1+ARWXTq0YMPJ97i53Ws/xkZWllJNYU4mpY2LM2yTlA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-memcached@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.62.0.tgz#561a9a9bdd8990038c8f3c14790a5d7b738b484a"
+  integrity sha512-kAajd/MtdRBh9PCrMM4fnusFRNPJDU1dv5w9cgnKtMfutRE6K03wBbGSeT3FD1M56sMYWVqPhiKUhfSZCMZrLg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/memcached" "^2.2.6"
+
+"@opentelemetry/instrumentation-mongodb@^0.72.0":
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.72.0.tgz#2b45ccd5e13a399287b3eb593121652810916526"
+  integrity sha512-WYgGzvlHzdoxHlrhysYtjxE4RC23j/iFZ66hdMJuAoczOWoD/xb6LhRwaz4CM+LKyKtcSIadAjSUyGv2B+SNwg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mongoose@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.65.0.tgz#f5bcd9dcf55c09c8a5098e36c3a2fe9f12a65ad4"
+  integrity sha512-P0iT4oKuinEFZlTIKPJC5hhnmiV9De9lEiLkGzSwnNLdkyHIWug8BfRp5ZROrYAQ9mm47H+WLB/ozvUvgzEvEA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mysql2@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.65.0.tgz#1e3007c0ea2c3e2291da0cc9ed7e6d8350b47556"
+  integrity sha512-Om6BJ/bmFBzNkGbAzj/UV5sCKX6jCGzhTl1Gqgtim/O0dnPE7F2zN65u16Fq3JgyypGAwT2iwh13tYdWkc8/RA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.42.0"
+
+"@opentelemetry/instrumentation-mysql@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.65.0.tgz#32abbb3df7a1f0647f6cda5857702a06ac351fc2"
+  integrity sha512-sh1wRjFaTt+8DOhJ0134rFtJoHVUXKI8faIWTbj4zZNw847dzUgmkO8xOluJ9Css0JzT4vCeZofJmq9mQmmESA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
+
+"@opentelemetry/instrumentation-nestjs-core@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.65.0.tgz#5602125070609dd21675aafabf6e6954d0f32708"
+  integrity sha512-/q8fN2M2zGl+gQRaF79dzqvyvVqHAI11c7xAQZy9W1eAtQScNwaQtPm0EUo5+aOgakaTksBrsiHUF0rQS24NsQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.30.0"
+
+"@opentelemetry/instrumentation-net@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-net/-/instrumentation-net-0.63.0.tgz#32bf0cc99558f7ad75c18f2e9c4f7459a24084d8"
+  integrity sha512-fvmVdL4SlsYZf74mq6iLBPd6JJHRAe5utzN7Wt9e4nwa2S3pgExA9poOEmBL1CvIR47MceTA/A8vgVCF23ebbw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-openai@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-openai/-/instrumentation-openai-0.17.0.tgz#963ec4b98a5fddc1610e418d7afe595ea1a6c385"
+  integrity sha512-X3aEZnzj7SJkn1nmqEoD9IljmqENnGrd0vcJngcEApT8uqhFaeimONqKeIzKYvUgC7k4OkAUxC7yfXzxIK1KlA==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.219.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.36.0"
+
+"@opentelemetry/instrumentation-oracledb@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-oracledb/-/instrumentation-oracledb-0.44.0.tgz#d310c5b2c6ef3600ec9eca779d792f62168258a6"
+  integrity sha512-ncEfP4rzuZXBHJJtzWLYctK4Pq/FvZRiASxlFY9CJG9kGjaFTfzBUys0NiP27alYPvpjj0uDAMheDk9nihO8ZA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+    "@types/oracledb" "6.5.2"
+
+"@opentelemetry/instrumentation-pg@^0.71.0":
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.71.0.tgz#81ab2bcd0c614f713fdc5548f9611c707af1eca0"
+  integrity sha512-jAhfyZeOkEKh3cQ5nm1tNWqHg7HFARyAe+p4BSoDHnB79c1woyEvDKqS11Hj/DjtceP+vrurIfcDs7Fqiy11mQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+    "@opentelemetry/sql-common" "^0.42.0"
+    "@types/pg" "8.15.6"
+    "@types/pg-pool" "2.0.7"
+
+"@opentelemetry/instrumentation-pino@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.65.0.tgz#8f30121ef3e009aa278451c1ce628b5c05328a7a"
+  integrity sha512-p6eh+NRmzi1F+/4QG7XDqRk4ICdCNTsM5vdcwUPnpMie2MddgY1/ENmWvCF9r0Kh6QQRA2kkpnhoJFaiRQ5kVw==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.219.0"
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-redis@^0.67.0":
+  version "0.67.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.67.0.tgz#125981100a0f71b63c7103b3d048d70ef1623509"
+  integrity sha512-TBjO4bPvfGH6bRjJJ+KrJhEqpHg3SWCFZ84MqsTWF639RQZmvkMhT2/DJsBAqqkq33IvHoDJysserqAfZN1s+Q==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/redis-common" "^0.38.3"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-restify@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.64.0.tgz#62dd0da545f8422d98a1e6944983003cfc984285"
+  integrity sha512-X+gL4KpfPAx7Y07zKQVtyJPckhCcYJdSlEz0Kq0iR5nkQ8/AVWJ05/txl4voZbZdCuNdn+uLZTtJ60bAQwputQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-router@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-router/-/instrumentation-router-0.63.0.tgz#e8918c6143a47a343671d185f9a77c989cc6e91f"
+  integrity sha512-zIpsZSHGvbaqiEazwUm1X0FkPnLXIwZcL/llu/UplkeGNU58bsw70l2uMqNqTb7J+tzsBC09CLVPty5BhW3X9Q==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-runtime-node@^0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.32.0.tgz#572a7dd28de5d8efa24b15d9d82bf40f06c4f794"
+  integrity sha512-Jo1jSgrHlah3lPpGNPsIpF0q52D5uSLRJrztWUoPc1/Tli2ZWZ+cArgNtcdmiLuKhW21MwYbbcrNw1fbOPeR3A==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.219.0"
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-socket.io@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.66.0.tgz#8c3eef6b0c90a679f0d950eb2d549adb462fe3a7"
+  integrity sha512-XrZmLkFJktVLd3biQiP8BAhupRwPWLHGIiDCfyDAnWI6borIL0wD6BpwFKKPT/etpu4/5OaeAQ7qs/S+FY9nhQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation-tedious@^0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.38.0.tgz#083cf029049f9d1083d122afbc75798ed1c0017c"
+  integrity sha512-9sRWyIMBHDqJvxRVZ+eQ7jHJ9Iu+DapO27WLZbQF1nyD8xIvEMuDonQ/HnlQiaRdwnqFknXSQTFusJUT3mNVyQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/tedious" "^4.0.14"
+
+"@opentelemetry/instrumentation-undici@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.29.0.tgz#271745a5acd112b73e75f0a06ec39f0493fab4f7"
+  integrity sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+    "@opentelemetry/semantic-conventions" "^1.24.0"
+
+"@opentelemetry/instrumentation-winston@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.63.0.tgz#25d72b3aa43ad2bef83696a82067777a65289312"
+  integrity sha512-NFMHLYODph0rWGfT/QLv75hCsu1sxVAV79L8HduBCMo181jOTSRZHaqxfrvDtFOsvgYBaiUBa7Ga50w47wM3FA==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.219.0"
+    "@opentelemetry/instrumentation" "^0.219.0"
+
+"@opentelemetry/instrumentation@0.219.0", "@opentelemetry/instrumentation@^0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz#84399affd8ee4a12cb199f325c4858654d8dedee"
+  integrity sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/otlp-exporter-base@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz#68f4908f45f6df577d8e1c5b42761645f01cffc5"
+  integrity sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+
+"@opentelemetry/otlp-grpc-exporter-base@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.219.0.tgz#626713dc38a8879cbc95304832971e6daa889248"
+  integrity sha512-iIk/s8QQu39zpTrRRmsW/Eg3SE2+Hg8tLWepr2FLRgmwUpNd0IpCTLJEHJ77hpt4hgIS8MAh44UYI4xQPZwWlw==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-transformer" "0.219.0"
+
+"@opentelemetry/otlp-transformer@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz#86305b29f564220666f6e410b7eded57bb5e6c3a"
+  integrity sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/propagator-aws-xray@^2.1.4":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-2.2.0.tgz#11ea47c755425526a0280d9a867f7625b8f48943"
+  integrity sha512-Yjvt2EjL+tfpkVOdKbhTPgpM4SIAez9nG6Q/QjQ3yfcJcjIWp59ph70SLfvmkSL6++3DCnuBG3iWcB18PwWavQ==
+
+"@opentelemetry/propagator-b3@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-2.8.0.tgz#d8dadd951831cc96bc2e44eadf04d2b3d1a9b320"
+  integrity sha512-SazlvuSKi5533rPHTW2TwBwdMakhjZST4SYs0YauuvfGDkT13KbG1gJS75hV0uWVeevhtVP9sAIlaZLTHdSbMg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+
+"@opentelemetry/propagator-jaeger@2.8.0", "@opentelemetry/propagator-jaeger@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.9.0.tgz#7fbb5943782aa8cb83d5c41c316cd8be00438747"
+  integrity sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==
+  dependencies:
+    "@opentelemetry/core" "2.9.0"
+
+"@opentelemetry/redis-common@^0.38.3":
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz#31a0464a48a991c29408614e3725d94db7c11aee"
+  integrity sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==
+
+"@opentelemetry/resource-detector-alibaba-cloud@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.34.0.tgz#c6d3348ec5487310a11159ff0b031e86eeb60630"
+  integrity sha512-hUs4CK7MbRfffw8y5zR4Mo37MJRR3Zt8Ub4rgMkIk7gL8jozjV7k+zwIk9grz5kGAuD406BDDIghaY8090K4Zw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+
+"@opentelemetry/resource-detector-aws@^2.19.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.21.0.tgz#852effe09e48faff8def60189d178ffb45d5736b"
+  integrity sha512-Veavy+khoywR+Hv065SU5jucFTGTiW1KXo39CsJ+8wqdYYz8jiRJPnQ20Kd+X9HbV2+Abb0l5CrJIdxK1ZOqBg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/resource-detector-azure@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.27.0.tgz#2839694bc1fdfdddda41963fc627180bd25e859c"
+  integrity sha512-m6HCEmK12QpEcWbKtvGpQtoDVceXtpB14AaaW/t5f6gHeLuGq1QivkuohkvKMkxgAdwIHxEQ8qof3whWBpd8JA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/semantic-conventions" "^1.37.0"
+
+"@opentelemetry/resource-detector-container@^0.8.10":
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-container/-/resource-detector-container-0.8.12.tgz#0b8c3f9e67463102d551896f899d9e19952810f4"
+  integrity sha512-EJRFfIY26whY0w5RDxMRXlfBDgDS001JYMHuOVuDBBsRrV4MBqoVajR9B0L9Vy728+w/HNVnSQkpJFacFr+klg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+
+"@opentelemetry/resource-detector-gcp@^0.54.0":
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.54.0.tgz#88a029ac98b41cbe10af48b1c7e681d9895a37ea"
+  integrity sha512-u+6sBzQO03QQGFhxjzFa7uNbH6iQpWTcrpWyomxuppH3AN/+1mm3DRVseS1CiRq9VBKrFO0UosWAdD7fWVUrrg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    gcp-metadata "^8.0.0"
+
+"@opentelemetry/resources@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.8.0.tgz#9bcb658ab6254f33099f4a95544b40d6f53cc946"
+  integrity sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/resources@^2.0.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.10.0.tgz#ce76c1c1baafce4c77bc29890965ba1f56671acc"
+  integrity sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==
+  dependencies:
+    "@opentelemetry/core" "2.10.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-logs@0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz#002433237908d24fa9e7f17eb4963f25f03d655c"
+  integrity sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-metrics@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz#c3f908d9e7e02fb855673fcfd4b298ce279e61f1"
+  integrity sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+
+"@opentelemetry/sdk-node@0.219.0", "@opentelemetry/sdk-node@^0.219.0":
+  version "0.219.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-node/-/sdk-node-0.219.0.tgz#a269bfbe122249bcc2027b67cfdcca4bded254b5"
+  integrity sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==
+  dependencies:
+    "@opentelemetry/api-logs" "0.219.0"
+    "@opentelemetry/configuration" "0.219.0"
+    "@opentelemetry/context-async-hooks" "2.8.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/exporter-logs-otlp-grpc" "0.219.0"
+    "@opentelemetry/exporter-logs-otlp-http" "0.219.0"
+    "@opentelemetry/exporter-logs-otlp-proto" "0.219.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc" "0.219.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.219.0"
+    "@opentelemetry/exporter-metrics-otlp-proto" "0.219.0"
+    "@opentelemetry/exporter-prometheus" "0.219.0"
+    "@opentelemetry/exporter-trace-otlp-grpc" "0.219.0"
+    "@opentelemetry/exporter-trace-otlp-http" "0.219.0"
+    "@opentelemetry/exporter-trace-otlp-proto" "0.219.0"
+    "@opentelemetry/exporter-zipkin" "2.8.0"
+    "@opentelemetry/instrumentation" "0.219.0"
+    "@opentelemetry/otlp-exporter-base" "0.219.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.219.0"
+    "@opentelemetry/propagator-b3" "2.8.0"
+    "@opentelemetry/propagator-jaeger" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/sdk-logs" "0.219.0"
+    "@opentelemetry/sdk-metrics" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+    "@opentelemetry/sdk-trace-node" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz#ec9c1d69e2e6fba256c9df0c8e8d67d42386d52b"
+  integrity sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==
+  dependencies:
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/resources" "2.8.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-node@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz#cbf68f817a15bf4ca5d9ff9fb60ef3a73f61337d"
+  integrity sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==
+  dependencies:
+    "@opentelemetry/context-async-hooks" "2.8.0"
+    "@opentelemetry/core" "2.8.0"
+    "@opentelemetry/sdk-trace-base" "2.8.0"
+
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.37.0":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz#f3f467e36c27332f0e735ec86cdcd78dd6f27865"
+  integrity sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==
+
+"@opentelemetry/sql-common@^0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.42.0.tgz#c0b3a28fd63263741c8b27e4ae84fc6395a2f21d"
+  integrity sha512-nwUwUU+8O8a4bnLqk6CodWeegGMEANgC94KTAhXcpGWLrW/2/hek/0ajNbjXnSOoNuCX+nteUPs46HFHhou9Xw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+
 "@paralleldrive/cuid2@^2.2.2":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz#3d62ea9e7be867d3fa94b9897fab5b0ae187d784"
   integrity sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==
   dependencies:
     "@noble/hashes" "^1.1.5"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.2.tgz#78d476333d85d5b1c792e257bca74ba080da49a4"
+  integrity sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==
+
+"@types/aws-lambda@^8.10.155":
+  version "8.10.162"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.162.tgz#589cfecdda3a996e9bdf20a73a26a0811cafb549"
+  integrity sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==
+
+"@types/bunyan@1.8.11":
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.11.tgz#0b9e7578a5aa2390faf12a460827154902299638"
+  integrity sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/co-body@^6.1.3":
   version "6.1.3"
@@ -44,17 +925,77 @@
     "@types/node" "*"
     "@types/qs" "*"
 
-"@types/node@*":
+"@types/connect@3.4.38":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
+"@types/memcached@^2.2.6":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@types/memcached/-/memcached-2.2.10.tgz#113f9e3a451d6b5e0a3822e06d9feb52e63e954a"
+  integrity sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/mysql@2.15.27":
+  version "2.15.27"
+  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
+  integrity sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@>=13.7.0":
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-26.3.0.tgz#757c33b17fe06db5a356582e9658603a1bd80caf"
   integrity sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==
   dependencies:
     undici-types "~8.3.0"
 
+"@types/oracledb@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@types/oracledb/-/oracledb-6.5.2.tgz#194cd0f13436f9e1e744a6e5e056a7ca400536d5"
+  integrity sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/pg-pool@2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz#c17945a74472d9a3beaf8e66d5aa6fc938328734"
+  integrity sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==
+  dependencies:
+    "@types/pg" "*"
+
+"@types/pg@*":
+  version "8.23.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.23.1.tgz#7e712ce02cf44ad100862127f10f52e9c6b9d227"
+  integrity sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
+"@types/pg@8.15.6":
+  version "8.15.6"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz#4df7590b9ac557cbe5479e0074ec1540cbddad9b"
+  integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/qs@*":
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.1.tgz#8606884272c63f0db96986bd3548650d8a9388bf"
   integrity sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==
+
+"@types/tedious@^4.0.14":
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/@types/tedious/-/tedious-4.0.14.tgz#868118e7a67808258c05158e9cad89ca58a2aec1"
+  integrity sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==
+  dependencies:
+    "@types/node" "*"
 
 accepts@^1.3.8:
   version "1.3.8"
@@ -63,6 +1004,33 @@ accepts@^1.3.8:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.3.0.tgz#247c8e7b70a1a43b10ce14c0226fcbf58e8815d5"
+  integrity sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==
+
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 asap@^2.0.0:
   version "2.0.6"
@@ -73,6 +1041,23 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
+brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
+  dependencies:
+    balanced-match "^1.0.0"
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
@@ -100,6 +1085,20 @@ call-bound@^1.0.2:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+cjs-module-lexer@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz#ab35b03c56ade05fe170c70e67ae89f60666847c"
+  integrity sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 co-body@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/co-body/-/co-body-6.2.0.tgz#afd776d60e5659f4eee862df83499698eb1aea1b"
@@ -110,6 +1109,18 @@ co-body@^6.2.0:
     qs "^6.5.2"
     raw-body "^2.3.3"
     type-is "^1.6.16"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -151,7 +1162,21 @@ cookies@~0.9.1:
     depd "~2.0.0"
     keygrip "~1.1.0"
 
-debug@^4.3.7:
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
+debug@4, debug@^4.3.5, debug@^4.3.7:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -205,6 +1230,11 @@ dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
@@ -216,6 +1246,16 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@^2.0.0:
   version "2.0.0"
@@ -231,6 +1271,11 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-module-lexer@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.3.2.tgz#311fa4f40168c1975c505477c51b23234d41ad55"
+  integrity sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.2"
@@ -249,6 +1294,11 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
+escalade@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
 escape-html@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -259,10 +1309,31 @@ eventsource@2.0.2:
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
   integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
 
 form-data@^4.0.5:
   version "4.0.6"
@@ -275,6 +1346,13 @@ form-data@^4.0.5:
     hasown "^2.0.4"
     mime-types "^2.1.35"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 formidable@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.4.tgz#ac9a593b951e829b3298f21aa9a2243932f32ed9"
@@ -283,6 +1361,11 @@ formidable@^3.5.4:
     "@paralleldrive/cuid2" "^2.2.2"
     dezalgo "^1.0.4"
     once "^1.4.0"
+
+forwarded-parse@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
+  integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
 
 fresh@~0.5.2:
   version "0.5.2"
@@ -293,6 +1376,30 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+gaxios@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.3.tgz#c5312f4254abc1b8ab53aef30c22c5229b80b1e1"
+  integrity sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+    rimraf "^5.0.1"
+
+gcp-metadata@^8.0.0:
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.4.tgz#07f987267431a03ae94f7733cbd088bf92fad0b9"
+  integrity sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==
+  dependencies:
+    gaxios "7.1.3"
+    google-logging-utils "1.1.3"
+    json-bigint "^1.0.0"
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -317,6 +1424,23 @@ get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
+
+glob@^10.3.7:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
+google-logging-utils@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 gopd@^1.2.0:
   version "1.2.0"
@@ -372,12 +1496,29 @@ http-errors@~1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+https-proxy-agent@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 iconv-lite@~0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+import-in-the-middle@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz#71420ed5eac24a358695bffacd7435b486c76d61"
+  integrity sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==
+  dependencies:
+    cjs-module-lexer "^2.2.0"
+    es-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
 
 inflation@^2.0.0:
   version "2.1.0"
@@ -394,6 +1535,25 @@ inherits@2.0.4, inherits@~2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jose@^4.15.9:
   version "4.15.9"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
@@ -405,6 +1565,13 @@ json-api-serializer@^2.6.6:
   integrity sha512-Q21X9pIBo53RiJfOat9xlhAOM7aYsgo5Pw+FlSA33Col5pQ3OdAHUwHuZcDGA/lbCrF8FvKDK0g+6GCGxLdhlg==
   dependencies:
     setimmediate "^1.0.5"
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 jsonapi-serializer@^3.6.9:
   version "3.6.9"
@@ -483,6 +1650,11 @@ koa@^3.0.1:
     type-is "^2.0.1"
     vary "^1.1.2"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -527,6 +1699,16 @@ lodash@^4.16.3, lodash@^4.18.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+long@^5.0.0, long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -589,6 +1771,23 @@ mime@2.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -598,6 +1797,20 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 object-hash@^2.2.0:
   version "2.2.0"
@@ -650,10 +1863,88 @@ openid-client@^5.7.1:
     object-hash "^2.2.0"
     oidc-token-hash "^5.0.3"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-protocol@*:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.16.0.tgz#cffb008826561ee9770a8a15dc21f269d731b305"
+  integrity sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==
+
+pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
+
+protobufjs@^7.5.5:
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
 
 qs@>=6.15.2, qs@^6.14.1, qs@^6.5.2:
   version "6.15.3"
@@ -672,6 +1963,26 @@ raw-body@^2.3.3:
     http-errors "~2.0.1"
     iconv-lite "~0.4.24"
     unpipe "~1.0.0"
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
+
+rimraf@^5.0.1:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.10.tgz#23b9843d3dc92db71f96e1a2ce92e39fd2a8221c"
+  integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
+  dependencies:
+    glob "^10.3.7"
 
 safe-buffer@^5.0.1:
   version "5.2.1"
@@ -697,6 +2008,18 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 side-channel-list@^1.0.1:
   version "1.0.1"
@@ -738,6 +2061,11 @@ side-channel@^1.1.1:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -747,6 +2075,38 @@ statuses@^2.0.1, statuses@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 superagent@^10.3.0:
   version "10.3.0"
@@ -762,6 +2122,11 @@ superagent@^10.3.0:
     methods "^1.1.2"
     mime "2.6.0"
     qs "^6.14.1"
+
+systeminformation@^5.31.6:
+  version "5.33.2"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.33.2.tgz#e62e12659d93e70d9310d8fc39dc409bac1c11e3"
+  integrity sha512-T0w9cJPXe0AVMOukHTBNMrqU9mf3LdRR6dxLdnNbM9LdKEcH5yWT5FEN7ljvgh4cjliLy7pICtViQtVeYqaZxg==
 
 toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
@@ -810,20 +2175,78 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.9.0:
+yaml@^2.0.0, yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 zod@4.3.6:
   version "4.3.6"

--- a/packages/agent-bff/docker/scan-gate.js
+++ b/packages/agent-bff/docker/scan-gate.js
@@ -1,17 +1,16 @@
-// Reports the image's library (npm) vulnerabilities.
+// Gates the image publish on library (npm) vulnerabilities by ORIGIN, not severity.
 //
 // Trivy splits findings into OS packages (gated natively in the workflow, blocking —
-// only fixable by bumping the base image here) and libraries. The libraries here are
-// the BFF's npm dependencies, already shipped to npm consumers — blocking the image
-// would desync GHCR from npm without removing the vuln, which is fixed at the source
-// via a dependency bump — plus the npm CLI the base image bundles, fixed by bumping
-// that base image. Neither is fixable in this Dockerfile → REPORT only.
+// only fixable by bumping the base image here) and libraries. Among libraries:
+//   - @opentelemetry/* are Docker-only (pinned in build-deps-manifest.js): the image
+//     is the ONLY place they exist and can be fixed → BLOCK.
+//   - everything else is either the BFF's npm dependencies, already shipped via the
+//     npm package (blocking the image would desync GHCR from npm without removing the
+//     vuln, which is fixed at the source), or the npm CLI the base image bundles
+//     → REPORT only.
 //
-// The image ships no Docker-only npm dependency today. The day it does (APM), that
-// dependency exists ONLY here and can only be fixed here — it must then BLOCK, the
-// way the workflow-executor image gates its @opentelemetry packages.
-//
-// Usage: node scan-gate.js <trivy-library-results.json>
+// Usage: node scan-gate.js <trivy-library-results.json>   (exits 1 if a blocking
+// OTel vuln is found; always prints every library finding for visibility)
 
 const fs = require('fs');
 
@@ -45,4 +44,15 @@ const summary = lines.join('\n');
 console.log(summary);
 if (process.env.GITHUB_STEP_SUMMARY) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 
-console.log('\nEvery library finding above is report-only — this step gates nothing today.');
+// Block only on Docker-only OTel packages — everything else is report-only.
+const blocking = findings.filter(f => f.pkg.startsWith('@opentelemetry/'));
+if (blocking.length) {
+  console.error(
+    `\n::error::${blocking.length} fixable vuln(s) in Docker-only @opentelemetry packages must be ` +
+      'fixed here (bump versions in build-deps-manifest.js): ' +
+      blocking.map(f => `${f.pkg}@${f.installed} (${f.id})`).join(', '),
+  );
+  process.exit(1);
+}
+
+console.log('\nNo blocking (Docker-only) library vulnerabilities — npm-shared deps are report-only.');

--- a/packages/agent-bff/docker/smoke-test.sh
+++ b/packages/agent-bff/docker/smoke-test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Smoke-test a built agent-bff image: prove the entrypoint works, the full module
 # graph loads (cli.js eagerly imports cli-core -> every @forestadmin + external
-# dep), the Redoc bundle shipped, and the server boots and answers.
+# dep), the Redoc bundle shipped, the OTel SDK initialises, and the server boots
+# and answers.
 # Run against a locally-loaded image before it is published.
 #
 # Usage: smoke-test.sh <image-ref>
@@ -37,12 +38,17 @@ grep -q '"openapi"' /tmp/bff-openapi.json
 # nothing reaches the network, whereas a fully configured boot would fetch the
 # environment id from FOREST_SERVER_URL and die on an unreachable host.
 # /health therefore reports `degraded` — the point is that it answers at all.
+#
+# OTEL_EXPORTER_OTLP_ENDPOINT is set so the SDK actually initialises: the packages
+# exist only in this image, so nothing else would prove they are loadable. The
+# receiver is unreachable on purpose — exporting is asynchronous and best-effort.
 CONTAINER=$(docker run -d -p "127.0.0.1:$PORT:3450" \
   -e FOREST_AUTH_SECRET=smoke-test \
   -e FOREST_ENV_SECRET="$(openssl rand -hex 32)" \
   -e FOREST_SERVER_URL=http://127.0.0.1:1 \
   -e FOREST_APP_URL=http://127.0.0.1:1 \
   -e AGENT_URL=http://127.0.0.1:1 \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
   "$IMAGE")
 trap 'docker logs "$CONTAINER" 2>&1 || true; docker rm -f "$CONTAINER" >/dev/null 2>&1 || true' EXIT
 
@@ -63,6 +69,10 @@ if echo "$logs" | grep -qiE "Cannot find module|MODULE_NOT_FOUND"; then
 fi
 if ! echo "$logs" | grep -q "Forest BFF started"; then
   echo "::error::the BFF did not reach startup — boot failure"
+  exit 1
+fi
+if ! echo "$logs" | grep -q "OpenTelemetry tracing enabled"; then
+  echo "::error::the OTel SDK did not initialise — packages missing from the image?"
   exit 1
 fi
 if [ "$status" != "503" ]; then

--- a/packages/agent-bff/docker/smoke-test.sh
+++ b/packages/agent-bff/docker/smoke-test.sh
@@ -157,6 +157,7 @@ CONTAINER=$(docker run -d -p "127.0.0.1:$PORT:3450" \
   -e FOREST_APP_URL=http://127.0.0.1:1 \
   -e AGENT_URL=http://127.0.0.1:1 \
   -e BFF_TOKEN_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
   "$IMAGE")
 
 status=""
@@ -180,4 +181,35 @@ if ! grep -q '"status":"ok"' /tmp/bff-health-ok.json; then
   exit 1
 fi
 
+# Stop this one rather than leave it to the trap: the shutdown path is the riskiest code in the
+# image and nothing else runs it there. Tracing is armed above against a collector that is not
+# listening, which is the case that matters — the span flush must give up on its own deadline and
+# let the process exit, not hold it until the orchestrator loses patience and SIGKILLs.
+#
+# -t 30 so this measures the BFF rather than whatever `docker stop` defaults to locally.
+STOP_STARTED=$(date +%s)
+docker stop -t 30 "$CONTAINER" >/dev/null
+STOP_ELAPSED=$(( $(date +%s) - STOP_STARTED ))
+STOP_CODE=$(docker inspect "$CONTAINER" --format '{{.State.ExitCode}}')
+logs=$(docker logs "$CONTAINER" 2>&1)
+
+if [ "$STOP_CODE" != "0" ]; then
+  echo "::error::the container exited $STOP_CODE on docker stop, expected 0 (137 means it was SIGKILLed)"
+  echo "$logs"
+  exit 1
+fi
+if ! echo "$logs" | grep -q "Forest BFF stopped"; then
+  echo "::error::the shutdown never completed — no 'Forest BFF stopped' in the logs"
+  echo "$logs"
+  exit 1
+fi
+# The README promises ~3s: a 2s flush deadline plus the 1s exit fallback. Anything near the OTLP
+# retry budget means the flush stopped being bounded.
+if [ "$STOP_ELAPSED" -gt 8 ]; then
+  echo "::error::shutdown took ${STOP_ELAPSED}s against a dead collector; the span flush is no longer bounded"
+  echo "$logs"
+  exit 1
+fi
+
+echo "shutdown with an unreachable collector: exit 0 in ${STOP_ELAPSED}s"
 echo "smoke test passed for $IMAGE"

--- a/packages/agent-bff/src/cli.ts
+++ b/packages/agent-bff/src/cli.ts
@@ -9,11 +9,14 @@ import { flushTracing } from './tracing-handle';
 if (require.main === module) {
   dispatchCli(process.argv.slice(2), process.env)
     .then(({ exitCode, server }) => {
-      // Only the server command has anything to shut down; `openapi` and the flags
-      // have already finished by the time they return.
-      // flushTracing is a no-op unless the image's tracing preload armed an SDK. Wiring it here,
-      // rather than letting the preload arm its own signal handler, is what makes the exit wait
-      // for the export instead of racing it.
+      // Only the server has anything to shut down. `openapi` and the flags are already finished by
+      // the time they return, and deliberately do NOT flush: calling shutdown on the SDK forces an
+      // export attempt whose retries hold the event loop long after the flush stops being awaited —
+      // measured at 9s against an unreachable collector, where the command otherwise exits in 1.3s.
+      // Losing the spans of a one-shot export is the cheaper side of that trade.
+      //
+      // Wiring the flush into the shutdown handler, rather than letting the preload arm a handler
+      // of its own, is what makes the server's exit wait for the export instead of racing it.
       if (server) armShutdown({ server, logger: createConsoleLogger(), flush: flushTracing });
       if (exitCode !== 0) process.exitCode = exitCode;
     })

--- a/packages/agent-bff/src/cli.ts
+++ b/packages/agent-bff/src/cli.ts
@@ -4,13 +4,17 @@ import createConsoleLogger from './adapters/console-logger';
 import { reportFatalError } from './cli-core';
 import dispatchCli from './cli-dispatch';
 import armShutdown from './shutdown';
+import { flushTracing } from './tracing-handle';
 
 if (require.main === module) {
   dispatchCli(process.argv.slice(2), process.env)
     .then(({ exitCode, server }) => {
       // Only the server command has anything to shut down; `openapi` and the flags
       // have already finished by the time they return.
-      if (server) armShutdown({ server, logger: createConsoleLogger() });
+      // flushTracing is a no-op unless the image's tracing preload armed an SDK. Wiring it here,
+      // rather than letting the preload arm its own signal handler, is what makes the exit wait
+      // for the export instead of racing it.
+      if (server) armShutdown({ server, logger: createConsoleLogger(), flush: flushTracing });
       if (exitCode !== 0) process.exitCode = exitCode;
     })
     .catch(reportFatalError);

--- a/packages/agent-bff/src/shutdown.ts
+++ b/packages/agent-bff/src/shutdown.ts
@@ -109,21 +109,26 @@ export default function armShutdown(options: ShutdownOptions): void {
     stopping = true;
     logger?.('Info', 'Shutting down', { signal, graceMs });
 
-    Promise.all([server.stop(graceMs), flush ? bounded(flush(), flushMs) : undefined])
-      .then(() => {
+    // allSettled, not all: a failing `stop()` must not short-circuit the flush. Promise.all is
+    // fail-fast, so the exit would fire while the export was still in flight and the force-exit
+    // fallback would cut it — losing exactly the telemetry that explains the failed shutdown.
+    Promise.allSettled([server.stop(graceMs), flush ? bounded(flush(), flushMs) : undefined]).then(
+      ([stopped]) => {
         if (interrupted) return;
+
+        if (stopped.status === 'rejected') {
+          // The server failed to close cleanly. Nothing left to salvage, and staying alive would
+          // hold the container open until it is killed — report it through the exit code instead.
+          logger?.('Error', 'Shutdown failed, exiting anyway', { signal });
+          exit(1);
+
+          return;
+        }
 
         logger?.('Info', 'Forest BFF stopped');
         exit(0);
-      })
-      .catch(() => {
-        if (interrupted) return;
-
-        // The server failed to close cleanly. Nothing left to salvage, and staying alive would
-        // hold the container open until it is killed — report it through the exit code instead.
-        logger?.('Error', 'Shutdown failed, exiting anyway', { signal });
-        exit(1);
-      });
+      },
+    );
   };
 
   for (const signal of SIGNALS) {

--- a/packages/agent-bff/src/shutdown.ts
+++ b/packages/agent-bff/src/shutdown.ts
@@ -10,6 +10,19 @@ export interface ShutdownOptions {
   logger?: Logger;
   /** How long in-flight requests get before their sockets are cut. */
   graceMs?: number;
+  /**
+   * Anything that must reach its destination before the process ends — today the buffered
+   * OpenTelemetry spans. It runs alongside `server.stop()` and is awaited with it, so the exit
+   * cannot cut an export that is still in flight.
+   */
+  flush?: () => Promise<void>;
+  /**
+   * The flush's own, much shorter deadline. It deliberately does not share `graceMs`: finishing a
+   * request someone is waiting on is worth ten seconds, telemetry is not, and an unreachable
+   * collector that held the process for the full grace period would be SIGKILLed by an orchestrator
+   * whose own patience starts at the same ten seconds — losing the shutdown, not just the spans.
+   */
+  flushMs?: number;
   /** Signal registration, as a seam: a test must not arm a handler on the real process. */
   onSignal?: (signal: NodeJS.Signals, handler: () => void) => void;
   exit?: (code: number) => void;
@@ -18,6 +31,7 @@ export interface ShutdownOptions {
 export const SIGNALS: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
 export const DEFAULT_GRACE_MS = 10_000;
 export const FORCE_EXIT_MS = 1_000;
+export const DEFAULT_FLUSH_MS = 2_000;
 
 /**
  * Ends the process without `process.exit`, which would discard whatever is still buffered on stdout
@@ -32,6 +46,24 @@ export const FORCE_EXIT_MS = 1_000;
 function defaultExit(code: number): void {
   process.exitCode = code;
   setTimeout(() => process.exit(code), FORCE_EXIT_MS).unref();
+}
+
+/**
+ * Gives a promise a deadline, resolving either way — a slow collector should cost the shutdown its
+ * last spans, not its ability to end. The timer is cleared on settle so it cannot hold the loop open
+ * once the work is done.
+ */
+function bounded(work: Promise<void>, ms: number): Promise<void> {
+  return new Promise(resolve => {
+    const timer = setTimeout(resolve, ms);
+
+    void work
+      .catch(() => undefined)
+      .then(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+  });
 }
 
 /**
@@ -51,6 +83,8 @@ export default function armShutdown(options: ShutdownOptions): void {
     server,
     logger,
     graceMs = DEFAULT_GRACE_MS,
+    flush,
+    flushMs = DEFAULT_FLUSH_MS,
     onSignal = (signal, handler) => {
       process.on(signal, handler);
     },
@@ -75,8 +109,7 @@ export default function armShutdown(options: ShutdownOptions): void {
     stopping = true;
     logger?.('Info', 'Shutting down', { signal, graceMs });
 
-    server
-      .stop(graceMs)
+    Promise.all([server.stop(graceMs), flush ? bounded(flush(), flushMs) : undefined])
       .then(() => {
         if (interrupted) return;
 

--- a/packages/agent-bff/src/tracing-handle.ts
+++ b/packages/agent-bff/src/tracing-handle.ts
@@ -1,0 +1,38 @@
+/**
+ * The one piece of state the preload and the CLI have to share.
+ *
+ * `--require` runs the preload in its own module, before `cli.js` is even loaded, so the SDK it
+ * builds has nowhere to go but a module both sides resolve to the same instance. Keeping it here —
+ * rather than having the preload arm a signal handler of its own — is what lets the shutdown path
+ * WAIT for the flush instead of racing it, and keeps the preload from consuming a signal the CLI
+ * has not armed a handler for yet.
+ *
+ * Nothing OpenTelemetry-specific is imported here, so the npm bin pays only for an empty variable.
+ */
+
+export interface TracingHandle {
+  shutdown(): Promise<void>;
+}
+
+let handle: TracingHandle | undefined;
+
+export function setTracingHandle(sdk: TracingHandle | undefined): void {
+  handle = sdk;
+}
+
+export function getTracingHandle(): TracingHandle | undefined {
+  return handle;
+}
+
+/**
+ * Flushes buffered spans, or resolves immediately when tracing was never armed — the shutdown path
+ * should not have to know which. A failing export is swallowed: a dead collector must not turn a
+ * clean shutdown into a failed one.
+ */
+export async function flushTracing(): Promise<void> {
+  try {
+    await handle?.shutdown();
+  } catch {
+    /* istanbul ignore next — nothing to do about it, and it must not change the exit code. */
+  }
+}

--- a/packages/agent-bff/src/tracing-handle.ts
+++ b/packages/agent-bff/src/tracing-handle.ts
@@ -28,6 +28,9 @@ export function getTracingHandle(): TracingHandle | undefined {
  * Flushes buffered spans, or resolves immediately when tracing was never armed — the shutdown path
  * should not have to know which. A failing export is swallowed: a dead collector must not turn a
  * clean shutdown into a failed one.
+ *
+ * No deadline here on purpose: `armShutdown` bounds whatever flush it is given, and it is the only
+ * caller. Bounding it twice would say the deadline lives in two places when it does not.
  */
 export async function flushTracing(): Promise<void> {
   try {

--- a/packages/agent-bff/src/tracing-preload.ts
+++ b/packages/agent-bff/src/tracing-preload.ts
@@ -4,7 +4,18 @@
 // The SDK is handed to `tracing-handle` rather than wired to a signal here. The CLI arms the only
 // termination handler, and it flushes through that handle — so a signal arriving before the CLI is
 // up cannot be swallowed by a listener that does not terminate anything.
+import createConsoleLogger from './adapters/console-logger';
 import initTracing from './tracing';
 import { setTracingHandle } from './tracing-handle';
 
-setTracingHandle(initTracing());
+// Nothing here may throw. A `--require` runs before the entry point, so an exception aborts the
+// process before the BFF exists at all — a dead container in exchange for optional, best-effort
+// telemetry. `initTracing` degrades on its own for the cases it knows about; this catches the rest,
+// including whatever a future SDK version decides to throw from `start()`.
+try {
+  setTracingHandle(initTracing());
+} catch (error) {
+  createConsoleLogger()('Warn', 'OpenTelemetry failed to initialise, starting untraced', {
+    reason: error instanceof Error ? error.message : String(error),
+  });
+}

--- a/packages/agent-bff/src/tracing-preload.ts
+++ b/packages/agent-bff/src/tracing-preload.ts
@@ -1,0 +1,5 @@
+// The `--require` entry point of the Docker image (see the Dockerfile's ENTRYPOINT). Separate from
+// `tracing.ts` on purpose: importing the setup must never arm an SDK, only calling it should.
+import initTracing from './tracing';
+
+initTracing();

--- a/packages/agent-bff/src/tracing-preload.ts
+++ b/packages/agent-bff/src/tracing-preload.ts
@@ -1,5 +1,10 @@
 // The `--require` entry point of the Docker image (see the Dockerfile's ENTRYPOINT). Separate from
 // `tracing.ts` on purpose: importing the setup must never arm an SDK, only calling it should.
+//
+// The SDK is handed to `tracing-handle` rather than wired to a signal here. The CLI arms the only
+// termination handler, and it flushes through that handle — so a signal arriving before the CLI is
+// up cannot be swallowed by a listener that does not terminate anything.
 import initTracing from './tracing';
+import { setTracingHandle } from './tracing-handle';
 
-initTracing();
+setTracingHandle(initTracing());

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -8,8 +8,8 @@ import createConsoleLogger from './adapters/console-logger';
  * apart is what lets this module be imported by a test without arming an SDK.
  *
  * The SDK is initialised only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so an install that never
- * opted into APM pays nothing. All configuration goes through the standard OTel environment
- * variables:
+ * opted into APM pays nothing. Ending the process is not this module's business — see `armFlush`.
+ * All configuration goes through the standard OTel environment variables:
  *
  *   OTEL_EXPORTER_OTLP_ENDPOINT   OTLP receiver (e.g. http://localhost:4318)
  *   OTEL_SERVICE_NAME             default: forestadmin-agent-bff
@@ -41,7 +41,6 @@ export interface TracingOptions {
   load?: () => OtelModules | undefined;
   /** Signal registration, as a seam: a test must not arm a handler on the real process. */
   onSignal?: (signal: NodeJS.Signals, handler: () => void) => void;
-  raise?: (signal: NodeJS.Signals) => void;
 }
 
 /** The packages this image installs for APM, and the export it takes from each. */
@@ -73,27 +72,22 @@ export function loadOtelModules(load: ModuleLoader = require): OtelModules | und
 }
 
 /**
- * Flushes buffered spans on the way out, then re-raises the signal so the default action terminates
- * the process. The BFF installs no signal handler of its own, and a listener SUPPRESSES the default
- * termination — arming one without re-raising would leave `docker stop` waiting out its timeout for
- * a SIGKILL. `once` has already removed this listener by the time the signal comes back around, so
- * the second delivery finds none and terminates.
+ * Flushes buffered spans on the way out, alongside the shutdown `armShutdown` runs — this handler
+ * does not end the process and must not try to. Ending it is `src/shutdown.ts`'s job: it closes the
+ * server, bounds the wait for in-flight requests and exits explicitly, which is the only thing that
+ * works when node is PID 1 (the kernel gives PID 1 no default disposition, so "let the default
+ * action terminate" ends in a SIGKILL rather than a clean exit).
  *
- * A failing flush must not keep the process alive either: the shutdown result is swallowed, the
- * signal is re-raised regardless.
+ * So this only flushes. Once both the flush and that shutdown settle the loop empties and the
+ * process exits on its own. A rejected flush is swallowed for the same reason: it must not become
+ * an unhandled rejection that outlives the shutdown it is running beside.
  */
-function armFlush(
-  sdk: OtelSdk,
-  options: Required<Pick<TracingOptions, 'onSignal' | 'raise'>>,
-): void {
+function armFlush(sdk: OtelSdk, onSignal: NonNullable<TracingOptions['onSignal']>): void {
   const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
 
   for (const signal of signals) {
-    options.onSignal(signal, () => {
-      void sdk
-        .shutdown()
-        .catch(() => undefined)
-        .then(() => options.raise(signal));
+    onSignal(signal, () => {
+      void sdk.shutdown().catch(() => undefined);
     });
   }
 }
@@ -114,9 +108,6 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
     load = loadOtelModules,
     onSignal = (signal, handler) => {
       process.once(signal, handler);
-    },
-    raise = signal => {
-      process.kill(process.pid, signal);
     },
   } = options;
 
@@ -144,7 +135,7 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   });
 
   sdk.start();
-  armFlush(sdk, { onSignal, raise });
+  armFlush(sdk, onSignal);
 
   logger('Info', 'OpenTelemetry tracing enabled', { serviceName, endpoint });
 

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -44,15 +44,29 @@ export interface TracingOptions {
   raise?: (signal: NodeJS.Signals) => void;
 }
 
-export function loadOtelModules(): OtelModules | undefined {
-  try {
-    /* eslint-disable global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies */
-    const { NodeSDK } = require('@opentelemetry/sdk-node');
-    const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
-    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
-    /* eslint-enable global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies */
+/** The packages this image installs for APM, and the export it takes from each. */
+export const OTEL_MODULE_IDS = {
+  sdk: '@opentelemetry/sdk-node',
+  instrumentations: '@opentelemetry/auto-instrumentations-node',
+  exporter: '@opentelemetry/exporter-trace-otlp-http',
+} as const;
 
-    return { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter };
+/**
+ * The module resolution, as a seam. These packages are absent everywhere except the Docker image,
+ * so the real `require` can only ever take the failure branch here — passing a loader is what lets
+ * the success branch, and the package ids it asks for, be exercised at all. A typo in one of them
+ * would otherwise surface as an untraced image and nothing else.
+ */
+export type ModuleLoader = (id: string) => Record<string, unknown>;
+
+export function loadOtelModules(load: ModuleLoader = require): OtelModules | undefined {
+  try {
+    return {
+      NodeSDK: load(OTEL_MODULE_IDS.sdk).NodeSDK,
+      getNodeAutoInstrumentations: load(OTEL_MODULE_IDS.instrumentations)
+        .getNodeAutoInstrumentations,
+      OTLPTraceExporter: load(OTEL_MODULE_IDS.exporter).OTLPTraceExporter,
+    } as OtelModules;
   } catch {
     return undefined;
   }

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -98,6 +98,15 @@ function armFlush(
   }
 }
 
+/**
+ * The OTel specification defines its boolean environment variables as case-insensitive, and this
+ * one is the kill switch: reading `TRUE` as "not disabled" would leave tracing running for someone
+ * who just asked for it to stop.
+ */
+function isDisabled(raw: string | undefined): boolean {
+  return raw?.trim().toLowerCase() === 'true';
+}
+
 export default function initTracing(options: TracingOptions = {}): OtelSdk | undefined {
   const {
     env = process.env,
@@ -111,7 +120,12 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
     },
   } = options;
 
-  if (!env.OTEL_EXPORTER_OTLP_ENDPOINT || env.OTEL_SDK_DISABLED === 'true') return undefined;
+  const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
+
+  // A blank endpoint counts as unset, not as "export to the OTel default": `env_file` hands an
+  // empty string through for a variable left blank in a `.env`, and arming the SDK against
+  // localhost:4318 is not what leaving the line empty asks for.
+  if (!endpoint || isDisabled(env.OTEL_SDK_DISABLED)) return undefined;
 
   const modules = load();
 
@@ -132,10 +146,7 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   sdk.start();
   armFlush(sdk, { onSignal, raise });
 
-  logger('Info', 'OpenTelemetry tracing enabled', {
-    serviceName,
-    endpoint: env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  });
+  logger('Info', 'OpenTelemetry tracing enabled', { serviceName, endpoint });
 
   return sdk;
 }

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -81,6 +81,29 @@ function isDisabled(raw: string | undefined): boolean {
   return raw?.trim().toLowerCase() === 'true';
 }
 
+/**
+ * Strips the credentials out of the endpoint before it reaches the logs. `https://user:token@host`
+ * is a legitimate way to reach a collector behind basic auth, and container logs are the last place
+ * that token should end up — this package does not echo a secret anywhere else either.
+ *
+ * An endpoint that does not parse is dropped from the log entirely rather than passed through: it
+ * cannot be redacted, so it cannot be shown. The SDK will fail on it soon enough on its own.
+ */
+export function redactEndpoint(endpoint: string): string | undefined {
+  try {
+    const url = new URL(endpoint);
+
+    if (!url.username && !url.password) return endpoint;
+
+    url.username = '';
+    url.password = '';
+
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
 export default function initTracing(options: TracingOptions = {}): OtelSdk | undefined {
   const { env = process.env, logger = createConsoleLogger(), load = loadOtelModules } = options;
 
@@ -109,7 +132,10 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
 
   sdk.start();
 
-  logger('Info', 'OpenTelemetry tracing enabled', { serviceName, endpoint });
+  logger('Info', 'OpenTelemetry tracing enabled', {
+    serviceName,
+    endpoint: redactEndpoint(endpoint),
+  });
 
   return sdk;
 }

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -38,6 +38,12 @@ export interface OtelModules {
 }
 
 export interface TracingOptions {
+  /**
+   * The environment OUR decisions read — whether to arm, what to name the service, which exporter
+   * to leave to the SDK. It stops there: `OTLPTraceExporter` reads the real `process.env` itself,
+   * so where spans are sent is not steerable from here and a test injecting `env` cannot assert it.
+   * Identical objects in production, so this is a limit on what the seam can test, not a behaviour.
+   */
   env?: NodeJS.ProcessEnv;
   logger?: Logger;
   /** The dynamic require, as a seam: the packages exist only in the Docker image. */
@@ -61,12 +67,21 @@ export type ModuleLoader = (id: string) => Record<string, unknown>;
 
 export function loadOtelModules(load: ModuleLoader = require): OtelModules | undefined {
   try {
-    return {
+    const modules = {
       NodeSDK: load(OTEL_MODULE_IDS.sdk).NodeSDK,
       getNodeAutoInstrumentations: load(OTEL_MODULE_IDS.instrumentations)
         .getNodeAutoInstrumentations,
       OTLPTraceExporter: load(OTEL_MODULE_IDS.exporter).OTLPTraceExporter,
-    } as OtelModules;
+    };
+
+    // Resolving is not the same as finding what we came for. A package that loads but no longer
+    // exports the name we read — a rename on a version bump — would otherwise hand back a truthy
+    // object of undefined members, skip the "packages not available" branch, and throw a
+    // TypeError inside a `--require`, before the entry point runs at all. That is a dead container
+    // for an APM layer that is supposed to degrade to a warning.
+    if (Object.values(modules).some(exported => typeof exported !== 'function')) return undefined;
+
+    return modules as OtelModules;
   } catch {
     return undefined;
   }
@@ -79,6 +94,23 @@ export function loadOtelModules(load: ModuleLoader = require): OtelModules | und
  */
 function isDisabled(raw: string | undefined): boolean {
   return raw?.trim().toLowerCase() === 'true';
+}
+
+/**
+ * The service name the environment already carries, by the spec's precedence: `OTEL_SERVICE_NAME`
+ * wins, then a `service.name` entry in the comma-separated `OTEL_RESOURCE_ATTRIBUTES` list.
+ * Undefined when neither names one, which is the only case where our own default should apply.
+ */
+export function serviceNameFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const explicit = env.OTEL_SERVICE_NAME?.trim();
+
+  if (explicit) return explicit;
+
+  return env.OTEL_RESOURCE_ATTRIBUTES?.split(',')
+    .map(entry => entry.split('='))
+    .filter(([key, value]) => key?.trim() === 'service.name' && value?.trim())
+    .map(([, value]) => value.trim())
+    .pop();
 }
 
 /**
@@ -108,11 +140,16 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   const { env = process.env, logger = createConsoleLogger(), load = loadOtelModules } = options;
 
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
+  const requestedExporter = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
 
-  // A blank endpoint counts as unset, not as "export to the OTel default": `env_file` hands an
-  // empty string through for a variable left blank in a `.env`, and arming the SDK against
+  // Either variable turns tracing on. Gating on the endpoint alone would make
+  // OTEL_TRACES_EXPORTER=console — the obvious first thing to reach for when debugging — require an
+  // OTLP collector to do anything, which is nonsense for an exporter that writes to stdout.
+  //
+  // A blank value counts as unset either way, not as "export to the OTel default": `env_file` hands
+  // an empty string through for a variable left blank in a `.env`, and arming the SDK against
   // localhost:4318 is not what leaving the line empty asks for.
-  if (!endpoint || isDisabled(env.OTEL_SDK_DISABLED)) return undefined;
+  if ((!endpoint && !requestedExporter) || isDisabled(env.OTEL_SDK_DISABLED)) return undefined;
 
   const modules = load();
 
@@ -123,7 +160,12 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   }
 
   const { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter } = modules;
-  const serviceName = env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
+
+  // Passing `serviceName` unconditionally would override OTEL_RESOURCE_ATTRIBUTES=service.name=...,
+  // which is a documented knob — someone setting only that would silently get our default. So we
+  // fill it in only when the environment names no service at all, and otherwise leave the SDK to
+  // apply the spec's own precedence (OTEL_SERVICE_NAME first, then the resource attribute).
+  const named = serviceNameFromEnv(env);
 
   // Supplying `traceExporter` puts NodeSDK on its manual-configuration path, where it never reads
   // OTEL_TRACES_EXPORTER. So we only supply one when the operator has not asked for something else:
@@ -135,10 +177,9 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   //
   // Instrumentation stays on in every case, so trace context keeps propagating to the agent and the
   // Forest SaaS whatever the export does.
-  const requestedExporter = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
   const exportsTraces = !requestedExporter || requestedExporter === 'otlp';
   const sdk = new NodeSDK({
-    serviceName,
+    ...(named ? {} : { serviceName: DEFAULT_SERVICE_NAME }),
     ...(exportsTraces ? { traceExporter: new OTLPTraceExporter() } : {}),
     instrumentations: [getNodeAutoInstrumentations()],
   });
@@ -146,7 +187,7 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   sdk.start();
 
   logger('Info', 'OpenTelemetry tracing enabled', {
-    serviceName,
+    serviceName: named ?? DEFAULT_SERVICE_NAME,
     // Naming the endpoint it will not export to would read as a promise it is not keeping. Saying
     // which exporter was asked for instead is what an operator needs to see when the SDK, not us,
     // is the one deciding.

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -124,9 +124,16 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
 
   const { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter } = modules;
   const serviceName = env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
+
+  // Supplying `traceExporter` puts NodeSDK on its manual-configuration path, where it never reads
+  // OTEL_TRACES_EXPORTER — so passing one unconditionally would silently ignore the standard way to
+  // turn export off. Omitting it on `none` hands the decision back to the SDK, which then configures
+  // no exporter. Instrumentation stays on either way, so trace context still propagates to the agent
+  // and the Forest SaaS; only the export stops, which is what the variable asks for.
+  const exportsTraces = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase() !== 'none';
   const sdk = new NodeSDK({
     serviceName,
-    traceExporter: new OTLPTraceExporter(),
+    ...(exportsTraces ? { traceExporter: new OTLPTraceExporter() } : {}),
     instrumentations: [getNodeAutoInstrumentations()],
   });
 
@@ -134,7 +141,8 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
 
   logger('Info', 'OpenTelemetry tracing enabled', {
     serviceName,
-    endpoint: redactEndpoint(endpoint),
+    // Naming the endpoint it will not export to would read as a promise it is not keeping.
+    ...(exportsTraces ? { endpoint: redactEndpoint(endpoint) } : { exporter: 'none' }),
   });
 
   return sdk;

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -1,0 +1,127 @@
+import type { Logger } from './ports/logger-port';
+
+import createConsoleLogger from './adapters/console-logger';
+
+/**
+ * The OpenTelemetry setup. `tracing-preload.ts` is what actually runs it, via `--require` before
+ * cli.js so the auto-instrumentation patches land before anything the app imports; keeping the two
+ * apart is what lets this module be imported by a test without arming an SDK.
+ *
+ * The SDK is initialised only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so an install that never
+ * opted into APM pays nothing. All configuration goes through the standard OTel environment
+ * variables:
+ *
+ *   OTEL_EXPORTER_OTLP_ENDPOINT   OTLP receiver (e.g. http://localhost:4318)
+ *   OTEL_SERVICE_NAME             default: forestadmin-agent-bff
+ *   OTEL_SDK_DISABLED             set to "true" to force-disable
+ *   OTEL_RESOURCE_ATTRIBUTES      e.g. deployment.environment=production
+ *
+ * The OTel packages are installed only into the Docker image's isolated deps (see
+ * `packages/agent-bff/docker/`), never shipped to npm consumers of the CLI — hence the dynamic
+ * require behind a seam, and the warning rather than a crash when they are absent.
+ */
+
+export const DEFAULT_SERVICE_NAME = 'forestadmin-agent-bff';
+
+interface OtelSdk {
+  start(): void;
+  shutdown(): Promise<void>;
+}
+
+export interface OtelModules {
+  NodeSDK: new (options: Record<string, unknown>) => OtelSdk;
+  getNodeAutoInstrumentations: () => unknown;
+  OTLPTraceExporter: new () => unknown;
+}
+
+export interface TracingOptions {
+  env?: NodeJS.ProcessEnv;
+  logger?: Logger;
+  /** The dynamic require, as a seam: the packages exist only in the Docker image. */
+  load?: () => OtelModules | undefined;
+  /** Signal registration, as a seam: a test must not arm a handler on the real process. */
+  onSignal?: (signal: NodeJS.Signals, handler: () => void) => void;
+  raise?: (signal: NodeJS.Signals) => void;
+}
+
+export function loadOtelModules(): OtelModules | undefined {
+  try {
+    /* eslint-disable global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies */
+    const { NodeSDK } = require('@opentelemetry/sdk-node');
+    const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+    /* eslint-enable global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies */
+
+    return { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Flushes buffered spans on the way out, then re-raises the signal so the default action terminates
+ * the process. The BFF installs no signal handler of its own, and a listener SUPPRESSES the default
+ * termination — arming one without re-raising would leave `docker stop` waiting out its timeout for
+ * a SIGKILL. `once` has already removed this listener by the time the signal comes back around, so
+ * the second delivery finds none and terminates.
+ *
+ * A failing flush must not keep the process alive either: the shutdown result is swallowed, the
+ * signal is re-raised regardless.
+ */
+function armFlush(
+  sdk: OtelSdk,
+  options: Required<Pick<TracingOptions, 'onSignal' | 'raise'>>,
+): void {
+  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
+
+  for (const signal of signals) {
+    options.onSignal(signal, () => {
+      void sdk
+        .shutdown()
+        .catch(() => undefined)
+        .then(() => options.raise(signal));
+    });
+  }
+}
+
+export default function initTracing(options: TracingOptions = {}): OtelSdk | undefined {
+  const {
+    env = process.env,
+    logger = createConsoleLogger(),
+    load = loadOtelModules,
+    onSignal = (signal, handler) => {
+      process.once(signal, handler);
+    },
+    raise = signal => {
+      process.kill(process.pid, signal);
+    },
+  } = options;
+
+  if (!env.OTEL_EXPORTER_OTLP_ENDPOINT || env.OTEL_SDK_DISABLED === 'true') return undefined;
+
+  const modules = load();
+
+  if (!modules) {
+    logger('Warn', 'OpenTelemetry packages not available, skipping APM initialisation');
+
+    return undefined;
+  }
+
+  const { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter } = modules;
+  const serviceName = env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
+  const sdk = new NodeSDK({
+    serviceName,
+    traceExporter: new OTLPTraceExporter(),
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
+
+  sdk.start();
+  armFlush(sdk, { onSignal, raise });
+
+  logger('Info', 'OpenTelemetry tracing enabled', {
+    serviceName,
+    endpoint: env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  });
+
+  return sdk;
+}

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -34,15 +34,14 @@ export interface OtelSdk {
 export interface OtelModules {
   NodeSDK: new (options: Record<string, unknown>) => OtelSdk;
   getNodeAutoInstrumentations: () => unknown;
-  OTLPTraceExporter: new () => unknown;
 }
 
 export interface TracingOptions {
   /**
-   * The environment OUR decisions read — whether to arm, what to name the service, which exporter
-   * to leave to the SDK. It stops there: `OTLPTraceExporter` reads the real `process.env` itself,
-   * so where spans are sent is not steerable from here and a test injecting `env` cannot assert it.
-   * Identical objects in production, so this is a limit on what the seam can test, not a behaviour.
+   * The environment OUR decisions read: whether to arm at all, and what to name the service when
+   * nothing else does. It stops there — the SDK reads the real `process.env` for everything about
+   * the export itself, so a test injecting `env` cannot assert where spans go. Identical objects in
+   * production, so this is a limit on what the seam can test, not a behaviour.
    */
   env?: NodeJS.ProcessEnv;
   logger?: Logger;
@@ -54,7 +53,6 @@ export interface TracingOptions {
 export const OTEL_MODULE_IDS = {
   sdk: '@opentelemetry/sdk-node',
   instrumentations: '@opentelemetry/auto-instrumentations-node',
-  exporter: '@opentelemetry/exporter-trace-otlp-http',
 } as const;
 
 /**
@@ -71,7 +69,6 @@ export function loadOtelModules(load: ModuleLoader = require): OtelModules | und
       NodeSDK: load(OTEL_MODULE_IDS.sdk).NodeSDK,
       getNodeAutoInstrumentations: load(OTEL_MODULE_IDS.instrumentations)
         .getNodeAutoInstrumentations,
-      OTLPTraceExporter: load(OTEL_MODULE_IDS.exporter).OTLPTraceExporter,
     };
 
     // Resolving is not the same as finding what we came for. A package that loads but no longer
@@ -139,16 +136,18 @@ export function redactEndpoint(endpoint: string): string | undefined {
 export default function initTracing(options: TracingOptions = {}): OtelSdk | undefined {
   const { env = process.env, logger = createConsoleLogger(), load = loadOtelModules } = options;
 
-  const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
-  const requestedExporter = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
-
-  // Either variable turns tracing on. Gating on the endpoint alone would make
-  // OTEL_TRACES_EXPORTER=console — the obvious first thing to reach for when debugging — require an
-  // OTLP collector to do anything, which is nonsense for an exporter that writes to stdout.
+  // Any of the three standard ways to say "export traces somewhere" turns tracing on. The per-signal
+  // endpoint counts as much as the generic one, and OTEL_TRACES_EXPORTER counts on its own —
+  // requiring an OTLP collector before `console` does anything would be nonsense for an exporter
+  // that writes to stdout, and it is the obvious first thing to reach for when debugging.
   //
-  // A blank value counts as unset either way, not as "export to the OTel default": `env_file` hands
+  // A blank value counts as unset throughout, not as "export to the OTel default": `env_file` hands
   // an empty string through for a variable left blank in a `.env`, and arming the SDK against
   // localhost:4318 is not what leaving the line empty asks for.
+  const endpoint =
+    env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT?.trim() || env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
+  const requestedExporter = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+
   if ((!endpoint && !requestedExporter) || isDisabled(env.OTEL_SDK_DISABLED)) return undefined;
 
   const modules = load();
@@ -159,7 +158,7 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
     return undefined;
   }
 
-  const { NodeSDK, getNodeAutoInstrumentations, OTLPTraceExporter } = modules;
+  const { NodeSDK, getNodeAutoInstrumentations } = modules;
 
   // Passing `serviceName` unconditionally would override OTEL_RESOURCE_ATTRIBUTES=service.name=...,
   // which is a documented knob — someone setting only that would silently get our default. So we
@@ -167,31 +166,29 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   // apply the spec's own precedence (OTEL_SERVICE_NAME first, then the resource attribute).
   const named = serviceNameFromEnv(env);
 
-  // Supplying `traceExporter` puts NodeSDK on its manual-configuration path, where it never reads
-  // OTEL_TRACES_EXPORTER. So we only supply one when the operator has not asked for something else:
-  // unset (our documented default, OTLP to the configured endpoint) or `otlp` (the same thing, said
-  // out loud). Anything else — `none`, `console`, `zipkin`, a list — is handed back to the SDK,
-  // which configures it from the environment. Sending spans to the OTLP endpoint because we did not
-  // recognise the value would be worse than not sending them: it is telemetry going somewhere the
-  // operator did not ask for, and the SDK says so out loud when it cannot honour the request.
+  // No `traceExporter`, deliberately. Passing one puts NodeSDK on its manual-configuration path,
+  // where it stops reading the environment — which is how OTEL_TRACES_EXPORTER, then
+  // OTEL_EXPORTER_OTLP_PROTOCOL, then the per-signal endpoint each turned out to be silently
+  // ignored, one review round after another. They were three symptoms of doing the SDK's job.
   //
-  // Instrumentation stays on in every case, so trace context keeps propagating to the agent and the
-  // Forest SaaS whatever the export does.
-  const exportsTraces = !requestedExporter || requestedExporter === 'otlp';
+  // sdk-node depends on every OTLP exporter and on the Zipkin one, so all of them are in the image
+  // already; leaving the choice to the SDK costs nothing and makes the whole standard surface work,
+  // protocol and per-signal overrides included. Our only decisions are whether to arm at all, and
+  // the service name when nothing else supplies one.
   const sdk = new NodeSDK({
     ...(named ? {} : { serviceName: DEFAULT_SERVICE_NAME }),
-    ...(exportsTraces ? { traceExporter: new OTLPTraceExporter() } : {}),
     instrumentations: [getNodeAutoInstrumentations()],
   });
 
   sdk.start();
 
+  // What was ASKED for, not what the SDK settled on — we no longer choose, so claiming a
+  // destination we did not pick would be inventing one. The endpoint is dropped when an exporter
+  // was named instead, since it would read as a promise this line cannot keep.
   logger('Info', 'OpenTelemetry tracing enabled', {
     serviceName: named ?? DEFAULT_SERVICE_NAME,
-    // Naming the endpoint it will not export to would read as a promise it is not keeping. Saying
-    // which exporter was asked for instead is what an operator needs to see when the SDK, not us,
-    // is the one deciding.
-    ...(exportsTraces ? { endpoint: redactEndpoint(endpoint) } : { exporter: requestedExporter }),
+    ...(requestedExporter ? { exporter: requestedExporter } : {}),
+    ...(endpoint && !requestedExporter ? { endpoint: redactEndpoint(endpoint) } : {}),
   });
 
   return sdk;

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -8,7 +8,10 @@ import createConsoleLogger from './adapters/console-logger';
  * apart is what lets this module be imported by a test without arming an SDK.
  *
  * The SDK is initialised only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so an install that never
- * opted into APM pays nothing. Ending the process is not this module's business — see `armFlush`.
+ * opted into APM pays nothing. Neither ending the process nor flushing on the way out is this
+ * module's business: it hands the SDK back, the preload parks it in `tracing-handle`, and the
+ * shutdown path flushes through that. Arming a signal handler here would consume a signal the CLI
+ * has not armed its own handler for yet, and nothing would then terminate the process.
  * All configuration goes through the standard OTel environment variables:
  *
  *   OTEL_EXPORTER_OTLP_ENDPOINT   OTLP receiver (e.g. http://localhost:4318)
@@ -23,7 +26,7 @@ import createConsoleLogger from './adapters/console-logger';
 
 export const DEFAULT_SERVICE_NAME = 'forestadmin-agent-bff';
 
-interface OtelSdk {
+export interface OtelSdk {
   start(): void;
   shutdown(): Promise<void>;
 }
@@ -39,8 +42,6 @@ export interface TracingOptions {
   logger?: Logger;
   /** The dynamic require, as a seam: the packages exist only in the Docker image. */
   load?: () => OtelModules | undefined;
-  /** Signal registration, as a seam: a test must not arm a handler on the real process. */
-  onSignal?: (signal: NodeJS.Signals, handler: () => void) => void;
 }
 
 /** The packages this image installs for APM, and the export it takes from each. */
@@ -72,27 +73,6 @@ export function loadOtelModules(load: ModuleLoader = require): OtelModules | und
 }
 
 /**
- * Flushes buffered spans on the way out, alongside the shutdown `armShutdown` runs — this handler
- * does not end the process and must not try to. Ending it is `src/shutdown.ts`'s job: it closes the
- * server, bounds the wait for in-flight requests and exits explicitly, which is the only thing that
- * works when node is PID 1 (the kernel gives PID 1 no default disposition, so "let the default
- * action terminate" ends in a SIGKILL rather than a clean exit).
- *
- * So this only flushes. Once both the flush and that shutdown settle the loop empties and the
- * process exits on its own. A rejected flush is swallowed for the same reason: it must not become
- * an unhandled rejection that outlives the shutdown it is running beside.
- */
-function armFlush(sdk: OtelSdk, onSignal: NonNullable<TracingOptions['onSignal']>): void {
-  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT'];
-
-  for (const signal of signals) {
-    onSignal(signal, () => {
-      void sdk.shutdown().catch(() => undefined);
-    });
-  }
-}
-
-/**
  * The OTel specification defines its boolean environment variables as case-insensitive, and this
  * one is the kill switch: reading `TRUE` as "not disabled" would leave tracing running for someone
  * who just asked for it to stop.
@@ -102,14 +82,7 @@ function isDisabled(raw: string | undefined): boolean {
 }
 
 export default function initTracing(options: TracingOptions = {}): OtelSdk | undefined {
-  const {
-    env = process.env,
-    logger = createConsoleLogger(),
-    load = loadOtelModules,
-    onSignal = (signal, handler) => {
-      process.once(signal, handler);
-    },
-  } = options;
+  const { env = process.env, logger = createConsoleLogger(), load = loadOtelModules } = options;
 
   const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
 
@@ -135,7 +108,6 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   });
 
   sdk.start();
-  armFlush(sdk, onSignal);
 
   logger('Info', 'OpenTelemetry tracing enabled', { serviceName, endpoint });
 

--- a/packages/agent-bff/src/tracing.ts
+++ b/packages/agent-bff/src/tracing.ts
@@ -126,11 +126,17 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
   const serviceName = env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
 
   // Supplying `traceExporter` puts NodeSDK on its manual-configuration path, where it never reads
-  // OTEL_TRACES_EXPORTER — so passing one unconditionally would silently ignore the standard way to
-  // turn export off. Omitting it on `none` hands the decision back to the SDK, which then configures
-  // no exporter. Instrumentation stays on either way, so trace context still propagates to the agent
-  // and the Forest SaaS; only the export stops, which is what the variable asks for.
-  const exportsTraces = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase() !== 'none';
+  // OTEL_TRACES_EXPORTER. So we only supply one when the operator has not asked for something else:
+  // unset (our documented default, OTLP to the configured endpoint) or `otlp` (the same thing, said
+  // out loud). Anything else — `none`, `console`, `zipkin`, a list — is handed back to the SDK,
+  // which configures it from the environment. Sending spans to the OTLP endpoint because we did not
+  // recognise the value would be worse than not sending them: it is telemetry going somewhere the
+  // operator did not ask for, and the SDK says so out loud when it cannot honour the request.
+  //
+  // Instrumentation stays on in every case, so trace context keeps propagating to the agent and the
+  // Forest SaaS whatever the export does.
+  const requestedExporter = env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  const exportsTraces = !requestedExporter || requestedExporter === 'otlp';
   const sdk = new NodeSDK({
     serviceName,
     ...(exportsTraces ? { traceExporter: new OTLPTraceExporter() } : {}),
@@ -141,8 +147,10 @@ export default function initTracing(options: TracingOptions = {}): OtelSdk | und
 
   logger('Info', 'OpenTelemetry tracing enabled', {
     serviceName,
-    // Naming the endpoint it will not export to would read as a promise it is not keeping.
-    ...(exportsTraces ? { endpoint: redactEndpoint(endpoint) } : { exporter: 'none' }),
+    // Naming the endpoint it will not export to would read as a promise it is not keeping. Saying
+    // which exporter was asked for instead is what an operator needs to see when the SDK, not us,
+    // is the one deciding.
+    ...(exportsTraces ? { endpoint: redactEndpoint(endpoint) } : { exporter: requestedExporter }),
   });
 
   return sdk;

--- a/packages/agent-bff/test/shutdown.test.ts
+++ b/packages/agent-bff/test/shutdown.test.ts
@@ -2,7 +2,7 @@ import type { Logger } from '../src/ports/logger-port';
 
 import armShutdown, { DEFAULT_GRACE_MS, FORCE_EXIT_MS } from '../src/shutdown';
 
-const flush = () =>
+const settle = () =>
   new Promise(resolve => {
     setImmediate(resolve);
   });
@@ -38,7 +38,7 @@ describe('armShutdown', () => {
       arm(500);
 
       handlers.SIGTERM();
-      await flush();
+      await settle();
 
       expect(stop).toHaveBeenCalledWith(500);
       expect(exit).toHaveBeenCalledWith(0);
@@ -48,7 +48,7 @@ describe('armShutdown', () => {
       arm();
 
       handlers.SIGINT();
-      await flush();
+      await settle();
 
       expect(stop).toHaveBeenCalledWith(DEFAULT_GRACE_MS);
     });
@@ -60,12 +60,67 @@ describe('armShutdown', () => {
       arm();
 
       handlers.SIGTERM();
-      await flush();
+      await settle();
 
       expect(exit).toHaveBeenCalledWith(1);
       expect(logger).toHaveBeenCalledWith('Error', 'Shutdown failed, exiting anyway', {
         signal: 'SIGTERM',
       });
+    });
+  });
+
+  describe('with a flush to run', () => {
+    it('should run it alongside the stop and exit only once both settle', async () => {
+      let releaseFlush: () => void = () => undefined;
+      const flush = jest.fn(
+        () =>
+          new Promise<void>(resolve => {
+            releaseFlush = resolve;
+          }),
+      );
+      armShutdown({ server: { stop }, logger, onSignal, exit, flush, flushMs: 500 });
+
+      handlers.SIGTERM();
+      await settle();
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(exit).not.toHaveBeenCalled();
+
+      releaseFlush();
+      await settle();
+
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    // A collector that never answers must cost the shutdown its last spans, not its ability to end.
+    // The deadline is the flush's own: telemetry does not get the grace period in-flight requests do.
+    it('should give up on the flush once its own deadline elapses', async () => {
+      jest.useFakeTimers();
+      const flush = jest.fn(
+        () =>
+          new Promise<void>(() => {
+            /* never settles */
+          }),
+      );
+      armShutdown({ server: { stop }, logger, onSignal, exit, flush, flushMs: 500 });
+
+      handlers.SIGTERM();
+      await Promise.resolve();
+      jest.advanceTimersByTime(500);
+      jest.useRealTimers();
+      await settle();
+
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    it('should not let a failing flush change the exit code', async () => {
+      const flush = jest.fn().mockRejectedValue(new Error('collector down'));
+      armShutdown({ server: { stop }, logger, onSignal, exit, flush });
+
+      handlers.SIGTERM();
+      await settle();
+
+      expect(exit).toHaveBeenCalledWith(0);
     });
   });
 
@@ -86,7 +141,7 @@ describe('armShutdown', () => {
       expect(exit).toHaveBeenCalledWith(1);
 
       release();
-      await flush();
+      await settle();
     });
 
     it('should not let the interrupted stop report success once it finishes', async () => {
@@ -101,7 +156,7 @@ describe('armShutdown', () => {
       handlers.SIGTERM();
       handlers.SIGINT();
       release();
-      await flush();
+      await settle();
 
       expect(exit).toHaveBeenCalledTimes(1);
       expect(exit).toHaveBeenCalledWith(1);
@@ -120,7 +175,7 @@ describe('armShutdown', () => {
       handlers.SIGTERM();
       handlers.SIGINT();
       fail(new Error('close failed'));
-      await flush();
+      await settle();
 
       expect(exit).toHaveBeenCalledTimes(1);
       expect(logger).not.toHaveBeenCalledWith(

--- a/packages/agent-bff/test/shutdown.test.ts
+++ b/packages/agent-bff/test/shutdown.test.ts
@@ -113,6 +113,33 @@ describe('armShutdown', () => {
       expect(exit).toHaveBeenCalledWith(0);
     });
 
+    // Promise.all is fail-fast: a rejected stop() would exit while the export was still in
+    // flight, losing exactly the spans that explain the failed shutdown.
+    it('should still wait for the flush when the server fails to close', async () => {
+      let releaseFlush: () => void = () => undefined;
+      const flush = jest.fn(
+        () =>
+          new Promise<void>(resolve => {
+            releaseFlush = resolve;
+          }),
+      );
+      stop.mockRejectedValue(new Error('close failed'));
+      armShutdown({ server: { stop }, logger, onSignal, exit, flush, flushMs: 500 });
+
+      handlers.SIGTERM();
+      await settle();
+
+      expect(exit).not.toHaveBeenCalled();
+
+      releaseFlush();
+      await settle();
+
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(logger).toHaveBeenCalledWith('Error', 'Shutdown failed, exiting anyway', {
+        signal: 'SIGTERM',
+      });
+    });
+
     it('should not let a failing flush change the exit code', async () => {
       const flush = jest.fn().mockRejectedValue(new Error('collector down'));
       armShutdown({ server: { stop }, logger, onSignal, exit, flush });

--- a/packages/agent-bff/test/tracing-handle.test.ts
+++ b/packages/agent-bff/test/tracing-handle.test.ts
@@ -1,0 +1,38 @@
+import { flushTracing, getTracingHandle, setTracingHandle } from '../src/tracing-handle';
+
+describe('tracing handle', () => {
+  afterEach(() => {
+    setTracingHandle(undefined);
+  });
+
+  it('should hand back the SDK the preload parked', () => {
+    const sdk = { shutdown: jest.fn().mockResolvedValue(undefined) };
+
+    setTracingHandle(sdk);
+
+    expect(getTracingHandle()).toBe(sdk);
+  });
+
+  describe('flushTracing', () => {
+    it('should flush through the parked SDK', async () => {
+      const shutdown = jest.fn().mockResolvedValue(undefined);
+      setTracingHandle({ shutdown });
+
+      await flushTracing();
+
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    });
+
+    // The npm bin never arms one, and the shutdown path should not have to know that.
+    it('should resolve when tracing was never armed', async () => {
+      await expect(flushTracing()).resolves.toBeUndefined();
+    });
+
+    // A dead collector must not turn a clean shutdown into a failed one.
+    it('should swallow a failing export', async () => {
+      setTracingHandle({ shutdown: jest.fn().mockRejectedValue(new Error('collector down')) });
+
+      await expect(flushTracing()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/agent-bff/test/tracing-preload.test.ts
+++ b/packages/agent-bff/test/tracing-preload.test.ts
@@ -1,0 +1,18 @@
+import initTracing from '../src/tracing';
+
+jest.mock('../src/tracing', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('tracing-preload', () => {
+  it('should arm tracing as soon as it is required, since --require is all that runs it', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      require('../src/tracing-preload');
+    });
+
+    expect(initTracing).toHaveBeenCalledTimes(1);
+    expect(initTracing).toHaveBeenCalledWith();
+  });
+});

--- a/packages/agent-bff/test/tracing-preload.test.ts
+++ b/packages/agent-bff/test/tracing-preload.test.ts
@@ -53,4 +53,25 @@ describe('tracing-preload', () => {
 
     expect(loadPreload()).toBeUndefined();
   });
+
+  // A --require runs before the entry point, so anything thrown here kills the process before the
+  // BFF exists — a dead container in exchange for optional telemetry.
+  it('should start untraced rather than let a failing setup abort the process', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    (initTracing as jest.Mock).mockImplementation(() => {
+      throw new Error('sdk.start blew up');
+    });
+
+    expect(loadPreload()).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const payload = JSON.parse(warn.mock.calls[0][0] as string);
+    expect(payload).toMatchObject({
+      level: 'Warn',
+      message: 'OpenTelemetry failed to initialise, starting untraced',
+      reason: 'sdk.start blew up',
+    });
+
+    jest.restoreAllMocks();
+  });
 });

--- a/packages/agent-bff/test/tracing-preload.test.ts
+++ b/packages/agent-bff/test/tracing-preload.test.ts
@@ -1,18 +1,56 @@
+import type * as TracingHandleModule from '../src/tracing-handle';
+
 import initTracing from '../src/tracing';
+
+type TracingHandle = TracingHandleModule.TracingHandle;
 
 jest.mock('../src/tracing', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 
+/**
+ * The preload and the handle have to come from the SAME module registry, or the preload parks the
+ * SDK on a copy nothing else can see — which is exactly the failure mode this file guards against
+ * in production too.
+ */
+function loadPreload(): TracingHandle | undefined {
+  let parked: TracingHandle | undefined;
+
+  jest.isolateModules(() => {
+    /* eslint-disable global-require, @typescript-eslint/no-var-requires */
+    require('../src/tracing-preload');
+    parked = (require('../src/tracing-handle') as typeof TracingHandleModule).getTracingHandle();
+    /* eslint-enable global-require, @typescript-eslint/no-var-requires */
+  });
+
+  return parked;
+}
+
 describe('tracing-preload', () => {
+  beforeEach(() => {
+    (initTracing as jest.Mock).mockReset();
+  });
+
   it('should arm tracing as soon as it is required, since --require is all that runs it', () => {
-    jest.isolateModules(() => {
-      // eslint-disable-next-line global-require
-      require('../src/tracing-preload');
-    });
+    loadPreload();
 
     expect(initTracing).toHaveBeenCalledTimes(1);
     expect(initTracing).toHaveBeenCalledWith();
+  });
+
+  // Parking it rather than arming a signal handler is what lets the shutdown path wait for the
+  // flush, and keeps the preload from swallowing a signal the CLI has not armed a handler for yet.
+  it('should park the SDK on the handle for the shutdown path to flush', () => {
+    const sdk = { shutdown: jest.fn() };
+    (initTracing as jest.Mock).mockReturnValue(sdk);
+
+    expect(loadPreload()).toBe(sdk);
+  });
+
+  it('should park nothing when tracing stayed off', () => {
+    (initTracing as jest.Mock).mockReturnValue(undefined);
+
+    expect(loadPreload()).toBeUndefined();
   });
 });

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -149,10 +149,10 @@ describe('initTracing', () => {
     });
 
     // Supplying traceExporter puts NodeSDK on its manual path, where it never reads
-    // OTEL_TRACES_EXPORTER — passing one unconditionally would silently ignore the standard way
-    // to turn export off.
-    it.each(['none', 'NONE', ' none '])(
-      'should configure no exporter when OTEL_TRACES_EXPORTER is %p',
+    // OTEL_TRACES_EXPORTER. Exporting to OTLP because we did not recognise the requested value
+    // would send telemetry somewhere the operator never asked for.
+    it.each(['none', 'NONE', ' none ', 'console', 'zipkin', 'otlp,console'])(
+      'should leave the exporter to the SDK when OTEL_TRACES_EXPORTER is %p',
       raw => {
         setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: raw } });
 
@@ -163,8 +163,8 @@ describe('initTracing', () => {
       },
     );
 
-    // Only the export stops; the spans still get created, so trace context keeps propagating.
-    it('should keep the instrumentations when export is turned off', () => {
+    // Only our exporter choice changes; the spans still get created, so context keeps propagating.
+    it('should keep the instrumentations when the exporter is left to the SDK', () => {
       setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'none' } });
 
       expect(NodeSDK).toHaveBeenCalledWith(
@@ -173,17 +173,18 @@ describe('initTracing', () => {
       expect(start).toHaveBeenCalledTimes(1);
     });
 
-    it('should not name an endpoint it will not export to', () => {
-      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'none' } });
+    it('should report which exporter was asked for instead of an endpoint it will not use', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'console' } });
 
       expect(logger).toHaveBeenCalledWith('Info', 'OpenTelemetry tracing enabled', {
         serviceName: DEFAULT_SERVICE_NAME,
-        exporter: 'none',
+        exporter: 'console',
       });
     });
 
-    it('should still export for any other exporter value', () => {
-      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'otlp' } });
+    // Unset is our documented default; `otlp` is the same thing said out loud.
+    it.each(['otlp', 'OTLP', ' otlp '])('should export over OTLP for %p', raw => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: raw } });
 
       expect(NodeSDK).toHaveBeenCalledWith(
         expect.objectContaining({ traceExporter: expect.any(OTLPTraceExporter) }),

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -1,7 +1,11 @@
 import type { Logger } from '../src/ports/logger-port';
 import type { OtelModules, TracingOptions } from '../src/tracing';
 
-import initTracing, { DEFAULT_SERVICE_NAME, loadOtelModules } from '../src/tracing';
+import initTracing, {
+  DEFAULT_SERVICE_NAME,
+  OTEL_MODULE_IDS,
+  loadOtelModules,
+} from '../src/tracing';
 
 const ENDPOINT = 'http://collector:4318';
 
@@ -189,9 +193,37 @@ describe('initTracing', () => {
 });
 
 describe('loadOtelModules', () => {
-  // The OpenTelemetry packages ship only in the Docker image, so this is the branch an
-  // npm consumer takes: it must report their absence, not throw out of the preload.
-  it('should return undefined when the packages are not installed', () => {
+  it('should take each entry point from the package that provides it', () => {
+    const packageExports = {
+      [OTEL_MODULE_IDS.sdk]: { NodeSDK: 'sdk' },
+      [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations: 'instrumentations' },
+      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter: 'exporter' },
+    } as Record<string, Record<string, unknown>>;
+    const load = jest.fn((id: string) => packageExports[id]);
+
+    expect(loadOtelModules(load)).toEqual({
+      NodeSDK: 'sdk',
+      getNodeAutoInstrumentations: 'instrumentations',
+      OTLPTraceExporter: 'exporter',
+    });
+    expect(load.mock.calls.map(([id]) => id)).toEqual([
+      '@opentelemetry/sdk-node',
+      '@opentelemetry/auto-instrumentations-node',
+      '@opentelemetry/exporter-trace-otlp-http',
+    ]);
+  });
+
+  it('should return undefined when a package cannot be resolved', () => {
+    const load = jest.fn(() => {
+      throw new Error("Cannot find module '@opentelemetry/sdk-node'");
+    });
+
+    expect(loadOtelModules(load)).toBeUndefined();
+  });
+
+  // The packages ship only in the Docker image, so this is the branch an npm consumer
+  // takes: it must report their absence, not throw out of the preload.
+  it('should return undefined against the real require, outside the Docker image', () => {
     expect(loadOtelModules()).toBeUndefined();
   });
 });

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -16,15 +16,10 @@ describe('initTracing', () => {
   let shutdown: jest.Mock;
   let NodeSDK: jest.Mock;
   let getNodeAutoInstrumentations: jest.Mock;
-  let OTLPTraceExporter: jest.Mock;
   let logger: jest.MockedFunction<Logger>;
 
   const modules = (): OtelModules =>
-    ({
-      NodeSDK,
-      getNodeAutoInstrumentations,
-      OTLPTraceExporter,
-    } as unknown as OtelModules);
+    ({ NodeSDK, getNodeAutoInstrumentations } as unknown as OtelModules);
 
   const setup = (options: Partial<TracingOptions> = {}) =>
     initTracing({
@@ -39,7 +34,6 @@ describe('initTracing', () => {
     shutdown = jest.fn().mockResolvedValue(undefined);
     NodeSDK = jest.fn().mockImplementation(() => ({ start, shutdown }));
     getNodeAutoInstrumentations = jest.fn().mockReturnValue('instrumentations');
-    OTLPTraceExporter = jest.fn().mockImplementation(() => 'exporter');
     logger = jest.fn();
   });
 
@@ -117,7 +111,6 @@ describe('initTracing', () => {
       setup({ env: { OTEL_TRACES_EXPORTER: 'console' } });
 
       expect(NodeSDK).toHaveBeenCalledTimes(1);
-      expect(OTLPTraceExporter).not.toHaveBeenCalled();
       expect(logger).toHaveBeenCalledWith(
         'Info',
         'OpenTelemetry tracing enabled',
@@ -133,16 +126,61 @@ describe('initTracing', () => {
     });
   });
 
+  // The per-signal endpoint is the standard way to point traces somewhere of their own, and it
+  // counts as much as the generic one for deciding whether to arm.
+  describe('when only OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set', () => {
+    const TRACES_ENDPOINT = 'http://traces-collector:4318/v1/traces';
+
+    it('should arm the SDK and report that endpoint', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: TRACES_ENDPOINT } });
+
+      expect(NodeSDK).toHaveBeenCalledTimes(1);
+      expect(logger).toHaveBeenCalledWith(
+        'Info',
+        'OpenTelemetry tracing enabled',
+        expect.objectContaining({ endpoint: TRACES_ENDPOINT }),
+      );
+    });
+
+    it('should take precedence over the generic endpoint when reporting', () => {
+      setup({
+        env: {
+          OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT,
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: TRACES_ENDPOINT,
+        },
+      });
+
+      expect(logger).toHaveBeenCalledWith(
+        'Info',
+        'OpenTelemetry tracing enabled',
+        expect.objectContaining({ endpoint: TRACES_ENDPOINT }),
+      );
+    });
+  });
+
   describe('when the packages are available', () => {
-    it('should start an SDK carrying the OTLP exporter and the auto-instrumentations', () => {
+    it('should start an SDK with the auto-instrumentations', () => {
       setup();
 
-      expect(NodeSDK).toHaveBeenCalledWith({
-        serviceName: DEFAULT_SERVICE_NAME,
-        traceExporter: expect.any(OTLPTraceExporter),
-        instrumentations: ['instrumentations'],
-      });
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.objectContaining({ instrumentations: ['instrumentations'] }),
+      );
       expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    // Passing one puts NodeSDK on its manual path, where it stops reading the environment — which
+    // is how OTEL_TRACES_EXPORTER, OTEL_EXPORTER_OTLP_PROTOCOL and the per-signal endpoint each
+    // ended up silently ignored.
+    it.each([
+      ['nothing else is set', {}],
+      ['an exporter is named', { OTEL_TRACES_EXPORTER: 'console' }],
+      ['a protocol is named', { OTEL_EXPORTER_OTLP_PROTOCOL: 'grpc' }],
+    ])('should never configure an exporter itself, even when %s', (_label, extra) => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, ...extra } });
+
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.not.objectContaining({ traceExporter: expect.anything() }),
+      );
     });
 
     // Passing serviceName would put our default ahead of the SDK's own precedence, so the two
@@ -181,68 +219,13 @@ describe('initTracing', () => {
       );
     });
 
-    it('should log the service name and endpoint it reports to', () => {
-      setup();
-
-      expect(logger).toHaveBeenCalledWith('Info', 'OpenTelemetry tracing enabled', {
-        serviceName: DEFAULT_SERVICE_NAME,
-        endpoint: ENDPOINT,
-      });
-    });
-
-    // Container logs are the last place a collector token should end up, and this package echoes
-    // no other secret anywhere.
-    it('should keep collector credentials out of that log line', () => {
-      setup({
-        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://user:s3cret@collector.example/v1/traces' },
-      });
-
-      const [, , context] = logger.mock.calls[0];
-      expect(context?.endpoint).toBe('https://collector.example/v1/traces');
-      expect(JSON.stringify(context)).not.toContain('s3cret');
-    });
-
-    // Supplying traceExporter puts NodeSDK on its manual path, where it never reads
-    // OTEL_TRACES_EXPORTER. Exporting to OTLP because we did not recognise the requested value
-    // would send telemetry somewhere the operator never asked for.
-    it.each(['none', 'NONE', ' none ', 'console', 'zipkin', 'otlp,console'])(
-      'should leave the exporter to the SDK when OTEL_TRACES_EXPORTER is %p',
-      raw => {
-        setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: raw } });
-
-        expect(NodeSDK).toHaveBeenCalledWith(
-          expect.not.objectContaining({ traceExporter: expect.anything() }),
-        );
-        expect(OTLPTraceExporter).not.toHaveBeenCalled();
-      },
-    );
-
-    // Only our exporter choice changes; the spans still get created, so context keeps propagating.
-    it('should keep the instrumentations when the exporter is left to the SDK', () => {
-      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'none' } });
-
-      expect(NodeSDK).toHaveBeenCalledWith(
-        expect.objectContaining({ instrumentations: ['instrumentations'] }),
-      );
-      expect(start).toHaveBeenCalledTimes(1);
-    });
-
-    it('should report which exporter was asked for instead of an endpoint it will not use', () => {
+    it('should report the exporter that was asked for rather than an endpoint it did not pick', () => {
       setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'console' } });
 
       expect(logger).toHaveBeenCalledWith('Info', 'OpenTelemetry tracing enabled', {
         serviceName: DEFAULT_SERVICE_NAME,
         exporter: 'console',
       });
-    });
-
-    // Unset is our documented default; `otlp` is the same thing said out loud.
-    it.each(['otlp', 'OTLP', ' otlp '])('should export over OTLP for %p', raw => {
-      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: raw } });
-
-      expect(NodeSDK).toHaveBeenCalledWith(
-        expect.objectContaining({ traceExporter: expect.any(OTLPTraceExporter) }),
-      );
     });
 
     it('should hand the SDK back for the shutdown path to flush through', () => {
@@ -297,23 +280,16 @@ describe('loadOtelModules', () => {
   it('should take each entry point from the package that provides it', () => {
     const NodeSDK = () => undefined;
     const getNodeAutoInstrumentations = () => undefined;
-    const OTLPTraceExporter = () => undefined;
     const packageExports = {
       [OTEL_MODULE_IDS.sdk]: { NodeSDK },
       [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations },
-      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter },
     } as Record<string, Record<string, unknown>>;
     const load = jest.fn((id: string) => packageExports[id]);
 
-    expect(loadOtelModules(load)).toEqual({
-      NodeSDK,
-      getNodeAutoInstrumentations,
-      OTLPTraceExporter,
-    });
+    expect(loadOtelModules(load)).toEqual({ NodeSDK, getNodeAutoInstrumentations });
     expect(load.mock.calls.map(([id]) => id)).toEqual([
       '@opentelemetry/sdk-node',
       '@opentelemetry/auto-instrumentations-node',
-      '@opentelemetry/exporter-trace-otlp-http',
     ]);
   });
 
@@ -331,12 +307,10 @@ describe('loadOtelModules', () => {
   it.each([
     ['sdk-node', OTEL_MODULE_IDS.sdk],
     ['auto-instrumentations-node', OTEL_MODULE_IDS.instrumentations],
-    ['exporter-trace-otlp-http', OTEL_MODULE_IDS.exporter],
   ])('should return undefined when %s loads without the export we read', (_label, missing) => {
     const complete = {
       [OTEL_MODULE_IDS.sdk]: { NodeSDK: () => undefined },
       [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations: () => undefined },
-      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter: () => undefined },
     } as Record<string, Record<string, unknown>>;
 
     expect(loadOtelModules(id => (id === missing ? {} : complete[id]))).toBeUndefined();

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '../src/ports/logger-port';
 import type { OtelModules, TracingOptions } from '../src/tracing';
 
-import initTracing, { DEFAULT_SERVICE_NAME } from '../src/tracing';
+import initTracing, { DEFAULT_SERVICE_NAME, loadOtelModules } from '../src/tracing';
 
 const ENDPOINT = 'http://collector:4318';
 
@@ -154,5 +154,44 @@ describe('initTracing', () => {
 
       expect(raise).toHaveBeenCalledWith('SIGTERM');
     });
+  });
+
+  describe('with the signal seams left to their defaults', () => {
+    let once: jest.SpyInstance;
+    let kill: jest.SpyInstance;
+
+    beforeEach(() => {
+      once = jest.spyOn(process, 'once').mockReturnValue(process);
+      kill = jest.spyOn(process, 'kill').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should register on the real process and re-raise through process.kill', async () => {
+      initTracing({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT },
+        logger,
+        load: () => modules(),
+      });
+
+      expect(once).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+      expect(once).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+
+      const [, handler] = once.mock.calls[0] as [string, () => void];
+      handler();
+      await flushMicrotasks();
+
+      expect(kill).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+    });
+  });
+});
+
+describe('loadOtelModules', () => {
+  // The OpenTelemetry packages ship only in the Docker image, so this is the branch an
+  // npm consumer takes: it must report their absence, not throw out of the preload.
+  it('should return undefined when the packages are not installed', () => {
+    expect(loadOtelModules()).toBeUndefined();
   });
 });

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -6,6 +6,7 @@ import initTracing, {
   OTEL_MODULE_IDS,
   loadOtelModules,
   redactEndpoint,
+  serviceNameFromEnv,
 } from '../src/tracing';
 
 const ENDPOINT = 'http://collector:4318';
@@ -109,6 +110,29 @@ describe('initTracing', () => {
     });
   });
 
+  // Tracing is on as soon as either variable says so. Requiring an OTLP endpoint for
+  // OTEL_TRACES_EXPORTER=console would make the obvious debugging move need a collector.
+  describe('when only OTEL_TRACES_EXPORTER is set', () => {
+    it('should still arm the SDK, with no endpoint of ours to hand it', () => {
+      setup({ env: { OTEL_TRACES_EXPORTER: 'console' } });
+
+      expect(NodeSDK).toHaveBeenCalledTimes(1);
+      expect(OTLPTraceExporter).not.toHaveBeenCalled();
+      expect(logger).toHaveBeenCalledWith(
+        'Info',
+        'OpenTelemetry tracing enabled',
+        expect.objectContaining({ exporter: 'console' }),
+      );
+    });
+
+    it('should stay off when it is blank', () => {
+      const sdk = setup({ env: { OTEL_TRACES_EXPORTER: '   ' } });
+
+      expect(sdk).toBeUndefined();
+      expect(NodeSDK).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when the packages are available', () => {
     it('should start an SDK carrying the OTLP exporter and the auto-instrumentations', () => {
       setup();
@@ -121,10 +145,40 @@ describe('initTracing', () => {
       expect(start).toHaveBeenCalledTimes(1);
     });
 
-    it('should prefer OTEL_SERVICE_NAME over the default service name', () => {
-      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SERVICE_NAME: 'bff-staging' } });
+    // Passing serviceName would put our default ahead of the SDK's own precedence, so the two
+    // documented ways of naming the service are left to it and only the fallback is ours.
+    it.each([
+      ['OTEL_SERVICE_NAME', { OTEL_SERVICE_NAME: 'bff-staging' }],
+      ['a service.name resource attribute', { OTEL_RESOURCE_ATTRIBUTES: 'service.name=bff-attr' }],
+    ])('should leave the service name to the SDK when %s is set', (_label, named) => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, ...named } });
 
-      expect(NodeSDK).toHaveBeenCalledWith(expect.objectContaining({ serviceName: 'bff-staging' }));
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.not.objectContaining({ serviceName: expect.anything() }),
+      );
+    });
+
+    it('should report the name the environment carries, whichever way it was set', () => {
+      setup({
+        env: {
+          OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT,
+          OTEL_RESOURCE_ATTRIBUTES: 'service.name=bff-attr',
+        },
+      });
+
+      expect(logger).toHaveBeenCalledWith(
+        'Info',
+        'OpenTelemetry tracing enabled',
+        expect.objectContaining({ serviceName: 'bff-attr' }),
+      );
+    });
+
+    it('should fall back to its own default when the environment names no service', () => {
+      setup();
+
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceName: DEFAULT_SERVICE_NAME }),
+      );
     });
 
     it('should log the service name and endpoint it reports to', () => {
@@ -212,19 +266,49 @@ describe('initTracing', () => {
   });
 });
 
+describe('serviceNameFromEnv', () => {
+  it('should prefer OTEL_SERVICE_NAME', () => {
+    expect(
+      serviceNameFromEnv({
+        OTEL_SERVICE_NAME: 'explicit',
+        OTEL_RESOURCE_ATTRIBUTES: 'service.name=attribute',
+      }),
+    ).toBe('explicit');
+  });
+
+  it('should fall back to service.name in the resource attributes', () => {
+    expect(
+      serviceNameFromEnv({
+        OTEL_RESOURCE_ATTRIBUTES: 'deployment.environment=prod,service.name=from-attributes',
+      }),
+    ).toBe('from-attributes');
+  });
+
+  it.each([
+    ['neither is set', {}],
+    ['both are blank', { OTEL_SERVICE_NAME: '  ', OTEL_RESOURCE_ATTRIBUTES: 'service.name=  ' }],
+    ['the attributes name something else', { OTEL_RESOURCE_ATTRIBUTES: 'host.name=box' }],
+  ])('should report no name when %s', (_label, env) => {
+    expect(serviceNameFromEnv(env)).toBeUndefined();
+  });
+});
+
 describe('loadOtelModules', () => {
   it('should take each entry point from the package that provides it', () => {
+    const NodeSDK = () => undefined;
+    const getNodeAutoInstrumentations = () => undefined;
+    const OTLPTraceExporter = () => undefined;
     const packageExports = {
-      [OTEL_MODULE_IDS.sdk]: { NodeSDK: 'sdk' },
-      [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations: 'instrumentations' },
-      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter: 'exporter' },
+      [OTEL_MODULE_IDS.sdk]: { NodeSDK },
+      [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations },
+      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter },
     } as Record<string, Record<string, unknown>>;
     const load = jest.fn((id: string) => packageExports[id]);
 
     expect(loadOtelModules(load)).toEqual({
-      NodeSDK: 'sdk',
-      getNodeAutoInstrumentations: 'instrumentations',
-      OTLPTraceExporter: 'exporter',
+      NodeSDK,
+      getNodeAutoInstrumentations,
+      OTLPTraceExporter,
     });
     expect(load.mock.calls.map(([id]) => id)).toEqual([
       '@opentelemetry/sdk-node',
@@ -239,6 +323,23 @@ describe('loadOtelModules', () => {
     });
 
     expect(loadOtelModules(load)).toBeUndefined();
+  });
+
+  // Resolving is not finding what we came for. A truthy object of undefined members would skip the
+  // "packages not available" branch and throw a TypeError inside a --require, before the entry
+  // point runs — a dead container for an APM layer that is meant to degrade to a warning.
+  it.each([
+    ['sdk-node', OTEL_MODULE_IDS.sdk],
+    ['auto-instrumentations-node', OTEL_MODULE_IDS.instrumentations],
+    ['exporter-trace-otlp-http', OTEL_MODULE_IDS.exporter],
+  ])('should return undefined when %s loads without the export we read', (_label, missing) => {
+    const complete = {
+      [OTEL_MODULE_IDS.sdk]: { NodeSDK: () => undefined },
+      [OTEL_MODULE_IDS.instrumentations]: { getNodeAutoInstrumentations: () => undefined },
+      [OTEL_MODULE_IDS.exporter]: { OTLPTraceExporter: () => undefined },
+    } as Record<string, Record<string, unknown>>;
+
+    expect(loadOtelModules(id => (id === missing ? {} : complete[id]))).toBeUndefined();
   });
 
   // The packages ship only in the Docker image, so this is the branch an npm consumer

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -148,6 +148,48 @@ describe('initTracing', () => {
       expect(JSON.stringify(context)).not.toContain('s3cret');
     });
 
+    // Supplying traceExporter puts NodeSDK on its manual path, where it never reads
+    // OTEL_TRACES_EXPORTER — passing one unconditionally would silently ignore the standard way
+    // to turn export off.
+    it.each(['none', 'NONE', ' none '])(
+      'should configure no exporter when OTEL_TRACES_EXPORTER is %p',
+      raw => {
+        setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: raw } });
+
+        expect(NodeSDK).toHaveBeenCalledWith(
+          expect.not.objectContaining({ traceExporter: expect.anything() }),
+        );
+        expect(OTLPTraceExporter).not.toHaveBeenCalled();
+      },
+    );
+
+    // Only the export stops; the spans still get created, so trace context keeps propagating.
+    it('should keep the instrumentations when export is turned off', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'none' } });
+
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.objectContaining({ instrumentations: ['instrumentations'] }),
+      );
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not name an endpoint it will not export to', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'none' } });
+
+      expect(logger).toHaveBeenCalledWith('Info', 'OpenTelemetry tracing enabled', {
+        serviceName: DEFAULT_SERVICE_NAME,
+        exporter: 'none',
+      });
+    });
+
+    it('should still export for any other exporter value', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_TRACES_EXPORTER: 'otlp' } });
+
+      expect(NodeSDK).toHaveBeenCalledWith(
+        expect.objectContaining({ traceExporter: expect.any(OTLPTraceExporter) }),
+      );
+    });
+
     it('should hand the SDK back for the shutdown path to flush through', () => {
       const sdk = setup();
 

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -22,7 +22,6 @@ describe('initTracing', () => {
   let OTLPTraceExporter: jest.Mock;
   let logger: jest.MockedFunction<Logger>;
   let onSignal: jest.Mock;
-  let raise: jest.Mock;
   let handlers: Record<string, () => void>;
 
   const modules = (): OtelModules =>
@@ -38,7 +37,6 @@ describe('initTracing', () => {
       logger,
       load: () => modules(),
       onSignal,
-      raise,
       ...options,
     });
 
@@ -53,7 +51,6 @@ describe('initTracing', () => {
     onSignal = jest.fn((signal: string, handler: () => void) => {
       handlers[signal] = handler;
     });
-    raise = jest.fn();
   });
 
   describe('when OTEL_EXPORTER_OTLP_ENDPOINT is absent', () => {
@@ -158,50 +155,54 @@ describe('initTracing', () => {
   });
 
   describe('on a termination signal', () => {
-    it('should flush the spans, then re-raise the same signal so the default action terminates', async () => {
+    it('should flush the buffered spans', async () => {
       setup();
 
       handlers.SIGTERM();
       await flushMicrotasks();
 
       expect(shutdown).toHaveBeenCalledTimes(1);
-      expect(raise).toHaveBeenCalledWith('SIGTERM');
     });
 
-    it('should re-raise SIGINT when SIGINT is what arrived', async () => {
+    // Ending the process belongs to armShutdown, which closes the server first. A flush that
+    // exited here would cut in-flight requests short; one that re-raised the signal would not
+    // end anything at all, since the kernel gives PID 1 no default disposition.
+    it('should leave ending the process to the shutdown handler', async () => {
+      const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+      const kill = jest.spyOn(process, 'kill').mockReturnValue(true);
       setup();
 
-      handlers.SIGINT();
+      handlers.SIGTERM();
       await flushMicrotasks();
 
-      expect(raise).toHaveBeenCalledWith('SIGINT');
+      expect(exit).not.toHaveBeenCalled();
+      expect(kill).not.toHaveBeenCalled();
+      jest.restoreAllMocks();
     });
 
-    it('should still re-raise when the flush rejects, so a failing exporter cannot hang the process', async () => {
+    it('should swallow a failing flush rather than leave an unhandled rejection behind', async () => {
       shutdown.mockRejectedValue(new Error('collector unreachable'));
       setup();
 
       handlers.SIGTERM();
       await flushMicrotasks();
 
-      expect(raise).toHaveBeenCalledWith('SIGTERM');
+      expect(shutdown).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('with the signal seams left to their defaults', () => {
+  describe('with the signal seam left to its default', () => {
     let once: jest.SpyInstance;
-    let kill: jest.SpyInstance;
 
     beforeEach(() => {
       once = jest.spyOn(process, 'once').mockReturnValue(process);
-      kill = jest.spyOn(process, 'kill').mockReturnValue(true);
     });
 
     afterEach(() => {
       jest.restoreAllMocks();
     });
 
-    it('should register on the real process and re-raise through process.kill', async () => {
+    it('should register the flush on the real process', async () => {
       initTracing({
         env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT },
         logger,
@@ -215,7 +216,7 @@ describe('initTracing', () => {
       handler();
       await flushMicrotasks();
 
-      expect(kill).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+      expect(shutdown).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -1,0 +1,158 @@
+import type { Logger } from '../src/ports/logger-port';
+import type { OtelModules, TracingOptions } from '../src/tracing';
+
+import initTracing, { DEFAULT_SERVICE_NAME } from '../src/tracing';
+
+const ENDPOINT = 'http://collector:4318';
+
+const flushMicrotasks = () =>
+  new Promise(resolve => {
+    setImmediate(resolve);
+  });
+
+describe('initTracing', () => {
+  let start: jest.Mock;
+  let shutdown: jest.Mock;
+  let NodeSDK: jest.Mock;
+  let getNodeAutoInstrumentations: jest.Mock;
+  let OTLPTraceExporter: jest.Mock;
+  let logger: jest.MockedFunction<Logger>;
+  let onSignal: jest.Mock;
+  let raise: jest.Mock;
+  let handlers: Record<string, () => void>;
+
+  const modules = (): OtelModules =>
+    ({
+      NodeSDK,
+      getNodeAutoInstrumentations,
+      OTLPTraceExporter,
+    } as unknown as OtelModules);
+
+  const setup = (options: Partial<TracingOptions> = {}) =>
+    initTracing({
+      env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT },
+      logger,
+      load: () => modules(),
+      onSignal,
+      raise,
+      ...options,
+    });
+
+  beforeEach(() => {
+    start = jest.fn();
+    shutdown = jest.fn().mockResolvedValue(undefined);
+    NodeSDK = jest.fn().mockImplementation(() => ({ start, shutdown }));
+    getNodeAutoInstrumentations = jest.fn().mockReturnValue('instrumentations');
+    OTLPTraceExporter = jest.fn().mockImplementation(() => 'exporter');
+    logger = jest.fn();
+    handlers = {};
+    onSignal = jest.fn((signal: string, handler: () => void) => {
+      handlers[signal] = handler;
+    });
+    raise = jest.fn();
+  });
+
+  describe('when OTEL_EXPORTER_OTLP_ENDPOINT is absent', () => {
+    it('should not build an SDK', () => {
+      const sdk = setup({ env: {} });
+
+      expect(sdk).toBeUndefined();
+      expect(NodeSDK).not.toHaveBeenCalled();
+      expect(logger).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when OTEL_SDK_DISABLED is "true"', () => {
+    it('should not build an SDK even with an endpoint configured', () => {
+      const sdk = setup({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SDK_DISABLED: 'true' },
+      });
+
+      expect(sdk).toBeUndefined();
+      expect(NodeSDK).not.toHaveBeenCalled();
+    });
+
+    it('should build an SDK for any other value', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SDK_DISABLED: 'false' } });
+
+      expect(NodeSDK).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the OpenTelemetry packages are missing', () => {
+    it('should warn and return no SDK instead of throwing', () => {
+      const sdk = setup({ load: () => undefined });
+
+      expect(sdk).toBeUndefined();
+      expect(logger).toHaveBeenCalledWith(
+        'Warn',
+        'OpenTelemetry packages not available, skipping APM initialisation',
+      );
+    });
+  });
+
+  describe('when the packages are available', () => {
+    it('should start an SDK carrying the OTLP exporter and the auto-instrumentations', () => {
+      setup();
+
+      expect(NodeSDK).toHaveBeenCalledWith({
+        serviceName: DEFAULT_SERVICE_NAME,
+        traceExporter: expect.any(OTLPTraceExporter),
+        instrumentations: ['instrumentations'],
+      });
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prefer OTEL_SERVICE_NAME over the default service name', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SERVICE_NAME: 'bff-staging' } });
+
+      expect(NodeSDK).toHaveBeenCalledWith(expect.objectContaining({ serviceName: 'bff-staging' }));
+    });
+
+    it('should log the service name and endpoint it reports to', () => {
+      setup();
+
+      expect(logger).toHaveBeenCalledWith('Info', 'OpenTelemetry tracing enabled', {
+        serviceName: DEFAULT_SERVICE_NAME,
+        endpoint: ENDPOINT,
+      });
+    });
+
+    it('should arm a flush on SIGTERM and SIGINT', () => {
+      setup();
+
+      expect(onSignal.mock.calls.map(([signal]) => signal)).toEqual(['SIGTERM', 'SIGINT']);
+    });
+  });
+
+  describe('on a termination signal', () => {
+    it('should flush the spans, then re-raise the same signal so the default action terminates', async () => {
+      setup();
+
+      handlers.SIGTERM();
+      await flushMicrotasks();
+
+      expect(shutdown).toHaveBeenCalledTimes(1);
+      expect(raise).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('should re-raise SIGINT when SIGINT is what arrived', async () => {
+      setup();
+
+      handlers.SIGINT();
+      await flushMicrotasks();
+
+      expect(raise).toHaveBeenCalledWith('SIGINT');
+    });
+
+    it('should still re-raise when the flush rejects, so a failing exporter cannot hang the process', async () => {
+      shutdown.mockRejectedValue(new Error('collector unreachable'));
+      setup();
+
+      handlers.SIGTERM();
+      await flushMicrotasks();
+
+      expect(raise).toHaveBeenCalledWith('SIGTERM');
+    });
+  });
+});

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -9,11 +9,6 @@ import initTracing, {
 
 const ENDPOINT = 'http://collector:4318';
 
-const flushMicrotasks = () =>
-  new Promise(resolve => {
-    setImmediate(resolve);
-  });
-
 describe('initTracing', () => {
   let start: jest.Mock;
   let shutdown: jest.Mock;
@@ -21,8 +16,6 @@ describe('initTracing', () => {
   let getNodeAutoInstrumentations: jest.Mock;
   let OTLPTraceExporter: jest.Mock;
   let logger: jest.MockedFunction<Logger>;
-  let onSignal: jest.Mock;
-  let handlers: Record<string, () => void>;
 
   const modules = (): OtelModules =>
     ({
@@ -36,7 +29,6 @@ describe('initTracing', () => {
       env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT },
       logger,
       load: () => modules(),
-      onSignal,
       ...options,
     });
 
@@ -47,10 +39,6 @@ describe('initTracing', () => {
     getNodeAutoInstrumentations = jest.fn().mockReturnValue('instrumentations');
     OTLPTraceExporter = jest.fn().mockImplementation(() => 'exporter');
     logger = jest.fn();
-    handlers = {};
-    onSignal = jest.fn((signal: string, handler: () => void) => {
-      handlers[signal] = handler;
-    });
   });
 
   describe('when OTEL_EXPORTER_OTLP_ENDPOINT is absent', () => {
@@ -147,76 +135,23 @@ describe('initTracing', () => {
       });
     });
 
-    it('should arm a flush on SIGTERM and SIGINT', () => {
-      setup();
+    it('should hand the SDK back for the shutdown path to flush through', () => {
+      const sdk = setup();
 
-      expect(onSignal.mock.calls.map(([signal]) => signal)).toEqual(['SIGTERM', 'SIGINT']);
-    });
-  });
-
-  describe('on a termination signal', () => {
-    it('should flush the buffered spans', async () => {
-      setup();
-
-      handlers.SIGTERM();
-      await flushMicrotasks();
-
-      expect(shutdown).toHaveBeenCalledTimes(1);
+      expect(sdk).toEqual(expect.objectContaining({ shutdown: expect.any(Function) }));
     });
 
-    // Ending the process belongs to armShutdown, which closes the server first. A flush that
-    // exited here would cut in-flight requests short; one that re-raised the signal would not
-    // end anything at all, since the kernel gives PID 1 no default disposition.
-    it('should leave ending the process to the shutdown handler', async () => {
-      const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
-      const kill = jest.spyOn(process, 'kill').mockReturnValue(true);
+    // Arming one here would swallow a signal the CLI has not armed its own handler for yet, and
+    // nothing would then terminate the process.
+    it('should register no signal handler of its own', () => {
+      const once = jest.spyOn(process, 'once').mockReturnValue(process);
+      const on = jest.spyOn(process, 'on').mockReturnValue(process);
+
       setup();
 
-      handlers.SIGTERM();
-      await flushMicrotasks();
-
-      expect(exit).not.toHaveBeenCalled();
-      expect(kill).not.toHaveBeenCalled();
+      expect(once).not.toHaveBeenCalled();
+      expect(on).not.toHaveBeenCalled();
       jest.restoreAllMocks();
-    });
-
-    it('should swallow a failing flush rather than leave an unhandled rejection behind', async () => {
-      shutdown.mockRejectedValue(new Error('collector unreachable'));
-      setup();
-
-      handlers.SIGTERM();
-      await flushMicrotasks();
-
-      expect(shutdown).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('with the signal seam left to its default', () => {
-    let once: jest.SpyInstance;
-
-    beforeEach(() => {
-      once = jest.spyOn(process, 'once').mockReturnValue(process);
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('should register the flush on the real process', async () => {
-      initTracing({
-        env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT },
-        logger,
-        load: () => modules(),
-      });
-
-      expect(once).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
-      expect(once).toHaveBeenCalledWith('SIGINT', expect.any(Function));
-
-      const [, handler] = once.mock.calls[0] as [string, () => void];
-      handler();
-      await flushMicrotasks();
-
-      expect(shutdown).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -64,12 +64,40 @@ describe('initTracing', () => {
       expect(NodeSDK).not.toHaveBeenCalled();
       expect(logger).not.toHaveBeenCalled();
     });
+
+    it('should treat a blank endpoint as unset rather than export to the OTel default', () => {
+      const sdk = setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: '   ' } });
+
+      expect(sdk).toBeUndefined();
+      expect(NodeSDK).not.toHaveBeenCalled();
+    });
+
+    it('should report the trimmed endpoint it exports to', () => {
+      setup({ env: { OTEL_EXPORTER_OTLP_ENDPOINT: ` ${ENDPOINT} ` } });
+
+      expect(logger).toHaveBeenCalledWith(
+        'Info',
+        'OpenTelemetry tracing enabled',
+        expect.objectContaining({ endpoint: ENDPOINT }),
+      );
+    });
   });
 
   describe('when OTEL_SDK_DISABLED is "true"', () => {
     it('should not build an SDK even with an endpoint configured', () => {
       const sdk = setup({
         env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SDK_DISABLED: 'true' },
+      });
+
+      expect(sdk).toBeUndefined();
+      expect(NodeSDK).not.toHaveBeenCalled();
+    });
+
+    // The OTel spec defines its boolean variables as case-insensitive, and this one is the kill
+    // switch: reading "TRUE" as "not disabled" leaves tracing on for someone asking it to stop.
+    it.each(['TRUE', 'True', ' true '])('should also honour %p', raw => {
+      const sdk = setup({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: ENDPOINT, OTEL_SDK_DISABLED: raw },
       });
 
       expect(sdk).toBeUndefined();

--- a/packages/agent-bff/test/tracing.test.ts
+++ b/packages/agent-bff/test/tracing.test.ts
@@ -5,6 +5,7 @@ import initTracing, {
   DEFAULT_SERVICE_NAME,
   OTEL_MODULE_IDS,
   loadOtelModules,
+  redactEndpoint,
 } from '../src/tracing';
 
 const ENDPOINT = 'http://collector:4318';
@@ -135,6 +136,18 @@ describe('initTracing', () => {
       });
     });
 
+    // Container logs are the last place a collector token should end up, and this package echoes
+    // no other secret anywhere.
+    it('should keep collector credentials out of that log line', () => {
+      setup({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://user:s3cret@collector.example/v1/traces' },
+      });
+
+      const [, , context] = logger.mock.calls[0];
+      expect(context?.endpoint).toBe('https://collector.example/v1/traces');
+      expect(JSON.stringify(context)).not.toContain('s3cret');
+    });
+
     it('should hand the SDK back for the shutdown path to flush through', () => {
       const sdk = setup();
 
@@ -189,5 +202,28 @@ describe('loadOtelModules', () => {
   // takes: it must report their absence, not throw out of the preload.
   it('should return undefined against the real require, outside the Docker image', () => {
     expect(loadOtelModules()).toBeUndefined();
+  });
+});
+
+describe('redactEndpoint', () => {
+  it('should leave an endpoint without credentials exactly as it is', () => {
+    expect(redactEndpoint('http://collector:4318/v1/traces')).toBe(
+      'http://collector:4318/v1/traces',
+    );
+  });
+
+  it.each([
+    ['a user and a password', 'https://user:s3cret@collector.example/v1/traces'],
+    ['a token as the user', 'https://s3cret@collector.example/v1/traces'],
+  ])('should strip %s while keeping the rest of the URL', (_label, endpoint) => {
+    const redacted = redactEndpoint(endpoint);
+
+    expect(redacted).toBe('https://collector.example/v1/traces');
+    expect(redacted).not.toContain('s3cret');
+  });
+
+  // It cannot be redacted, so it cannot be shown. The SDK fails on it soon enough on its own.
+  it('should drop an endpoint it cannot parse rather than pass it through', () => {
+    expect(redactEndpoint('not a url')).toBeUndefined();
   });
 });


### PR DESCRIPTION
> Stacked on #1848 — review that one first, this PR's diff is only the OpenTelemetry layer.

Bundles OpenTelemetry APM into the `agent-bff` Docker image, the way the workflow-executor image already does.

## How it works

`src/tracing.ts` holds the setup; `src/tracing-preload.ts` is the two-line `--require` entry point the Dockerfile's `ENTRYPOINT` loads before `cli.js`, so the auto-instrumentation patches land before the app imports anything. Keeping them apart is what lets the setup be imported by a test without arming an SDK.

Tracing is **off until `OTEL_EXPORTER_OTLP_ENDPOINT` is set**, so a deployment that never opted into APM pays nothing but the require. Configuration is entirely standard OTel environment variables (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`).

The packages are pinned in the image's isolated dependency tree only, never shipped to npm consumers — hence the dynamic require behind a seam, and a warning rather than a crash when they are absent.

## Two things worth a look

**The signal handler re-raises.** The BFF installs no signal handler of its own, and registering a listener *suppresses* Node's default termination — arming one to flush spans without re-raising would leave `docker stop` waiting out its timeout for a SIGKILL. So the handler flushes, then re-raises the same signal; `once` has already removed the listener, so the second delivery finds none and terminates. A rejected flush re-raises anyway, so a dead collector cannot hang the process.

**`scan-gate.js` blocks again.** `@opentelemetry/*` exists only in this image and can only be fixed here, so a fixable CRITICAL/HIGH in one of them now fails the publish. Everything else stays report-only. `**/@opentelemetry/propagator-jaeger` is pinned to 2.9.0 (CVE-2026-59892) — `auto-instrumentations-node` still asks for 2.8.0.

## Verified locally (arm64)

- image rebuilt, smoke test passes and now asserts `OpenTelemetry tracing enabled` in the logs — the packages exist only in the image, so nothing else would prove they are loadable
- `yarn audit` on the regenerated isolated lockfile: 0 vulnerabilities across 335 packages
- 11 new tests on the setup (both `load` and signal paths through injected seams); the full agent-bff suite is green at 1217 tests
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle OpenTelemetry APM into agent-bff Docker image
> - Adds `tracing-preload.ts` loaded via `node --require` in the Dockerfile ENTRYPOINT so auto-instrumentation is applied before app modules load. Initialization is gated on `OTEL_EXPORTER_OTLP_ENDPOINT` and stays inert otherwise.
> - Adds `tracing.ts` with environment-driven SDK setup, OTLP exporter selection, credential redaction in logs, and a dynamic module loader that tolerates missing OTel packages outside Docker.
> - Extends `shutdown.ts` to run a bounded telemetry flush in parallel with server stop; flush failures do not affect exit codes.
> - Updates `build-deps-manifest.js` to merge pinned `@opentelemetry/*` packages into the Docker dependency install, and `scan-gate.js` now fails the image publish on vulnerabilities found in Docker-only `@opentelemetry/*` packages.
> - Risk: `scan-gate.js` now calls `process.exit(1)` on vulnerabilities in `@opentelemetry/*` packages; bumping versions in `OTEL_DEPENDENCIES` requires refreshing `deps/yarn.lock`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1849 opened
>
> - Changed tracing enablement logic in `initTracing` to activate when either `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_TRACES_EXPORTER` environment variables contain non-blank values, treating blank values as unset, while continuing to respect `OTEL_SDK_DISABLED` as a short-circuit [296a6c2]
> - Wrapped `setTracingHandle(initTracing())` call in `tracing-preload.ts` with try-catch to prevent exceptions during `--require` preload from aborting the process, logging a warning and continuing untraced on failure [296a6c2]
> - Introduced `serviceNameFromEnv` utility and modified `initTracing` to respect OpenTelemetry specification precedence for service name resolution, only applying default when environment provides no name [296a6c2]
> - Added validation in `loadOtelModules` to verify that resolved OpenTelemetry packages export the expected functions (`NodeSDK`, `getNodeAutoInstrumentations`, `OTLPTraceExporter`), returning undefined if any export is missing or non-function [296a6c2]
> - Enhanced smoke test in `docker/smoke-test.sh` to enable tracing via `OTEL_EXPORTER_OTLP_ENDPOINT` and validate graceful shutdown within bounded time when collector is unreachable [296a6c2]
> - Expanded test coverage in `tracing.test.ts` and `tracing-preload.test.ts` to verify new enablement conditions, service name precedence, module export validation, and error handling during initialization [296a6c2]
> - Removed `OTEL_DEPENDENCIES` export from `docker/build-deps-manifest.js` module and extended comments explaining pinned OpenTelemetry dependency policy and Renovate constraints [296a6c2]
> - Updated README.md documentation to clarify OpenTelemetry tracing behavior including enablement conditions, service name precedence, SDK disable semantics, shipped exporters, and failure handling [296a6c2]
> - Removed manual construction of `OTLPTraceExporter` from `@opentelemetry/exporter-trace-otlp-http` in the `agent-bff` tracing initialization [5a07686]
> - Documented OpenTelemetry environment variable configuration in `agent-bff` README [5a07686]
> - Updated `agent-bff` tracing test suite to remove `OTLPTraceExporter` expectations and validate SDK-based configuration [5a07686]
> - Expanded documentation explaining OpenTelemetry package bundling behavior in Docker image [50d3f1d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5a1f19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->