### PR TITLE
feat(agent-bff): let the agent transport be injected

### DIFF
--- a/packages/agent-bff/src/action/action-routes-middleware.ts
+++ b/packages/agent-bff/src/action/action-routes-middleware.ts
@@ -4,6 +4,7 @@ import type {
   AgentActionClient,
   AgentActionClientOptions,
 } from './agent-action-client';
+import type { AgentTransport } from '../agent/agent-transport';
 import type { Logger } from '../ports/logger-port';
 import type ReadModelStore from '../read-model/read-model-store';
 import type { Context, Middleware } from 'koa';
@@ -91,8 +92,7 @@ function describePayloadShape(raw: unknown): string {
 
 export interface ActionRoutesMiddlewareOptions {
   store: ReadModelStore;
-  agentUrl: string;
-  timeoutMs?: number;
+  transport: AgentTransport;
   logger: Logger;
   createClient?: (options: AgentActionClientOptions) => AgentActionClient;
 }
@@ -179,8 +179,7 @@ async function handleExecute({
 
 export default function createActionRoutesMiddleware({
   store,
-  agentUrl,
-  timeoutMs,
+  transport,
   logger,
   createClient = defaultCreateAgentActionClient,
 }: ActionRoutesMiddlewareOptions): Middleware {
@@ -214,10 +213,9 @@ export default function createActionRoutesMiddleware({
     const values = parseValues(body.values);
 
     const client = createClient({
-      agentUrl,
+      transport,
       token,
       actionEndpoints: readModel.getActionEndpoints(),
-      timeoutMs,
     });
 
     const action = await callAgent(

--- a/packages/agent-bff/src/action/agent-action-client.ts
+++ b/packages/agent-bff/src/action/agent-action-client.ts
@@ -1,9 +1,8 @@
+import type { AgentTransport } from '../agent/agent-transport';
 import type { ActionEndpointsByCollection } from '@forestadmin/agent-client';
 import type { ForestServerActionFormLayoutElement } from '@forestadmin/forestadmin-client';
 
 import { createRemoteAgentClient } from '@forestadmin/agent-client';
-
-import createAgentHttpRequester from '../agent/create-agent-http-requester';
 
 export interface ActionFormField {
   getName(): string;
@@ -42,10 +41,9 @@ export interface AgentActionClient {
 }
 
 export interface AgentActionClientOptions {
-  agentUrl: string;
+  transport: AgentTransport;
   token: string;
   actionEndpoints: ActionEndpointsByCollection;
-  timeoutMs?: number;
 }
 
 // The raw layout must be read AFTER tryToSetFields: a change hook rebuilds fields+layout in place.
@@ -65,16 +63,15 @@ export function extractRawLayout(action: ActionForm): ForestServerActionFormLayo
  * than reimplementing it. The endpoint map from the read-model is the action allow-list.
  */
 export default function createAgentActionClient({
-  agentUrl,
+  transport,
   token,
   actionEndpoints,
-  timeoutMs,
 }: AgentActionClientOptions): AgentActionClient {
   const client = createRemoteAgentClient({
-    url: agentUrl,
+    url: transport.url,
     token,
     actionEndpoints,
-    httpRequester: createAgentHttpRequester(token, agentUrl, timeoutMs),
+    httpRequester: transport.createRequester(token),
   });
 
   return {

--- a/packages/agent-bff/src/agent/agent-transport.ts
+++ b/packages/agent-bff/src/agent/agent-transport.ts
@@ -1,0 +1,28 @@
+import type { HttpRequester } from '@forestadmin/agent-client';
+
+import createAgentHttpRequester from './create-agent-http-requester';
+
+/**
+ * How the BFF reaches the agent. Everything that talks to the agent takes one of these instead of a
+ * URL, so the same routes serve a remote agent over HTTP and an agent embedded in the same process.
+ */
+export interface AgentTransport {
+  /**
+   * Base url `createRemoteAgentClient` still requires. Over HTTP it is the agent; in-process it is a
+   * sentinel that never reaches the network, since the requester answers before any socket is opened.
+   */
+  url: string;
+  createRequester(token: string): HttpRequester;
+}
+
+export interface HttpTransportOptions {
+  agentUrl: string;
+  timeoutMs?: number;
+}
+
+export function createHttpTransport({ agentUrl, timeoutMs }: HttpTransportOptions): AgentTransport {
+  return {
+    url: agentUrl,
+    createRequester: token => createAgentHttpRequester(token, agentUrl, timeoutMs),
+  };
+}

--- a/packages/agent-bff/src/agent/in-process-transport.ts
+++ b/packages/agent-bff/src/agent/in-process-transport.ts
@@ -2,6 +2,8 @@ import type { AgentTransport } from './agent-transport';
 
 import { HttpRequester } from '@forestadmin/agent-client';
 
+import { streamingUnsupported } from '../http/bff-local-errors';
+
 /** A sentinel that never reaches the network: `query` answers before any socket is opened. */
 const IN_PROCESS_URL = 'http://in-process.agent';
 
@@ -25,6 +27,12 @@ export interface AgentDispatchResponse {
  * structurally so neither package has to depend on the other for six primitive fields.
  */
 export interface AgentDispatcher {
+  /**
+   * Bounding the call is the implementor's duty: there is no socket to abort, so nothing here can
+   * cut a hung agent handler loose. When `timeoutMs` is absent the deployment configured none —
+   * apply the 10s ceiling `HttpRequester.query` always has rather than waiting forever. A dispatch
+   * that fails, times out included, must reject.
+   */
   request(request: AgentDispatchRequest): Promise<AgentDispatchResponse>;
 }
 
@@ -41,10 +49,11 @@ class InProcessRequester extends HttpRequester {
     super(bearerToken, { url: IN_PROCESS_URL });
   }
 
-  // No socket to stream from, and nothing in the BFF streams today. Throw rather than fire a doomed
-  // request at the sentinel host.
+  // No socket to stream from, and nothing in the BFF streams today. A typed 501 rather than a raw
+  // Error, so the day a route does reach here the client is told what is missing instead of being
+  // sent looking for a network the request never crossed.
   override async stream(): Promise<void> {
-    throw new Error('Streaming is not supported over the in-process transport');
+    throw streamingUnsupported('Streaming is not supported over the in-process transport');
   }
 
   override async query<Data = unknown>({
@@ -64,22 +73,21 @@ class InProcessRequester extends HttpRequester {
     contentType?: 'application/json' | 'text/csv';
     skipDeserialization?: boolean;
   }): Promise<Data> {
+    const target = InProcessRequester.toDispatchTarget(path);
+
     const {
       status,
       body: responseBody,
       text,
-    } = await this.dispatcher.request({
+    } = await this.dispatch({
       method,
-      // Callers hand over raw segments — a record id, a collection name — because `buildUrl` escapes
-      // the whole path on the HTTP side, and `agent-data-client` says so in a comment. Escaping the
-      // same way is what keeps a given record id addressing the same record over both transports.
-      path: HttpRequester.escapeUrlSlug(path.startsWith('/') ? path : `/${path}`),
+      path: target.path,
       headers: {
         Authorization: `Bearer ${this.bearerToken}`,
         'Content-Type': contentType ?? 'application/json',
         Accept: contentType ?? 'application/json',
       },
-      query: { timezone: 'Europe/Paris', ...query },
+      query: { timezone: 'Europe/Paris', ...target.query, ...query },
       payload: body,
       timeoutMs: maxTimeAllowed ?? this.defaultTimeoutMs,
     });
@@ -87,6 +95,39 @@ class InProcessRequester extends HttpRequester {
     if (status >= 400) throw this.buildError(status, responseBody, text);
 
     return this.deserialize<Data>(responseBody, text, skipDeserialization);
+  }
+
+  /**
+   * A rejection here is the agent throwing or the dispatch itself failing — never a network hop,
+   * since there is none. Rethrown with the shape an agent 5xx has, so `mapAgentError` logs the real
+   * cause and answers `agent_unavailable` instead of sending whoever debugs it to look for a socket.
+   */
+  private async dispatch(request: AgentDispatchRequest): Promise<AgentDispatchResponse> {
+    try {
+      return await this.dispatcher.request(request);
+    } catch (error) {
+      const detail = error instanceof Error ? error.stack ?? error.message : String(error);
+
+      throw this.buildError(500, { errors: [{ detail }] });
+    }
+  }
+
+  /**
+   * Callers hand over raw segments — a record id, a collection name — because `buildUrl` escapes the
+   * whole path on the HTTP side, so the escaping has to happen here too. Escaping alone is not
+   * enough: `escapeUrlSlug` prefixes `+?*` with a backslash, which the WHATWG parser `buildUrl`
+   * feeds reads as a path separator, and that parse also resolves `..` and splits a trailing query
+   * off. Running it here is what keeps a given id addressing the same record over both transports —
+   * both remain wrong for those three characters, which is PRD-1124's to fix on both at once.
+   */
+  private static toDispatchTarget(path: string): {
+    path: string;
+    query: Record<string, string>;
+  } {
+    const normalized = path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${IN_PROCESS_URL}${HttpRequester.escapeUrlSlug(normalized)}`);
+
+    return { path: url.pathname, query: Object.fromEntries(url.searchParams) };
   }
 }
 

--- a/packages/agent-bff/src/agent/in-process-transport.ts
+++ b/packages/agent-bff/src/agent/in-process-transport.ts
@@ -1,0 +1,106 @@
+import type { AgentTransport } from './agent-transport';
+
+import { HttpRequester } from '@forestadmin/agent-client';
+
+/** A sentinel that never reaches the network: `query` answers before any socket is opened. */
+const IN_PROCESS_URL = 'http://in-process.agent';
+
+export interface AgentDispatchRequest {
+  method: 'get' | 'post' | 'put' | 'delete';
+  path: string;
+  headers: Record<string, string>;
+  query?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+export interface AgentDispatchResponse {
+  status: number;
+  body: unknown;
+  text?: string;
+}
+
+/**
+ * Dispatches a request into an agent living in the same process, without a socket. Declared
+ * structurally so neither package has to depend on the other for six primitive fields.
+ */
+export interface AgentDispatcher {
+  request(request: AgentDispatchRequest): Promise<AgentDispatchResponse>;
+}
+
+/**
+ * Reaches the agent through the dispatcher instead of the network, reusing `HttpRequester`'s parse
+ * helpers so results and error shape stay identical to the HTTP path.
+ */
+class InProcessRequester extends HttpRequester {
+  constructor(
+    private readonly bearerToken: string,
+    private readonly dispatcher: AgentDispatcher,
+    private readonly defaultTimeoutMs?: number,
+  ) {
+    super(bearerToken, { url: IN_PROCESS_URL });
+  }
+
+  // No socket to stream from, and nothing in the BFF streams today. Throw rather than fire a doomed
+  // request at the sentinel host.
+  override async stream(): Promise<void> {
+    throw new Error('Streaming is not supported over the in-process transport');
+  }
+
+  override async query<Data = unknown>({
+    method,
+    path,
+    body,
+    query,
+    maxTimeAllowed,
+    contentType,
+    skipDeserialization,
+  }: {
+    method: 'get' | 'post' | 'put' | 'delete';
+    path: string;
+    body?: Record<string, unknown>;
+    query?: Record<string, unknown>;
+    maxTimeAllowed?: number;
+    contentType?: 'application/json' | 'text/csv';
+    skipDeserialization?: boolean;
+  }): Promise<Data> {
+    const {
+      status,
+      body: responseBody,
+      text,
+    } = await this.dispatcher.request({
+      method,
+      // Callers hand over raw segments — a record id, a collection name — because `buildUrl` escapes
+      // the whole path on the HTTP side, and `agent-data-client` says so in a comment. Escaping the
+      // same way is what keeps a given record id addressing the same record over both transports.
+      path: HttpRequester.escapeUrlSlug(path.startsWith('/') ? path : `/${path}`),
+      headers: {
+        Authorization: `Bearer ${this.bearerToken}`,
+        'Content-Type': contentType ?? 'application/json',
+        Accept: contentType ?? 'application/json',
+      },
+      query: { timezone: 'Europe/Paris', ...query },
+      payload: body,
+      timeoutMs: maxTimeAllowed ?? this.defaultTimeoutMs,
+    });
+
+    if (status >= 400) throw this.buildError(status, responseBody, text);
+
+    return this.deserialize<Data>(responseBody, text, skipDeserialization);
+  }
+}
+
+export interface InProcessTransportOptions {
+  dispatcher: AgentDispatcher;
+  timeoutMs?: number;
+}
+
+export default function createInProcessTransport({
+  dispatcher,
+  timeoutMs,
+}: InProcessTransportOptions): AgentTransport {
+  return {
+    url: IN_PROCESS_URL,
+    createRequester: token => new InProcessRequester(token, dispatcher, timeoutMs),
+  };
+}

--- a/packages/agent-bff/src/build-bff.ts
+++ b/packages/agent-bff/src/build-bff.ts
@@ -14,6 +14,7 @@ import Koa from 'koa';
 import createActionRoutesMiddleware from './action/action-routes-middleware';
 import createConsoleLogger from './adapters/console-logger';
 import createAgentStubMiddleware from './agent/agent-stub';
+import { createHttpTransport } from './agent/agent-transport';
 import AiProxyClient from './ai/ai-proxy-client';
 import createAiRoutesMiddleware, { AI_QUERY_ROUTE } from './ai/ai-routes-middleware';
 import createApiKeyAuthenticator from './api-key/api-key-authenticator';
@@ -282,8 +283,10 @@ function toUnfoldSource(
 
   return {
     store: bundle.store,
-    agentUrl: config.agentUrl,
-    timeoutMs: config.agentTimeoutMs,
+    transport: createHttpTransport({
+      agentUrl: config.agentUrl,
+      timeoutMs: config.agentTimeoutMs,
+    }),
     logger,
   };
 }
@@ -334,10 +337,12 @@ function buildAgentRouteMiddlewares(
     return [permissionsMiddleware, createAgentStubMiddleware()];
   }
 
+  const transport = createHttpTransport({ agentUrl, timeoutMs });
+
   return [
     permissionsMiddleware,
-    createDataRoutesMiddleware({ store, agentUrl, timeoutMs, logger }),
-    createActionRoutesMiddleware({ store, agentUrl, timeoutMs, logger }),
+    createDataRoutesMiddleware({ store, transport, logger }),
+    createActionRoutesMiddleware({ store, transport, logger }),
   ];
 }
 

--- a/packages/agent-bff/src/data/agent-data-client.ts
+++ b/packages/agent-bff/src/data/agent-data-client.ts
@@ -1,9 +1,8 @@
-import createAgentHttpRequester from '../agent/create-agent-http-requester';
+import type { AgentTransport } from '../agent/agent-transport';
 
 export interface AgentDataClientOptions {
-  agentUrl: string;
+  transport: AgentTransport;
   token: string;
-  timeoutMs?: number;
 }
 
 export interface AgentDataClient {
@@ -29,11 +28,10 @@ export interface AgentDataClient {
  * endpoint's raw payload, which `collection.count()` coerces through `Number()` and loses.
  */
 export default function createAgentDataClient({
-  agentUrl,
+  transport,
   token,
-  timeoutMs,
 }: AgentDataClientOptions): AgentDataClient {
-  const requester = createAgentHttpRequester(token, agentUrl, timeoutMs);
+  const requester = transport.createRequester(token);
 
   // Segments are passed raw: HttpRequester.buildUrl already runs the whole path through
   // escapeUrlSlug/encodeURI, so pre-encoding here would double-encode (`|` -> `%257C`).

--- a/packages/agent-bff/src/data/data-routes-middleware.ts
+++ b/packages/agent-bff/src/data/data-routes-middleware.ts
@@ -5,6 +5,7 @@ import type {
   RelationCountRequestBody,
   RelationListRequestBody,
 } from './agent-query';
+import type { AgentTransport } from '../agent/agent-transport';
 import type { Logger } from '../ports/logger-port';
 import type { CapabilitiesResult } from '../read-model/capabilities-cache';
 import type ReadModel from '../read-model/read-model';
@@ -43,8 +44,7 @@ const RELATION_ROUTE = /^\/agent\/v1\/([^/]+)\/relations\/([^/]+)\/(list|count)$
 
 export interface DataRoutesMiddlewareOptions {
   store: ReadModelStore;
-  agentUrl: string;
-  timeoutMs?: number;
+  transport: AgentTransport;
   logger: Logger;
   createClient?: (options: AgentDataClientOptions) => AgentDataClient;
 }
@@ -53,8 +53,7 @@ interface RequestHandlerDeps {
   collection: string;
   client: AgentDataClient;
   store: ReadModelStore;
-  agentUrl: string;
-  timeoutMs?: number;
+  transport: AgentTransport;
   token: string;
   timezone: string;
   logger: Logger;
@@ -86,11 +85,7 @@ function resolveCapabilities(
     () =>
       deps.store.getCapabilities(
         collection,
-        createAgentCapabilitiesFetcher({
-          agentUrl: deps.agentUrl,
-          token: deps.token,
-          timeoutMs: deps.timeoutMs,
-        }),
+        createAgentCapabilitiesFetcher({ transport: deps.transport, token: deps.token }),
       ),
     deps.logger,
   );
@@ -306,8 +301,7 @@ async function handleRelation(
 
 export default function createDataRoutesMiddleware({
   store,
-  agentUrl,
-  timeoutMs,
+  transport,
   logger,
   createClient = defaultCreateAgentDataClient,
 }: DataRoutesMiddlewareOptions): Middleware {
@@ -336,10 +330,9 @@ export default function createDataRoutesMiddleware({
 
     const deps: RequestHandlerDeps = {
       collection,
-      client: createClient({ agentUrl, token, timeoutMs }),
+      client: createClient({ transport, token }),
       store,
-      agentUrl,
-      timeoutMs,
+      transport,
       token,
       timezone: ctx.state.timezone as string,
       logger,

--- a/packages/agent-bff/src/http/bff-local-errors.ts
+++ b/packages/agent-bff/src/http/bff-local-errors.ts
@@ -40,6 +40,12 @@ export function unsupportedActionResult(message = 'Unsupported action result'): 
   return new BffHttpError(501, 'unsupported_action_result', message);
 }
 
+export function streamingUnsupported(
+  message = 'Streaming is not supported over this transport',
+): BffHttpError {
+  return new BffHttpError(501, 'streaming_unsupported', message);
+}
+
 export function actionError(message = 'The action failed', details?: unknown): BffHttpError {
   return new BffHttpError(400, 'action_error', message, { details });
 }

--- a/packages/agent-bff/src/openapi/unfolded-document.ts
+++ b/packages/agent-bff/src/openapi/unfolded-document.ts
@@ -1,4 +1,5 @@
 import type { Unfolding } from './unfolding';
+import type { AgentTransport } from '../agent/agent-transport';
 import type { Logger } from '../ports/logger-port';
 import type ReadModel from '../read-model/read-model';
 import type ReadModelStore from '../read-model/read-model-store';
@@ -11,8 +12,7 @@ import createAgentCapabilitiesFetcher from '../read-model/agent-capabilities-fet
 /** Everything needed to unfold. Absent when the deployment cannot reach its schema or its agent. */
 export interface UnfoldSource {
   store: ReadModelStore;
-  agentUrl: string;
-  timeoutMs?: number;
+  transport: AgentTransport;
   logger: Logger;
 }
 
@@ -37,11 +37,7 @@ export default async function buildUnfoldedDocument(
   const unfolding = await collectUnfolding({
     readModel,
     store: source.store,
-    capabilitiesFetcher: createAgentCapabilitiesFetcher({
-      agentUrl: source.agentUrl,
-      token,
-      timeoutMs: source.timeoutMs,
-    }),
+    capabilitiesFetcher: createAgentCapabilitiesFetcher({ transport: source.transport, token }),
     logger: source.logger,
   });
 

--- a/packages/agent-bff/src/read-model/agent-capabilities-fetcher.ts
+++ b/packages/agent-bff/src/read-model/agent-capabilities-fetcher.ts
@@ -1,14 +1,12 @@
 import type { CapabilitiesFetcher } from './capabilities-cache';
+import type { AgentTransport } from '../agent/agent-transport';
 
 import { createRemoteAgentClient } from '@forestadmin/agent-client';
 
-import createAgentHttpRequester from '../agent/create-agent-http-requester';
-
 export interface AgentCapabilitiesFetcherOptions {
-  agentUrl: string;
+  transport: AgentTransport;
   /** A borrowed request token, or a factory when the caller can mint one per fetch. */
   token: string | (() => string);
-  timeoutMs?: number;
 }
 
 /**
@@ -20,15 +18,14 @@ export interface AgentCapabilitiesFetcherOptions {
  * expired token. A request can only borrow its caller's, so it passes the string.
  */
 export default function createAgentCapabilitiesFetcher({
-  agentUrl,
+  transport,
   token,
-  timeoutMs,
 }: AgentCapabilitiesFetcherOptions): CapabilitiesFetcher {
   const clientFor = (bearer: string) =>
     createRemoteAgentClient({
-      url: agentUrl,
+      url: transport.url,
       token: bearer,
-      httpRequester: createAgentHttpRequester(bearer, agentUrl, timeoutMs),
+      httpRequester: transport.createRequester(bearer),
     });
 
   if (typeof token === 'string') {

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -13,6 +13,7 @@ import Koa from 'koa';
 import request from 'supertest';
 
 import createActionRoutesMiddleware from '../../src/action/action-routes-middleware';
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import createErrorMiddleware from '../../src/http/error-middleware';
 import SchemaUnavailableError from '../../src/read-model/errors';
 import {
@@ -25,6 +26,8 @@ import {
   readModel,
   storeOf,
 } from '../helpers/action-routes';
+
+const TRANSPORT = createHttpTransport({ agentUrl: 'https://agent.example.com' });
 
 describe('action routes middleware', () => {
   it('forwards the configured agent timeout to the action client', async () => {
@@ -43,8 +46,7 @@ describe('action routes middleware', () => {
     app.use(
       createActionRoutesMiddleware({
         store: storeOf(readModel),
-        agentUrl: 'https://agent.example.com',
-        timeoutMs: 2500,
+        transport: createHttpTransport({ agentUrl: 'https://agent.example.com', timeoutMs: 2500 }),
         logger: noopLogger,
         createClient,
       }),
@@ -54,7 +56,9 @@ describe('action routes middleware', () => {
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: ['42'], values: {} });
 
-    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2500 }));
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ transport: expect.objectContaining({ url: expect.any(String) }) }),
+    );
   });
 
   it('leaves the action client timeout undefined when none is configured', async () => {
@@ -73,7 +77,7 @@ describe('action routes middleware', () => {
     app.use(
       createActionRoutesMiddleware({
         store: storeOf(readModel),
-        agentUrl: 'https://agent.example.com',
+        transport: TRANSPORT,
         logger: noopLogger,
         createClient,
       }),
@@ -83,7 +87,7 @@ describe('action routes middleware', () => {
       .post('/agent/v1/users/actions/approve/form')
       .send({ recordIds: ['42'], values: {} });
 
-    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: undefined }));
+    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ token: 'agent-jwt' }));
   });
 
   it('returns the full form shape with fields, canExecute, requiredFields, skippedFields and layout', async () => {

--- a/packages/agent-bff/test/action/action-routes-middleware.test.ts
+++ b/packages/agent-bff/test/action/action-routes-middleware.test.ts
@@ -61,7 +61,7 @@ describe('action routes middleware', () => {
     );
   });
 
-  it('leaves the action client timeout undefined when none is configured', async () => {
+  it('rebuilds the client on every call, with that call own agent token', async () => {
     const createClient = jest.fn(
       () => clientOf(makeAction({ fields: [], layout: [], skipped: [] })) as AgentActionClient,
     );
@@ -71,7 +71,7 @@ describe('action routes middleware', () => {
     app.use(bodyParser());
     app.use(async (ctx, next) => {
       ctx.state.timezone = TIMEZONE;
-      ctx.state.agentToken = 'agent-jwt';
+      ctx.state.agentToken = ctx.get('x-agent-token');
       await next();
     });
     app.use(
@@ -85,9 +85,22 @@ describe('action routes middleware', () => {
 
     await request(app.callback())
       .post('/agent/v1/users/actions/approve/form')
+      .set('x-agent-token', 'jwt-1')
+      .send({ recordIds: ['42'], values: {} });
+    await request(app.callback())
+      .post('/agent/v1/users/actions/approve/form')
+      .set('x-agent-token', 'jwt-2')
       .send({ recordIds: ['42'], values: {} });
 
-    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ token: 'agent-jwt' }));
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(createClient).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ token: 'jwt-1', transport: TRANSPORT }),
+    );
+    expect(createClient).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ token: 'jwt-2', transport: TRANSPORT }),
+    );
   });
 
   it('returns the full form shape with fields, canExecute, requiredFields, skippedFields and layout', async () => {

--- a/packages/agent-bff/test/action/agent-action-client.test.ts
+++ b/packages/agent-bff/test/action/agent-action-client.test.ts
@@ -1,6 +1,11 @@
 import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 
 import createAgentActionClient from '../../src/action/agent-action-client';
+import { createHttpTransport } from '../../src/agent/agent-transport';
+
+function transportTo(agentUrl: string, timeoutMs?: number) {
+  return createHttpTransport({ agentUrl, timeoutMs });
+}
 
 jest.mock('@forestadmin/agent-client');
 
@@ -26,7 +31,7 @@ describe('createAgentActionClient', () => {
 
     const actionEndpoints = { users: { approve: {} } } as never;
     const client = createAgentActionClient({
-      agentUrl: 'https://agent.example.com',
+      transport: transportTo('https://agent.example.com'),
       token: 'jwt-token',
       actionEndpoints,
     });
@@ -58,10 +63,9 @@ describe('createAgentActionClient', () => {
     });
 
     createAgentActionClient({
-      agentUrl: 'https://agent',
+      transport: transportTo('https://agent', 2500),
       token: 'tok',
       actionEndpoints: {} as never,
-      timeoutMs: 2500,
     });
 
     const httpRequester = createRemoteAgentClientMock.mock.calls[0][0]

--- a/packages/agent-bff/test/agent/in-process-transport.test.ts
+++ b/packages/agent-bff/test/agent/in-process-transport.test.ts
@@ -1,6 +1,11 @@
 import type { AgentDispatcher } from '../../src/agent/in-process-transport';
 
+import { AgentHttpError, HttpRequester } from '@forestadmin/agent-client';
+import nock from 'nock';
+
 import createInProcessTransport from '../../src/agent/in-process-transport';
+
+const AGENT_URL = 'http://in-process.agent';
 
 function dispatcherReturning(response: {
   status: number;
@@ -10,7 +15,33 @@ function dispatcherReturning(response: {
   return { request: jest.fn().mockResolvedValue(response) };
 }
 
+/** What superagent actually puts on the wire for `path`, so parity is measured, not asserted. */
+async function httpTarget(path: string): Promise<{ path: string; query: URLSearchParams }> {
+  let sent = '';
+  nock(AGENT_URL)
+    .get(/.*/)
+    .reply(function reply() {
+      sent = this.req.path;
+
+      return [200, {}];
+    });
+
+  await new HttpRequester('tok', { url: AGENT_URL }).query({ method: 'get', path });
+
+  const [pathname, search] = sent.split('?');
+
+  return { path: pathname, query: new URLSearchParams(search) };
+}
+
+function entriesOf(query: URLSearchParams): [string, string][] {
+  return [...query.entries()].sort();
+}
+
 describe('createInProcessTransport', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('should dispatch the request with the bearer token and the caller query', async () => {
     const dispatcher = dispatcherReturning({ status: 200, body: { data: [] } });
     const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
@@ -31,28 +62,35 @@ describe('createInProcessTransport', () => {
     });
   });
 
-  describe('when a path segment needs escaping', () => {
-    it('should escape it exactly as buildUrl does on the HTTP path', async () => {
+  describe('when a path segment carries a character the HTTP path rewrites', () => {
+    it.each([
+      ['a space', '/forest/orders/A B'],
+      ['a plus, which escapeUrlSlug turns into a path separator', '/forest/orders/A+c'],
+      ['a star', '/forest/orders/a*b'],
+      ['a question mark, which splits a query off', '/forest/orders/q?x'],
+      ['a traversal the URL parser resolves', '/forest/users/../admin'],
+    ])('should reach the same agent path as the HTTP transport for %s', async (_label, path) => {
       const dispatcher = dispatcherReturning({ status: 200, body: {} });
       const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+      const overHttp = await httpTarget(path);
 
-      await requester.query({ method: 'get', path: '/forest/orders/A B+c' });
+      await requester.query({ method: 'get', path });
 
-      expect(dispatcher.request).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/forest/orders/A%20B\\+c' }),
-      );
+      const dispatched = dispatcher.request.mock.calls[0][0];
+      expect(dispatched.path).toBe(overHttp.path);
+      expect(entriesOf(new URLSearchParams(dispatched.query))).toEqual(entriesOf(overHttp.query));
     });
+  });
 
-    it('should prefix a relative path with a slash, as buildUrl does', async () => {
-      const dispatcher = dispatcherReturning({ status: 200, body: {} });
-      const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+  it('should prefix a relative path with a slash, as buildUrl does', async () => {
+    const dispatcher = dispatcherReturning({ status: 200, body: {} });
+    const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
 
-      await requester.query({ method: 'get', path: 'forest/users' });
+    await requester.query({ method: 'get', path: 'forest/users' });
 
-      expect(dispatcher.request).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/forest/users' }),
-      );
-    });
+    expect(dispatcher.request).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/forest/users' }),
+    );
   });
 
   describe('when the caller sets no timeout', () => {
@@ -81,26 +119,58 @@ describe('createInProcessTransport', () => {
 
   describe('when the agent answers with an error status', () => {
     it('should throw the same AgentHttpError shape as the HTTP path', async () => {
-      const dispatcher = dispatcherReturning({
+      const body = { errors: [{ name: 'ForbiddenError', detail: 'Forbidden' }] };
+      const text = JSON.stringify(body);
+      const dispatcher = dispatcherReturning({ status: 403, body, text });
+      const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+      nock(AGENT_URL).get(/.*/).reply(403, body);
+
+      const overHttp = (await new HttpRequester('tok', { url: AGENT_URL })
+        .query({ method: 'get', path: '/forest/users' })
+        .catch(error => error)) as AgentHttpError;
+      const overDispatch = await requester
+        .query({ method: 'get', path: '/forest/users' })
+        .catch(error => error);
+
+      expect(overDispatch).toBeInstanceOf(AgentHttpError);
+      expect(overDispatch).toMatchObject({
+        name: 'AgentHttpError',
+        message: overHttp.message,
         status: 403,
-        body: { errors: [{ detail: 'Forbidden' }] },
+        body,
+        responseText: text,
       });
+    });
+  });
+
+  describe('when the dispatch itself fails', () => {
+    it('should carry the cause under a 500, not a transport failure', async () => {
+      const dispatcher = { request: jest.fn().mockRejectedValue(new Error('agent hook exploded')) };
       const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
 
-      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
-        { status: 403 },
+      const error = (await requester
+        .query({ method: 'get', path: '/forest/users' })
+        .catch(caught => caught)) as AgentHttpError;
+
+      expect(error).toBeInstanceOf(AgentHttpError);
+      expect(error.status).toBe(500);
+      expect((error.body as { errors: { detail: string }[] }).errors[0].detail).toContain(
+        'agent hook exploded',
       );
     });
   });
 
-  it('should refuse to stream, since there is no socket to stream from', async () => {
+  it('should refuse to stream with a 501, since there is no socket to stream from', async () => {
     const dispatcher = dispatcherReturning({ status: 200, body: {} });
     const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
 
     const stream = requester.stream as () => Promise<void>;
 
-    await expect(stream()).rejects.toThrow(
-      'Streaming is not supported over the in-process transport',
-    );
+    await expect(stream()).rejects.toMatchObject({
+      name: 'BffHttpError',
+      status: 501,
+      type: 'streaming_unsupported',
+      message: 'Streaming is not supported over the in-process transport',
+    });
   });
 });

--- a/packages/agent-bff/test/agent/in-process-transport.test.ts
+++ b/packages/agent-bff/test/agent/in-process-transport.test.ts
@@ -1,0 +1,106 @@
+import type { AgentDispatcher } from '../../src/agent/in-process-transport';
+
+import createInProcessTransport from '../../src/agent/in-process-transport';
+
+function dispatcherReturning(response: {
+  status: number;
+  body: unknown;
+  text?: string;
+}): AgentDispatcher & { request: jest.Mock } {
+  return { request: jest.fn().mockResolvedValue(response) };
+}
+
+describe('createInProcessTransport', () => {
+  it('should dispatch the request with the bearer token and the caller query', async () => {
+    const dispatcher = dispatcherReturning({ status: 200, body: { data: [] } });
+    const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+
+    await requester.query({ method: 'post', path: '/forest/users', body: { a: 1 } });
+
+    expect(dispatcher.request).toHaveBeenCalledWith({
+      method: 'post',
+      path: '/forest/users',
+      headers: {
+        Authorization: 'Bearer tok',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      query: { timezone: 'Europe/Paris' },
+      payload: { a: 1 },
+      timeoutMs: undefined,
+    });
+  });
+
+  describe('when a path segment needs escaping', () => {
+    it('should escape it exactly as buildUrl does on the HTTP path', async () => {
+      const dispatcher = dispatcherReturning({ status: 200, body: {} });
+      const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+
+      await requester.query({ method: 'get', path: '/forest/orders/A B+c' });
+
+      expect(dispatcher.request).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/forest/orders/A%20B\\+c' }),
+      );
+    });
+
+    it('should prefix a relative path with a slash, as buildUrl does', async () => {
+      const dispatcher = dispatcherReturning({ status: 200, body: {} });
+      const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+
+      await requester.query({ method: 'get', path: 'forest/users' });
+
+      expect(dispatcher.request).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/forest/users' }),
+      );
+    });
+  });
+
+  describe('when the caller sets no timeout', () => {
+    it('should fall back to the configured one', async () => {
+      const dispatcher = dispatcherReturning({ status: 200, body: {} });
+      const requester = createInProcessTransport({ dispatcher, timeoutMs: 2500 }).createRequester(
+        'tok',
+      );
+
+      await requester.query({ method: 'get', path: '/forest/users' });
+
+      expect(dispatcher.request).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2500 }));
+    });
+
+    it('should let an explicit maxTimeAllowed win', async () => {
+      const dispatcher = dispatcherReturning({ status: 200, body: {} });
+      const requester = createInProcessTransport({ dispatcher, timeoutMs: 2500 }).createRequester(
+        'tok',
+      );
+
+      await requester.query({ method: 'get', path: '/forest/users', maxTimeAllowed: 100 });
+
+      expect(dispatcher.request).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 100 }));
+    });
+  });
+
+  describe('when the agent answers with an error status', () => {
+    it('should throw the same AgentHttpError shape as the HTTP path', async () => {
+      const dispatcher = dispatcherReturning({
+        status: 403,
+        body: { errors: [{ detail: 'Forbidden' }] },
+      });
+      const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+
+      await expect(requester.query({ method: 'get', path: '/forest/users' })).rejects.toMatchObject(
+        { status: 403 },
+      );
+    });
+  });
+
+  it('should refuse to stream, since there is no socket to stream from', async () => {
+    const dispatcher = dispatcherReturning({ status: 200, body: {} });
+    const requester = createInProcessTransport({ dispatcher }).createRequester('tok');
+
+    const stream = requester.stream as () => Promise<void>;
+
+    await expect(stream()).rejects.toThrow(
+      'Streaming is not supported over the in-process transport',
+    );
+  });
+});

--- a/packages/agent-bff/test/build-bff.test.ts
+++ b/packages/agent-bff/test/build-bff.test.ts
@@ -2,10 +2,17 @@ import type { Logger } from '../src/ports/logger-port';
 
 import request from 'supertest';
 
+import { createHttpTransport } from '../src/agent/agent-transport';
 import buildBff from '../src/build-bff';
 import { parseConfig } from '../src/config/env-config';
 import version from '../src/version';
 import { restoreFetchAfterEach, stubEnvironmentIdFetch } from './helpers/fetch-stub';
+
+jest.mock('../src/agent/agent-transport', () => {
+  const actual = jest.requireActual('../src/agent/agent-transport');
+
+  return { ...actual, createHttpTransport: jest.fn(actual.createHttpTransport) };
+});
 
 const VALID_ENV = {
   FOREST_AUTH_SECRET: 'auth-secret',
@@ -28,7 +35,21 @@ describe('buildBff', () => {
   restoreFetchAfterEach();
 
   beforeEach(() => {
+    jest.mocked(createHttpTransport).mockClear();
     stubEnvironmentIdFetch();
+  });
+
+  it('should cap every transport it builds with the configured BFF_AGENT_TIMEOUT_MS', async () => {
+    await buildBff({
+      config: parseConfig({ ...VALID_ENV, BFF_AGENT_TIMEOUT_MS: '2500' }),
+      logger: noopLogger,
+    });
+
+    const built = jest.mocked(createHttpTransport).mock.calls.map(([options]) => options);
+    const capped = { agentUrl: VALID_ENV.AGENT_URL, timeoutMs: 2500 };
+
+    expect(built).not.toHaveLength(0);
+    expect(built).toEqual(built.map(() => capped));
   });
 
   describe('when every required key is present', () => {

--- a/packages/agent-bff/test/data/agent-data-client.test.ts
+++ b/packages/agent-bff/test/data/agent-data-client.test.ts
@@ -1,6 +1,11 @@
 import { HttpRequester } from '@forestadmin/agent-client';
 
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import createAgentDataClient from '../../src/data/agent-data-client';
+
+function transportTo(agentUrl: string, timeoutMs?: number) {
+  return createHttpTransport({ agentUrl, timeoutMs });
+}
 
 jest.mock('@forestadmin/agent-client');
 
@@ -18,14 +23,14 @@ describe('createAgentDataClient', () => {
   });
 
   it('should build the requester with the agent url and token', () => {
-    createAgentDataClient({ agentUrl: 'https://agent.example.com', token: 'tok' });
+    createAgentDataClient({ transport: transportTo('https://agent.example.com'), token: 'tok' });
 
     expect(HttpRequester).toHaveBeenCalledWith('tok', { url: 'https://agent.example.com' });
   });
 
   it('should query the list endpoint (deserialized) for the given collection', async () => {
     query.mockResolvedValue([{ id: '1' }]);
-    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+    const client = createAgentDataClient({ transport: transportTo('https://agent'), token: 'tok' });
 
     const result = await client.list('users', { timezone: 'Europe/Paris', filters: '{}' });
 
@@ -39,9 +44,8 @@ describe('createAgentDataClient', () => {
 
   it('should apply the configured timeout as maxTimeAllowed on every query', async () => {
     const client = createAgentDataClient({
-      agentUrl: 'https://agent',
+      transport: transportTo('https://agent', 2500),
       token: 'tok',
-      timeoutMs: 2500,
     });
 
     await client.list('users', { timezone: 'Europe/Paris' });
@@ -75,7 +79,7 @@ describe('createAgentDataClient', () => {
 
   it('should query the count endpoint with skipDeserialization to read the raw payload', async () => {
     query.mockResolvedValue({ meta: { count: 'deactivated' } });
-    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+    const client = createAgentDataClient({ transport: transportTo('https://agent'), token: 'tok' });
 
     const result = await client.countRaw('users', { timezone: 'Europe/Paris' });
 
@@ -89,7 +93,7 @@ describe('createAgentDataClient', () => {
   });
 
   it('should request the relation list path without pre-encoding the segments', async () => {
-    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+    const client = createAgentDataClient({ transport: transportTo('https://agent'), token: 'tok' });
 
     await client.listRelation('users', 'tenant-1|42', 'posts', { timezone: 'Europe/Paris' });
 
@@ -101,7 +105,7 @@ describe('createAgentDataClient', () => {
   });
 
   it('should request the relation count path with skipDeserialization and no pre-encoding', async () => {
-    const client = createAgentDataClient({ agentUrl: 'https://agent', token: 'tok' });
+    const client = createAgentDataClient({ transport: transportTo('https://agent'), token: 'tok' });
 
     await client.countRelationRaw('users', 'tenant-1|42', 'posts', { timezone: 'Europe/Paris' });
 

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -143,7 +143,7 @@ describe('data routes middleware', () => {
       expect(createClient).toHaveBeenCalledWith({ transport: TRANSPORT, token: 'jwt-123' });
     });
 
-    it('should build one client per request with the configured transport', async () => {
+    it('should build one client per request, each bound to that request token', async () => {
       const createClient = jest.fn(() => ({ list: async () => [] } as unknown as AgentDataClient));
       const app = new Koa();
       app.silent = true;
@@ -151,7 +151,7 @@ describe('data routes middleware', () => {
       app.use(bodyParser());
       app.use(async (ctx, next) => {
         ctx.state.timezone = TIMEZONE;
-        ctx.state.agentToken = 'agent-jwt';
+        ctx.state.agentToken = ctx.get('x-agent-token');
         await next();
       });
       app.use(
@@ -163,9 +163,18 @@ describe('data routes middleware', () => {
         }),
       );
 
-      await request(app.callback()).post('/agent/v1/users/list').send({});
+      await request(app.callback())
+        .post('/agent/v1/users/list')
+        .set('x-agent-token', 'jwt-1')
+        .send({});
+      await request(app.callback())
+        .post('/agent/v1/users/list')
+        .set('x-agent-token', 'jwt-2')
+        .send({});
 
-      expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ transport: TRANSPORT }));
+      expect(createClient).toHaveBeenCalledTimes(2);
+      expect(createClient).toHaveBeenNthCalledWith(1, { transport: TRANSPORT, token: 'jwt-1' });
+      expect(createClient).toHaveBeenNthCalledWith(2, { transport: TRANSPORT, token: 'jwt-2' });
     });
   });
 

--- a/packages/agent-bff/test/data/data-routes-middleware.test.ts
+++ b/packages/agent-bff/test/data/data-routes-middleware.test.ts
@@ -1,4 +1,4 @@
-import type { AgentDataClient } from '../../src/data/agent-data-client';
+import type { AgentDataClient, AgentDataClientOptions } from '../../src/data/agent-data-client';
 import type { Logger } from '../../src/ports/logger-port';
 import type { CapabilitiesResult } from '../../src/read-model/capabilities-cache';
 import type ReadModelStore from '../../src/read-model/read-model-store';
@@ -8,11 +8,14 @@ import { bodyParser } from '@koa/bodyparser';
 import Koa from 'koa';
 import request from 'supertest';
 
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import createDataRoutesMiddleware from '../../src/data/data-routes-middleware';
 import createErrorMiddleware from '../../src/http/error-middleware';
 import SchemaUnavailableError from '../../src/read-model/errors';
 import ReadModel from '../../src/read-model/read-model';
 import { collection, column, polymorphic, relation } from '../read-model/fixtures';
+
+const TRANSPORT = createHttpTransport({ agentUrl: 'https://agent.example.com' });
 
 const TIMEZONE = 'Europe/Paris';
 
@@ -51,8 +54,6 @@ function storeOf(
   } as unknown as ReadModelStore;
 }
 
-const AGENT_URL = 'https://agent.example.com';
-
 function buildApp(
   store: ReadModelStore,
   client: Partial<AgentDataClient>,
@@ -62,7 +63,7 @@ function buildApp(
     logger = noopLogger,
   }: {
     agentToken?: string | null;
-    createClient?: (options: { agentUrl: string; token: string }) => AgentDataClient;
+    createClient?: (options: AgentDataClientOptions) => AgentDataClient;
     logger?: Logger;
   } = {},
 ) {
@@ -78,7 +79,7 @@ function buildApp(
   app.use(
     createDataRoutesMiddleware({
       store,
-      agentUrl: AGENT_URL,
+      transport: TRANSPORT,
       logger,
       createClient,
     }),
@@ -133,20 +134,16 @@ describe('data routes middleware', () => {
       expect(list).not.toHaveBeenCalled();
     });
 
-    it('should forward the agent url and resolved token to the data client', async () => {
+    it('should forward the transport and resolved token to the data client', async () => {
       const createClient = jest.fn(() => ({ list: async () => [] } as unknown as AgentDataClient));
       const app = buildApp(storeOf(usersReadModel), {}, { agentToken: 'jwt-123', createClient });
 
       await request(app.callback()).post('/agent/v1/users/list').send({});
 
-      expect(createClient).toHaveBeenCalledWith({
-        agentUrl: AGENT_URL,
-        token: 'jwt-123',
-        timeoutMs: undefined,
-      });
+      expect(createClient).toHaveBeenCalledWith({ transport: TRANSPORT, token: 'jwt-123' });
     });
 
-    it('should forward the configured agent timeout to the data client', async () => {
+    it('should build one client per request with the configured transport', async () => {
       const createClient = jest.fn(() => ({ list: async () => [] } as unknown as AgentDataClient));
       const app = new Koa();
       app.silent = true;
@@ -160,8 +157,7 @@ describe('data routes middleware', () => {
       app.use(
         createDataRoutesMiddleware({
           store: storeOf(usersReadModel),
-          agentUrl: AGENT_URL,
-          timeoutMs: 2500,
+          transport: TRANSPORT,
           logger: noopLogger,
           createClient,
         }),
@@ -169,7 +165,7 @@ describe('data routes middleware', () => {
 
       await request(app.callback()).post('/agent/v1/users/list').send({});
 
-      expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 2500 }));
+      expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ transport: TRANSPORT }));
     });
   });
 

--- a/packages/agent-bff/test/data/fixtures/live-agent-harness.ts
+++ b/packages/agent-bff/test/data/fixtures/live-agent-harness.ts
@@ -8,6 +8,7 @@ import jsonwebtoken from 'jsonwebtoken';
 import Koa from 'koa';
 import net from 'net';
 
+import { createHttpTransport } from '../../../src/agent/agent-transport';
 import createDataRoutesMiddleware from '../../../src/data/data-routes-middleware';
 import createErrorMiddleware from '../../../src/http/error-middleware';
 import CapabilitiesCache from '../../../src/read-model/capabilities-cache';
@@ -80,7 +81,13 @@ export function buildApp(agentUrl: string, schemaPath: string): Koa {
     ctx.state.agentToken = token;
     await next();
   });
-  app.use(createDataRoutesMiddleware({ store, agentUrl, logger: noopLogger }));
+  app.use(
+    createDataRoutesMiddleware({
+      store,
+      transport: createHttpTransport({ agentUrl }),
+      logger: noopLogger,
+    }),
+  );
 
   return app;
 }

--- a/packages/agent-bff/test/helpers/action-routes.ts
+++ b/packages/agent-bff/test/helpers/action-routes.ts
@@ -6,6 +6,7 @@ import { bodyParser } from '@koa/bodyparser';
 import Koa from 'koa';
 
 import createActionRoutesMiddleware from '../../src/action/action-routes-middleware';
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import createErrorMiddleware from '../../src/http/error-middleware';
 import ReadModel from '../../src/read-model/read-model';
 import { action, collection, column } from '../read-model/fixtures';
@@ -122,7 +123,7 @@ export function buildApp(
   app.use(
     createActionRoutesMiddleware({
       store,
-      agentUrl: 'https://agent.example.com',
+      transport: createHttpTransport({ agentUrl: 'https://agent.example.com' }),
       logger,
       createClient: () => client,
     }),
@@ -148,7 +149,7 @@ export function buildAppWithTerminal(client: AgentActionClient) {
   app.use(
     createActionRoutesMiddleware({
       store: storeOf(readModel),
-      agentUrl: 'https://agent.example.com',
+      transport: createHttpTransport({ agentUrl: 'https://agent.example.com' }),
       logger: noopLogger,
       createClient: () => client,
     }),

--- a/packages/agent-bff/test/http/bff-local-errors.test.ts
+++ b/packages/agent-bff/test/http/bff-local-errors.test.ts
@@ -6,6 +6,7 @@ import {
   openapiDisabled,
   relationNotAllowed,
   schemaUnavailable,
+  streamingUnsupported,
   unknownAction,
   unknownCollection,
   unknownRelation,
@@ -25,6 +26,7 @@ describe('bff local errors', () => {
     [schemaUnavailable, 'schema_unavailable', 503],
     [unsupportedActionResult, 'unsupported_action_result', 501],
     [openapiDisabled, 'openapi_disabled', 404],
+    [streamingUnsupported, 'streaming_unsupported', 501],
   ])('%p builds a %s error with status %d', (factory, type, status) => {
     expect(factory()).toMatchObject({ type, status });
   });

--- a/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-generated-client.test.ts
@@ -11,6 +11,7 @@ import Koa from 'koa';
 import path from 'path';
 
 import createActionRoutesMiddleware from '../../src/action/action-routes-middleware';
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import { BFF_KEY_HEADER } from '../../src/api-key/api-key-middleware';
 import dispatchCli from '../../src/cli-dispatch';
 import createDataRoutesMiddleware from '../../src/data/data-routes-middleware';
@@ -186,7 +187,7 @@ function buildApp(): Koa {
   app.use(
     createDataRoutesMiddleware({
       store,
-      agentUrl: ENV.AGENT_URL,
+      transport: createHttpTransport({ agentUrl: ENV.AGENT_URL }),
       logger: noopLogger,
       createClient: () => dataClient,
     }),
@@ -194,7 +195,7 @@ function buildApp(): Koa {
   app.use(
     createActionRoutesMiddleware({
       store,
-      agentUrl: ENV.AGENT_URL,
+      transport: createHttpTransport({ agentUrl: ENV.AGENT_URL }),
       logger: noopLogger,
       createClient: () => actionClient,
     }),

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -4,6 +4,7 @@ import type { Middleware } from 'koa';
 
 import request from 'supertest';
 
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import runCli from '../../src/cli-core';
 import { issueBffAccessToken } from '../../src/oauth/bff-token';
 import createOpenApiRoutes, { OPENAPI_PATH } from '../../src/openapi/openapi-routes';
@@ -424,7 +425,11 @@ describe('GET /agent/openapi.json', () => {
         version: '1.2.3',
         enabled: true,
         hasAiQueryRoute: false,
-        source: { store, agentUrl: 'https://agent.example.com', logger: noopLogger },
+        source: {
+          store,
+          transport: createHttpTransport({ agentUrl: 'https://agent.example.com' }),
+          logger: noopLogger,
+        },
       });
     }
 

--- a/packages/agent-bff/test/read-model/agent-capabilities-fetcher.test.ts
+++ b/packages/agent-bff/test/read-model/agent-capabilities-fetcher.test.ts
@@ -1,6 +1,11 @@
 import { HttpRequester, createRemoteAgentClient } from '@forestadmin/agent-client';
 
+import { createHttpTransport } from '../../src/agent/agent-transport';
 import createAgentCapabilitiesFetcher from '../../src/read-model/agent-capabilities-fetcher';
+
+function transportTo(agentUrl: string, timeoutMs?: number) {
+  return createHttpTransport({ agentUrl, timeoutMs });
+}
 
 jest.mock('@forestadmin/agent-client');
 
@@ -23,7 +28,10 @@ describe('createAgentCapabilitiesFetcher', () => {
     const collection = jest.fn().mockReturnValue({ capabilities });
     createRemoteAgentClientMock.mockReturnValue({ collection });
 
-    const fetcher = createAgentCapabilitiesFetcher({ agentUrl: 'https://agent', token: 'tok' });
+    const fetcher = createAgentCapabilitiesFetcher({
+      transport: transportTo('https://agent'),
+      token: 'tok',
+    });
     const result = await fetcher('users');
 
     expect(HttpRequester).toHaveBeenCalledWith('tok', { url: 'https://agent' });
@@ -43,7 +51,10 @@ describe('createAgentCapabilitiesFetcher', () => {
       .mockReturnValue({ capabilities: jest.fn().mockResolvedValue({ fields: [] }) });
     createRemoteAgentClientMock.mockReturnValue({ collection });
 
-    const fetcher = createAgentCapabilitiesFetcher({ agentUrl: 'https://agent', token: 'tok' });
+    const fetcher = createAgentCapabilitiesFetcher({
+      transport: transportTo('https://agent'),
+      token: 'tok',
+    });
     await fetcher('users');
     await fetcher('orders');
 
@@ -58,7 +69,7 @@ describe('createAgentCapabilitiesFetcher', () => {
     let minted = 0;
 
     const fetcher = createAgentCapabilitiesFetcher({
-      agentUrl: 'https://agent',
+      transport: transportTo('https://agent'),
       token: () => {
         minted += 1;
 
@@ -83,9 +94,8 @@ describe('createAgentCapabilitiesFetcher', () => {
     });
 
     await createAgentCapabilitiesFetcher({
-      agentUrl: 'https://agent',
+      transport: transportTo('https://agent', 2500),
       token: 'tok',
-      timeoutMs: 2500,
     })('users');
 
     const httpRequester = createRemoteAgentClientMock.mock.calls[0][0]


### PR DESCRIPTION
Stacked on #1871.

## Why

`data-routes-middleware`, `agent-action-client` and `agent-capabilities-fetcher` each took an `agentUrl` (plus a `timeoutMs`) and built their own `HttpRequester`. A socket was the only way to reach the agent, which is exactly what an agent embedding the BFF in its own process cannot use.

## What

One `AgentTransport` replaces the `{ agentUrl, timeoutMs }` pair everywhere:

- `createHttpTransport` — what the standalone BFF uses; identical behavior to before.
- `createInProcessTransport` — reaches an agent in the same process through an injected dispatcher, declared structurally so neither package needs a dependency on the other for six primitive fields.

`InProcessRequester` subclasses `HttpRequester` so the deserialization and the `AgentHttpError` shape stay identical to the HTTP path, and it escapes the path the way `buildUrl` does. That last point matters: `agent-data-client` passes raw segments *on purpose* (its comment says pre-encoding would double-encode), so the escaping has to happen in the transport or the two paths address records differently.

Worth noting for the review: `escapeUrlSlug` is `encodeURI` plus escaping of `+?*`, and `encodeURI` leaves `#` and `?` alone — so a `#` inside a primary key is mishandled on **both** transports, not just in-process. That is a pre-existing issue tracked in PRD-1124, not something this PR fixes; what this PR guarantees is that the two transports behave the same.

`stream()` throws in-process: there is no socket to stream from, and nothing in the BFF streams today.

## Tests

82 suites, 1362 tests. New `in-process-transport` suite covers the dispatched shape, the escaping (a space and a `+` are observable, unlike `#`), the leading-slash normalization, the timeout precedence, the error mapping and the stream refusal. The middleware suites now assert the transport reaches the client, and the timeout assertions moved down to the client suites where the transport is built.

Fixes PRD-1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inject `AgentTransport` and lazy `EnvironmentIdResolver` into BFF middlewares
> - Replaces separate agent URL and timeout options with a single `AgentTransport` dependency across data, action, OpenAPI, and capabilities modules so each route shares one transport.
> - Introduces `createEnvironmentIdResolver` which defers the Forest environment-ID fetch to request time, caches successes indefinitely, shares concurrent in-flight requests, and retries failures after a 5-second TTL.
> - Adds `EnvironmentFetchError` with permanent-vs-retryable classification (4xx except 429 = permanent) and `tolerateEnvironmentIdFailure` so the context route returns 200 without an ID when resolution fails.
> - Risk: OAuth and AI route contracts change from a numeric `environmentId` to an `EnvironmentIdResolver`; out-of-tree callers passing the old option will fail to compile. The BFF no longer fetches an environment ID at boot, so startup no longer fails when the Forest server is unreachable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ee76a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->