### PR TITLE
fix(agent-bff): type the action form and execute 200 responses

### DIFF
--- a/packages/agent-bff/src/action/action-execute-mapper.ts
+++ b/packages/agent-bff/src/action/action-execute-mapper.ts
@@ -11,15 +11,15 @@ export interface ActionExecuteSuccessBody {
 
 export interface ActionExecuteWebhookBody {
   type: 'webhook';
-  url: unknown;
-  method: unknown;
+  url: string;
+  method: string;
   headers: unknown;
   body: unknown;
 }
 
 export interface ActionExecuteRedirectBody {
   type: 'redirect';
-  path: unknown;
+  path: string;
 }
 
 export interface ActionExecuteUnsupportedBody {

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -271,7 +271,7 @@ const ROUTES: RouteDefinition[] = [
     request: ActionRequestSchema,
     response: ActionFormResponseSchema,
     responseDescription:
-      'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying'
+      'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying',
     params: ['collection', 'action'],
     bodyRequired: true,
   },
@@ -282,7 +282,7 @@ const ROUTES: RouteDefinition[] = [
     request: ActionRequestSchema,
     response: ActionResultSchema,
     responseDescription:
-      'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying'
+      'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying',
     params: ['collection', 'action'],
     bodyRequired: true,
     executeResults: true,

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -5,7 +5,9 @@ import { OpenAPIRegistry, OpenApiGeneratorV31 } from '@asteasolutions/zod-to-ope
 
 import ComponentPool from './component-pool';
 import {
+  ActionFormResponseSchema,
   ActionRequestSchema,
+  ActionResultSchema,
   AiQueryRequestSchema,
   ContextResponseSchema,
   CountRequestSchema,
@@ -267,9 +269,9 @@ const ROUTES: RouteDefinition[] = [
     operationId: 'getActionForm',
     summary: 'Load the form of a custom action',
     request: ActionRequestSchema,
-    response: z.unknown(),
+    response: ActionFormResponseSchema,
     responseDescription:
-      'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying',
+      'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying'
     params: ['collection', 'action'],
     bodyRequired: true,
   },
@@ -278,9 +280,9 @@ const ROUTES: RouteDefinition[] = [
     operationId: 'executeAction',
     summary: 'Execute a custom action',
     request: ActionRequestSchema,
-    response: z.unknown(),
+    response: ActionResultSchema,
     responseDescription:
-      'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying',
+      'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying'
     params: ['collection', 'action'],
     bodyRequired: true,
     executeResults: true,

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -145,6 +145,95 @@ export const ActionRequestSchema = z
       'targets no record. Every id is coerced to a string before reaching the agent.',
   });
 
+const ActionFormResponseFieldSchema = z
+  .object({
+    name: z.string(),
+    // Verbatim from the agent, so a list field carries `['String']` rather than `'StringList'`.
+    type: z.union([z.string(), z.array(z.string())]),
+    value: z.unknown().optional(),
+    isRequired: z.boolean(),
+    enumValues: z.union([z.array(z.string()), z.null()]).optional(),
+  })
+  .openapi('ActionFormResponseField', {
+    description:
+      'A form field with its current value. `value` is the resolved value at load time and is ' +
+      'absent when the field carries none; `enumValues` is present only on an Enum field, and ' +
+      'null when the agent declares no options.',
+  });
+
+export const ActionFormResponseSchema = z
+  .object({
+    fields: z.array(ActionFormResponseFieldSchema),
+    canExecute: z.boolean(),
+    requiredFields: z.array(z.string()),
+    skippedFields: z.array(z.string()),
+    layout: z.array(z.unknown()),
+  })
+  .openapi('ActionFormResponse', {
+    description:
+      'The loaded form. `canExecute` is true only when every required field already carries a ' +
+      'value: an explicit empty string or 0 counts as present, only a missing one does not. ' +
+      '`requiredFields` names the required fields still missing a value. `skippedFields` names ' +
+      'the submitted fields the static form does not carry; the same names are rejected with 400 ' +
+      'on execute. `layout` is the agent layout tree relayed verbatim (pages, rows, separators, ' +
+      'HTML blocks and field references, discriminated by `component`); it is the agent own ' +
+      'contract, so it is left untyped here.',
+  });
+
+export const ActionResultSuccessSchema = z
+  .object({
+    type: z.literal('success'),
+    message: z.union([z.string(), z.null()]),
+    invalidated: z.array(z.string()),
+    html: z
+      .union([z.string(), z.null()])
+      .describe(
+        'Untrusted HTML relayed verbatim from the agent result: sanitize it before rendering ' +
+          '(stored/reflected XSS risk). Null when the result carries none.',
+      ),
+  })
+  .openapi('ActionResultSuccess', {
+    description:
+      'The action ran. `invalidated` lists the collections whose records changed and should be ' +
+      're-fetched; `message` is the agent wording, null when the result carries none.',
+  });
+
+export const ActionResultWebhookSchema = z
+  .object({
+    type: z.literal('webhook'),
+    url: z.string(),
+    method: z.string(),
+    headers: z.unknown().optional(),
+    body: z.unknown().optional(),
+  })
+  .openapi('ActionResultWebhook', {
+    description:
+      'The action asks the caller to fire an HTTP request. `headers` and `body` are relayed ' +
+      'from the agent payload and are absent when it carried none.',
+  });
+
+export const ActionResultRedirectSchema = z
+  .object({
+    type: z.literal('redirect'),
+    path: z.string(),
+  })
+  .openapi('ActionResultRedirect', {
+    description: 'The action asks the caller to navigate to `path`, relayed verbatim.',
+  });
+
+export const ActionResultSchema = z
+  .discriminatedUnion('type', [
+    ActionResultSuccessSchema,
+    ActionResultWebhookSchema,
+    ActionResultRedirectSchema,
+  ])
+  .openapi('ActionResult', {
+    description:
+      'The normalized execute result, discriminated by `type`. These three are the only 200 ' +
+      'bodies: a result the BFF cannot normalize answers 501 instead (see the execute 501 ' +
+      'response), and a form the agent rejects answers 400 action_error.',
+  });
+
 const ForestRecordMetaSchema = z
   .object({
     collection: z.string(),

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -148,9 +148,6 @@ export const ActionRequestSchema = z
 const ActionFormResponseFieldSchema = z
   .object({
     name: z.string(),
-    // Verbatim from the agent, so a list field carries exactly `['String']` rather than
-    // `'StringList'`: an array of exactly one string. Length is pinned (zod-to-openapi maps
-    // min/max but not `.length`) because `prefixItems` alone would still admit extra elements.
     type: z.union([z.string(), z.array(z.string()).min(1).max(1)]),
     value: z.unknown().optional(),
     isRequired: z.boolean(),
@@ -183,7 +180,7 @@ export const ActionFormResponseSchema = z
       'contract, so it is left untyped here.',
   });
 
-export const ActionResultSuccessSchema = z
+const ActionResultSuccessSchema = z
   .object({
     type: z.literal('success'),
     message: z.union([z.string(), z.null()]),
@@ -201,7 +198,7 @@ export const ActionResultSuccessSchema = z
       're-fetched; `message` is the agent wording, null when the result carries none.',
   });
 
-export const ActionResultWebhookSchema = z
+const ActionResultWebhookSchema = z
   .object({
     type: z.literal('webhook'),
     url: z.string(),
@@ -215,7 +212,7 @@ export const ActionResultWebhookSchema = z
       'from the agent payload: absent when it omitted them, an explicit null relayed as null.',
   });
 
-export const ActionResultRedirectSchema = z
+const ActionResultRedirectSchema = z
   .object({
     type: z.literal('redirect'),
     path: z.string(),

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -149,8 +149,9 @@ const ActionFormResponseFieldSchema = z
   .object({
     name: z.string(),
     // Verbatim from the agent, so a list field carries exactly `['String']` rather than
-    // `'StringList'`: a one-element tuple, never a free-form array.
-    type: z.union([z.string(), z.tuple([z.string()])]),
+    // `'StringList'`: an array of exactly one string. Length is pinned (zod-to-openapi maps
+    // min/max but not `.length`) because `prefixItems` alone would still admit extra elements.
+    type: z.union([z.string(), z.array(z.string()).min(1).max(1)]),
     value: z.unknown().optional(),
     isRequired: z.boolean(),
     enumValues: z.union([z.array(z.string()), z.null()]).optional(),

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -145,7 +145,7 @@ export const ActionRequestSchema = z
       'targets no record. Every id is coerced to a string before reaching the agent.',
   });
 
-const UNTRUSTED_HTML_NOTE = 'sanitize it before rendering (stored/reflected XSS risk).';
+const UNTRUSTED_HTML_NOTE = 'sanitize it before rendering (stored/reflected XSS risk)';
 
 const ActionFormResponseFieldSchema = z
   .object({
@@ -191,7 +191,7 @@ const ActionResultSuccessSchema = z
     html: z
       .union([z.string(), z.null()])
       .describe(
-        `Untrusted HTML relayed verbatim from the agent result: ${UNTRUSTED_HTML_NOTE} Null ` +
+        `Untrusted HTML relayed verbatim from the agent result: ${UNTRUSTED_HTML_NOTE}. Null ` +
           'when the result carries none.',
       ),
   })
@@ -200,7 +200,9 @@ const ActionResultSuccessSchema = z
       'The action ran. `invalidated` names the relations of the acted-on collection whose ' +
       'Related Data should be re-fetched — the agent fills it from ' +
       '`resultBuilder.success(message, { invalidated })` and the BFF relays it from the agent ' +
-      '`refresh.relationships`. `message` is the agent wording, null when the result carries none.',
+      '`refresh.relationships`. `message` is the agent wording: an agent-nodejs success with ' +
+      'no message serializes the empty string, so null means the agent omitted `success` ' +
+      'entirely.',
   });
 
 const ActionResultWebhookSchema = z
@@ -408,11 +410,11 @@ export const ErrorResponseSchema = z
       'The error envelope. `details` is left untyped because its shape depends on `type`: ' +
       '`{ field }` on unknown_field and field_not_filterable, `{ field, validOperators }` on ' +
       'invalid_filter_operator, `{ maxDepth }` on filter_too_deep, `{ fields }` on ' +
-      'relation_field_not_supported, `{ roleIdsAllowedToApprove }` on ' +
-      'action_requires_approval, and `{ html }` on action_error. An error forwarded from the ' +
-      'agent carries the agent own payload instead, and any other type carries no `details` at ' +
-      `all. The action_error html is untrusted agent output relayed verbatim: ${UNTRUSTED_HTML_NOTE} ` +
-      'exactly like the execute success html.',
+      'relation_field_not_supported, and, when the agent supplies them, ' +
+      '`{ roleIdsAllowedToApprove }` on action_requires_approval and `{ html }` on action_error. ' +
+      'An error forwarded from the agent carries the agent own payload instead, and any other ' +
+      'type carries no `details` at all. The action_error html is untrusted agent output relayed ' +
+      `verbatim: ${UNTRUSTED_HTML_NOTE}, exactly like the execute success html.`,
   });
 
 export const MessagelessErrorResponseSchema = z

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -148,17 +148,19 @@ export const ActionRequestSchema = z
 const ActionFormResponseFieldSchema = z
   .object({
     name: z.string(),
-    // Verbatim from the agent, so a list field carries `['String']` rather than `'StringList'`.
-    type: z.union([z.string(), z.array(z.string())]),
+    // Verbatim from the agent, so a list field carries exactly `['String']` rather than
+    // `'StringList'`: a one-element tuple, never a free-form array.
+    type: z.union([z.string(), z.tuple([z.string()])]),
     value: z.unknown().optional(),
     isRequired: z.boolean(),
     enumValues: z.union([z.array(z.string()), z.null()]).optional(),
   })
   .openapi('ActionFormResponseField', {
     description:
-      'A form field with its current value. `value` is the resolved value at load time and is ' +
-      'absent when the field carries none; `enumValues` is present only on an Enum field, and ' +
-      'null when the agent declares no options.',
+      'A form field with its current value. `value` is the resolved value at load time: absent ' +
+      'when the field carries none (the resolved value was undefined), an explicit null is ' +
+      'serialized as null. `enumValues` is present only on an Enum field, and null when the ' +
+      'agent declares no options.',
   });
 
 export const ActionFormResponseSchema = z
@@ -209,7 +211,7 @@ export const ActionResultWebhookSchema = z
   .openapi('ActionResultWebhook', {
     description:
       'The action asks the caller to fire an HTTP request. `headers` and `body` are relayed ' +
-      'from the agent payload and are absent when it carried none.',
+      'from the agent payload: absent when it omitted them, an explicit null relayed as null.',
   });
 
 export const ActionResultRedirectSchema = z

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -145,6 +145,8 @@ export const ActionRequestSchema = z
       'targets no record. Every id is coerced to a string before reaching the agent.',
   });
 
+const UNTRUSTED_HTML_NOTE = 'sanitize it before rendering (stored/reflected XSS risk).';
+
 const ActionFormResponseFieldSchema = z
   .object({
     name: z.string(),
@@ -189,8 +191,8 @@ const ActionResultSuccessSchema = z
     html: z
       .union([z.string(), z.null()])
       .describe(
-        'Untrusted HTML relayed verbatim from the agent result: sanitize it before rendering ' +
-          '(stored/reflected XSS risk). Null when the result carries none.',
+        `Untrusted HTML relayed verbatim from the agent result: ${UNTRUSTED_HTML_NOTE} Null ` +
+          'when the result carries none.',
       ),
   })
   .openapi('ActionResultSuccess', {
@@ -407,10 +409,10 @@ export const ErrorResponseSchema = z
       '`{ field }` on unknown_field and field_not_filterable, `{ field, validOperators }` on ' +
       'invalid_filter_operator, `{ maxDepth }` on filter_too_deep, `{ fields }` on ' +
       'relation_field_not_supported, `{ roleIdsAllowedToApprove }` on ' +
-      'action_requires_approval, and `{ html }` on action_error. That html is untrusted agent ' +
-      'output relayed verbatim — sanitize it before rendering (stored/reflected XSS risk), ' +
-      'exactly like the execute success html. Errors forwarded from the agent carry the agent ' +
-      'own payload instead.',
+      'action_requires_approval, and `{ html }` on action_error. An error forwarded from the ' +
+      'agent carries the agent own payload instead, and any other type carries no `details` at ' +
+      `all. The action_error html is untrusted agent output relayed verbatim: ${UNTRUSTED_HTML_NOTE} ` +
+      'exactly like the execute success html.',
   });
 
 export const MessagelessErrorResponseSchema = z

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -172,7 +172,8 @@ export const ActionFormResponseSchema = z
   .openapi('ActionFormResponse', {
     description:
       'The loaded form. `canExecute` is true only when every required field already carries a ' +
-      'value: an explicit empty string or 0 counts as present, only a missing one does not. ' +
+      'value: a null or absent value counts as missing, an explicit empty string or 0 as ' +
+      'present. ' +
       '`requiredFields` names the required fields still missing a value. `skippedFields` names ' +
       'the submitted fields the static form does not carry; the same names are rejected with 400 ' +
       'on execute. `layout` is the agent layout tree relayed verbatim (pages, rows, separators, ' +
@@ -194,8 +195,10 @@ const ActionResultSuccessSchema = z
   })
   .openapi('ActionResultSuccess', {
     description:
-      'The action ran. `invalidated` lists the collections whose records changed and should be ' +
-      're-fetched; `message` is the agent wording, null when the result carries none.',
+      'The action ran. `invalidated` names the relations of the acted-on collection whose ' +
+      'Related Data should be re-fetched — the agent fills it from ' +
+      '`resultBuilder.success(message, { invalidated })` and the BFF relays it from the agent ' +
+      '`refresh.relationships`. `message` is the agent wording, null when the result carries none.',
   });
 
 const ActionResultWebhookSchema = z
@@ -398,7 +401,17 @@ export const ErrorResponseSchema = z
       details: z.unknown().optional(),
     }),
   })
