### PR TITLE
chore(security): patch 1 Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "**/eslint/js-yaml": "^4.3.1",
     "**/@eslint/eslintrc/js-yaml": "^4.3.1",
     "**/@semrel-extra/topo/js-yaml": "^4.3.1",
+    "**/@hey-api/json-schema-ref-parser/js-yaml": "^4.3.1",
     "**/@oclif/core/js-yaml": "^3.15.1",
     "**/@istanbuljs/load-nyc-config/js-yaml": "^3.15.1",
     "semantic-release": "^25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11332,17 +11332,10 @@ js-tiktoken@^1.0.12:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1, js-yaml@4.3.1, js-yaml@^4.1.0, js-yaml@^4.3.1:
+js-yaml@4.1.1, js-yaml@4.2.0, js-yaml@4.3.1, js-yaml@^4.1.0, js-yaml@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
   integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

1 fixed, 2 ignored, 1 deferred, 1 resolutions added, 0 resolutions removed, 0 could-not-auto-fix | label: :lock: security applied

## Fixed

| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [ ] | [#466](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/466) | js-yaml | npm | 4.2.0 → 4.3.1 | high | Added scoped resolution `**/@hey-api/json-schema-ref-parser/js-yaml: ^4.3.1` (transitive via `@forestadmin/agent-bff → @hey-api/openapi-ts → @hey-api/json-schema-ref-parser@1.4.4`, which pins `js-yaml: 4.2.0` exactly) |

## Ignored

| Dismissed | Alert | Package | Reason |
|---|---|---|---|
| - [ ] | [#474](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/474) | image-size | No upstream patch exists yet (`first_patched_version` is null on the advisory). |
| - [ ] | [#475](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/475) | image-size | No upstream patch exists yet (`first_patched_version` is null on the advisory). |

## Deferred

- [#476](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/476) — js-yaml: created 2026-08-24, less than 7 days old at the time of this run. Note: the resolution added for [#466](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/466) bumps the same vulnerable `js-yaml@4.2.0` up to `4.3.1`, which is outside the vulnerable range for [#476](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/476) (`>= 4.0.0, < 4.3.0`), so it will auto-close on merge.

## Resolutions added

| Alert | Package + pin | Parent chain tried | Why the bump wasn't viable | Form |
|---|---|---|---|---|
| [#466](https://github.com/ForestAdmin/agent-nodejs/security/dependabot/466) | `js-yaml: ^4.3.1` | `@forestadmin/agent-bff → @hey-api/openapi-ts → @hey-api/json-schema-ref-parser@1.4.4` (which pins `js-yaml: "4.2.0"` exactly, i.e. `=4.2.0` not a range) | Bumping `@hey-api/openapi-ts` (a direct dep of `@forestadmin/agent-bff`) would be a large upstream change unrelated to this alert and its own current version still resolves `@hey-api/json-schema-ref-parser@1.4.4` with the exact `4.2.0` pin — the sub-dep pin is exact, so no ancestor bump within the same major closes the alert. Pin `js-yaml` to `^4.3.1` inside this chain only. | scoped |

## Resolutions removed

None. Spot-checked every existing entry in `resolutions` with `yarn why <pkg>` after the install — every pinned package is still present in the resolved tree, so none are stale.

## Could not auto-fix

None.

## Risks

- **js-yaml 4.2.0 → 4.3.1** (scoped to the `@hey-api/json-schema-ref-parser` chain, used at build time by `@forestadmin/agent-bff`'s openapi generation): patch-level bump within the same 4.x major. The advisory (CVE-2026-59870 backport) fixes quadratic CPU consumption on adversarial `!!omap` YAML input; no API changes. Peer deps unchanged. No test updates expected.

## Manual testing

Covered by CI.

## Validation

✅ CI green (Actions + commit statuses; app-based checks not monitored)
