### PR TITLE
fix(agent-bff): advertise mode 1 on the data and action routes

### DIFF
--- a/packages/agent-bff/src/docs/docs-samples.ts
+++ b/packages/agent-bff/src/docs/docs-samples.ts
@@ -110,21 +110,22 @@ const SAMPLES_SCRIPT = `
         function authHeader(spec, operation) {
           var schemes = (spec.components || {}).securitySchemes || {};
           var requirements = operation.security || spec.security || [];
-          var header = null;
+          var apiKey = null;
+          var bearer = null;
 
           requirements.forEach(function (requirement) {
             Object.keys(requirement).forEach(function (name) {
               var scheme = schemes[name] || {};
 
               if (scheme.type === 'apiKey' && scheme.in === 'header') {
-                header = { name: scheme.name, prefix: '', secret: true };
-              } else if (!header && scheme.type === 'http' && scheme.scheme === 'bearer') {
-                header = { name: 'Authorization', prefix: 'Bearer ', secret: true };
+                apiKey = { name: scheme.name, prefix: '', secret: true };
+              } else if (scheme.type === 'http' && scheme.scheme === 'bearer') {
+                bearer = { name: 'Authorization', prefix: 'Bearer ', secret: true };
               }
             });
           });
 
-          return header || { name: KEY_HEADER, prefix: '', secret: true };
+          return apiKey || bearer || { name: KEY_HEADER, prefix: '', secret: true };
         }
 
         /**

--- a/packages/agent-bff/src/docs/docs-samples.ts
+++ b/packages/agent-bff/src/docs/docs-samples.ts
@@ -107,7 +107,6 @@ const SAMPLES_SCRIPT = `
           return body;
         }
 
-        // The scheme the operation names, so a document that renames or re-types it stays right.
         function authHeader(spec, operation) {
           var schemes = (spec.components || {}).securitySchemes || {};
           var requirements = operation.security || spec.security || [];
@@ -115,13 +114,11 @@ const SAMPLES_SCRIPT = `
 
           requirements.forEach(function (requirement) {
             Object.keys(requirement).forEach(function (name) {
-              if (header) return;
-
               var scheme = schemes[name] || {};
 
               if (scheme.type === 'apiKey' && scheme.in === 'header') {
                 header = { name: scheme.name, prefix: '', secret: true };
-              } else if (scheme.type === 'http' && scheme.scheme === 'bearer') {
+              } else if (!header && scheme.type === 'http' && scheme.scheme === 'bearer') {
                 header = { name: 'Authorization', prefix: 'Bearer ', secret: true };
               }
             });

--- a/packages/agent-bff/src/docs/docs-samples.ts
+++ b/packages/agent-bff/src/docs/docs-samples.ts
@@ -107,6 +107,8 @@ const SAMPLES_SCRIPT = `
           return body;
         }
 