-  .openapi('ErrorResponse');
+  .openapi('ErrorResponse', {
+    description:
+      'The error envelope. `details` is left untyped because its shape depends on `type`: ' +
+      '`{ field }` on unknown_field and field_not_filterable, `{ field, validOperators }` on ' +
+      'invalid_filter_operator, `{ maxDepth }` on filter_too_deep, `{ fields }` on ' +
+      'relation_field_not_supported, `{ roleIdsAllowedToApprove }` on ' +
+      'action_requires_approval, and `{ html }` on action_error. That html is untrusted agent ' +
+      'output relayed verbatim — sanitize it before rendering (stored/reflected XSS risk), ' +
+      'exactly like the execute success html. Errors forwarded from the agent carry the agent ' +
+      'own payload instead.',
+  });
 
 export const MessagelessErrorResponseSchema = z
   .object({

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -556,7 +556,7 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer
       request,
       response: pool.reuse('ActionFormResponse', ActionFormResponseSchema),
       responseDescription:
-        'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying'
+        'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying',
       bodyRequired: true,
     });
 
@@ -569,7 +569,7 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer
       request,
       response: pool.reuse('ActionResult', ActionResultSchema),
       responseDescription:
-        'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying'
+        'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying',
       bodyRequired: true,
       executeResults: true,
     });

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -16,6 +16,8 @@ import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas31';
 import toFieldSchema from './field-schemas';
 import createNamer from './names';
 import {
+  ActionFormResponseSchema,
+  ActionResultSchema,
   CountResponseSchema,
   ListResponseSchema,
   OPERATORS,
@@ -535,6 +537,8 @@ function registerRelationOperations(
 }
 
 function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer): void {
+  const { pool } = deps;
+
   plan.collection.actions.forEach(action => {
     const actionKey = namer(`${plan.key}_${action.name}`);
     const request = registerActionRequest(deps, plan, action, actionKey);
@@ -550,9 +554,9 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer
       summary: `Load the form of ${action.name} on ${plan.collection.name}`,
       description: `Loads the form of the custom action. ${identity} An unknown submitted field is skipped here, not rejected.`,
       request,
-      response: {},
+      response: pool.reuse('ActionFormResponse', ActionFormResponseSchema),
       responseDescription:
-        'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying',
+        'The action form fields; htmlBlock layout content is sanitized server-side against an allowlist before relaying'
       bodyRequired: true,
     });
 
@@ -563,9 +567,9 @@ function registerActionOperations(deps: Deps, plan: CollectionPlan, namer: Namer
       summary: `Execute ${action.name} on ${plan.collection.name}`,
       description: `Executes the custom action. ${identity} A submitted field the loaded form does not carry is rejected with 400.`,
       request,
-      response: {},
+      response: pool.reuse('ActionResult', ActionResultSchema),
       responseDescription:
-        'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying',
+        'The normalized action result; a success result html field is sanitized server-side against an allowlist before relaying'
       bodyRequired: true,
       executeResults: true,
     });

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -510,9 +510,10 @@ describe('the documented action responses', () => {
       properties: { type: { anyOf: unknown[] } };
     };
 
+    // Length is pinned: an unpinned array form would still admit extra elements in OpenAPI 3.1.
     expect(field.properties.type.anyOf).toEqual([
       { type: 'string' },
-      { type: 'array', prefixItems: [{ type: 'string' }] },
+      { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 1 },
     ]);
   });
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -505,14 +505,14 @@ describe('the documented action responses', () => {
     });
   });
 
