### PR TITLE
fix(bff): let a key with allowedOrigins serve non-browser clients

### DIFF
--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -146,7 +146,8 @@ normalized away, no trailing slash, no wildcard, no subdomain matching):
   `403 origin_not_allowed`. A request with no `Origin` at all — a server-side client such as curl,
   a Node backend or CI, an empty header counting as none — passes: there the API key is the
   boundary, not the origin. An opaque `Origin: null` (sandboxed iframe, cross-origin redirect) is a
-  present origin and is rejected. An empty per-key list is a no-op.
+  present origin and is rejected. An empty per-key list is a no-op. The OpenAPI document says the
+  same on the `bffApiKey` security scheme, so a consumer reading the document alone learns it too.
 
 **Local development:** browsers still enforce CORS against `localhost`, so add your dev origin(s) to
 `BFF_ALLOWED_ORIGINS` (e.g. `BFF_ALLOWED_ORIGINS=http://localhost:4200`) — there is no dev bypass.

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -146,8 +146,7 @@ normalized away, no trailing slash, no wildcard, no subdomain matching):
   `403 origin_not_allowed`. A request with no `Origin` at all — a server-side client such as curl,
   a Node backend or CI, an empty header counting as none — passes: there the API key is the
   boundary, not the origin. An opaque `Origin: null` (sandboxed iframe, cross-origin redirect) is a
-  present origin and is rejected. An empty per-key list is a no-op. The OpenAPI document says the
-  same on the `bffApiKey` security scheme, so a consumer reading the document alone learns it too.
+  present origin and is rejected. An empty per-key list is a no-op.
 
 **Local development:** browsers still enforce CORS against `localhost`, so add your dev origin(s) to
 `BFF_ALLOWED_ORIGINS` (e.g. `BFF_ALLOWED_ORIGINS=http://localhost:4200`) — there is no dev bypass.

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -142,8 +142,11 @@ normalized away, no trailing slash, no wildcard, no subdomain matching):
   blocks). Applies to `POST /oauth/token` too. Preflight `OPTIONS` from an allow-listed origin gets
   the allowed methods + headers; credentials are never enabled.
 - **Layer 2 (per-key authorization, Mode 2 only)** — when the resolved key has a non-empty
-  `allowedOrigins`, the request `Origin` must also be in that list (a missing `Origin` is rejected),
-  else `403 origin_not_allowed`. An empty per-key list is a no-op.
+  `allowedOrigins`, an `Origin` sent by the client must be in that list, else
+  `403 origin_not_allowed`. A request with no `Origin` at all — a server-side client such as curl,
+  a Node backend or CI, an empty header counting as none — passes: there the API key is the
+  boundary, not the origin. An opaque `Origin: null` (sandboxed iframe, cross-origin redirect) is a
+  present origin and is rejected. An empty per-key list is a no-op.
 
 **Local development:** browsers still enforce CORS against `localhost`, so add your dev origin(s) to
 `BFF_ALLOWED_ORIGINS` (e.g. `BFF_ALLOWED_ORIGINS=http://localhost:4200`) — there is no dev bypass.

--- a/packages/agent-bff/src/cors/cors-middleware.ts
+++ b/packages/agent-bff/src/cors/cors-middleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from 'koa';
 
-import { originAllowed } from './origin';
+import { hasOrigin, originAllowed } from './origin';
 
 export const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
 export const ALLOWED_HEADERS =