+        // The page only ever unlocks with the API key, so it wins wherever an operation takes it;
+        // a session-only operation still samples the bearer it names.
         function authHeader(spec, operation) {
           var schemes = (spec.components || {}).securitySchemes || {};
           var requirements = operation.security || spec.security || [];

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -409,7 +409,7 @@ export function generateOpenApiDocument(
     path: `${ROUTE_PREFIX}/context`,
     operationId: 'getContext',
     summary: 'Read the exposed schema contract',
-    security: [{ [SESSION_SCHEME]: [] }, { [API_KEY_SCHEME]: [] }],
+    security: SECURITY,
     request: {},
     responses: {
       200: {

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -27,7 +27,7 @@ export const ROUTE_PREFIX = '/agent/v1';
 const SESSION_SCHEME = 'bffSession';
 const API_KEY_SCHEME = 'bffApiKey';
 
-const SECURITY = [{ [API_KEY_SCHEME]: [] }];
+const SECURITY = [{ [SESSION_SCHEME]: [] }, { [API_KEY_SCHEME]: [] }];
 
 const ERROR_STATUSES: Record<string, string> = {
   400: 'Malformed body, a malformed URL-encoded path segment, an invalid filter operator, a filter nested too deep, ambiguous credentials, an unsupported page, a missing or invalid timezone, an unknown submitted action field, or a rejected action form (type action_error)',
@@ -393,7 +393,9 @@ export function generateOpenApiDocument(
     scheme: 'bearer',
     description:
       'Mode 1: the BFF session token issued after the OAuth login. Accepted on the context ' +
-      'contract; the data and action routes advertise the API key only.',
+      'contract and on every data and action route, where the BFF mints the agent token from the ' +
+      'session. The session must carry a usable rendering, otherwise the request is rejected ' +
+      'with 401.',
   });
   registry.registerComponent('securitySchemes', API_KEY_SCHEME, {
     type: 'apiKey',

--- a/packages/agent-bff/test/docs/docs-page.test.ts
+++ b/packages/agent-bff/test/docs/docs-page.test.ts
@@ -155,13 +155,23 @@ const API_KEY_SPEC = {
     },
     '/agent/v1/My%20Coll/actions/Mark%2Fdone/execute': {
       post: {
-        security: [{ bffSession: [] }],
+        security: [{ bffSession: [] }, { bffApiKey: [] }],
         responses: { 200: {} },
         requestBody: {
           required: true,
           content: {
             'application/json': { schema: { $ref: '#/components/schemas/ActionRequest' } },
           },
+        },
+      },
+    },
+    '/agent/v1/ai/query': {
+      post: {
+        security: [{ bffSession: [] }],
+        responses: { 200: {} },
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { type: 'object' } } },
         },
       },
     },
@@ -311,11 +321,12 @@ describe('the code samples the docs page injects', () => {
   const LIST = '/agent/v1/My%20Coll/list';
   const RELATION = '/agent/v1/My%20Coll/relations/orders/list';
   const ACTION = '/agent/v1/My%20Coll/actions/Mark%2Fdone/execute';
+  const AI_QUERY = '/agent/v1/ai/query';
 
   it('should offer the three languages on every operation', async () => {
     const page = await render(API_KEY_SPEC);
 
-    [LIST, RELATION, ACTION].forEach(path => {
+    [LIST, RELATION, ACTION, AI_QUERY].forEach(path => {
       expect(page.samplesOf(path).map(sample => sample.lang)).toEqual([
         'cURL',
         'JavaScript',
@@ -361,18 +372,20 @@ describe('the code samples the docs page injects', () => {
     page.allSources().forEach(source => expect(source).toContain('X-Forest-Timezone'));
   });
 
-  it('should take the auth header from the scheme the operation names', async () => {
+  it('should take the auth header from the scheme a session-only operation names', async () => {
     const page = await render(API_KEY_SPEC);
 
-    expect(page.sourceOf(ACTION, 'cURL')).toContain('-H "Authorization: Bearer $BFF_KEY"');
-    expect(page.sourceOf(ACTION, 'cURL')).not.toContain('X-Forest-Bff-Key');
+    expect(page.sourceOf(AI_QUERY, 'cURL')).toContain('-H "Authorization: Bearer $BFF_KEY"');
+    expect(page.sourceOf(AI_QUERY, 'cURL')).not.toContain('X-Forest-Bff-Key');
   });
 
   it('should sample the key on an operation accepting both, since the reader unlocked with one', async () => {
     const page = await render(API_KEY_SPEC);
 
-    expect(page.sourceOf(LIST, 'cURL')).toContain('-H "X-Forest-Bff-Key: $BFF_KEY"');
-    expect(page.sourceOf(LIST, 'cURL')).not.toContain('Authorization');
+    [LIST, ACTION].forEach(path => {
+      expect(page.sourceOf(path, 'cURL')).toContain('-H "X-Forest-Bff-Key: $BFF_KEY"');
+      expect(page.sourceOf(path, 'cURL')).not.toContain('Authorization');
+    });
   });
 
   it('should read the key from the environment in node, not inline it', async () => {
@@ -403,7 +416,7 @@ describe('the code samples the docs page injects', () => {
     expect(page.sourceOf(RELATION, 'Ruby')).toContain(
       "request['X-Forest-Bff-Key'] = ENV.fetch('BFF_KEY')",
     );
-    expect(page.sourceOf(ACTION, 'Ruby')).toContain(
+    expect(page.sourceOf(AI_QUERY, 'Ruby')).toContain(
       `request['Authorization'] = "Bearer #{ENV.fetch('BFF_KEY')}"`,
     );
     expect(page.sourceOf(RELATION, 'Ruby')).toContain('request = Net::HTTP::Post.new(uri)');

--- a/packages/agent-bff/test/docs/docs-page.test.ts
+++ b/packages/agent-bff/test/docs/docs-page.test.ts
@@ -131,7 +131,7 @@ const API_KEY_SPEC = {
   paths: {
     '/agent/v1/My%20Coll/list': {
       post: {
-        security: [{ bffApiKey: [] }],
+        security: [{ bffSession: [] }, { bffApiKey: [] }],
         responses: { 200: {} },
         requestBody: {
           required: false,
@@ -366,6 +366,13 @@ describe('the code samples the docs page injects', () => {
 
     expect(page.sourceOf(ACTION, 'cURL')).toContain('-H "Authorization: Bearer $BFF_KEY"');
     expect(page.sourceOf(ACTION, 'cURL')).not.toContain('X-Forest-Bff-Key');
+  });
+
+  it('should sample the key on an operation accepting both, since the reader unlocked with one', async () => {
+    const page = await render(API_KEY_SPEC);
+
+    expect(page.sourceOf(LIST, 'cURL')).toContain('-H "X-Forest-Bff-Key: $BFF_KEY"');
+    expect(page.sourceOf(LIST, 'cURL')).not.toContain('Authorization');
   });
 
   it('should read the key from the environment in node, not inline it', async () => {

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -166,21 +166,11 @@ describe('generateOpenApiDocument', () => {
   });
 
   it('should let both auth modes reach every data and action operation, as mode 1 mints an agent token', () => {
-    const securityByPath = Object.fromEntries(
-      Object.entries(document.paths ?? {})
-        .filter(([path]) => path !== AI_QUERY_PATH)
-        .filter(([, item]) => (item as { post?: unknown }).post !== undefined)
-        .map(([path, item]) => [path, (item as { post: { security: unknown } }).post.security]),
-    );
-    const bothModes = [{ bffSession: [] }, { bffApiKey: [] }];
+    const operations = dataOperations();
 
-    expect(securityByPath).toEqual({
-      [`${ROUTE_PREFIX}/{collection}/list`]: bothModes,
-      [`${ROUTE_PREFIX}/{collection}/count`]: bothModes,
-      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/list`]: bothModes,
-      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/count`]: bothModes,
-      [`${ROUTE_PREFIX}/{collection}/actions/{action}/form`]: bothModes,
-      [`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`]: bothModes,
+    expect(operations).toHaveLength(6);
+    operations.forEach(operation => {
+      expect(operation.security).toEqual([{ bffSession: [] }, { bffApiKey: [] }]);
     });
   });
 
@@ -205,7 +195,6 @@ describe('generateOpenApiDocument', () => {
 
     expect(session.description).toContain('Accepted on the context contract');
     expect(session.description).toContain('every data and action route');
-    expect(session.description).not.toContain('advertise the API key only');
   });
 
   it('should require a body where parentId or recordIds is mandatory', () => {

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -165,12 +165,22 @@ describe('generateOpenApiDocument', () => {
     });
   });
 
-  it('should secure every data operation with the API key only, the one mode those routes accept', () => {
-    const operations = dataOperations();
+  it('should let both auth modes reach every data and action operation, as mode 1 mints an agent token', () => {
+    const securityByPath = Object.fromEntries(
+      Object.entries(document.paths ?? {})
+        .filter(([path]) => path !== AI_QUERY_PATH)
+        .filter(([, item]) => (item as { post?: unknown }).post !== undefined)
+        .map(([path, item]) => [path, (item as { post: { security: unknown } }).post.security]),
+    );
+    const bothModes = [{ bffSession: [] }, { bffApiKey: [] }];
 
-    expect(operations).toHaveLength(6);
-    operations.forEach(operation => {
-      expect(operation.security).toEqual([{ bffApiKey: [] }]);
+    expect(securityByPath).toEqual({
+      [`${ROUTE_PREFIX}/{collection}/list`]: bothModes,
+      [`${ROUTE_PREFIX}/{collection}/count`]: bothModes,
+      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/list`]: bothModes,
+      [`${ROUTE_PREFIX}/{collection}/relations/{relation}/count`]: bothModes,
+      [`${ROUTE_PREFIX}/{collection}/actions/{action}/form`]: bothModes,
+      [`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`]: bothModes,
     });
   });
 
@@ -188,7 +198,8 @@ describe('generateOpenApiDocument', () => {
     ).bffSession;
 
     expect(session.description).toContain('Accepted on the context contract');
-    expect(session.description).toContain('the data and action routes advertise the API key only');
+    expect(session.description).toContain('every data and action route');
+    expect(session.description).not.toContain('advertise the API key only');
   });
 
   it('should require a body where parentId or recordIds is mandatory', () => {

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -184,6 +184,12 @@ describe('generateOpenApiDocument', () => {
     });
   });
 
+  it('should keep the ai query relay on the session alone, the only credential it can forward', () => {
+    const ai = (document.paths ?? {})[AI_QUERY_PATH] as { post: { security: unknown } };
+
+    expect(ai.post.security).toEqual([{ bffSession: [] }]);
+  });
+
   it('should let both auth modes reach the context contract, which is not caller-scoped', () => {
     const context = (document.paths ?? {})[`${ROUTE_PREFIX}/context`] as {
       get: { security: unknown };

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -11,6 +11,7 @@ import Koa from 'koa';
 import path from 'path';
 
 import createActionRoutesMiddleware from '../../src/action/action-routes-middleware';
+import { BFF_KEY_HEADER } from '../../src/api-key/api-key-middleware';
 import dispatchCli from '../../src/cli-dispatch';
 import createDataRoutesMiddleware from '../../src/data/data-routes-middleware';
 import createErrorMiddleware from '../../src/http/error-middleware';
@@ -151,6 +152,11 @@ function storeOf(readModel: ReadModel): ReadModelStore {
   } as unknown as ReadModelStore;
 }
 
+type AuthCallback = (scheme: { name?: string }) => string | undefined;
+
+const SCHEME_AWARE_AUTH: AuthCallback = scheme =>
+  scheme.name === BFF_KEY_HEADER ? API_KEY : undefined;
+
 const receivedKeys: string[] = [];
 const receivedAuthorizations: string[] = [];
 
@@ -161,7 +167,7 @@ function buildApp(): Koa {
   app.use(createErrorMiddleware({ logger: noopLogger }));
   app.use(bodyParser());
   app.use(async (ctx, next) => {
-    receivedKeys.push(ctx.get('X-Forest-Bff-Key'));
+    receivedKeys.push(ctx.get(BFF_KEY_HEADER));
     receivedAuthorizations.push(ctx.get('Authorization'));
     // Auth is out of this test's scope (the gate is its own ticket): the request arrives with agent
     // credentials already resolved, exactly as the auth chain would have left it.
@@ -199,6 +205,7 @@ function documentedOperators(document: {
 
 describe('a client generated from the emitted OpenAPI document', () => {
   let codegenOutput: string;
+  let configure: (auth: AuthCallback) => unknown;
   let document: ReturnType<typeof JSON.parse>;
   let sdk: Record<string, Call>;
   let server: Server;
@@ -265,12 +272,13 @@ describe('a client generated from the emitted OpenAPI document', () => {
     server = buildApp().listen(0);
     const { port } = server.address() as { port: number };
 
-    client.setConfig({
-      baseUrl: `http://127.0.0.1:${port}`,
-      auth: (scheme: { name?: string }) =>
-        scheme.name === 'X-Forest-Bff-Key' ? API_KEY : undefined,
-      headers: { [TIMEZONE_HEADER]: TIMEZONE },
-    });
+    configure = auth =>
+      client.setConfig({
+        baseUrl: `http://127.0.0.1:${port}`,
+        auth,
+        headers: { [TIMEZONE_HEADER]: TIMEZONE },
+      });
+    configure(SCHEME_AWARE_AUTH);
   }, CODEGEN_TIMEOUT_MS * 2);
 
   afterAll(async () => {
@@ -346,10 +354,25 @@ describe('a client generated from the emitted OpenAPI document', () => {
       expect(receivedKeys).toEqual([API_KEY]);
     });
 
-    it('should send no Authorization header beside the key, which the BFF rejects as ambiguous', async () => {
+    it('should send the key alone when the caller reads the scheme it is answering', async () => {
       await sdk.countRecordsUsers({ body: {} });
 
       expect(receivedAuthorizations).toEqual(['']);
+    });
+
+    it('should send both credentials when the caller answers every scheme with the same token, which the BFF rejects with 400 ambiguous_credentials', async () => {
+      configure(() => API_KEY);
+
+      try {
+        await sdk.countRecordsUsers({ body: {} });
+      } finally {
+        configure(SCHEME_AWARE_AUTH);
+      }
+
+      expect({ keys: receivedKeys, authorizations: receivedAuthorizations }).toEqual({
+        keys: [API_KEY],
+        authorizations: [`Bearer ${API_KEY}`],
+      });
     });
   });
 

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -346,7 +346,7 @@ describe('a client generated from the emitted OpenAPI document', () => {
       expect(receivedKeys).toEqual([API_KEY]);
     });
 
-    it('should send the key alone, since a route accepting both credentials rejects both at once', async () => {
+    it('should send no Authorization header beside the key, which the BFF rejects as ambiguous', async () => {
       await sdk.countRecordsUsers({ body: {} });
 
       expect(receivedAuthorizations).toEqual(['']);

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -152,6 +152,7 @@ function storeOf(readModel: ReadModel): ReadModelStore {
 }
 
 const receivedKeys: string[] = [];
+const receivedAuthorizations: string[] = [];
 
 function buildApp(): Koa {
   const store = storeOf(new ReadModel(SCHEMA));
@@ -161,6 +162,7 @@ function buildApp(): Koa {
   app.use(bodyParser());
   app.use(async (ctx, next) => {
     receivedKeys.push(ctx.get('X-Forest-Bff-Key'));
+    receivedAuthorizations.push(ctx.get('Authorization'));
     // Auth is out of this test's scope (the gate is its own ticket): the request arrives with agent
     // credentials already resolved, exactly as the auth chain would have left it.
     ctx.state.agentToken = 'agent-jwt';
@@ -265,7 +267,8 @@ describe('a client generated from the emitted OpenAPI document', () => {
 
     client.setConfig({
       baseUrl: `http://127.0.0.1:${port}`,
-      auth: () => API_KEY,
+      auth: (scheme: { name?: string }) =>
+        scheme.name === 'X-Forest-Bff-Key' ? API_KEY : undefined,
       headers: { [TIMEZONE_HEADER]: TIMEZONE },
     });
   }, CODEGEN_TIMEOUT_MS * 2);
@@ -283,6 +286,7 @@ describe('a client generated from the emitted OpenAPI document', () => {
 
   beforeEach(() => {
     receivedKeys.length = 0;
+    receivedAuthorizations.length = 0;
   });
 
   describe('when a standard codegen reads the document', () => {
@@ -340,6 +344,12 @@ describe('a client generated from the emitted OpenAPI document', () => {
       await sdk.countRecordsUsers({ body: {} });
 
       expect(receivedKeys).toEqual([API_KEY]);
+    });
+
+    it('should send the key alone, since a route accepting both credentials rejects both at once', async () => {
+      await sdk.countRecordsUsers({ body: {} });
+
+      expect(receivedAuthorizations).toEqual(['']);
     });
   });
 


### PR DESCRIPTION
Stacked on #1845 (`feat/prd-1033-ai-query-proxy`), which merges first. Only the last commit belongs to this PR; everything else in the diff comes from the parent.

fixes PRD-936

## What

`SECURITY` in `openapi-document.ts` now lists `bffSession` alongside `bffApiKey`, so the six data and action paths advertise both auth modes. The `bffSession` scheme description no longer says those routes take the API key only; it states the real constraint instead — the session must carry a usable rendering, or the request is rejected with 401.

## Why

Mode 1 has reached data and action routes since #1800 (PRD-866): `auth-mode-middleware.ts` mints an agent token from the OAuth principal into `ctx.state.agentToken`, and `requireAgentToken` reads it. `security` is the field a code generator reads, so every generated client kept sending an API key on data routes and Mode 1 looked unsupported.

Two lines of production code, plus the fallout of advertising a second scheme: the docs page samples and the generated client both picked the first scheme in the list and switched to the bearer, so a reader who unlocked with an API key got a snippet sending a credential they do not hold, and a client configured with one blanket `auth` callback sent BOTH headers and got 400 `ambiguous_credentials`. `docs-samples.ts` now prefers the API key wherever an operation accepts it, and the generated-client test pins the scheme-discriminating callback with a regression test on the `Authorization` header. No auth behaviour changes.

## How to test

```
cd packages/agent-bff && npx jest test/openapi
node dist/cli.js openapi | jq -r '.paths | to_entries[] | .key as $p | .value | to_entries[] | "\($p) -> \([.value.security[]? | keys[]] | join(", "))"'
```

Every data and action path prints `bffSession, bffApiKey`.

---

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