-  it('should carry a field type that is a string or an array of strings, verbatim from the agent', () => {
+  it('should carry a field type that is a string or the one-element list form, verbatim from the agent', () => {
     const field = schemas.ActionFormResponseField as unknown as {
       properties: { type: { anyOf: unknown[] } };
     };
 
     expect(field.properties.type.anyOf).toEqual([
       { type: 'string' },
-      { type: 'array', items: { type: 'string' } },
+      { type: 'array', prefixItems: [{ type: 'string' }] },
     ]);
   });
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -647,8 +647,6 @@ describe('the documented action responses', () => {
     expect(success.properties.html.description).toContain('sanitize');
   });
 });
-  });
-});
 
 describe('the documented search inputs', () => {
   function propertiesOf(name: string): Record<string, { $ref?: string }> {

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -542,6 +542,26 @@ describe('the documented action responses', () => {
     ]);
   });
 
+  it('should say invalidated names relations, not collections', () => {
+    const success = schemas.ActionResultSuccess as { description: string };
+
+    expect(success.description).toContain('names the relations of the acted-on collection');
+    expect(success.description).not.toContain('lists the collections');
+  });
+
+  it('should say a null value counts as missing for canExecute, like an absent one', () => {
+    const form = schemas.ActionFormResponse as { description: string };
+
+    expect(form.description).toContain('a null or absent value counts as missing');
+  });
+
+  it('should warn that the action_error details html is untrusted, like the success html', () => {
+    const error = schemas.ErrorResponse as { description: string };
+
+    expect(error.description).toContain('`{ html }` on action_error');
+    expect(error.description).toContain('sanitize it before rendering');
+  });
+
   it('should discriminate the result union on type with exactly the three 200 branches', () => {
     const result = schemas.ActionResult as unknown as {
       oneOf: { $ref: string }[];

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -488,6 +488,121 @@ describe('the documented ai query path', () => {
   });
 });
 
+describe('the documented action responses', () => {
+  it('should type the form 200 response rather than leave it free-form', () => {
+    const form = responsesOf(`${ROUTE_PREFIX}/{collection}/actions/{action}/form`);
+
+    expect(form['200'].content?.['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/ActionFormResponse',
+    });
+  });
+
+  it('should type the execute 200 response as the discriminated result union', () => {
+    const execute = responsesOf(`${ROUTE_PREFIX}/{collection}/actions/{action}/execute`);
+
+    expect(execute['200'].content?.['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/ActionResult',
+    });
+  });
+
+  it('should carry a field type that is a string or an array of strings, verbatim from the agent', () => {
+    const field = schemas.ActionFormResponseField as unknown as {
+      properties: { type: { anyOf: unknown[] } };
+    };
+
+    expect(field.properties.type.anyOf).toEqual([
+      { type: 'string' },
+      { type: 'array', items: { type: 'string' } },
+    ]);
+  });
+
+  it('should require exactly the keys the form mappers always assign', () => {
+    const field = schemas.ActionFormResponseField as { required: string[] };
+    const form = schemas.ActionFormResponse as { required: string[] };
+
+    expect([...field.required].sort()).toEqual(['isRequired', 'name', 'type']);
+    expect([...form.required].sort()).toEqual([
+      'canExecute',
+      'fields',
+      'layout',
+      'requiredFields',
+      'skippedFields',
+    ]);
+  });
+
+  it('should keep a missing value and a non-enum field honest on the wire', () => {
+    const field = schemas.ActionFormResponseField as unknown as {
+      properties: { value: unknown; enumValues: { anyOf: unknown[] } };
+    };
+
+    // `value` is dropped by JSON serialization when the field carries none, so it stays optional;
+    // `enumValues` is emitted only on Enum fields, null included.
+    expect(field.properties.value).toEqual({});
+    expect(field.properties.enumValues.anyOf).toEqual([
+      { type: 'array', items: { type: 'string' } },
+      { type: 'null' },
+    ]);
+  });
+
+  it('should discriminate the result union on type with exactly the three 200 branches', () => {
+    const result = schemas.ActionResult as unknown as {
+      oneOf: { $ref: string }[];
+      discriminator: { propertyName: string; mapping: Record<string, string> };
+    };
+
+    expect(result.oneOf).toEqual([
+      { $ref: '#/components/schemas/ActionResultSuccess' },
+      { $ref: '#/components/schemas/ActionResultWebhook' },
+      { $ref: '#/components/schemas/ActionResultRedirect' },
+    ]);
+    expect(result.discriminator.propertyName).toBe('type');
+    expect(result.discriminator.mapping).toEqual({
+      success: '#/components/schemas/ActionResultSuccess',
+      webhook: '#/components/schemas/ActionResultWebhook',
+      redirect: '#/components/schemas/ActionResultRedirect',
+    });
+  });
+
+  it('should require the nullable message and html on success, which the mapper always assigns', () => {
+    const success = schemas.ActionResultSuccess as unknown as {
+      properties: { message: { anyOf: unknown[] }; html: { anyOf: unknown[] } };
+      required: string[];
+    };
+
+    expect(success.properties.message.anyOf).toEqual([{ type: 'string' }, { type: 'null' }]);
+    expect(success.properties.html.anyOf).toEqual([{ type: 'string' }, { type: 'null' }]);
+    expect([...success.required].sort()).toEqual(['html', 'invalidated', 'message', 'type']);
+  });
+
+  it('should mark the webhook headers and body optional, which the agent payload can omit', () => {
+    const webhook = schemas.ActionResultWebhook as unknown as {
+      properties: { headers: unknown; body: unknown };
+      required: string[];
+    };
+
+    expect(webhook.properties.headers).toEqual({});
+    expect(webhook.properties.body).toEqual({});
+    expect([...webhook.required].sort()).toEqual(['method', 'type', 'url']);
+  });
+
+  it('should require the redirect path', () => {
+    const redirect = schemas.ActionResultRedirect as { required: string[] };
+
+    expect([...redirect.required].sort()).toEqual(['path', 'type']);
+  });
+
+  it('should carry the untrusted-html warning on success.html (PRD-1095)', () => {
+    const success = schemas.ActionResultSuccess as unknown as {
+      properties: { html: { description: string } };
+    };
+
+    expect(success.properties.html.description).toContain('Untrusted HTML');
+    expect(success.properties.html.description).toContain('sanitize');
+  });
+});
+  });
+});
+
 describe('the documented search inputs', () => {
   function propertiesOf(name: string): Record<string, { $ref?: string }> {
     return (schemas[name] as { properties: Record<string, { $ref?: string }> }).properties;

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -510,7 +510,6 @@ describe('the documented action responses', () => {
       properties: { type: { anyOf: unknown[] } };
     };
 
-    // Length is pinned: an unpinned array form would still admit extra elements in OpenAPI 3.1.
     expect(field.properties.type.anyOf).toEqual([
       { type: 'string' },
       { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 1 },
@@ -536,8 +535,6 @@ describe('the documented action responses', () => {
       properties: { value: unknown; enumValues: { anyOf: unknown[] } };
     };
 
-    // `value` is dropped by JSON serialization when the field carries none, so it stays optional;
-    // `enumValues` is emitted only on Enum fields, null included.
     expect(field.properties.value).toEqual({});
     expect(field.properties.enumValues.anyOf).toEqual([
       { type: 'array', items: { type: 'string' } },

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -530,12 +530,17 @@ describe('the documented action responses', () => {
     ]);
   });
 
-  it('should keep a missing value and a non-enum field honest on the wire', () => {
-    const field = schemas.ActionFormResponseField as unknown as {
-      properties: { value: unknown; enumValues: { anyOf: unknown[] } };
-    };
+  it('should leave value unconstrained, since an unresolved one is absent from the body', () => {
+    const field = schemas.ActionFormResponseField as unknown as { properties: { value: unknown } };
 
     expect(field.properties.value).toEqual({});
+  });
+
+  it('should type enumValues as a string list or null, null when the agent declares none', () => {
+    const field = schemas.ActionFormResponseField as unknown as {
+      properties: { enumValues: { anyOf: unknown[] } };
+    };
+
     expect(field.properties.enumValues.anyOf).toEqual([
       { type: 'array', items: { type: 'string' } },
       { type: 'null' },

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -560,11 +560,35 @@ describe('the documented action responses', () => {
     expect(form.description).toContain('a null or absent value counts as missing');
   });
 
+  it('should say a null success message means the agent omitted success entirely', () => {
+    const success = schemas.ActionResultSuccess as { description: string };
+
+    expect(success.description).toContain('an agent-nodejs success with no message serializes');
+    expect(success.description).toContain('null means the agent omitted `success` entirely');
+  });
+
   it('should warn that the action_error details html is untrusted, like the success html', () => {
     const error = schemas.ErrorResponse as { description: string };
 
     expect(error.description).toContain('`{ html }` on action_error');
     expect(error.description).toContain('sanitize it before rendering');
+  });
+
+  it('should say the approval and action_error details are conditional on the agent supplying them', () => {
+    const error = schemas.ErrorResponse as { description: string };
+
+    expect(error.description).toContain('when the agent supplies them');
+    expect(error.description).toContain(
+      '`{ roleIdsAllowedToApprove }` on action_requires_approval',
+    );
+  });
+
+  it('should splice the untrusted-html note into a well-formed sentence', () => {
+    const error = schemas.ErrorResponse as { description: string };
+
+    expect(error.description).toContain(
+      '(stored/reflected XSS risk), exactly like the execute success html',
+    );
   });
 
   it('should discriminate the result union on type with exactly the three 200 branches', () => {

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -138,8 +138,6 @@ function makeAction(): Action {
         isRequired: () => false,
       },
       {
-        // A list-typed field, so the generated client carries the array form the agent really
-        // sends; `value` is undefined, which the mapper drops rather than serialize.
         getName: () => 'tags',
         getType: () => ['String'],
         getValue: () => undefined,

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -137,6 +137,14 @@ function makeAction(): Action {
         getValue: () => null,
         isRequired: () => false,
       },
+      {
+        // A list-typed field, so the generated client carries the array form the agent really
+        // sends; `value` is undefined, which the mapper drops rather than serialize.
+        getName: () => 'tags',
+        getType: () => ['String'],
+        getValue: () => undefined,
+        isRequired: () => false,
+      },
     ],
     getEnumField: () => ({ getOptions: () => undefined }),
     getLayout: () => ({ layout: [] }),
@@ -316,6 +324,19 @@ describe('a client generated from the emitted OpenAPI document', () => {
       expect(operators).toEqual([DOCUMENTED_OPERATOR]);
       expect(operators.filter(operator => !types.includes(`'${operator}'`))).toEqual([]);
     });
+
+    it('should expose the typed action form and result the document declares', () => {
+      const types = readFileSync(path.join(CLIENT_DIR, 'types.gen.ts'), 'utf8');
+
+      [
+        'ActionFormResponse',
+        'ActionFormResponseField',
+        'ActionResult',
+        'ActionResultSuccess',
+        'ActionResultWebhook',
+        'ActionResultRedirect',
+      ].forEach(name => expect(types).toMatch(new RegExp(`export type ${name}\\b`)));
+    });
   });
 
   describe('when the generated client lists and counts a collection', () => {
@@ -412,7 +433,10 @@ describe('a client generated from the emitted OpenAPI document', () => {
       expect({ status: response.status, data }).toEqual({
         status: 200,
         data: {
-          fields: [{ name: 'comment', type: 'String', value: null, isRequired: false }],
+          fields: [
+            { name: 'comment', type: 'String', value: null, isRequired: false },
+            { name: 'tags', type: ['String'], isRequired: false },
+          ],
           canExecute: true,
           requiredFields: [],
           skippedFields: [],

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -349,6 +349,45 @@ describe('the unfolded document', () => {
     expect(request.required).toEqual(['recordIds']);
   });
 
+  it('should reference the shared action response components rather than an empty schema', () => {
+    const form = operation('My%20Coll/actions/Mark%20as%20paid%2Fdone/form') as unknown as {
+      responses: Record<string, { content: Record<string, { schema: { $ref: string } }> }>;
+    };
+    const execute = operation('My%20Coll/actions/Mark%20as%20paid%2Fdone/execute') as unknown as {
+      responses: Record<string, { content: Record<string, { schema: { $ref: string } }> }>;
+    };
+
+    expect(form.responses['200'].content['application/json'].schema.$ref).toBe(
+      '#/components/schemas/ActionFormResponse',
+    );
+    expect(execute.responses['200'].content['application/json'].schema.$ref).toBe(
+      '#/components/schemas/ActionResult',
+    );
+  });
+
+  it('should share one response schema per verb across every unfolded action', () => {
+    const refsOf = (prefix: string) =>
+      Object.values(paths)
+        .map(
+          path =>
+            path.post as unknown as {
+              operationId?: string;
+              responses?: Record<string, { content: Record<string, { schema: { $ref: string } }> }>;
+            },
+        )
+        .filter(item => item.operationId?.startsWith(prefix))
+        .map(item => item.responses?.['200'].content['application/json'].schema.$ref);
+
+    expect(refsOf('getActionForm')).toEqual([
+      '#/components/schemas/ActionFormResponse',
+      '#/components/schemas/ActionFormResponse',
+    ]);
+    expect(refsOf('executeAction')).toEqual([
+      '#/components/schemas/ActionResult',
+      '#/components/schemas/ActionResult',
+    ]);
+  });
+
   it('should share one response component per error status across every unfolded path', () => {
     const errors = Object.values(paths).flatMap(path =>
       Object.entries(path.post.responses as Record<string, unknown>).filter(
@@ -553,8 +592,16 @@ describe('an unfolded document with no action', () => {
     expect(Object.keys(withoutActions.components?.responses ?? {})).not.toContain(
       'UnsupportedActionResult',
     );
-    expect(Object.keys(withoutActions.components?.schemas ?? {})).not.toContain(
+    [
       'MessagelessErrorResponse',
+      'ActionFormResponse',
+      'ActionFormResponseField',
+      'ActionResult',
+      'ActionResultSuccess',
+      'ActionResultWebhook',
+      'ActionResultRedirect',
+    ].forEach(name =>
+      expect(Object.keys(withoutActions.components?.schemas ?? {})).not.toContain(name),
     );
   });
 });


### PR DESCRIPTION
## What

The action `/form` and `/execute` 200 responses were published with an empty schema, so a generated client got no type for either. Both the generic and the unfolded documents now reference shared components:

- `ActionFormResponse` — the loaded form, its fields, `canExecute` and the relayed `layout`.
- `ActionResult` — a union discriminated on `type` with the three bodies the BFF returns at 200: `success`, `webhook`, `redirect`.

`ErrorResponse` also gained a description: `details` is polymorphic, and until now nothing said what it carries per error `type`.

fixes PRD-1097

## Why

Actions are the product of an admin app. Making every consumer reverse-engineer the shapes by calling the routes is the most expensive typing gap in the document.

## Why three branches and not five

The ticket lists five result forms. Two of them are not 200 bodies:

- `error` — the agent answers 400 and the BFF re-throws it as `action_error` (`action-routes-middleware.ts`), so it is an `ErrorResponse`.
- `file` — a binary stream with no JSON marker, so it falls through to the 501 `unsupported_action_result` the execute response already documents.

Publishing them inside `ActionResult` would say they can arrive with a 200. They cannot.

## Requiredness follows the wire, not the interfaces

`value`, `headers` and `body` are optional because serialization drops an `undefined` key. `message` and `html` are required and nullable because the mapper always assigns them. `ActionExecuteWebhookBody.url` / `.method` and `ActionExecuteRedirectBody.path` were `unknown` on the TypeScript side while the published schema said `string` — the schema was right (`isWebhook` and the `redirectTo` guard prove it before the body is built), so the interfaces were tightened to match.

## The `details` catalogue

Enumerated per `type` in prose rather than typed: `error.type` is an open string (agent errors are relayed with their own payload), so there is no discriminator OpenAPI can key a `oneOf` on. The list is exhaustive — `invalidRequest` is the only other factory that accepts `details` and no caller passes it — and the description says so.

The `action_error` entry carries the untrusted-html warning, in the same words as the execute success `html`.

**Expected conflict with #1859 (PRD-1095):** that branch sanitizes this html at the BFF. This one is off `main`, so "untrusted, sanitize before rendering" is accurate here. Whichever lands second flips both descriptions to say it is sanitized server-side.

## How to test

`yarn workspace @forestadmin/agent-bff test` — the openapi suite asserts the emitted schemas and runs a live `@hey-api/openapi-ts` codegen round-trip against the real routes.

No runtime change.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