@@ -17,9 +17,9 @@ export default function createCorsMiddleware({
   return async function corsMiddleware(ctx, next) {
     const origin = ctx.get('Origin');
 
-    if (origin) ctx.vary('Origin');
+    if (hasOrigin(origin)) ctx.vary('Origin');
 
-    const allowed = origin ? originAllowed(origin, allowedOrigins) : false;
+    const allowed = hasOrigin(origin) && originAllowed(origin, allowedOrigins);
 
     if (allowed) ctx.set('Access-Control-Allow-Origin', origin);
 

--- a/packages/agent-bff/src/cors/cors-middleware.ts
+++ b/packages/agent-bff/src/cors/cors-middleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from 'koa';
 
-import { hasOrigin, originAllowed } from './origin';
+import { originAllowed } from './origin';
 
 export const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
 export const ALLOWED_HEADERS =
@@ -17,9 +17,9 @@ export default function createCorsMiddleware({
   return async function corsMiddleware(ctx, next) {
     const origin = ctx.get('Origin');
 
-    if (hasOrigin(origin)) ctx.vary('Origin');
+    if (origin) ctx.vary('Origin');
 
-    const allowed = hasOrigin(origin) && originAllowed(origin, allowedOrigins);
+    const allowed = origin ? originAllowed(origin, allowedOrigins) : false;
 
     if (allowed) ctx.set('Access-Control-Allow-Origin', origin);
 

--- a/packages/agent-bff/src/cors/origin.ts
+++ b/packages/agent-bff/src/cors/origin.ts
@@ -1,3 +1,7 @@
+export function hasOrigin(raw: string): boolean {
+  return raw !== '';
+}
+
 export function normalizeOrigin(raw: string | undefined | null): string | null {
   if (raw === undefined || raw === null) return null;
 

--- a/packages/agent-bff/src/cors/origin.ts
+++ b/packages/agent-bff/src/cors/origin.ts
@@ -1,12 +1,12 @@
-export function hasOrigin(raw: string | undefined | null): boolean {
+export function hasOrigin(raw: string | undefined | null): raw is string {
   return raw !== undefined && raw !== null && raw.trim() !== '';
 }
 
 export function normalizeOrigin(raw: string | undefined | null): string | null {
-  if (raw === undefined || raw === null) return null;
+  if (!hasOrigin(raw)) return null;
 
   const trimmed = raw.trim();
-  if (trimmed === '' || trimmed === 'null') return null;
+  if (trimmed === 'null') return null;
 
   let url: URL;
 

--- a/packages/agent-bff/src/cors/origin.ts
+++ b/packages/agent-bff/src/cors/origin.ts
@@ -1,5 +1,5 @@
-export function hasOrigin(raw: string): boolean {
-  return raw !== '';
+export function hasOrigin(raw: string | undefined | null): boolean {
+  return raw !== undefined && raw !== null && raw.trim() !== '';
 }
 
 export function normalizeOrigin(raw: string | undefined | null): string | null {

--- a/packages/agent-bff/src/cors/per-key-origin.ts
+++ b/packages/agent-bff/src/cors/per-key-origin.ts
@@ -7,8 +7,9 @@ export default function createPerKeyOriginMiddleware(): Middleware {
   return async function perKeyOriginMiddleware(ctx, next) {
     const identity = ctx.state.apiKeyIdentity as { allowedOrigins?: string[] } | undefined;
     const allowedOrigins = identity?.allowedOrigins ?? [];
+    const origin = ctx.get('Origin');
 
-    if (allowedOrigins.length > 0 && !originAllowed(ctx.get('Origin'), allowedOrigins)) {
+    if (allowedOrigins.length > 0 && origin && !originAllowed(origin, allowedOrigins)) {
       throw originNotAllowed();
     }
 

--- a/packages/agent-bff/src/cors/per-key-origin.ts
+++ b/packages/agent-bff/src/cors/per-key-origin.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from 'koa';
 
-import { originAllowed } from './origin';
+import { hasOrigin, originAllowed } from './origin';
 import { originNotAllowed } from '../http/bff-http-error';
 
 export default function createPerKeyOriginMiddleware(): Middleware {
@@ -9,7 +9,7 @@ export default function createPerKeyOriginMiddleware(): Middleware {
     const allowedOrigins = identity?.allowedOrigins ?? [];
     const origin = ctx.get('Origin');
 
-    if (allowedOrigins.length > 0 && origin && !originAllowed(origin, allowedOrigins)) {
+    if (allowedOrigins.length > 0 && hasOrigin(origin) && !originAllowed(origin, allowedOrigins)) {
       throw originNotAllowed();
     }
 

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -401,7 +401,12 @@ export function generateOpenApiDocument(
     type: 'apiKey',
     in: 'header',
     name: 'X-Forest-Bff-Key',
-    description: 'Mode 2: a BFF API key. Never send both this and an Authorization header.',
+    description:
+      'Mode 2: a BFF API key. Never send both this and an Authorization header. A key created ' +
+      'with allowedOrigins restricts browser callers only: an Origin the client sends must be in ' +
+      'that list, else 403 origin_not_allowed, while a request with no Origin at all — curl, a ' +
+      'server-side client, CI — passes, because there the key is the boundary rather than the ' +
+      'origin. The opaque Origin null is a present origin and is rejected.',
   });
 
   registry.registerPath({

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -405,8 +405,9 @@ export function generateOpenApiDocument(
       'Mode 2: a BFF API key. Never send both this and an Authorization header. A key created ' +
       'with allowedOrigins restricts browser callers only: an Origin the client sends must be in ' +
       'that list, else 403 origin_not_allowed, while a request with no Origin at all — curl, a ' +
-      'server-side client, CI — passes, because there the key is the boundary rather than the ' +
-      'origin. The opaque Origin null is a present origin and is rejected.',
+      'server-side client, CI, an empty Origin header counting as none — passes, because there ' +
+      'the key is the boundary rather than the origin. The opaque Origin null is a present origin ' +
+      'and is rejected.',
   });
 
   registry.registerPath({

--- a/packages/agent-bff/test/cors/origin.test.ts
+++ b/packages/agent-bff/test/cors/origin.test.ts
@@ -1,4 +1,20 @@
-import { normalizeOrigin, originAllowed, parseAllowedOrigins } from '../../src/cors/origin';
+import {
+  hasOrigin,
+  normalizeOrigin,
+  originAllowed,
+  parseAllowedOrigins,
+} from '../../src/cors/origin';
+
+describe('hasOrigin', () => {
+  it('is false for the empty string koa returns when the header is absent', () => {
+    expect(hasOrigin('')).toBe(false);
+  });
+
+  it('is true for any present value, even an opaque or malformed one', () => {
+    expect(hasOrigin('null')).toBe(true);
+    expect(hasOrigin('not a url')).toBe(true);
+  });
+});
 
 describe('normalizeOrigin', () => {
   it.each([

--- a/packages/agent-bff/test/cors/origin.test.ts
+++ b/packages/agent-bff/test/cors/origin.test.ts
@@ -14,6 +14,12 @@ describe('hasOrigin', () => {
     expect(hasOrigin('null')).toBe(true);
     expect(hasOrigin('not a url')).toBe(true);
   });
+
+  it('is false for blank or absent input, the same contract normalizeOrigin takes', () => {
+    expect(hasOrigin('   ')).toBe(false);
+    expect(hasOrigin(undefined)).toBe(false);
+    expect(hasOrigin(null)).toBe(false);
+  });
 });
 
 describe('normalizeOrigin', () => {

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -89,15 +89,6 @@ describe('per-key origin middleware (layer 2)', () => {
     expectOriginForbidden(response);
   });
 
-  it('treats a whitespace-only Origin header like an absent one and proceeds', async () => {
-    const response = await request(buildApp(['https://a.com']).callback())
-      .get('/agent/x')
-      .set('Origin', '   ');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({ reached: true });
-  });
-
   it('treats an empty Origin header like an absent one and proceeds', async () => {
     const response = await request(buildApp(['https://a.com']).callback())
       .get('/agent/x')

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -89,6 +89,15 @@ describe('per-key origin middleware (layer 2)', () => {
     expectOriginForbidden(response);
   });
 
+  it('treats a whitespace-only Origin header like an absent one and proceeds', async () => {
+    const response = await request(buildApp(['https://a.com']).callback())
+      .get('/agent/x')
+      .set('Origin', '   ');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ reached: true });
+  });
+
   it('treats an empty Origin header like an absent one and proceeds', async () => {
     const response = await request(buildApp(['https://a.com']).callback())
       .get('/agent/x')

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -21,6 +21,13 @@ function buildApp(allowedOrigins?: string[]) {
   return app;
 }
 
+function expectOriginForbidden(response: request.Response) {
+  expect(response.status).toBe(403);
+  expect(response.body).toEqual({
+    error: { type: 'origin_not_allowed', status: 403, message: expect.any(String) },
+  });
+}
+
 describe('per-key origin middleware (layer 2)', () => {
   it('proceeds when the origin is in the per-key list', async () => {
     const response = await request(buildApp(['https://a.com']).callback())
@@ -36,10 +43,7 @@ describe('per-key origin middleware (layer 2)', () => {
       .get('/agent/x')
       .set('Origin', 'https://b.com');
 
-    expect(response.status).toBe(403);
-    expect(response.body).toEqual({
-      error: { type: 'origin_not_allowed', status: 403, message: expect.any(String) },
-    });
+    expectOriginForbidden(response);
   });
 
   it('matches a per-key origin returned by SaaS in a non-normalized form', async () => {
@@ -70,10 +74,15 @@ describe('per-key origin middleware (layer 2)', () => {
       .get('/agent/x')
       .set('Origin', 'null');
 
-    expect(response.status).toBe(403);
-    expect(response.body).toEqual({
-      error: { type: 'origin_not_allowed', status: 403, message: expect.any(String) },
-    });
+    expectOriginForbidden(response);
+  });
+
+  it('returns 403 when the per-key list is non-empty and the Origin is present but not a parseable origin', async () => {
+    const response = await request(buildApp(['https://a.com']).callback())
+      .get('/agent/x')
+      .set('Origin', 'garbage');
+
+    expectOriginForbidden(response);
   });
 
   it('treats an empty Origin header like an absent one and proceeds', async () => {

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -58,11 +58,31 @@ describe('per-key origin middleware (layer 2)', () => {
     expect(response.status).toBe(200);
   });
 
-  it('returns 403 when the per-key list is non-empty and the request has no Origin', async () => {
+  it('proceeds when the per-key list is non-empty and the request has no Origin', async () => {
     const response = await request(buildApp(['https://a.com']).callback()).get('/agent/x');
 
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ reached: true });
+  });
+
+  it('returns 403 when the per-key list is non-empty and the Origin is the opaque null', async () => {
+    const response = await request(buildApp(['https://a.com']).callback())
+      .get('/agent/x')
+      .set('Origin', 'null');
+
     expect(response.status).toBe(403);
-    expect(response.body.error.type).toBe('origin_not_allowed');
+    expect(response.body).toEqual({
+      error: { type: 'origin_not_allowed', status: 403, message: expect.any(String) },
+    });
+  });
+
+  it('treats an empty Origin header like an absent one and proceeds', async () => {
+    const response = await request(buildApp(['https://a.com']).callback())
+      .get('/agent/x')
+      .set('Origin', '');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ reached: true });
   });
 
   it('does not restrict an oauth request, which carries no per-key identity', async () => {

--- a/packages/agent-bff/test/cors/per-key-origin.test.ts
+++ b/packages/agent-bff/test/cors/per-key-origin.test.ts
@@ -24,7 +24,11 @@ function buildApp(allowedOrigins?: string[]) {
 function expectOriginForbidden(response: request.Response) {
   expect(response.status).toBe(403);
   expect(response.body).toEqual({
-    error: { type: 'origin_not_allowed', status: 403, message: expect.any(String) },
+    error: {
+      type: 'origin_not_allowed',
+      status: 403,
+      message: 'Origin is not allowed for this key',
+    },
   });
 }
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -197,6 +197,15 @@ describe('generateOpenApiDocument', () => {
     expect(session.description).toContain('every data and action route');
   });
 
+  it('should say in the api key scheme that allowedOrigins gates browsers only', () => {
+    const apiKey = (document.components?.securitySchemes as Record<string, { description: string }>)
+      .bffApiKey;
+
+    expect(apiKey.description).toContain('restricts browser callers only');
+    expect(apiKey.description).toContain('a request with no Origin at all');
+    expect(apiKey.description).toContain('opaque Origin null is a present origin and is rejected');
+  });
+
   it('should require a body where parentId or recordIds is mandatory', () => {
     const requiredByPath = Object.fromEntries(
       Object.entries(document.paths ?? {})

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -203,6 +203,7 @@ describe('generateOpenApiDocument', () => {
 
     expect(apiKey.description).toContain('restricts browser callers only');
     expect(apiKey.description).toContain('a request with no Origin at all');
+    expect(apiKey.description).toContain('an empty Origin header counting as none');
     expect(apiKey.description).toContain('opaque Origin null is a present origin and is rejected');
   });
 


### PR DESCRIPTION
## What

Layer 2 (per-key `allowedOrigins`) now only rejects an `Origin` the client actually sent. A request with no `Origin` header — curl, a Node backend, CI — passes.

One condition in `packages/agent-bff/src/cors/per-key-origin.ts`: read the header once, skip the allow-list check when the client sent nothing.

fixes PRD-1102

## Why

A key created with `allowedOrigins: ["http://localhost:4567"]` was usable from a browser only. Koa returns `''` for an absent header, `normalizeOrigin('')` returns `null`, `originAllowed` then returns `false` — so every server-side client got `403 origin_not_allowed`, with nothing in the error or the docs to explain it. The workaround was provisioning a second, origins-less key.

The `Origin` is not the boundary for a server client; the API key is. The API key middleware runs before this guard (`cli-core.ts`) and is the only writer of `ctx.state.apiKeyIdentity`, so no unauthenticated request reaches the relaxed path.

## Scope and safety

- A present, unlisted `Origin` still gets 403. Unchanged, still tested.
- `Origin: null` (sandboxed iframe, cross-origin redirect) is a **present** origin and still gets 403. The ticket suggested `normalizeOrigin(...) !== null` as the skip condition; that would have let the opaque origin through, and a browser *can* produce it. Asking whether the client sent anything at all keeps every browser-producible origin gated.
- A present but unparseable `Origin` still gets 403, as before.
- Layer 1 (`BFF_ALLOWED_ORIGINS`, `cors-middleware.ts`) is untouched — byte-identical to `main`. The two layers need opposite absent-`Origin` semantics, which is why the fix is at the caller and not in `originAllowed`.
- An empty per-key list stays a no-op; OAuth requests carry no per-key identity and stay unrestricted.

A blank `Origin:` header counts as absent and passes. That is not a new decision so much as a fact about HTTP: Node strips leading and trailing whitespace from header values, so `Origin:` and `Origin:    ` both reach koa as the empty string, indistinguishable from no header at all. No browser sends either — an opaque origin serializes to the literal string `null`, which stays rejected.

## Documented, not just fixed

`bffApiKey` in the OpenAPI document said only "a BFF API key". It now carries the rule, so a consumer reading the document alone learns that a key with `allowedOrigins` gates browsers and not server-side callers, and that `Origin: null` is rejected. A test pins it against the README.

## How to test

`yarn workspace @forestadmin/agent-bff test`

The no-Origin case in `test/cors/per-key-origin.test.ts` was flipped from 403 to 200 as the ticket asked, and two route cases were added: `Origin: null` gets 403, an empty header gets 200. The blank-input contract of `hasOrigin` is pinned in `test/cors/origin.test.ts` rather than through the route, since HTTP cannot deliver whitespace to it.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
