### PR TITLE
fix(agent-bff): expose search on unfolded request schemas

### DIFF
--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -11,7 +11,7 @@ document.
 ## The routes it serves
 
 Everything the agent proxy exposes lives under `/agent/v1`. The data and action routes are `POST`
-— the filter, projection, search and paging all travel in the body, never in the query string:
+— the filter, projection, sort, search and paging all travel in the body, never in the query string:
 
 | Route | Method | What it does |
 | --- | --- | --- |

--- a/packages/agent-bff/README.md
+++ b/packages/agent-bff/README.md
@@ -11,7 +11,7 @@ document.
 ## The routes it serves
 
 Everything the agent proxy exposes lives under `/agent/v1`. The data and action routes are `POST`
-— the filter, projection and paging all travel in the body, never in the query string:
+— the filter, projection, search and paging all travel in the body, never in the query string:
 
 | Route | Method | What it does |
 | --- | --- | --- |

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -21,6 +21,8 @@ import {
   OPERATORS,
   PageSchema,
   ParentIdSchema,
+  SearchExtendedSchema,
+  SearchSchema,
   SortClauseSchema,
   TimezoneSchema,
 } from './schemas';
@@ -265,19 +267,23 @@ function registerRequests(deps: Deps, plan: Omit<CollectionPlan, 'requests'>): R
   const { collection, key } = plan;
   const refs = fieldRefs(deps, plan);
   const timezone = pool.reuse('Timezone', TimezoneSchema);
+  const search = pool.reuse('Search', SearchSchema);
+  const searchExtended = pool.reuse('SearchExtended', SearchExtendedSchema);
 
   return {
     list: pool.add(`ListRequest_${key}`, {
       type: 'object',
       description: requestDescription(
         collection,
-        `Filter, sort and project records of ${quoted(collection.name)}.`,
+        `Filter, search, sort and project records of ${quoted(collection.name)}.`,
       ),
       properties: {
         filter: refs.filter,
         projection: { type: 'array', items: refs.projectable },
         sort: { type: 'array', items: refs.sort },
         page: pool.reuse('Page', PageSchema),
+        search,
+        searchExtended,
         timezone,
       },
     }),
@@ -285,9 +291,9 @@ function registerRequests(deps: Deps, plan: Omit<CollectionPlan, 'requests'>): R
       type: 'object',
       description: requestDescription(
         collection,
-        `Count records of ${quoted(collection.name)} matching a filter.`,
+        `Count records of ${quoted(collection.name)} matching a filter and a search.`,
       ),
-      properties: { filter: refs.filter, timezone },
+      properties: { filter: refs.filter, search, searchExtended, timezone },
     }),
   };
 }
@@ -346,18 +352,18 @@ function registerRelationRequests(
     properties: { parentId },
     required: ['parentId'],
   };
-  const description =
-    `Filter, sort and projection apply to ${quoted(foreign.collection.name)}, the foreign ` +
+  const describe = (inputs: string) =>
+    `${inputs} apply to ${quoted(foreign.collection.name)}, the foreign ` +
     `collection of ${quoted(plan.collection.name)}.${quoted(relation.name)}; the parent only ` +
     'resolves which records are related.';
 
   return {
     list: pool.add(`RelationListRequest_${relationKey}`, {
-      description,
+      description: describe('Filter, sort, projection and search'),
       allOf: [foreign.requests.list, parentProperties],
     }),
     count: pool.add(`RelationCountRequest_${relationKey}`, {
-      description,
+      description: describe('Filter and search'),
       allOf: [foreign.requests.count, parentProperties],
     }),
   };

--- a/packages/agent-bff/src/openapi/unfolded-paths.ts
+++ b/packages/agent-bff/src/openapi/unfolded-paths.ts
@@ -291,7 +291,8 @@ function registerRequests(deps: Deps, plan: Omit<CollectionPlan, 'requests'>): R
       type: 'object',
       description: requestDescription(
         collection,
-        `Count records of ${quoted(collection.name)} matching a filter and a search.`,
+        `Count records of ${quoted(collection.name)}. Accepts the same search inputs as list, so ` +
+          'a client can count exactly the rows its search returns.',
       ),
       properties: { filter: refs.filter, search, searchExtended, timezone },
     }),

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -42,6 +42,28 @@ function dereference(ref: string): Record<string, unknown> {
   return schemas[ref.replace('#/components/schemas/', '')];
 }
 
