### PR TITLE
fix(datasource-customizer): let a narrowed search be permission-checked instead of refused

### DIFF
--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -1,5 +1,8 @@
 import type { CollectionDecorator, DataSource, RecordData } from '@forestadmin/datasource-toolkit';
 
+import type { SearchReplaceDefinition } from '@forestadmin/datasource-customizer';
+
+import { DataSourceCustomizer } from '@forestadmin/datasource-customizer';
 import { CollectionActionEvent } from '@forestadmin/forestadmin-client';
 import { createMockContext } from '@shopify/jest-koa-mocks';
 
@@ -526,6 +529,90 @@ describe('read permissions on related collections', () => {
       );
 
       expect(list.mock.calls[0][1]).toMatchObject({ search: 'martin', searchExtended: true });
+    });
+  });
+
+  // The suite above stubs `getSearchedFields` to pin the route's policy. These run the real
+  // `replaceSearch` field selection through the whole stack instead, so what the decorator reports
+  // and what the route does with it are checked together.
+  describe('extended search through a real replaceSearch field selection', () => {
+    const buildCustomizedDataSource = async (definition: SearchReplaceDefinition) => {
+      const base = buildDataSource();
+      const customizer = new DataSourceCustomizer();
+
+      customizer.addDataSource(async () => base);
+      customizer.customizeCollection('cards', collection => collection.replaceSearch(definition));
+
+      return { base, dataSource: await customizer.getDataSource(() => {}) };
+    };
+
+    it('should refuse an extended search by naming a denied path, not for want of a footprint', async () => {
+      const { base, dataSource } = await buildCustomizedDataSource({
+        includeFields: ['holder:nationalId'],
+      });
+      const services = buildServices(['accounts', 'contracts', 'organizations']);
+      const list = jest.spyOn(base.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      // The refusal a field selection buys: the denied collection is named, where the handler form
+      // could only be told the fields were undeterminable.
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        ),
+      ).rejects.toThrow(
+        /You cannot search on 'holder:\w+': you are not allowed to read the 'holders' collection\./,
+      );
+
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should refuse it on a plain search too, where the handler form was served', async () => {
+      const { base, dataSource } = await buildCustomizedDataSource({
+        includeFields: ['holder:nationalId'],
+      });
+      const services = buildServices();
+      const list = jest.spyOn(base.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin' } }),
+        ),
+      ).rejects.toThrow("You cannot search on 'holder:nationalId'");
+
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    it('should serve the extended search a handler form would have refused', async () => {
+      const { base, dataSource } = await buildCustomizedDataSource({
+        includeFields: ['holder:nationalId'],
+      });
+      const services = buildServices(['holders', 'accounts', 'contracts', 'organizations']);
+      const list = jest.spyOn(base.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await new List(services, options, dataSource, 'cards').handleList(
+        buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+      );
+
+      // Served, and the search really reached the included path rather than being dropped.
+      expect(JSON.stringify(list.mock.calls[0][1].conditionTree)).toContain('holder:nationalId');
+    });
+
+    it('should still refuse the extended search of the equivalent handler', async () => {
+      const { base, dataSource } = await buildCustomizedDataSource(value => ({
+        field: 'panLast4',
+        operator: 'Contains',
+        value,
+      }));
+      const services = buildServices(['holders', 'accounts', 'contracts', 'organizations']);
+      const list = jest.spyOn(base.getCollection('cards'), 'list').mockResolvedValue([]);
+
+      await expect(
+        new List(services, options, dataSource, 'cards').handleList(
+          buildContext({ query: { search: 'martin', searchExtended: '1' } }),
+        ),
+      ).rejects.toThrow("You cannot run an extended search on the 'cards' collection");
+
+      expect(list).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/agent/test/security/related-read-permissions.test.ts
+++ b/packages/agent/test/security/related-read-permissions.test.ts
@@ -1,6 +1,5 @@
-import type { CollectionDecorator, DataSource, RecordData } from '@forestadmin/datasource-toolkit';
-
 import type { SearchReplaceDefinition } from '@forestadmin/datasource-customizer';
+import type { CollectionDecorator, DataSource, RecordData } from '@forestadmin/datasource-toolkit';
 
 import { DataSourceCustomizer } from '@forestadmin/datasource-customizer';
 import { CollectionActionEvent } from '@forestadmin/forestadmin-client';

--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -12,7 +12,7 @@ import type {
   UpdateOverrideHandler,
 } from './decorators/override/types';
 import type { RelationDefinition } from './decorators/relation/types';
-import type { SearchDefinition } from './decorators/search/types';
+import type { SearchReplaceDefinition } from './decorators/search/types';
 import type { SegmentDefinition } from './decorators/segment/types';
 import type { WriteDefinition } from './decorators/write/write-replace/types';
 import type {
@@ -600,6 +600,8 @@ export default class CollectionCustomizer<
    * A field selection narrows the same default search, so the agent knows which columns are read
    * and checks them against the caller's read permissions: an extended search keeps working, and a
    * path the role may not read is refused by name. Prefer it whenever it expresses what you need.
+   * On a collection whose datasource searches natively (`enableSearch()`), it does not narrow that
+   * native search — it replaces it with the agent's own per-column one, restricted to the selection.
    *
    * A handler is unrestricted, and pays for it. The fields it reads are exempt from read
    * permissions on a plain search: the caller supplies the text and the handler picks the fields,
@@ -616,12 +618,12 @@ export default class CollectionCustomizer<
    *   return { field: 'name', operator: 'Contains', value: searchString };
    * });
    */
-  replaceSearch(definition: SearchDefinition<S, N>): this {
+  replaceSearch(definition: SearchReplaceDefinition<S, N>): this {
     return this.pushCustomization(async () => {
       this.stack.search
         .getCollection(this.name)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .replaceSearch(definition as SearchDefinition<any, any>);
+        .replaceSearch(definition as SearchReplaceDefinition<any, any>);
     });
   }
 

--- a/packages/datasource-customizer/src/collection-customizer.ts
+++ b/packages/datasource-customizer/src/collection-customizer.ts
@@ -595,16 +595,22 @@ export default class CollectionCustomizer<
   }
 
   /**
-   * Replace the behavior of the search bar
+   * Replace the behavior of the search bar, either with a handler or with a field selection.
    *
-   * On a plain search, the fields the handler reads are exempt from read permissions: the caller
-   * supplies the text and the handler picks the fields, so the agent cannot tell an intended one
-   * from one the role may not read. Point a handler at a column of a collection a role cannot read
-   * and that role can test values against it, reading each answer from whether rows come back.
-   * An extended search is refused rather than exempted, because the caller owns that flag and can
-   * compare the same term with it off and on.
-   * @param definition handler to describe the new behavior
+   * A field selection narrows the same default search, so the agent knows which columns are read
+   * and checks them against the caller's read permissions: an extended search keeps working, and a
+   * path the role may not read is refused by name. Prefer it whenever it expresses what you need.
+   *
+   * A handler is unrestricted, and pays for it. The fields it reads are exempt from read
+   * permissions on a plain search: the caller supplies the text and the handler picks the fields,
+   * so the agent cannot tell an intended one from one the role may not read. Point a handler at a
+   * column of a collection a role cannot read and that role can test values against it, reading
+   * each answer from whether rows come back. An extended search is refused outright rather than
+   * exempted, because the caller owns that flag and can compare the same term with it off and on.
+   * @param definition a handler describing the new behavior, or the fields the default search reads
    * @see {@link https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/search Documentation Link}
+   * @example
+   * .replaceSearch({ includeFields: ['project:name'], excludeFields: ['description'] });
    * @example
    * .replaceSearch(async (searchString) => {
    *   return { field: 'name', operator: 'Contains', value: searchString };

--- a/packages/datasource-customizer/src/decorators/search/collection.ts
+++ b/packages/datasource-customizer/src/decorators/search/collection.ts
@@ -1,5 +1,6 @@
 import type { SearchOptions } from './collection-search-context';
-import type { SearchDefinition } from './types';
+import type { QueryContext } from './generated-parser/QueryParser';
+import type { SearchDefinition, SearchFieldsDefinition, SearchHandlerDefinition } from './types';
 import type {
   Caller,
   Collection,
@@ -15,7 +16,7 @@ import type {
 import { CollectionDecorator, ConditionTreeFactory } from '@forestadmin/datasource-toolkit';
 
 import CollectionSearchContext from './collection-search-context';
-import { getLeafCollectionName, getSearchedFieldPaths, lenientGetSchema } from './field-paths';
+import { getLeafCollectionName, lenientGetSchema } from './field-paths';
 import { extractSpecifiedFields, generateConditionTree, parseQuery } from './parse-query';
 
 export default class SearchCollectionDecorator extends CollectionDecorator {
@@ -27,6 +28,14 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
     this.searchable = true;
     this.replacer = replacer;
     this.markSchemaAsDirty();
+  }
+
+  private get handler(): SearchHandlerDefinition | null {
+    return typeof this.replacer === 'function' ? this.replacer : null;
+  }
+
+  private get fieldSelection(): SearchFieldsDefinition | null {
+    return this.replacer && typeof this.replacer !== 'function' ? this.replacer : null;
   }
 
   disable() {
@@ -53,11 +62,12 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
       );
       let tree: ConditionTree;
 
-      if (this.replacer) {
-        const plainTree = await this.replacer(filter.search, filter.searchExtended, ctx);
+      if (this.handler) {
+        const plainTree = await this.handler(filter.search, filter.searchExtended, ctx);
         tree = ConditionTreeFactory.fromPlainObject(plainTree);
       } else {
         tree = this.generateSearchFilter(caller, filter.search, {
+          ...this.fieldSelection,
           extended: filter.searchExtended,
         });
       }
@@ -75,20 +85,21 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
     return filter;
   }
 
-  private generateSearchFilter(
-    caller: Caller,
-    searchText: string,
+  /**
+   * Both the condition tree and the footprint `getSearchedFields` reports must come from here:
+   * a path the search reads without appearing in the footprint is a column read unchecked.
+   */
+  private getSearchableFields(
+    parsedQuery: QueryContext,
     options?: SearchOptions,
-  ): ConditionTree {
-    const parsedQuery = parseQuery(searchText);
-
+  ): Map<string, ColumnSchema> {
     const specifiedFields = options?.onlyFields ? [] : extractSpecifiedFields(parsedQuery);
 
     const defaultFields = options?.onlyFields
       ? []
       : this.getFields(this.childCollection, Boolean(options?.extended));
 
-    const searchableFields = new Map(
+    return new Map(
       [
         ...defaultFields,
         ...[...specifiedFields, ...(options?.onlyFields ?? []), ...(options?.includeFields ?? [])]
@@ -99,6 +110,15 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
         .filter(Boolean)
         .filter(([field]) => !options?.excludeFields?.includes(field)),
     );
+  }
+
+  private generateSearchFilter(
+    caller: Caller,
+    searchText: string,
+    options?: SearchOptions,
+  ): ConditionTree {
+    const parsedQuery = parseQuery(searchText);
+    const searchableFields = this.getSearchableFields(parsedQuery, options);
 
     const conditionTree = generateConditionTree(caller, parsedQuery, [...searchableFields]);
 
@@ -121,15 +141,14 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
 
   /**
    * Answers against `childCollection`, which is what the search actually reads — a field hidden by
-   * the publication or renaming layers above is still searched. Returns `null` when a replacer is
-   * installed: the customer's handler chooses the fields, and the caller only supplies the text.
+   * the publication or renaming layers above is still searched. Returns `null` only when a handler
+   * is installed: it chooses the fields, and the caller only supplies the text.
    */
   override getSearchedFields(search: string, extended: boolean): SearchedField[] | null {
-    if (this.replacer) return null;
+    if (this.handler) return null;
 
     const paths = [
-      ...getSearchedFieldPaths(this.childCollection, search),
-      ...this.getFields(this.childCollection, extended).map(([path]) => path),
+      ...this.getSearchableFields(parseQuery(search), { ...this.fieldSelection, extended }).keys(),
     ];
 
     return paths.map(path => ({

--- a/packages/datasource-customizer/src/decorators/search/collection.ts
+++ b/packages/datasource-customizer/src/decorators/search/collection.ts
@@ -1,6 +1,10 @@
 import type { SearchOptions } from './collection-search-context';
 import type { QueryContext } from './generated-parser/QueryParser';
-import type { SearchDefinition, SearchFieldsDefinition, SearchHandlerDefinition } from './types';
+import type {
+  SearchFieldsDefinition,
+  SearchHandlerDefinition,
+  SearchReplaceDefinition,
+} from './types';
 import type {
   Caller,
   Collection,
@@ -21,10 +25,10 @@ import { extractSpecifiedFields, generateConditionTree, parseQuery } from './par
 
 export default class SearchCollectionDecorator extends CollectionDecorator {
   override dataSource: DataSourceDecorator<SearchCollectionDecorator>;
-  replacer: SearchDefinition = null;
+  replacer: SearchReplaceDefinition = null;
   searchable = true;
 
-  replaceSearch(replacer: SearchDefinition): void {
+  replaceSearch(replacer: SearchReplaceDefinition): void {
     this.searchable = true;
     this.replacer = replacer;
     this.markSchemaAsDirty();
@@ -99,6 +103,13 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
       ? []
       : this.getFields(this.childCollection, Boolean(options?.extended));
 
+    // Resolved the same way the included ones are, or `excludeFields: ['panLast4']` would silently
+    // fail to drop a `pan_last4` column that `includeFields` resolves. An unresolvable name is kept
+    // as written: it excludes nothing either way.
+    const excludedFields = new Set(
+      (options?.excludeFields ?? []).map(name => lenientGetSchema(this, name)?.field ?? name),
+    );
+
     return new Map(
       [
         ...defaultFields,
@@ -108,7 +119,7 @@ export default class SearchCollectionDecorator extends CollectionDecorator {
           .map(schema => [schema.field, schema.schema] as [string, ColumnSchema]),
       ]
         .filter(Boolean)
-        .filter(([field]) => !options?.excludeFields?.includes(field)),
+        .filter(([field]) => !excludedFields.has(field)),
     );
   }
 

--- a/packages/datasource-customizer/src/decorators/search/field-paths.ts
+++ b/packages/datasource-customizer/src/decorators/search/field-paths.ts
@@ -44,8 +44,12 @@ export function lenientGetSchema(
 }
 
 /**
- * The field paths a search string reaches through the `relation.column:term` syntax, resolved the
- * same way the search decorator resolves them — fuzzily, and across to-many relations too.
+ * The field paths a search string reaches through the `relation.column:term` syntax, resolved
+ * fuzzily and across to-many relations too.
+ *
+ * Unused by the decorator, which derives its own footprint from `getSearchableFields` so the paths
+ * it reports and the ones it searches cannot diverge. Kept only because it has been exported from
+ * the package index since 1.71.x; nothing keeps it in step with what a search actually reads.
  */
 export function getSearchedFieldPaths(collection: Collection, search: string): string[] {
   return extractSpecifiedFields(parseQuery(search))

--- a/packages/datasource-customizer/src/decorators/search/types.ts
+++ b/packages/datasource-customizer/src/decorators/search/types.ts
@@ -1,7 +1,8 @@
 import type CollectionSearchContext from './collection-search-context';
+import type { SearchOptions } from './collection-search-context';
 import type { TCollectionName, TConditionTree, TSchema } from '../../templates';
 
-export type SearchDefinition<
+export type SearchHandlerDefinition<
   S extends TSchema = TSchema,
   N extends TCollectionName<S> = TCollectionName<S>,
 > = (
@@ -9,3 +10,14 @@ export type SearchDefinition<
   extended: boolean,
   context: CollectionSearchContext<S, N>,
 ) => Promise<TConditionTree<S, N>> | TConditionTree<S, N>;
+
+/** `extended` is omitted on purpose: that flag is the caller's, and comes from the request. */
+export type SearchFieldsDefinition<
+  S extends TSchema = TSchema,
+  N extends TCollectionName<S> = TCollectionName<S>,
+> = Omit<SearchOptions<S, N>, 'extended'>;
+
+export type SearchDefinition<
+  S extends TSchema = TSchema,
+  N extends TCollectionName<S> = TCollectionName<S>,
+> = SearchHandlerDefinition<S, N> | SearchFieldsDefinition<S, N>;

--- a/packages/datasource-customizer/src/decorators/search/types.ts
+++ b/packages/datasource-customizer/src/decorators/search/types.ts
@@ -11,13 +11,23 @@ export type SearchHandlerDefinition<
   context: CollectionSearchContext<S, N>,
 ) => Promise<TConditionTree<S, N>> | TConditionTree<S, N>;
 
+/**
+ * The handler form's published name, kept pointing at the handler alone: it shipped as a callable
+ * type, and widening it to a union would stop compiling for anyone who calls what they typed with
+ * it. `SearchReplaceDefinition` is the union `replaceSearch` accepts.
+ */
+export type SearchDefinition<
+  S extends TSchema = TSchema,
+  N extends TCollectionName<S> = TCollectionName<S>,
+> = SearchHandlerDefinition<S, N>;
+
 /** `extended` is omitted on purpose: that flag is the caller's, and comes from the request. */
 export type SearchFieldsDefinition<
   S extends TSchema = TSchema,
   N extends TCollectionName<S> = TCollectionName<S>,
 > = Omit<SearchOptions<S, N>, 'extended'>;
 
-export type SearchDefinition<
+export type SearchReplaceDefinition<
   S extends TSchema = TSchema,
   N extends TCollectionName<S> = TCollectionName<S>,
 > = SearchHandlerDefinition<S, N> | SearchFieldsDefinition<S, N>;

--- a/packages/datasource-customizer/src/index.ts
+++ b/packages/datasource-customizer/src/index.ts
@@ -14,7 +14,11 @@ export { ComputedDefinition } from './decorators/computed/types';
 export { OperatorDefinition } from './decorators/operators-emulate/types';
 export { RelationDefinition } from './decorators/relation/types';
 export { getSearchedFieldPaths } from './decorators/search/field-paths';
-export { SearchDefinition } from './decorators/search/types';
+export {
+  SearchDefinition,
+  SearchFieldsDefinition,
+  SearchHandlerDefinition,
+} from './decorators/search/types';
 export { SegmentDefinition } from './decorators/segment/types';
 export * from './decorators/write/write-replace/types';
 export * from './decorators/hook/types';

--- a/packages/datasource-customizer/src/index.ts
+++ b/packages/datasource-customizer/src/index.ts
@@ -18,6 +18,7 @@ export {
   SearchDefinition,
   SearchFieldsDefinition,
   SearchHandlerDefinition,
+  SearchReplaceDefinition,
 } from './decorators/search/types';
 export { SegmentDefinition } from './decorators/segment/types';
 export * from './decorators/write/write-replace/types';

--- a/packages/datasource-customizer/test/decorators/search/collections.test.ts
+++ b/packages/datasource-customizer/test/decorators/search/collections.test.ts
@@ -144,6 +144,66 @@ describe('SearchCollectionDecorator', () => {
       });
     });
 
+    describe('when a field selection is provided', () => {
+      const buildTexts = () =>
+        buildCollection({
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            name: factories.columnSchema.text().build(),
+            description: factories.columnSchema.text().build(),
+          },
+        });
+
+      test('it narrows the default search the same way the equivalent handler does', async () => {
+        const decorator = buildTexts();
+        decorator.replaceSearch({ excludeFields: ['name'] });
+
+        const filter = factories.filter.build({ search: 'something', searchExtended: true });
+
+        expect(await decorator.refineFilter(caller, filter)).toEqual({
+          ...filter,
+          conditionTree: new ConditionTreeLeaf('description', 'IContains', 'something'),
+          search: null,
+        });
+      });
+
+      test('it forwards the caller-owned extended flag rather than pinning it', async () => {
+        const decorator = buildCollection(
+          {
+            fields: {
+              id: factories.columnSchema.uuidPrimaryKey().build(),
+              holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+              holder: factories.manyToOneSchema.build({
+                foreignCollection: 'holders',
+                foreignKey: 'holderId',
+              }),
+            },
+          },
+          [
+            factories.collection.build({
+              name: 'holders',
+              schema: factories.collectionSchema.build({
+                fields: { name: factories.columnSchema.text().build() },
+              }),
+            }),
+          ],
+        );
+        decorator.replaceSearch({ excludeFields: [] });
+
+        const plain = await decorator.refineFilter(
+          caller,
+          factories.filter.build({ search: 'martin', searchExtended: false }),
+        );
+        const extended = await decorator.refineFilter(
+          caller,
+          factories.filter.build({ search: 'martin', searchExtended: true }),
+        );
+
+        expect(JSON.stringify(plain.conditionTree)).not.toContain('holder:name');
+        expect(JSON.stringify(extended.conditionTree)).toContain('holder:name');
+      });
+    });
+
     describe('when the search is defined and the collection schema is not searchable', () => {
       describe('when the search is empty', () => {
         test('returns the same filter and set search as null', async () => {
@@ -800,5 +860,122 @@ describe('getSearchedFields', () => {
     decorator.replaceSearch(value => ({ field: 'id', operator: 'Equal', value }));
 
     expect(decorator.getSearchedFields('martin', true)).toBeNull();
+  });
+
+  describe('when a field selection narrows the default search', () => {
+    test('it answers the footprint instead of refusing to tell', () => {
+      const decorator = buildCards();
+      decorator.replaceSearch({ excludeFields: ['panLast4'] });
+
+      expect(decorator.getSearchedFields('martin', true)).toContainEqual({
+        path: 'holder:nationalId',
+        collection: 'holders',
+      });
+    });
+
+    test('it drops an excluded field from the footprint', () => {
+      const decorator = buildCards();
+      decorator.replaceSearch({ excludeFields: ['panLast4'] });
+
+      const searched = decorator.getSearchedFields('martin', true);
+
+      expect(searched.every(({ path }) => path !== 'panLast4')).toBe(true);
+    });
+
+    test('it names the leaf collection of an included relation path, extended or not', () => {
+      const decorator = buildCards();
+      decorator.replaceSearch({ includeFields: ['holder:nationalId'] });
+
+      expect(decorator.getSearchedFields('martin', false)).toContainEqual({
+        path: 'holder:nationalId',
+        collection: 'holders',
+      });
+    });
+
+    test('it reports only the replaced set when onlyFields is given', () => {
+      const decorator = buildCards();
+      decorator.replaceSearch({ onlyFields: ['holder:nationalId'] });
+
+      expect(decorator.getSearchedFields('martin', true)).toEqual([
+        { path: 'holder:nationalId', collection: 'holders' },
+      ]);
+    });
+
+    test('it covers every path the search actually reads', async () => {
+      const decorator = buildCollection(
+        {
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            panLast4: factories.columnSchema.text().build(),
+            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            holder: factories.manyToOneSchema.build({
+              foreignCollection: 'holders',
+              foreignKey: 'holderId',
+            }),
+          },
+        },
+        [
+          factories.collection.build({
+            name: 'holders',
+            schema: factories.collectionSchema.build({
+              fields: { nationalId: factories.columnSchema.text().build() },
+            }),
+          }),
+        ],
+      );
+      decorator.replaceSearch({ includeFields: ['holder:nationalId'] });
+
+      const footprint = decorator
+        .getSearchedFields('martin', true)
+        .map(({ path }) => path)
+        .sort();
+
+      const { conditionTree } = await decorator.refineFilter(
+        caller,
+        factories.filter.build({ search: 'martin', searchExtended: true }),
+      );
+      const read = [...new Set(conditionTree.projection)].sort();
+
+      expect(read).toContain('holder:nationalId');
+      expect(footprint).toEqual(expect.arrayContaining(read));
+    });
+
+    // `onlyFields` drops the `field:term` syntax from the searchable set, and the walker then
+    // searches the replaced set with the term reassembled.
+    test('it covers what a dot-syntax term reads once onlyFields replaced the set', async () => {
+      const decorator = buildCollection(
+        {
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            panLast4: factories.columnSchema.text().build(),
+            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            holder: factories.manyToOneSchema.build({
+              foreignCollection: 'holders',
+              foreignKey: 'holderId',
+            }),
+          },
+        },
+        [
+          factories.collection.build({
+            name: 'holders',
+            schema: factories.collectionSchema.build({
+              fields: { nationalId: factories.columnSchema.text().build() },
+            }),
+          }),
+        ],
+      );
+      decorator.replaceSearch({ onlyFields: ['holder:nationalId'] });
+
+      const footprint = decorator.getSearchedFields('panLast4:1850', true).map(({ path }) => path);
+
+      const { conditionTree } = await decorator.refineFilter(
+        caller,
+        factories.filter.build({ search: 'panLast4:1850', searchExtended: true }),
+      );
+      const read = [...new Set(conditionTree.projection)];
+
+      expect(footprint).toEqual(['holder:nationalId']);
+      expect(footprint).toEqual(expect.arrayContaining(read));
+    });
   });
 });

--- a/packages/datasource-customizer/test/decorators/search/collections.test.ts
+++ b/packages/datasource-customizer/test/decorators/search/collections.test.ts
@@ -863,6 +863,31 @@ describe('getSearchedFields', () => {
   });
 
   describe('when a field selection narrows the default search', () => {
+    // Every column searchable by an `IContains` term, so what the condition tree reads can be
+    // compared against what the footprint claims.
+    const buildSearchableCards = () =>
+      buildCollection(
+        {
+          fields: {
+            id: factories.columnSchema.uuidPrimaryKey().build(),
+            panLast4: factories.columnSchema.text().build(),
+            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
+            holder: factories.manyToOneSchema.build({
+              foreignCollection: 'holders',
+              foreignKey: 'holderId',
+            }),
+          },
+        },
+        [
+          factories.collection.build({
+            name: 'holders',
+            schema: factories.collectionSchema.build({
+              fields: { nationalId: factories.columnSchema.text().build() },
+            }),
+          }),
+        ],
+      );
+
     test('it answers the footprint instead of refusing to tell', () => {
       const decorator = buildCards();
       decorator.replaceSearch({ excludeFields: ['panLast4'] });
@@ -902,27 +927,7 @@ describe('getSearchedFields', () => {
     });
 
     test('it covers every path the search actually reads', async () => {
-      const decorator = buildCollection(
-        {
-          fields: {
-            id: factories.columnSchema.uuidPrimaryKey().build(),
-            panLast4: factories.columnSchema.text().build(),
-            holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
-            holder: factories.manyToOneSchema.build({
-              foreignCollection: 'holders',
-              foreignKey: 'holderId',
-            }),
-          },
-        },
-        [
-          factories.collection.build({
-            name: 'holders',
-            schema: factories.collectionSchema.build({
-              fields: { nationalId: factories.columnSchema.text().build() },
-            }),
-          }),
-        ],
-      );
+      const decorator = buildSearchableCards();
       decorator.replaceSearch({ includeFields: ['holder:nationalId'] });
 
       const footprint = decorator
@@ -940,14 +945,52 @@ describe('getSearchedFields', () => {
       expect(footprint).toEqual(expect.arrayContaining(read));
     });
 
-    // `onlyFields` drops the `field:term` syntax from the searchable set, and the walker then
-    // searches the replaced set with the term reassembled.
-    test('it covers what a dot-syntax term reads once onlyFields replaced the set', async () => {
+    test('it covers every path the search actually reads once excludeFields dropped one', async () => {
+      const decorator = buildSearchableCards();
+      decorator.replaceSearch({ excludeFields: ['panLast4'] });
+
+      const footprint = decorator
+        .getSearchedFields('martin', true)
+        .map(({ path }) => path)
+        .sort();
+
+      const { conditionTree } = await decorator.refineFilter(
+        caller,
+        factories.filter.build({ search: 'martin', searchExtended: true }),
+      );
+      const read = [...new Set(conditionTree.projection)].sort();
+
+      expect(read).not.toContain('panLast4');
+      expect(read).toContain('holder:nationalId');
+      expect(footprint).toEqual(expect.arrayContaining(read));
+    });
+
+    test('it excludes a column whose name the selection spells in another case', async () => {
+      const decorator = buildCollection({
+        fields: {
+          id: factories.columnSchema.uuidPrimaryKey().build(),
+          pan_last4: factories.columnSchema.text().build(),
+          label: factories.columnSchema.text().build(),
+        },
+      });
+      decorator.replaceSearch({ excludeFields: ['panLast4'] });
+
+      const { conditionTree } = await decorator.refineFilter(
+        caller,
+        factories.filter.build({ search: 'martin', searchExtended: false }),
+      );
+
+      expect(decorator.getSearchedFields('martin', false).map(({ path }) => path)).not.toContain(
+        'pan_last4',
+      );
+      expect(conditionTree).toEqual(new ConditionTreeLeaf('label', 'IContains', 'martin'));
+    });
+
+    test('it excludes a relation path the selection spells in another case', () => {
       const decorator = buildCollection(
         {
           fields: {
             id: factories.columnSchema.uuidPrimaryKey().build(),
-            panLast4: factories.columnSchema.text().build(),
             holderId: factories.columnSchema.build({ columnType: 'Uuid' }),
             holder: factories.manyToOneSchema.build({
               foreignCollection: 'holders',
@@ -959,11 +1002,22 @@ describe('getSearchedFields', () => {
           factories.collection.build({
             name: 'holders',
             schema: factories.collectionSchema.build({
-              fields: { nationalId: factories.columnSchema.text().build() },
+              fields: { national_id: factories.columnSchema.text().build() },
             }),
           }),
         ],
       );
+      decorator.replaceSearch({ excludeFields: ['holder:nationalId'] });
+
+      expect(decorator.getSearchedFields('martin', true).map(({ path }) => path)).not.toContain(
+        'holder:national_id',
+      );
+    });
+
+    // `onlyFields` drops the `field:term` syntax from the searchable set, and the walker then
+    // searches the replaced set with the term reassembled.
+    test('it covers what a dot-syntax term reads once onlyFields replaced the set', async () => {
+      const decorator = buildSearchableCards();
       decorator.replaceSearch({ onlyFields: ['holder:nationalId'] });
 
       const footprint = decorator.getSearchedFields('panLast4:1850', true).map(({ path }) => path);


### PR DESCRIPTION
## Why

#1840 refuses an extended search whenever `getSearchedFields` cannot state what the search reads, and the search decorator answers `null` for **any** `replaceSearch`:

```ts
override getSearchedFields(search: string, extended: boolean): SearchedField[] | null {
  if (this.replacer) return null;
  ...
```

That refusal is correct for a handler that picks its own fields. It is too broad for the common case — a handler that only *narrows* the default search:

```ts
collection.replaceSearch((value, extended, context) =>
  context.generateSearchFilter(value, { extended, includeFields: ['project:name'] }),
);
```

Here the fields are a declarative list and the footprint is exactly computable, yet the collection loses extended search entirely. Three collections in the Forest SaaS back-end hit this on the 1.97.3 bump (`trial`, `subscription`, `invoice`) — one caught by a test, two silently. `subscription` and `invoice` pass two-level paths (`billing:project:name`) that the plain default search cannot express, so dropping the handler is not a workaround.

The refusal exists because the footprint could not be *stated*, not because it could not be *known*. `generateSearchFilter` already computes it: `searchableFields` is the answer.

## What

`replaceSearch` now takes either form:

| Definition | Footprint | Extended search |
| --- | --- | --- |
| function (unchanged) | unknown | refused |
| **field selection** (new) | exact | **checked per path**, denied ones refused by name |

```ts
// permission-checked, extended search preserved
collection.replaceSearch({ includeFields: ['project:name'], excludeFields: ['description'] });
```

`extended` is deliberately absent from the object type (`Omit<SearchOptions, 'extended'>`): the caller owns that flag, so it is forwarded from the request rather than pinned by the customization. A test pins that forwarding, and `tsc` rejects both `{ extended: true }` and a misspelt key.

## Migrating a handler is not a no-op — it is stricter

Worth stating plainly, because it is the one thing that can surprise: a field selection is **more** restrictive than the handler it replaces, not less.

An included relation path is reported on a plain search too, not only an extended one. So it gets permission-checked where the handler was *exempted* — and that exemption only ever existed because the footprint was unknown. Concretely, `replaceSearch({ includeFields: ['project:name'] })` starts refusing a plain search for a role that cannot read `projects`, where the handler form served it.

That is the correct posture, and it is the same permission sweep #1840 already asks for. But it means converting a handler is a behavioural change to plan, not a mechanical rewrite.

## The part worth reviewing

Both derivations are unified behind `getSearchableFields`, and `generateSearchFilter` / `getSearchedFields` now come from it. They were computed separately — `getSearchedFields` reimplemented a subset via `getSearchedFieldPaths` + `getFields` — which is exactly why the footprint could only be stated for the plain default search, and would have drifted from what the query reads.

That invariant is what makes the permission check trustworthy, so it is pinned rather than assumed, in two tests:

- `it covers every path the search actually reads` — every path in the generated condition tree is in the reported footprint, asserting the traversed path by name so it cannot pass vacuously on a search that never leaves the root collection.
- `it covers what a dot-syntax term reads once onlyFields replaced the set` — the sharp case: `onlyFields` drops the `field:term` syntax from the searchable set, and the walker then searches the replaced set with the term reassembled. A separately-derived footprint would have missed which columns that actually reads.

The invariant is also structural, not just tested: `ConditionTreeQueryWalker` only ever builds leaves from the field list it is handed, which is that same map.

Two incidental effects of the unification, both improvements: the footprint is deduplicated (it is a `Map`, and the specified-field and default-field lists could overlap), and specified fields resolve through the same `lenientGetSchema(this, …)` call the query builder uses instead of a parallel one. One consequence to be aware of: the footprint's *order* changes (defaults first), so when several paths are denied, the error names a different one than before. No test depended on it.

## Not in scope

- **`getSearchedFields` still claims a footprint it cannot guarantee when the child collection searches natively.** `refineFilter` hands that search straight down (`!this.childCollection.schema.searchable`), so the child reads whatever it likes, while `getSearchedFields` reports an enumeration of the child's columns. `agent-ruby` guards this case explicitly (`enumerable_search?` is `@replacer.nil? && !@child_collection.schema[:searchable]`) and node does not. Narrow today — no shipped datasource calls `enableSearch()`, only `packages/_example` — but it is an unverified claim, and closing it would refuse extended search on those collections, which is a separate decision from this PR.
- `getSearchedFieldPaths` is now unused in `src`. It is exported from the package index as of 1.71.x, so it is left in place rather than removed in a patch.
- A handler's footprint is still unknowable. Inferring it would mean either running customer code twice or authorizing after `refineFilter`, both out of proportion here.

## Tests

`packages/datasource-customizer/test/decorators/search/collections.test.ts`: 8 added — the footprint answered rather than refused, `excludeFields` / `includeFields` / `onlyFields` reflected in it, the leaf collection of a relation path named on a plain search as well as an extended one, the extended flag forwarded rather than pinned, and the two footprint-covers-what-is-read invariants.

Verified locally: `datasource-customizer` 875 passed / 63 suites; `packages/agent` security + authorization + utils 508 passed / 25 suites (the #1840 suite included, unchanged); tsc clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let field-selection `replaceSearch` be permission-checked instead of refused
> - Extends `CollectionCustomizer.replaceSearch` to accept a `SearchReplaceDefinition` union: either a handler function or a field-selection object (`includeFields`, `excludeFields`, `onlyFields`).
> - When a field selection is provided, `SearchCollectionDecorator.refineFilter` generates a narrowed search filter via `generateSearchFilter` and forwards the request's `extended` flag, so the search goes through normal permission checks rather than being refused.
> - `getSearchedFields` now returns a concrete footprint for field-selection and default-search modes (instead of `null`); it returns `null` only when a handler function is installed.
> - `getSearchableFields` unifies resolution of searchable fields from default fields, query-specified fields, and the selection's sets; `excludeFields`/`includeFields` are resolved case-insensitively and leniently against actual schema names, ignoring unresolved names.
> - Risk: `getSearchedFields` now returns a concrete footprint in field-selection mode where it previously returned `null` — any consumer relying on `null` to detect a customized search will see different values; `excludeFields` with names not matching any schema field are silently ignored instead of erroring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf0af5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->