### PR TITLE
fix(agent-bff): reject non-json content types with 415

### DIFF
--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -80,6 +80,9 @@ function agentScoped(middleware: Middleware): Middleware {
 function createBodyParser(hasAiQueryRoute: boolean): Middleware {
   const extendTypes = { json: JSON_BODY_TYPES };
   const parseBody = bodyParser({ jsonLimit: BODY_LIMIT, extendTypes });
+
+  if (!hasAiQueryRoute) return parseBody;
+
   const parseAiBody = bodyParser({
     jsonLimit: AI_BODY_LIMIT,
     enableTypes: ['json'],
@@ -87,7 +90,7 @@ function createBodyParser(hasAiQueryRoute: boolean): Middleware {
   });
 
   return async function selectedBodyParser(ctx, next) {
-    if (hasAiQueryRoute && ctx.path === AI_QUERY_ROUTE) {
+    if (ctx.path === AI_QUERY_ROUTE) {
       await parseAiBody(ctx, next);
 
       return;

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -72,12 +72,12 @@ function agentScoped(middleware: Middleware): Middleware {
   };
 }
 
-function createBodyParser(hasAiQueryRoute: boolean): Middleware {
+function createBodyParser(hasAiQueryRoute: boolean, hasAgentEdge: boolean): Middleware {
   const parseBody = bodyParser({ jsonLimit: BODY_LIMIT });
   const parseAiBody = bodyParser({ jsonLimit: AI_BODY_LIMIT, enableTypes: ['json'] });
 
   return async function selectedBodyParser(ctx, next) {
-    if (isAgentPath(ctx.path)) rejectNonJsonBody(ctx);
+    if (hasAgentEdge && isAgentPath(ctx.path)) rejectNonJsonBody(ctx);
 
     if (hasAiQueryRoute && ctx.path === AI_QUERY_ROUTE) {
       await parseAiBody(ctx, next);
@@ -401,7 +401,7 @@ export default async function runCli(
   const middlewares = [
     createCorsMiddleware({ allowedOrigins: config.allowedOrigins }),
     ...agentErrorMiddleware,
-    createBodyParser(aiMiddlewares.length > 0),
+    createBodyParser(aiMiddlewares.length > 0, agentMiddlewares.length > 0),
     ...oauth.middlewares,
     // Outside the agent-scoped chain on purpose: the viewer is a public page, the document it fetches
     // is not. Gated on the edge being mounted too, like the error middleware above: with no agent

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -55,21 +55,11 @@ function hasBody(ctx: Parameters<Middleware>[0]): boolean {
   return (ctx.request.length ?? 0) > 0 || ctx.get('transfer-encoding') !== '';
 }
 
-function isJsonType(mime: string): boolean {
-  return mime === 'application/json' || (mime.startsWith('application/') && mime.endsWith('+json'));
-}
-
 function createJsonOnlyGuard(): Middleware {
   return async function jsonOnlyGuard(ctx, next) {
-    if (!BODY_METHODS.has(ctx.method)) {
-      await next();
-
-      return;
+    if (BODY_METHODS.has(ctx.method) && hasBody(ctx) && !ctx.is(JSON_BODY_TYPES)) {
+      throw unsupportedMediaType();
     }
-
-    const mime = ctx.request.type.trim().toLowerCase();
-
-    if (mime === '' ? hasBody(ctx) : !isJsonType(mime)) throw unsupportedMediaType();
 
     await next();
   };

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -49,15 +49,30 @@ function isAgentPath(path: string): boolean {
 
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
 
-function rejectNonJsonBody(ctx: Parameters<Middleware>[0]): void {
-  if (!BODY_METHODS.has(ctx.method)) return;
-  if (ctx.request.type === '') return;
+const JSON_BODY_TYPES = ['application/json', 'application/*+json'];
 
-  const mime = ctx.request.type.toLowerCase();
+function hasBody(ctx: Parameters<Middleware>[0]): boolean {
+  return (ctx.request.length ?? 0) > 0 || ctx.get('transfer-encoding') !== '';
+}
 
-  if (mime !== 'application/json' && !(mime.startsWith('application/') && mime.endsWith('+json'))) {
-    throw unsupportedMediaType();
-  }
+function isJsonType(mime: string): boolean {
+  return mime === 'application/json' || (mime.startsWith('application/') && mime.endsWith('+json'));
+}
+
+function createJsonOnlyGuard(): Middleware {
+  return async function jsonOnlyGuard(ctx, next) {
+    if (!BODY_METHODS.has(ctx.method)) {
+      await next();
+
+      return;
+    }
+
+    const mime = ctx.request.type.trim().toLowerCase();
+
+    if (mime === '' ? hasBody(ctx) : !isJsonType(mime)) throw unsupportedMediaType();
+
+    await next();
+  };
 }
 
 function agentScoped(middleware: Middleware): Middleware {
@@ -72,13 +87,16 @@ function agentScoped(middleware: Middleware): Middleware {
   };
 }
 
-function createBodyParser(hasAiQueryRoute: boolean, hasAgentEdge: boolean): Middleware {
-  const parseBody = bodyParser({ jsonLimit: BODY_LIMIT });
-  const parseAiBody = bodyParser({ jsonLimit: AI_BODY_LIMIT, enableTypes: ['json'] });
+function createBodyParser(hasAiQueryRoute: boolean): Middleware {
+  const extendTypes = { json: JSON_BODY_TYPES };
+  const parseBody = bodyParser({ jsonLimit: BODY_LIMIT, extendTypes });
+  const parseAiBody = bodyParser({
+    jsonLimit: AI_BODY_LIMIT,
+    enableTypes: ['json'],
+    extendTypes,
+  });
 
   return async function selectedBodyParser(ctx, next) {
-    if (hasAgentEdge && isAgentPath(ctx.path)) rejectNonJsonBody(ctx);
-
     if (hasAiQueryRoute && ctx.path === AI_QUERY_ROUTE) {
       await parseAiBody(ctx, next);
 
@@ -396,12 +414,14 @@ export default async function runCli(
   const oauth = await buildOAuthMiddlewares(config, logger);
   const aiMiddlewares = buildAiMiddlewares(config, oauth, logger);
   const agentMiddlewares = buildAgentMiddlewares(config, logger, oauth, aiMiddlewares);
-  const agentErrorMiddleware =
-    agentMiddlewares.length > 0 ? [agentScoped(createErrorMiddleware({ logger }))] : [];
+  const hasAgentEdge = agentMiddlewares.length > 0;
+  const agentErrorMiddleware = hasAgentEdge ? [agentScoped(createErrorMiddleware({ logger }))] : [];
+  const agentJsonOnlyGuard = hasAgentEdge ? [agentScoped(createJsonOnlyGuard())] : [];
   const middlewares = [
     createCorsMiddleware({ allowedOrigins: config.allowedOrigins }),
     ...agentErrorMiddleware,
-    createBodyParser(aiMiddlewares.length > 0, agentMiddlewares.length > 0),
+    ...agentJsonOnlyGuard,
+    createBodyParser(aiMiddlewares.length > 0),
     ...oauth.middlewares,
     // Outside the agent-scoped chain on purpose: the viewer is a public page, the document it fetches
     // is not. Gated on the edge being mounted too, like the error middleware above: with no agent

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -25,7 +25,7 @@ import createPerKeyOriginMiddleware from './cors/per-key-origin';
 import createDataRoutesMiddleware from './data/data-routes-middleware';
 import createDocsRoutes from './docs/docs-routes';
 import { extractErrorMessage } from './errors';
-import { unauthorized } from './http/bff-http-error';
+import { unauthorized, unsupportedMediaType } from './http/bff-http-error';
 import BFFHttpServer from './http/bff-http-server';
 import BODY_LIMIT, { AI_BODY_LIMIT } from './http/body-limit';
 import createErrorMiddleware from './http/error-middleware';
@@ -47,6 +47,22 @@ function isAgentPath(path: string): boolean {
   return path === '/agent' || path.startsWith('/agent/');
 }
 
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+
+// @koa/bodyparser skips a content type that matches no enableType without an error, which turns a
+// filtered query into an unfiltered one. Agent routes declare application/json only, so reject any
+// other declared type instead of letting the body be read as absent.
+function rejectNonJsonBody(ctx: Parameters<Middleware>[0]): void {
+  if (!BODY_METHODS.has(ctx.method)) return;
+  if (ctx.request.type === '') return;
+
+  const mime = ctx.request.type.toLowerCase();
+
+  if (mime !== 'application/json' && !(mime.startsWith('application/') && mime.endsWith('+json'))) {
+    throw unsupportedMediaType();
+  }
+}
+
 function agentScoped(middleware: Middleware): Middleware {
   return async function scoped(ctx, next) {
     if (!isAgentPath(ctx.path)) {
@@ -61,13 +77,13 @@ function agentScoped(middleware: Middleware): Middleware {
 
 function createBodyParser(hasAiQueryRoute: boolean): Middleware {
   const parseBody = bodyParser({ jsonLimit: BODY_LIMIT });
-
-  if (!hasAiQueryRoute) return parseBody;
-
   const parseAiBody = bodyParser({ jsonLimit: AI_BODY_LIMIT, enableTypes: ['json'] });
 
   return async function selectedBodyParser(ctx, next) {
-    if (ctx.path === AI_QUERY_ROUTE) {
+    // The error middleware that renders the 415 is agent-scoped, so the guard must be too.
+    if (isAgentPath(ctx.path)) rejectNonJsonBody(ctx);
+
+    if (hasAiQueryRoute && ctx.path === AI_QUERY_ROUTE) {
       await parseAiBody(ctx, next);
 
       return;

--- a/packages/agent-bff/src/cli-core.ts
+++ b/packages/agent-bff/src/cli-core.ts
@@ -49,9 +49,6 @@ function isAgentPath(path: string): boolean {
 
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
 
-// @koa/bodyparser skips a content type that matches no enableType without an error, which turns a
-// filtered query into an unfiltered one. Agent routes declare application/json only, so reject any
-// other declared type instead of letting the body be read as absent.
 function rejectNonJsonBody(ctx: Parameters<Middleware>[0]): void {
   if (!BODY_METHODS.has(ctx.method)) return;
   if (ctx.request.type === '') return;
@@ -80,7 +77,6 @@ function createBodyParser(hasAiQueryRoute: boolean): Middleware {
   const parseAiBody = bodyParser({ jsonLimit: AI_BODY_LIMIT, enableTypes: ['json'] });
 
   return async function selectedBodyParser(ctx, next) {
-    // The error middleware that renders the 415 is agent-scoped, so the guard must be too.
     if (isAgentPath(ctx.path)) rejectNonJsonBody(ctx);
 
     if (hasAiQueryRoute && ctx.path === AI_QUERY_ROUTE) {

--- a/packages/agent-bff/src/http/bff-http-error.ts
+++ b/packages/agent-bff/src/http/bff-http-error.ts
@@ -95,3 +95,9 @@ export function relationFieldNotSupported(fields: string[]): BffHttpError {
     { details: { fields } },
   );
 }
+
+export function unsupportedMediaType(
+  message = 'Only application/json request bodies are supported on agent routes',
+): BffHttpError {
+  return new BffHttpError(415, 'unsupported_media_type', message);
+}

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -35,7 +35,7 @@ const ERROR_STATUSES: Record<string, string> = {
   403: 'The action needs approval before it runs (the body carries the approving roles), the Forest identity behind the API key is not allowed, the origin is not allowed for this key, or the agent refused the collection, relation, or action',
   404: 'Unknown collection, relation, or action',
   413: `The request body exceeds the BFF limit of ${BODY_LIMIT}`,
-  415: 'The request declares a character set the server cannot decode. Other content types are NOT rejected: a form-urlencoded body is parsed and validated like JSON (its values arrive as strings, so typed fields such as page.limit fail with 400), while any other non-JSON content type is read as an absent body, silently dropping filters and pagination',
+  415: 'The request Content-Type is neither application/json nor an application/*+json type, including form-urlencoded, and is rejected with 415 instead of being silently dropped; or the declared character set cannot be decoded',
   422: 'A field is unknown, not filterable, or is a nested relation path',
   429: 'The agent rate-limited the request',
   500: 'The agent payload could not be mapped to the BFF contract, or the BFF hit an unexpected error',
@@ -165,7 +165,7 @@ const AI_DUAL_SHAPED_ERRORS: Record<string, string> = {
   401: `The BFF session is missing, invalid or expired, or the Forest server refused the access token this route forwards. ${AI_RELAYED_OR_ENVELOPE}`,
   403: `The request presented an API key instead of a session (type oauth_required), or the Forest server refused the query. ${AI_RELAYED_OR_ENVELOPE}`,
   413: `The request body exceeds the AI query limit of ${AI_BODY_LIMIT}, or the Forest AI proxy refused it as too large. ${AI_RELAYED_OR_ENVELOPE}`,
-  415: `The request declares a character set the BFF cannot decode. ${AI_RELAYED_OR_ENVELOPE}`,
+  415: `The request Content-Type is not application/json, or declares a character set the BFF cannot decode. ${AI_RELAYED_OR_ENVELOPE}`,
   429: `The Forest AI proxy rate-limited the query. ${AI_RELAYED_OR_ENVELOPE}`,
 };
 
@@ -316,10 +316,9 @@ const TIMEZONE_HEADER = z
 const SHARED_DESCRIPTION =
   'The timezone is resolved from the `X-Forest-Timezone` header first, then a `timezone` body ' +
   'field, then the BFF default when one is configured. A deployment without a default rejects a ' +
-  'request carrying neither with 400 missing_timezone, so send one of the two to be safe. Sending ' +
-  'a content type other than application/json is not an error: a form-urlencoded body is parsed ' +
-  'like JSON, while any other content type is read as absent, which silently drops any filter, ' +
-  'sort, or page.';
+  'request carrying neither with 400 missing_timezone, so send one of the two to be safe. Agent ' +
+  'routes read application/json (and application/*+json) bodies only: any other Content-Type, ' +
+  'form-urlencoded included, is rejected with 415 instead of being read as an absent body.';
 
 const GENERIC_DESCRIPTION =
   'Paths are generic: one per operation, with the collection, relation and action passed as path ' +

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -35,7 +35,7 @@ const ERROR_STATUSES: Record<string, string> = {
   403: 'The action needs approval before it runs (the body carries the approving roles), the Forest identity behind the API key is not allowed, the origin is not allowed for this key, or the agent refused the collection, relation, or action',
   404: 'Unknown collection, relation, or action',
   413: `The request body exceeds the BFF limit of ${BODY_LIMIT}`,
-  415: 'The request Content-Type is neither application/json nor an application/*+json type, including form-urlencoded, and is rejected with 415 instead of being silently dropped; or the declared character set cannot be decoded',
+  415: 'The request Content-Type is neither application/json nor an application/*+json type, including form-urlencoded, and is rejected with 415 instead of being silently dropped; a request carrying a body with no Content-Type at all is rejected the same way; or the declared character set cannot be decoded',
   422: 'A field is unknown, not filterable, or is a nested relation path',
   429: 'The agent rate-limited the request',
   500: 'The agent payload could not be mapped to the BFF contract, or the BFF hit an unexpected error',
@@ -165,7 +165,7 @@ const AI_DUAL_SHAPED_ERRORS: Record<string, string> = {
   401: `The BFF session is missing, invalid or expired, or the Forest server refused the access token this route forwards. ${AI_RELAYED_OR_ENVELOPE}`,
   403: `The request presented an API key instead of a session (type oauth_required), or the Forest server refused the query. ${AI_RELAYED_OR_ENVELOPE}`,
   413: `The request body exceeds the AI query limit of ${AI_BODY_LIMIT}, or the Forest AI proxy refused it as too large. ${AI_RELAYED_OR_ENVELOPE}`,
-  415: `The request Content-Type is not application/json, or declares a character set the BFF cannot decode. ${AI_RELAYED_OR_ENVELOPE}`,
+  415: `The request Content-Type is neither application/json nor an application/*+json type, or the request carries a body with no Content-Type at all, or it declares a character set the BFF cannot decode. ${AI_RELAYED_OR_ENVELOPE}`,
   429: `The Forest AI proxy rate-limited the query. ${AI_RELAYED_OR_ENVELOPE}`,
 };
 
@@ -318,7 +318,8 @@ const SHARED_DESCRIPTION =
   'field, then the BFF default when one is configured. A deployment without a default rejects a ' +
   'request carrying neither with 400 missing_timezone, so send one of the two to be safe. Agent ' +
   'routes read application/json (and application/*+json) bodies only: any other Content-Type, ' +
-  'form-urlencoded included, is rejected with 415 instead of being read as an absent body.';
+  'form-urlencoded included, is rejected with 415 instead of being read as an absent body, and ' +
+  'so is a body sent with no Content-Type at all. A bodyless POST needs no Content-Type.';
 
 const GENERIC_DESCRIPTION =
   'Paths are generic: one per operation, with the collection, relation and action passed as path ' +

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -353,10 +353,10 @@ function registerAiQueryPath(
       'because only the OAuth flow yields the Forest access token this route forwards. The ' +
       'environment and rendering are derived server-side, so sending forest-* headers has no ' +
       `effect. The body limit is ${AI_BODY_LIMIT} here rather than the ${BODY_LIMIT} of every ` +
-      'other route, and only application/json is parsed: any other content type arrives as an ' +
-      'empty body, is relayed as {} and the Forest server rejects the query. This path is ' +
-      'published only by a ' +
-      'deployment whose OAuth configuration is complete, since the relay needs a session.',
+      'other route, and only application/json and application/*+json are read: any other ' +
+      'content type, and a body sent with none at all, is rejected with 415 before the relay. ' +
+      'This path is published only by a deployment whose OAuth configuration is complete, ' +
+      'since the relay needs a session.',
     security: [{ [SESSION_SCHEME]: [] }],
     request: {
       body: { required: true, content: { 'application/json': { schema: AiQueryRequestSchema } } },

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -185,7 +185,115 @@ describe('runCli', () => {
       }
     });
 
-    it('should leave a form body unparsed rather than let the generic parser cap it at its form limit', async () => {
+    it('should return 415 unsupported_media_type when a data route body arrives as text/plain', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .set('Content-Type', 'text/plain')
+          .send(JSON.stringify({ page: { limit: 5 } }));
+
+        expect(response.status).toBe(415);
+        expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should reject a form body on a data route with 415, not parse it as JSON', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .type('form')
+          .send('page.limit=5');
+
+        expect(response.status).toBe(415);
+        expect(response.body.error.type).toBe('unsupported_media_type');
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should return 415 on the ai route for a non-JSON content type, before auth', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/ai/query')
+          .set('Authorization', `Bearer ${sessionToken()}`)
+          .set('Content-Type', 'text/plain')
+          .send(JSON.stringify({ messages: [] }));
+
+        expect(response.status).toBe(415);
+        expect(response.body.error.type).toBe('unsupported_media_type');
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should still parse an application/*+json body on a data route', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .set('Content-Type', 'application/vnd.api+json')
+          .send(JSON.stringify({ page: { limit: 5 } }));
+
+        expect(response.status).not.toBe(415);
+        expect(response.status).toBe(401);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should still parse a JSON body carrying a charset parameter', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .set('Content-Type', 'application/json; charset=utf-8')
+          .send(JSON.stringify({ page: { limit: 5 } }));
+
+        expect(response.status).not.toBe(415);
+        expect(response.status).toBe(401);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should not reject a bodyless POST that carries no Content-Type', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback).post('/agent/v1/books/list');
+
+        expect(response.status).not.toBe(415);
+        expect(response.status).toBe(401);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should never guard a GET request, whatever its Content-Type', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .get('/agent/v1/permissions')
+          .set('Content-Type', 'text/plain');
+
+        expect(response.status).not.toBe(415);
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it('should reject a form body on the ai route with 415 before auth, not parse or cap it', async () => {
       const server = await runCli(OAUTH_ENV, noopLogger);
 
       try {
@@ -196,7 +304,8 @@ describe('runCli', () => {
           .send(`messages=${'x'.repeat(100_000)}`);
 
         expect(response.status).not.toBe(413);
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(415);
+        expect(response.body.error.type).toBe('unsupported_media_type');
       } finally {
         await server.stop();
       }

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -234,31 +234,40 @@ describe('runCli', () => {
       }
     });
 
-    it('should still parse an application/*+json body on a data route', async () => {
+    it.each([
+      ['application/vnd.api+json', 'a +json type the parser knows'],
+      ['application/ld+json', 'a +json type only the wildcard covers'],
+      ['application/json; charset=utf-8', 'a charset parameter'],
+      ['application/json ; charset=utf-8', 'a space before the parameter separator'],
+    ])(
+      'should parse a data-route body declared as %s (%s), proven by the size limit firing',
+      async contentType => {
+        const server = await runCli(OAUTH_ENV, noopLogger);
+
+        try {
+          const response = await request(server.callback)
+            .post('/agent/v1/books/list')
+            .set('Content-Type', contentType)
+            .send(JSON.stringify({ filler: 'x'.repeat(20_000) }));
+
+          expect(response.status).toBe(413);
+        } finally {
+          await server.stop();
+        }
+      },
+    );
+
+    it('should reject a body sent with no Content-Type at all, the last silent-drop path', async () => {
       const server = await runCli(OAUTH_ENV, noopLogger);
 
       try {
         const response = await request(server.callback)
           .post('/agent/v1/books/list')
-          .set('Content-Type', 'application/vnd.api+json')
+          .set('Content-Type', '')
           .send(JSON.stringify({ page: { limit: 5 } }));
 
-        expect(response.status).toBe(401);
-      } finally {
-        await server.stop();
-      }
-    });
-
-    it('should still parse a JSON body carrying a charset parameter', async () => {
-      const server = await runCli(OAUTH_ENV, noopLogger);
-
-      try {
-        const response = await request(server.callback)
-          .post('/agent/v1/books/list')
-          .set('Content-Type', 'application/json; charset=utf-8')
-          .send(JSON.stringify({ page: { limit: 5 } }));
-
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(415);
+        expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });
       } finally {
         await server.stop();
       }

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -211,7 +211,7 @@ describe('runCli', () => {
           .send('page.limit=5');
 
         expect(response.status).toBe(415);
-        expect(response.body.error.type).toBe('unsupported_media_type');
+        expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });
       } finally {
         await server.stop();
       }
@@ -228,7 +228,7 @@ describe('runCli', () => {
           .send(JSON.stringify({ messages: [] }));
 
         expect(response.status).toBe(415);
-        expect(response.body.error.type).toBe('unsupported_media_type');
+        expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });
       } finally {
         await server.stop();
       }
@@ -243,7 +243,6 @@ describe('runCli', () => {
           .set('Content-Type', 'application/vnd.api+json')
           .send(JSON.stringify({ page: { limit: 5 } }));
 
-        expect(response.status).not.toBe(415);
         expect(response.status).toBe(401);
       } finally {
         await server.stop();
@@ -259,7 +258,6 @@ describe('runCli', () => {
           .set('Content-Type', 'application/json; charset=utf-8')
           .send(JSON.stringify({ page: { limit: 5 } }));
 
-        expect(response.status).not.toBe(415);
         expect(response.status).toBe(401);
       } finally {
         await server.stop();
@@ -272,7 +270,6 @@ describe('runCli', () => {
       try {
         const response = await request(server.callback).post('/agent/v1/books/list');
 
-        expect(response.status).not.toBe(415);
         expect(response.status).toBe(401);
       } finally {
         await server.stop();
@@ -305,7 +302,7 @@ describe('runCli', () => {
 
         expect(response.status).not.toBe(413);
         expect(response.status).toBe(415);
-        expect(response.body.error.type).toBe('unsupported_media_type');
+        expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });
       } finally {
         await server.stop();
       }

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -301,8 +301,8 @@ describe('runCli', () => {
       try {
         const response = await request(server.callback)
           .post('/agent/v1/books/list')
-          .set('Content-Type', '')
-          .send(JSON.stringify({ page: { limit: 5 } }));
+          .send(JSON.stringify({ page: { limit: 5 } }))
+          .unset('Content-Type');
 
         expect(response.status).toBe(415);
         expect(response.body.error).toMatchObject({ type: 'unsupported_media_type', status: 415 });

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -403,6 +403,21 @@ describe('runCli', () => {
         await server.stop();
       }
     });
+
+    it('should answer 404 on a non-json agent body instead of an unrendered 415', async () => {
+      const server = await runCli({ ...VALID_ENV, FOREST_AUTH_SECRET: undefined }, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .set('Content-Type', 'text/plain')
+          .send(JSON.stringify({ page: { limit: 5 } }));
+
+        expect(response.status).toBe(404);
+      } finally {
+        await server.stop();
+      }
+    });
   });
 
   describe('when BFF_ALLOWED_ORIGINS has malformed entries', () => {

--- a/packages/agent-bff/test/cli-core.test.ts
+++ b/packages/agent-bff/test/cli-core.test.ts
@@ -257,6 +257,44 @@ describe('runCli', () => {
       },
     );
 
+    it.each([
+      ['application/json; charset', 'a parameter with no value'],
+      ['application/json;;', 'a dangling separator'],
+      ['text/plain', 'a type the parser would skip'],
+    ])(
+      'should reject a data-route body declared as %s (%s) instead of dropping it',
+      async contentType => {
+        const server = await runCli(OAUTH_ENV, noopLogger);
+
+        try {
+          const response = await request(server.callback)
+            .post('/agent/v1/books/list')
+            .set('Content-Type', contentType)
+            .send(JSON.stringify({ page: { limit: 5 } }));
+
+          expect(response.status).toBe(415);
+        } finally {
+          await server.stop();
+        }
+      },
+    );
+
+    it('should let a bodyless POST through whatever Content-Type it declares', async () => {
+      const server = await runCli(OAUTH_ENV, noopLogger);
+
+      try {
+        const response = await request(server.callback)
+          .post('/agent/v1/books/list')
+          .set('Content-Type', 'text/plain')
+          .set('Content-Length', '0')
+          .send();
+
+        expect(response.status).not.toBe(415);
+      } finally {
+        await server.stop();
+      }
+    });
+
     it('should reject a body sent with no Content-Type at all, the last silent-drop path', async () => {
       const server = await runCli(OAUTH_ENV, noopLogger);
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -393,13 +393,13 @@ describe('generateOpenApiDocument', () => {
     expect(list['422'].description).not.toContain('operator');
   });
 
-  it('should distinguish a form body, which is parsed, from other non-JSON bodies, which drop', () => {
+  it('should reject every non-JSON body with 415, form-urlencoded included', () => {
     const list = listResponses();
 
-    expect(list['415'].description).toContain('NOT rejected');
     expect(list['415'].description).toContain('form-urlencoded');
-    expect(document.info.description).toContain('form-urlencoded');
-    expect(document.info.description).toContain('silently');
+    expect(list['415'].description).toContain('415');
+    expect(document.info.description).toContain('415');
+    expect(document.info.description).not.toContain('silently');
   });
 
   it('should name the 403s the BFF itself emits, not only the agent passthrough', () => {

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -461,6 +461,17 @@ describe('generateOpenApiDocument', () => {
   });
 });
 
+describe('the documented ai query path', () => {
+  it('should say a non-json body is rejected here, matching the 415 the guard raises', () => {
+    const { description } = document.paths[`${ROUTE_PREFIX}/ai/query`].post as {
+      description: string;
+    };
+
+    expect(description).toContain('rejected with 415 before the relay');
+    expect(description).not.toContain('relayed as {}');
+  });
+});
+
 describe('the documented search inputs', () => {
   function propertiesOf(name: string): Record<string, { $ref?: string }> {
     return (schemas[name] as { properties: Record<string, { $ref?: string }> }).properties;


### PR DESCRIPTION
## What

Agent routes (POST/PUT/PATCH under `/agent`) answer `415 unsupported_media_type` when the body cannot be read as JSON:

- a non-JSON `Content-Type`, form-urlencoded included;
- **no** `Content-Type` at all on a request that carries a body.

`application/json` and `application/*+json` parse. A bodyless POST needs no `Content-Type`.

fixes PRD-1099

## Why

`@koa/bodyparser` skips a content type that matches no enabled type, without an error. The body became `{}`, so `/User/list` ran unfiltered and answered **200** — a wrong result set with a success status. `fetch(url, { method: 'POST', body: JSON.stringify(...) })` sends `text/plain;charset=UTF-8` when you forget the header, so this was one missing line away in any browser client.

The document declared 415 on 91 operations. It was unreachable.

## How

One guard, `agentScoped(createJsonOnlyGuard())`, mounted before the parser and gated on the agent chain being up — the same shape as the agent error middleware. It throws before any parsing, so the 415 fires before auth, next to the existing 413.

The guard asks the same question the parser asks — `ctx.is(JSON_BODY_TYPES)`, which is koa's wrapper over the `type-is` the parser itself calls — instead of matching the header by hand. Hand-matching left a hole: koa's `request.type` is a bare `header.split(';')[0]`, while the parser goes through `content-type.parse`, which **throws** on a parameter with no value. So `application/json; charset` and `application/json;;` looked like `application/json` to a hand-rolled guard, were skipped by the parser, and became `{}` — the original bug, on a header a client can produce by accident.

Both sides read the same constant:

```ts
const JSON_BODY_TYPES = ['application/json', 'application/*+json'];
```

That matters. `@koa/bodyparser` only knows six fixed JSON types, so a guard promising `application/*+json` would have let `application/ld+json` through to the silent drop this PR is closing. Passing the list explicitly is also deliberate: `extendTypes` is merged with lodash `merge`, which merges arrays **index by index**, so `{ json: ['application/*+json'] }` alone would overwrite `application/json` at index 0 — and `type-is` does not match a bare `application/json` against the wildcard. Every ordinary JSON body would have drawn a 415.

Going through `type-is` also handles the parameter forms for free: `application/json; charset=utf-8` and the legal-but-odd `application/json ; charset=utf-8` both parse, where a `split(';')[0]` comparison rejected the second on a trailing space.

## Breaking

- Form-urlencoded on agent routes used to parse as JSON with string values. It now gets 415. The document only ever declared `application/json`.
- A request carrying a body with no `Content-Type` used to have that body dropped. It now gets 415, which is what RFC 9110 allows a recipient to do with a payload it cannot identify.

A **bodyless** POST is never rejected, whatever it declares: with nothing to parse there is nothing to drop. The guard checks `Content-Length > 0` or a `Transfer-Encoding` header before it looks at the type.

`/oauth/token` keeps its form and JSON bodies — it is outside the agent scope.

## How to test

- `yarn workspace @forestadmin/agent-bff test`
- POST `/agent/v1/<collection>/list` with `Content-Type: text/plain` and a filter body: 415. Same body as `application/json`: filtered rows.

The parse-side tests send an oversized body and expect **413** rather than 401: the size limit only fires once the parser has read the body, so it is the cheapest proof that the content type reached a parser instead of being dropped.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