+function propertiesOf(path: string): Record<string, { $ref?: string }> {
+  const schema = requestSchema(path) as unknown as {
+    properties?: Record<string, { $ref?: string }>;
+    allOf?: [{ $ref: string }, unknown];
+  };
+
+  if (schema.properties) return schema.properties;
+
+  const foreign = dereference(schema.allOf?.[0].$ref ?? '') as unknown as {
+    properties: Record<string, { $ref?: string }>;
+  };
+
+  return foreign.properties;
+}
+
+function expectSearchInputsOn(path: string): void {
+  const properties = propertiesOf(path);
+
+  expect(properties.search).toEqual({ $ref: '#/components/schemas/Search' });
+  expect(properties.searchExtended).toEqual({ $ref: '#/components/schemas/SearchExtended' });
+}
+
 // The leaf alternatives of a filter tree are its `$ref` ones; the branch alternative is inlined.
 function leavesOf(treeName: string): { fields: string[]; operators: string[] }[] {
   const { anyOf } = schemas[treeName] as unknown as { anyOf: { $ref?: string }[] };
@@ -222,17 +244,10 @@ describe('the unfolded document', () => {
 
   it.each([['My%20Coll/list'], ['My%20Coll/count']])(
     'should expose the search inputs on %s, which the runtime honours',
-    path => {
-      const request = requestSchema(path) as unknown as {
-        properties: Record<string, { $ref?: string }>;
-      };
-
-      expect(request.properties.search).toEqual({ $ref: '#/components/schemas/Search' });
-      expect(request.properties.searchExtended).toEqual({
-        $ref: '#/components/schemas/SearchExtended',
-      });
-    },
+    path => expectSearchInputsOn(path),
   );
+
+
 
   it('should share one search component across collections rather than unfold one each', () => {
     const searchNames = Object.keys(schemas).filter(name => name.startsWith('Search'));
@@ -242,32 +257,31 @@ describe('the unfolded document', () => {
 
   it.each([['orders/list'], ['orders/count']])(
     'should still expose the search inputs on %s, whose capabilities failed',
-    path => {
-      const request = requestSchema(path) as unknown as {
-        properties: Record<string, { $ref?: string }>;
-      };
-
-      expect(request.properties.search).toEqual({ $ref: '#/components/schemas/Search' });
-      expect(request.properties.searchExtended).toEqual({
-        $ref: '#/components/schemas/SearchExtended',
-      });
-    },
+    path => expectSearchInputsOn(path),
   );
+
+
 
   it.each([['My%20Coll/relations/orders/list'], ['My%20Coll/relations/orders/count']])(
     'should carry the search inputs to %s through the foreign collection request',
-    path => {
-      const { allOf } = requestSchema(path) as unknown as { allOf: [{ $ref: string }, unknown] };
-      const { properties } = dereference(allOf[0].$ref) as unknown as {
-        properties: Record<string, { $ref?: string }>;
-      };
-
-      expect(properties.search).toEqual({ $ref: '#/components/schemas/Search' });
-      expect(properties.searchExtended).toEqual({
-        $ref: '#/components/schemas/SearchExtended',
-      });
-    },
+    path => expectSearchInputsOn(path),
   );
+
+
+  it('should mirror the generic list and count inputs, so an input never lands on one document only', () => {
+    const generic = generateOpenApiDocument('9.9.9').components?.schemas as Record<
+      string,
+      { properties?: Record<string, unknown> }
+    >;
+
+    expect(Object.keys(propertiesOf('My%20Coll/list'))).toEqual(
+      Object.keys(generic.ListRequest.properties ?? {}),
+    );
+    expect(Object.keys(propertiesOf('My%20Coll/count'))).toEqual(
+      Object.keys(generic.CountRequest.properties ?? {}),
+    );
+  });
+
 
 
   it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -220,6 +220,56 @@ describe('the unfolded document', () => {
     expect(request.properties.page.$ref).toBe('#/components/schemas/Page');
   });
 
+  it.each([['My%20Coll/list'], ['My%20Coll/count']])(
+    'should expose the search inputs on %s, which the runtime honours',
+    path => {
+      const request = requestSchema(path) as unknown as {
+        properties: Record<string, { $ref?: string }>;
+      };
+
+      expect(request.properties.search).toEqual({ $ref: '#/components/schemas/Search' });
+      expect(request.properties.searchExtended).toEqual({
+        $ref: '#/components/schemas/SearchExtended',
+      });
+    },
+  );
+
+  it('should share one search component across collections rather than unfold one each', () => {
+    const searchNames = Object.keys(schemas).filter(name => name.startsWith('Search'));
+
+    expect(searchNames.sort()).toEqual(['Search', 'SearchExtended']);
+  });
+
+  it.each([['orders/list'], ['orders/count']])(
+    'should still expose the search inputs on %s, whose capabilities failed',
+    path => {
+      const request = requestSchema(path) as unknown as {
+        properties: Record<string, { $ref?: string }>;
+      };
+
+      expect(request.properties.search).toEqual({ $ref: '#/components/schemas/Search' });
+      expect(request.properties.searchExtended).toEqual({
+        $ref: '#/components/schemas/SearchExtended',
+      });
+    },
+  );
+
+  it.each([['My%20Coll/relations/orders/list'], ['My%20Coll/relations/orders/count']])(
+    'should carry the search inputs to %s through the foreign collection request',
+    path => {
+      const { allOf } = requestSchema(path) as unknown as { allOf: [{ $ref: string }, unknown] };
+      const { properties } = dereference(allOf[0].$ref) as unknown as {
+        properties: Record<string, { $ref?: string }>;
+      };
+
+      expect(properties.search).toEqual({ $ref: '#/components/schemas/Search' });
+      expect(properties.searchExtended).toEqual({
+        $ref: '#/components/schemas/SearchExtended',
+      });
+    },
+  );
+
+
   it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {
     const branch = branchOf('Filter_My_Coll') as unknown as { not: { required: string[] } };
 
@@ -257,6 +307,24 @@ describe('the unfolded document', () => {
     };
 
     expect(request.allOf[0].$ref).toBe('#/components/schemas/ListRequest_orders');
+  });
+
+  it('should say search applies to the foreign collection too, like filter, sort and projection', () => {
+    const { description } = requestSchema('My%20Coll/relations/orders/list') as unknown as {
+      description: string;
+    };
+
+    expect(description).toContain('Filter, sort, projection and search apply to "orders"');
+  });
+
+  it('should not promise sort or projection on a relation count, which carries neither', () => {
+    const { description } = requestSchema('My%20Coll/relations/orders/count') as unknown as {
+      description: string;
+    };
+
+    expect(description).toContain('Filter and search apply to "orders"');
+    expect(description).not.toContain('projection');
+    expect(description).not.toContain('sort');
   });
 
   it('should require parentId on a relation request and name the parent key it belongs to', () => {

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -247,8 +247,6 @@ describe('the unfolded document', () => {
     path => expectSearchInputsOn(path),
   );
 
-
-
   it('should share one search component across collections rather than unfold one each', () => {
     const searchNames = Object.keys(schemas).filter(name => name.startsWith('Search'));
 
@@ -259,8 +257,6 @@ describe('the unfolded document', () => {
     'should still expose the search inputs on %s, whose capabilities failed',
     path => expectSearchInputsOn(path),
   );
-
-
 
   it.each([['My%20Coll/relations/orders/list'], ['My%20Coll/relations/orders/count']])(
     'should carry the search inputs to %s through the foreign collection request',
@@ -287,8 +283,6 @@ describe('the unfolded document', () => {
       Object.keys(generic.CountRequest.properties ?? {}),
     );
   });
-
-
 
   it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {
     const branch = branchOf('Filter_My_Coll') as unknown as { not: { required: string[] } };

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -267,6 +267,12 @@ describe('the unfolded document', () => {
     path => expectSearchInputsOn(path),
   );
 
+  it('should tell a count caller its search inputs match list, not that a search is required', () => {
+    const { description } = requestSchema('My%20Coll/count') as unknown as { description: string };
+
+    expect(description).toContain('Accepts the same search inputs as list');
+    expect(description).not.toContain('matching a filter and a search');
+  });
 
   it('should mirror the generic list and count inputs, so an input never lands on one document only', () => {
     const generic = generateOpenApiDocument('9.9.9').components?.schemas as Record<


### PR DESCRIPTION
## What

The unfolded (per-collection) OpenAPI document exposes `search` and `searchExtended` on every list and count request. Generated clients were missing both inputs although the runtime honours them on all four path families — list, count, relation list, relation count.

- `ListRequest_<key>` and `CountRequest_<key>` carry `search` / `searchExtended` as `$ref`s to one shared `Search` / `SearchExtended` pair, registered through `ComponentPool.reuse` exactly like `Page` and `Timezone`.
- Relation requests inherit both through their `allOf` head.
- The relation descriptions are split by shape: list says "Filter, sort, projection and search", count says only "Filter and search". The previous shared string promised sort and projection to count, which carries neither.
- The count description no longer says "matching a filter and a search" — both keys are optional, and the useful statement is the one the generic document already made: it accepts the same search inputs as list, so a count can be trusted against the list it describes.

fixes PRD-1103

## Overlaps with #1855

That branch closes the request bodies (`additionalProperties: false`) and, to do it, had to publish `search` / `searchExtended` on the unfolded bodies too — a closed body that omits an input the runtime accepts would declare valid requests invalid. So the two PRs touch the same lines, deliberately, from opposite directions.

Whichever lands second will conflict on `registerRequests`. #1855 also **flattens the relation bodies out of their `allOf`**, so the "relations inherit through the `allOf` head" sentence above becomes stale once it merges — the inputs then arrive by spread instead, and the outcome for a consumer is identical.

## Known limitation

Same as the generic document: a collection that is not searchable still shows a documented `search` input, and using it answers 400 "Collection is not searchable". Gating on a searchable flag needs a signal the BFF capabilities do not carry today.

## How to test

- `yarn workspace @forestadmin/agent-bff test test/openapi` — redocly lint over the served document included
- `yarn workspace @forestadmin/agent-bff test`
- Two consecutive builds of the unfolded document produce identical bytes.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
