### PR TITLE
fix(agent-bff): document the default page size in the openapi document

### DIFF
--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -53,7 +53,12 @@ export const SortClauseSchema = SortClauseInput.openapi('SortClause', {
 export const PageSchema = PageInput.openapi('Page', {
   description:
     'The agent paginates by page number, so `offset` must be a whole multiple of `limit`. ' +
-    'Any other offset is rejected with 400 invalid_request.',
+    'Any other offset is rejected with 400 invalid_request. `limit` and `offset` are both ' +
+    'required once `page` is sent, but the object itself is optional on every list — and ' +
+    'omitting it is not a request for the whole collection. The BFF then forwards no ' +
+    'pagination, so the agent applies its own default: the first page (offset 0), a limit ' +
+    'of 15 records on the Node agent. Anything past that page is silently missing. Send ' +
+    '`page` and walk it to read a collection in full.',
 });
 
 export const TimezoneSchema = TimezoneInput.openapi('Timezone', {
@@ -161,7 +166,12 @@ export const ListResponseSchema = z
   .openapi('ListResponse', {
     description:
       'Records are flat, each carrying a `__forest` envelope. The list never carries a total: ' +
-      'call the count endpoint for that, which is why `countStatus` is always `not_requested`.',
+      'call the count endpoint for that, which is why `countStatus` is always `not_requested`. ' +
+      'It is always one page, not guaranteed to be the whole collection: a request that omitted ' +
+      "`page` still gets a page, the agent's default (up to 15 records from the start on the " +
+      'Node agent), so a response of exactly that default length is probably truncated, and ' +
+      'nothing in the body says so. Send `page` and walk it. Count gives the total unless the ' +
+      'collection disables it.',
   });
 
 export const CountResponseSchema = z

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -528,12 +528,17 @@ describe('the documented search inputs', () => {
   it('should warn that a search query can filter on a collection the BFF does not expose', () => {
     expect(schemas.Search.description).toContain('does not expose');
   });
+});
 
+describe('the documented pagination inputs', () => {
   it('should publish the default page applied when page is absent', () => {
     expect(schemas.Page.description).toContain('the object itself is optional');
     expect(schemas.Page.description).toContain('the first page (offset 0)');
     expect(schemas.Page.description).toContain('a limit of 15 records on the Node agent');
     expect(schemas.Page.description).toContain('silently missing');
+  });
+
+  it('should require both limit and offset once page is sent', () => {
     expect(schemas.Page.required).toEqual(['limit', 'offset']);
   });
 

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -528,6 +528,20 @@ describe('the documented search inputs', () => {
   it('should warn that a search query can filter on a collection the BFF does not expose', () => {
     expect(schemas.Search.description).toContain('does not expose');
   });
+
+  it('should publish the default page applied when page is absent', () => {
+    expect(schemas.Page.description).toContain('the object itself is optional');
+    expect(schemas.Page.description).toContain('the first page (offset 0)');
+    expect(schemas.Page.description).toContain('a limit of 15 records on the Node agent');
+    expect(schemas.Page.description).toContain('silently missing');
+    expect(schemas.Page.required).toEqual(['limit', 'offset']);
+  });
+
+  it('should warn on the response that a page-less list is one page, not the collection', () => {
+    expect(schemas.ListResponse.description).toContain('not guaranteed to be the whole collection');
+    expect(schemas.ListResponse.description).toContain('up to 15 records from the start');
+    expect(schemas.ListResponse.description).toContain('probably truncated');
+  });
 });
 
 describe('serializeOpenApi', () => {

--- a/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-unfolded.test.ts
@@ -192,6 +192,16 @@ describe('the unfolded document', () => {
     expect(request.properties.sort.items?.$ref).toBe('#/components/schemas/SortClause_My_Coll');
   });
 
+  it('should leave page optional here too, pointing at the shared Page component', () => {
+    const request = requestSchema('My%20Coll/list') as unknown as {
+      required?: string[];
+      properties: Record<string, { $ref?: string }>;
+    };
+
+    expect(request.required ?? []).not.toContain('page');
+    expect(request.properties.page.$ref).toBe('#/components/schemas/Page');
+  });
+
   it('should make every leaf and the branch mutually exclusive, which the runtime enforces', () => {
     const branch = branchOf('Filter_My_Coll') as unknown as { not: { required: string[] } };
 


### PR DESCRIPTION
## What

The `Page` and `ListResponse` component descriptions now say what a list request **without** `page` returns: the agent's default page. On the Node agent that is the first page (offset 0) with a limit of 15 records.

The text also says what the body does not: the response is not guaranteed to hold the whole collection, a response of exactly that length is probably truncated, and nothing in the payload flags it. So a consumer is told to send `page` and walk it.

Description strings only. `page` stays optional, no request is newly rejected, no wire change.

fixes PRD-1101

## Why

A consumer building a client from the document alone had no way to learn that omitting `page` silently truncates the list — it looked like "the collection", and for any collection over 15 rows it was not.

The number is attributed to the Node agent rather than stated flatly, because agent-bff can front other agent implementations with their own defaults. `count` is mentioned with its own caveat: a collection can deactivate it.

## How to test

```bash
cd packages/agent-bff && yarn test test/openapi
```

Redocly lint on the generic, unfolded and ai-less documents, plus assertions on the generated descriptions — `offset 0`, `limit of 15 records`, `not guaranteed to be the whole collection`, `probably truncated` — and a separate test naming the `limit`/`offset` requirement so it is discoverable by whoever changes it.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
