### PR TITLE
feat(agent-bff): let the emitted paths carry a mount prefix

### DIFF
--- a/packages/agent-bff/src/base-path.ts
+++ b/packages/agent-bff/src/base-path.ts
@@ -35,3 +35,43 @@ export default function normalizeBasePath(input?: string): string {
 
   return collapsed;
 }
+
+/**
+ * What the caller actually asked for, as a prefix, rather than what the deployment was configured
+ * with. A host that serves the BFF under a sub-path of its own — `app.use('/api', sub)` — strips
+ * that sub-path before the request lands here, so the configured value is only half the truth and
+ * every absolute path the BFF emits would miss it.
+ *
+ * The host preserves the untouched url on the request (`originalUrl`, the convention Express and
+ * Connect already follow), so the prefix is the difference between it and what this app was handed.
+ * Suffix removal rather than concatenation: the untouched url already contains the configured
+ * prefix, and re-appending it would emit `/api/bff/bff`.
+ *
+ * Falls back to the configured value whenever the two cannot be related — a standalone deployment
+ * has no `originalUrl` at all, and a host that rewrote the path beyond a prefix is not something to
+ * guess at.
+ */
+export function resolveEmittedBase(
+  untouchedUrl: string | undefined,
+  seenUrl: string,
+  configured: string,
+): string {
+  if (typeof untouchedUrl !== 'string' || !untouchedUrl.endsWith(seenUrl)) return configured;
+
+  const prefix = untouchedUrl.slice(0, untouchedUrl.length - seenUrl.length);
+
+  return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+}
+
+/**
+ * Same thing, read off a Koa context. Defensive on purpose: a caller exercising a middleware with a
+ * hand-built context has no `req` at all, and an emitted path is never worth throwing over.
+ */
+export function emittedBaseOf(
+  ctx: { req?: unknown; originalUrl?: string; url?: string },
+  configured: string,
+): string {
+  const untouched = (ctx.req as { originalUrl?: string } | undefined)?.originalUrl;
+
+  return resolveEmittedBase(untouched, ctx.originalUrl ?? ctx.url ?? '', configured);
+}

--- a/packages/agent-bff/src/base-path.ts
+++ b/packages/agent-bff/src/base-path.ts
@@ -1,0 +1,37 @@
+import { ConfigurationError } from './errors';
+
+const SHAPE = /^(\/[A-Za-z0-9_-]+)+$/;
+
+/**
+ * The prefix is interpolated raw into everything the BFF emits — the docs page's absolute paths and
+ * the OpenAPI `servers` entry — so it is normalized once, here, before anything reads it. The two
+ * inputs that hurt are the ones that still look right:
+ *
+ * - `'/'` would emit `//agent/openapi.json`, an RFC 3986 network-path reference: a browser resolves
+ *   `agent` as a HOST, so the page loads neither its document nor its bundle.
+ * - `'bff'` would emit a RELATIVE `servers` url, which a generator resolves against wherever it read
+ *   the document from rather than against the origin — the page and the generated client then
+ *   disagree silently.
+ *
+ * Anything that is not a plain path prefix is rejected rather than repaired: the value comes from the
+ * embedding host, usually an environment variable, and a mount the host does not serve is a
+ * misconfiguration to report, not a url to publish.
+ */
+export default function normalizeBasePath(input?: string): string {
+  if (!input) return '';
+
+  const trimmed = input.trim();
+
+  if (trimmed === '' || trimmed === '/') return '';
+
+  const collapsed = `/${trimmed}`.replace(/\/+/g, '/').replace(/\/+$/, '');
+
+  if (!SHAPE.test(collapsed)) {
+    throw new ConfigurationError(
+      `Invalid BFF base path "${input}": use a plain path prefix like "/bff" ` +
+        `(letters, digits, "-" and "_" only).`,
+    );
+  }
+
+  return collapsed;
+}

--- a/packages/agent-bff/src/build-bff.ts
+++ b/packages/agent-bff/src/build-bff.ts
@@ -22,6 +22,7 @@ import ApiKeyClient from './api-key/api-key-client';
 import createApiKeyMiddleware from './api-key/api-key-middleware';
 import createResolveCache from './api-key/resolve-cache';
 import createAuthModeMiddleware from './auth/auth-mode-middleware';
+import normalizeBasePath from './base-path';
 import warnMissingConfig from './config/missing-config-warning';
 import createContextRoutesMiddleware from './context/context-routes-middleware';
 import createCorsMiddleware from './cors/cors-middleware';
@@ -58,6 +59,9 @@ export interface BuildBffOptions {
    * Prefix the host serves this BFF under, `/bff` for an embedded one. Routing is the host's job —
    * it strips the prefix before the request lands here — but the paths the BFF *emits* (the OpenAPI
    * `servers` entry, the docs page's asset and document urls) must carry it.
+   *
+   * A plain path prefix, with or without its leading slash; `'/'` and `''` both mean the BFF owns the
+   * origin root. Normalized by `normalizeBasePath`, which throws on anything else.
    */
   basePath?: string;
 }
@@ -442,8 +446,12 @@ function buildAgentMiddlewares(
 export default async function buildBff({
   config,
   logger = createConsoleLogger(),
-  basePath = '',
+  basePath,
 }: BuildBffOptions): Promise<Bff> {
+  // Before anything is assembled: a mount the host does not serve must fail at boot, not surface as
+  // a docs page that cannot load itself.
+  const mountPath = normalizeBasePath(basePath);
+
   if (config.invalidAllowedOrigins.length > 0) {
     logger('Warn', 'Ignoring malformed BFF_ALLOWED_ORIGINS entries', {
       entries: config.invalidAllowedOrigins,
@@ -454,7 +462,7 @@ export default async function buildBff({
 
   const oauth = buildOAuthMiddlewares(config, logger);
   const aiMiddlewares = buildAiMiddlewares(config, oauth, logger);
-  const agentMiddlewares = buildAgentMiddlewares(config, logger, oauth, aiMiddlewares, basePath);
+  const agentMiddlewares = buildAgentMiddlewares(config, logger, oauth, aiMiddlewares, mountPath);
   const hasAgentEdge = agentMiddlewares.length > 0;
   const agentErrorMiddleware = hasAgentEdge ? [agentScoped(createErrorMiddleware({ logger }))] : [];
   const agentJsonOnlyGuard = hasAgentEdge ? [agentScoped(createJsonOnlyGuard())] : [];
@@ -473,7 +481,7 @@ export default async function buildBff({
     createDocsRoutes({
       enabled: config.openapiEnabled && agentMiddlewares.length > 0,
       documentPath: OPENAPI_PATH,
-      basePath,
+      basePath: mountPath,
       logger,
     }),
     ...agentMiddlewares,

--- a/packages/agent-bff/src/build-bff.ts
+++ b/packages/agent-bff/src/build-bff.ts
@@ -54,6 +54,12 @@ export type BffCallback = (req: IncomingMessage, res: ServerResponse) => void | 
 export interface BuildBffOptions {
   config: BFFConfig;
   logger?: Logger;
+  /**
+   * Prefix the host serves this BFF under, `/bff` for an embedded one. Routing is the host's job —
+   * it strips the prefix before the request lands here — but the paths the BFF *emits* (the OpenAPI
+   * `servers` entry, the docs page's asset and document urls) must carry it.
+   */
+  basePath?: string;
 }
 
 export interface Bff {
@@ -376,6 +382,7 @@ function buildAgentMiddlewares(
   logger: Logger,
   oauth: OAuthEdge,
   aiMiddlewares: Middleware[],
+  basePath: string,
 ): Middleware[] {
   const { forestAuthSecret, defaultTimezone } = config;
 
@@ -405,6 +412,7 @@ function buildAgentMiddlewares(
       source,
       hasAiQueryRoute: aiMiddlewares.length > 0,
       publicUrl: config.publicUrl,
+      basePath,
     }),
     ...(bundle
       ? [
@@ -434,6 +442,7 @@ function buildAgentMiddlewares(
 export default async function buildBff({
   config,
   logger = createConsoleLogger(),
+  basePath = '',
 }: BuildBffOptions): Promise<Bff> {
   if (config.invalidAllowedOrigins.length > 0) {
     logger('Warn', 'Ignoring malformed BFF_ALLOWED_ORIGINS entries', {
@@ -445,7 +454,7 @@ export default async function buildBff({
 
   const oauth = buildOAuthMiddlewares(config, logger);
   const aiMiddlewares = buildAiMiddlewares(config, oauth, logger);
-  const agentMiddlewares = buildAgentMiddlewares(config, logger, oauth, aiMiddlewares);
+  const agentMiddlewares = buildAgentMiddlewares(config, logger, oauth, aiMiddlewares, basePath);
   const hasAgentEdge = agentMiddlewares.length > 0;
   const agentErrorMiddleware = hasAgentEdge ? [agentScoped(createErrorMiddleware({ logger }))] : [];
   const agentJsonOnlyGuard = hasAgentEdge ? [agentScoped(createJsonOnlyGuard())] : [];
@@ -464,6 +473,7 @@ export default async function buildBff({
     createDocsRoutes({
       enabled: config.openapiEnabled && agentMiddlewares.length > 0,
       documentPath: OPENAPI_PATH,
+      basePath,
       logger,
     }),
     ...agentMiddlewares,

--- a/packages/agent-bff/src/docs/docs-routes.ts
+++ b/packages/agent-bff/src/docs/docs-routes.ts
@@ -16,6 +16,11 @@ export interface DocsRoutesOptions {
   enabled: boolean;
   /** Where the shell fetches the document. Passed in so this module never reaches into `src/openapi`. */
   documentPath: string;
+  /**
+   * Prefix the host serves the BFF under. The page carries absolute paths — the browser resolves
+   * them against the origin, not against the page — so they must carry the prefix too.
+   */
+  basePath?: string;
   logger: Logger;
   /** The bundle lookup, as a seam: an install that shipped without the asset is a real state to serve. */
   resolveBundlePath?: () => string | undefined;
@@ -57,6 +62,7 @@ export function resolveBundle(directory: string = __dirname): string | undefined
 export default function createDocsRoutes({
   enabled,
   documentPath,
+  basePath = '',
   logger,
   resolveBundlePath = resolveBundle,
 }: DocsRoutesOptions): Middleware {
@@ -66,7 +72,9 @@ export default function createDocsRoutes({
     logger('Warn', `API documentation page disabled: ${BUNDLE_FILE} is missing from this install`);
   }
 
-  const page = bundle ? renderDocsPage(documentPath, DOCS_BUNDLE_PATH) : undefined;
+  const page = bundle
+    ? renderDocsPage(`${basePath}${documentPath}`, `${basePath}${DOCS_BUNDLE_PATH}`)
+    : undefined;
   let script: string | undefined;
 
   return async function docsRoutes(ctx, next) {

--- a/packages/agent-bff/src/docs/docs-routes.ts
+++ b/packages/agent-bff/src/docs/docs-routes.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 
 import renderDocsPage from './docs-page';
+import { emittedBaseOf } from '../base-path';
 
 export const DOCS_PATH = '/docs';
 export const DOCS_BUNDLE_PATH = '/docs/redoc.standalone.js';
@@ -72,9 +73,20 @@ export default function createDocsRoutes({
     logger('Warn', `API documentation page disabled: ${BUNDLE_FILE} is missing from this install`);
   }
 
-  const page = bundle
-    ? renderDocsPage(`${basePath}${documentPath}`, `${basePath}${DOCS_BUNDLE_PATH}`)
-    : undefined;
+  // Rendered per request rather than once: the prefix depends on where the host serves the BFF,
+  // which only the request knows. Memoized per prefix, of which a deployment has one in practice.
+  const pages = new Map<string, string>();
+
+  const pageFor = (base: string): string => {
+    const cached = pages.get(base);
+    if (cached !== undefined) return cached;
+
+    const rendered = renderDocsPage(`${base}${documentPath}`, `${base}${DOCS_BUNDLE_PATH}`);
+    pages.set(base, rendered);
+
+    return rendered;
+  };
+
   let script: string | undefined;
 
   return async function docsRoutes(ctx, next) {
@@ -112,6 +124,6 @@ export default function createDocsRoutes({
     ctx.status = 200;
     ctx.type = 'text/html';
     ctx.set('Cache-Control', 'no-store');
-    ctx.body = page;
+    ctx.body = pageFor(emittedBaseOf(ctx, basePath));
   };
 }

--- a/packages/agent-bff/src/docs/docs-samples.ts
+++ b/packages/agent-bff/src/docs/docs-samples.ts
@@ -13,10 +13,14 @@ const SESSION_VARIABLE = 'BFF_SESSION';
  * In the page rather than in the document, deliberately. Three samples per operation weigh ~73 KB on
  * a 16-collection schema and several hundred KB on a large one, which every consumer of
  * `/agent/openapi.json` would pay for an extension only a viewer reads — where this costs one
- * function whatever the operation count. It also lets a sample carry the REAL origin: the document
- * declares `servers` root-relative unless `BFF_PUBLIC_URL` is set, so a sample built into it could
- * only hold a placeholder host, while the page knows where it is served from and emits a command
- * that runs as pasted.
+ * function whatever the operation count. It also lets a sample carry the REAL origin: unless
+ * `BFF_PUBLIC_URL` is set, the document's `servers` entry is root-relative — at most a mount prefix,
+ * never a host — so a sample built into it could only hold a placeholder host, while the page knows
+ * the origin it was served from.
+ *
+ * The two halves therefore compose — origin from the page, prefix from the document — rather than
+ * either one alone: a BFF mounted under `/bff` answers on the page's origin, but at `/bff/agent/...`,
+ * and a sample that skipped the prefix would 404, or worse reach whatever owns the origin root.
  *
  * The key is never inlined: each language reads it from the environment, so a copied sample cannot
  * carry a credential into a shell history or a paste.
@@ -294,7 +298,7 @@ const SAMPLES_SCRIPT = `
           return lines.join('\\n');
         }
 
-        function decorateWithSamples(spec, origin) {
+        function decorateWithSamples(spec, base) {
           var paths = spec.paths || {};
 
           Object.keys(paths).forEach(function (path) {
@@ -307,7 +311,7 @@ const SAMPLES_SCRIPT = `
 
               var body = exampleBody(spec, operation);
               var headers = headersOf(spec, operation, body);
-              var url = origin + samplePath(spec, item, operation, path);
+              var url = base + samplePath(spec, item, operation, path);
               var verb = method.toUpperCase();
 
               operation['x-codeSamples'] = [
@@ -322,13 +326,29 @@ const SAMPLES_SCRIPT = `
         }
 
         /**
+         * The base every sample is built on, read off the document's own \`servers\` entry so the
+         * snippets and the generated clients cannot disagree. An entry that already carries a scheme
+         * and a host is the base as it stands; a bare prefix is appended to the origin the page was
+         * served from, and \`/\` means the BFF owns that origin root.
+         */
+        function sampleBase(spec) {
+          var mount = (((spec.servers || [])[0]) || {}).url || '/';
+
+          while (mount.length > 1 && mount.slice(-1) === '/') mount = mount.slice(0, -1);
+
+          if (mount.indexOf('//') === 0 || mount.indexOf('://') !== -1) return mount;
+
+          return mount === '/' ? window.location.origin : window.location.origin + mount;
+        }
+
+        /**
          * Samples are a convenience; the document is the point. A shape the generator cannot walk
          * costs the reader its snippets, never the page — and reporting it as a Redoc render failure
          * would send them looking in the wrong place.
          */
         function withSamples(spec) {
           try {
-            return decorateWithSamples(spec, window.location.origin);
+            return decorateWithSamples(spec, sampleBase(spec));
           } catch (samplesError) {
             return spec;
           }

--- a/packages/agent-bff/src/openapi/openapi-document.ts
+++ b/packages/agent-bff/src/openapi/openapi-document.ts
@@ -562,13 +562,20 @@ const RELATIVE_SERVER_DESCRIPTION =
 export interface GenerateOpenApiDocumentOptions {
   unfolding?: Unfolding;
   hasAiQueryRoute?: boolean;
-  /** The deployment's own external base URL, from `BFF_PUBLIC_URL`. Absent falls back to `/`. */
+  /** The deployment's own external base URL, from `BFF_PUBLIC_URL`. Takes precedence. */
   publicUrl?: string;
+  /** Where the BFF answers from the caller's point of view. Empty when it owns the origin root. */
+  basePath?: string;
 }
 
 export function generateOpenApiDocument(
   version: string,
-  { unfolding, hasAiQueryRoute = false, publicUrl }: GenerateOpenApiDocumentOptions = {},
+  {
+    unfolding,
+    hasAiQueryRoute = false,
+    publicUrl,
+    basePath = '',
+  }: GenerateOpenApiDocumentOptions = {},
 ): OpenAPIObject {
   const registry = new OpenAPIRegistry();
   const hasActions =
@@ -688,7 +695,7 @@ export function generateOpenApiDocument(
     servers: [
       publicUrl
         ? { url: publicUrl, description: CONFIGURED_SERVER_DESCRIPTION }
-        : { url: '/', description: RELATIVE_SERVER_DESCRIPTION },
+        : { url: basePath || '/', description: RELATIVE_SERVER_DESCRIPTION },
     ],
   });
 }

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -19,6 +19,8 @@ export interface OpenApiRoutesOptions {
   enabled: boolean;
   hasAiQueryRoute: boolean;
   publicUrl?: string;
+  /** Prefix the host serves the BFF under, so a generated client targets the right base url. */
+  basePath?: string;
   /** Absent (no agent or no read-model configuration) serves the generic document. */
   source?: UnfoldSource;
 }
@@ -29,10 +31,13 @@ export default function createOpenApiRoutes({
   source,
   hasAiQueryRoute,
   publicUrl,
+  basePath,
 }: OpenApiRoutesOptions): Middleware {
   const generic =
     enabled && !source
-      ? serializeOpenApi(generateOpenApiDocument(version, { hasAiQueryRoute, publicUrl }))
+      ? serializeOpenApi(
+          generateOpenApiDocument(version, { hasAiQueryRoute, publicUrl, basePath }),
+        )
       : undefined;
 
   // Memoized on the read-model identity: the store builds a new one per schema generation, so the
@@ -60,6 +65,7 @@ export default function createOpenApiRoutes({
       version,
       hasAiQueryRoute,
       publicUrl,
+      basePath,
     });
 
     // A schema refresh landing during the capabilities fan-out mixes the new generation's field sets

--- a/packages/agent-bff/src/openapi/openapi-routes.ts
+++ b/packages/agent-bff/src/openapi/openapi-routes.ts
@@ -5,6 +5,7 @@ import type { Middleware } from 'koa';
 import { generateOpenApiDocument, serializeOpenApi } from './openapi-document';
 import buildUnfoldedDocument from './unfolded-document';
 import { hasDegradedCollection } from './unfolding';
+import { emittedBaseOf } from '../base-path';
 import { requireAgentToken, resolveReadModel } from '../http/agent-route-helpers';
 import { openapiDisabled } from '../http/bff-local-errors';
 
@@ -33,22 +34,32 @@ export default function createOpenApiRoutes({
   publicUrl,
   basePath,
 }: OpenApiRoutesOptions): Middleware {
-  const generic =
-    enabled && !source
-      ? serializeOpenApi(
-          generateOpenApiDocument(version, { hasAiQueryRoute, publicUrl, basePath }),
-        )
-      : undefined;
+  // Both documents carry the prefix the caller reached the BFF under, which only the request knows,
+  // so both are memoized per prefix instead of built once. A deployment has one prefix in practice.
+  const generics = new Map<string, string>();
+
+  const genericFor = (base: string): string => {
+    const cached = generics.get(base);
+    if (cached !== undefined) return cached;
+
+    const document = serializeOpenApi(
+      generateOpenApiDocument(version, { hasAiQueryRoute, publicUrl, basePath: base }),
+    );
+    generics.set(base, document);
+
+    return document;
+  };
 
   // Memoized on the read-model identity: the store builds a new one per schema generation, so the
   // document is rebuilt exactly when the schema it describes changed.
-  let unfolded: { readModel: ReadModel; document: string } | undefined;
+  const unfoldedByBase = new Map<string, { readModel: ReadModel; document: string }>();
 
   async function resolveDocument(
     ctx: Parameters<Middleware>[0],
+    base: string,
     attemptsLeft = MAX_GENERATION_RETRIES,
   ): Promise<string> {
-    if (!source) return generic as string;
+    if (!source) return genericFor(base);
 
     if (attemptsLeft <= 0) {
       throw new Error('Schema generation kept changing while building the OpenAPI document');
@@ -59,13 +70,14 @@ export default function createOpenApiRoutes({
     const token = requireAgentToken(ctx);
     const readModel = await resolveReadModel(source.store);
 
-    if (unfolded?.readModel === readModel) return unfolded.document;
+    const memoized = unfoldedByBase.get(base);
+    if (memoized?.readModel === readModel) return memoized.document;
 
     const { document, unfolding } = await buildUnfoldedDocument(source, readModel, token, {
       version,
       hasAiQueryRoute,
       publicUrl,
-      basePath,
+      basePath: base,
     });
 
     // A schema refresh landing during the capabilities fan-out mixes the new generation's field sets
@@ -73,7 +85,7 @@ export default function createOpenApiRoutes({
     // nor cached — a consumer would generate a client from a self-contradictory schema. Bounded like
     // `ReadModelStore.getCapabilities`, and driven by the 24h schema TTL rather than request volume.
     if ((await resolveReadModel(source.store)) !== readModel) {
-      return resolveDocument(ctx, attemptsLeft - 1);
+      return resolveDocument(ctx, base, attemptsLeft - 1);
     }
 
     // Only a complete document is memoized. The memo key is the schema generation, which moves on a
@@ -82,7 +94,7 @@ export default function createOpenApiRoutes({
     // the revision. `CapabilitiesCache` deliberately caches successes only; this keeps that true
     // end to end, at the cost of re-running the fan-out until the agent answers again.
     if (!hasDegradedCollection(unfolding)) {
-      unfolded = { readModel, document };
+      unfoldedByBase.set(base, { readModel, document });
     }
 
     return document;
@@ -99,7 +111,7 @@ export default function createOpenApiRoutes({
       throw openapiDisabled();
     }
 
-    const document = await resolveDocument(ctx);
+    const document = await resolveDocument(ctx, emittedBaseOf(ctx, basePath ?? ''));
 
     ctx.status = 200;
     ctx.type = 'application/json';

--- a/packages/agent-bff/src/openapi/unfolded-document.ts
+++ b/packages/agent-bff/src/openapi/unfolded-document.ts
@@ -26,13 +26,14 @@ export interface UnfoldOptions {
   version: string;
   hasAiQueryRoute: boolean;
   publicUrl?: string;
+  basePath?: string;
 }
 
 export default async function buildUnfoldedDocument(
   source: UnfoldSource,
   readModel: ReadModel,
   token: string | (() => string),
-  { version, hasAiQueryRoute, publicUrl }: UnfoldOptions,
+  { version, hasAiQueryRoute, publicUrl, basePath }: UnfoldOptions,
 ): Promise<UnfoldedDocument> {
   const unfolding = await collectUnfolding({
     readModel,
@@ -43,7 +44,7 @@ export default async function buildUnfoldedDocument(
 
   return {
     document: serializeOpenApi(
-      generateOpenApiDocument(version, { unfolding, hasAiQueryRoute, publicUrl }),
+      generateOpenApiDocument(version, { unfolding, hasAiQueryRoute, publicUrl, basePath }),
     ),
     unfolding,
   };

--- a/packages/agent-bff/test/base-path.test.ts
+++ b/packages/agent-bff/test/base-path.test.ts
@@ -1,0 +1,41 @@
+import normalizeBasePath from '../src/base-path';
+import { ConfigurationError } from '../src/errors';
+
+describe('normalizeBasePath', () => {
+  describe('when the BFF owns the origin root', () => {
+    it.each([
+      ['nothing', undefined],
+      ['an empty string', ''],
+      ['blanks', '   '],
+      ['the root path', '/'],
+    ])('should return an empty prefix for %s, since // would name a host', (_, input) => {
+      expect(normalizeBasePath(input)).toBe('');
+    });
+  });
+
+  describe('when the host serves the BFF under a prefix', () => {
+    it.each([
+      ['a plain prefix', '/bff', '/bff'],
+      ['a missing leading slash', 'bff', '/bff'],
+      ['a trailing slash', '/bff/', '/bff'],
+      ['duplicated slashes', '//bff//admin//', '/bff/admin'],
+      ['surrounding blanks', '  /bff  ', '/bff'],
+      ['a nested prefix', '/api/bff', '/api/bff'],
+    ])('should normalize %s to an absolute prefix', (_, input, expected) => {
+      expect(normalizeBasePath(input)).toBe(expected);
+    });
+  });
+
+  describe('when the value is not a plain path prefix', () => {
+    it.each([
+      ['a full url', 'https://bff.example.com/bff'],
+      ['a query string', '/bff?key=1'],
+      ['a fragment', '/bff#docs'],
+      ['a space inside a segment', '/my bff'],
+      ['a traversal', '/bff/../admin'],
+    ])('should reject %s rather than publish a mount nobody serves', (_, input) => {
+      expect(() => normalizeBasePath(input)).toThrow(ConfigurationError);
+      expect(() => normalizeBasePath(input)).toThrow(`Invalid BFF base path "${input}"`);
+    });
+  });
+});

--- a/packages/agent-bff/test/build-bff.test.ts
+++ b/packages/agent-bff/test/build-bff.test.ts
@@ -110,6 +110,45 @@ describe('buildBff', () => {
     expect(response.status).toBe(401);
   });
 
+  describe('when the host serves the BFF under a prefix', () => {
+    it('should point the docs page at the prefixed document and bundle', async () => {
+      const { callback } = await buildBff({
+        config: parseConfig(VALID_ENV),
+        logger: noopLogger,
+        basePath: '/bff',
+      });
+
+      const response = await request(callback).get('/docs');
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('/bff/agent/openapi.json');
+      expect(response.text).toContain('/bff/docs/redoc.standalone.js');
+    });
+
+    it('should leave the routes themselves unprefixed, since the host strips before dispatching', async () => {
+      const { callback } = await buildBff({
+        config: parseConfig(VALID_ENV),
+        logger: noopLogger,
+        basePath: '/bff',
+      });
+
+      const response = await request(callback).get('/health');
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('when the BFF owns the origin root', () => {
+    it('should emit unprefixed asset paths', async () => {
+      const callback = await buildCallback(VALID_ENV);
+
+      const response = await request(callback).get('/docs');
+
+      expect(response.text).toContain('"/agent/openapi.json"');
+      expect(response.text).toContain('src="/docs/redoc.standalone.js"');
+    });
+  });
+
   describe('when BFF_ALLOWED_ORIGINS carries a malformed entry', () => {
     it('should warn once with the rejected entries', async () => {
       const logger = jest.fn();

--- a/packages/agent-bff/test/build-bff.test.ts
+++ b/packages/agent-bff/test/build-bff.test.ts
@@ -121,8 +121,8 @@ describe('buildBff', () => {
       const response = await request(callback).get('/docs');
 
       expect(response.status).toBe(200);
-      expect(response.text).toContain('/bff/agent/openapi.json');
-      expect(response.text).toContain('/bff/docs/redoc.standalone.js');
+      expect(response.text).toContain('"/bff/agent/openapi.json"');
+      expect(response.text).toContain('src="/bff/docs/redoc.standalone.js"');
     });
 
     it('should leave the routes themselves unprefixed, since the host strips before dispatching', async () => {
@@ -146,6 +146,32 @@ describe('buildBff', () => {
 
       expect(response.text).toContain('"/agent/openapi.json"');
       expect(response.text).toContain('src="/docs/redoc.standalone.js"');
+    });
+
+    it('should emit the same paths for the root basePath, not a // that names a host', async () => {
+      const { callback } = await buildBff({
+        config: parseConfig(VALID_ENV),
+        logger: noopLogger,
+        basePath: '/',
+      });
+
+      const response = await request(callback).get('/docs');
+
+      expect(response.text).toContain('"/agent/openapi.json"');
+      expect(response.text).toContain('src="/docs/redoc.standalone.js"');
+      expect(response.text).not.toContain('//agent/openapi.json');
+    });
+  });
+
+  describe('when the basePath is not a plain path prefix', () => {
+    it('should refuse to build rather than publish a mount nobody serves', async () => {
+      await expect(
+        buildBff({
+          config: parseConfig(VALID_ENV),
+          logger: noopLogger,
+          basePath: 'https://bff.example.com',
+        }),
+      ).rejects.toThrow('Invalid BFF base path "https://bff.example.com"');
     });
   });
 

--- a/packages/agent-bff/test/docs/docs-page.test.ts
+++ b/packages/agent-bff/test/docs/docs-page.test.ts
@@ -349,6 +349,33 @@ describe('the code samples the docs page injects', () => {
     );
   });
 
+  it('should target the mount prefix the document declares, not the origin root', async () => {
+    const page = await render({ ...API_KEY_SPEC, servers: [{ url: '/bff' }] });
+
+    expect(page.sourceOf(RELATION, 'cURL')).toContain(
+      `curl -X POST '${ORIGIN}/bff/agent/v1/My%20Coll/relations/orders/list'`,
+    );
+  });
+
+  it('should build on the origin alone when the document declares the root', async () => {
+    const page = await render({ ...API_KEY_SPEC, servers: [{ url: '/' }] });
+
+    expect(page.sourceOf(LIST, 'cURL')).toContain(
+      `curl -X POST '${ORIGIN}/agent/v1/My%20Coll/list'`,
+    );
+  });
+
+  it('should keep a server url that already carries a host, rather than prefix the page origin', async () => {
+    const page = await render({
+      ...API_KEY_SPEC,
+      servers: [{ url: 'https://public.example.com/bff/' }],
+    });
+
+    expect(page.sourceOf(RELATION, 'JavaScript')).toContain(
+      'https://public.example.com/bff/agent/v1/My%20Coll/relations/orders/list',
+    );
+  });
+
   it('should double-quote the secret header, since single quotes stop the shell expanding it', async () => {
     const page = await render(API_KEY_SPEC);
     const curl = page.sourceOf(RELATION, 'cURL');

--- a/packages/agent-bff/test/emitted-base.test.ts
+++ b/packages/agent-bff/test/emitted-base.test.ts
@@ -1,0 +1,35 @@
+import { resolveEmittedBase } from '../src/base-path';
+
+describe('resolveEmittedBase', () => {
+  describe('when the host preserved the untouched url', () => {
+    it('should return the prefix the caller actually reached the BFF under', () => {
+      expect(resolveEmittedBase('/api/bff/docs', '/docs', '/bff')).toBe('/api/bff');
+    });
+
+    it('should not re-append the configured prefix, which the untouched url already carries', () => {
+      expect(resolveEmittedBase('/bff/docs', '/docs', '/bff')).toBe('/bff');
+    });
+
+    it('should keep the query string out of the prefix, since both urls carry it', () => {
+      expect(resolveEmittedBase('/api/bff/docs?x=1', '/docs?x=1', '/bff')).toBe('/api/bff');
+    });
+
+    it('should return an empty prefix when the BFF owns the origin root', () => {
+      expect(resolveEmittedBase('/docs', '/docs', '')).toBe('');
+    });
+
+    it('should not leave a trailing slash for a host mounted at the root', () => {
+      expect(resolveEmittedBase('//docs', '/docs', '/bff')).toBe('');
+    });
+  });
+
+  describe('when the two urls cannot be related', () => {
+    it('should fall back to the configured prefix rather than guess', () => {
+      expect(resolveEmittedBase('/rewritten/elsewhere', '/docs', '/bff')).toBe('/bff');
+    });
+
+    it('should fall back when the host preserved nothing, as a standalone deployment does', () => {
+      expect(resolveEmittedBase(undefined, '/docs', '')).toBe('');
+    });
+  });
+});

--- a/packages/agent-bff/test/openapi/openapi-document.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-document.test.ts
@@ -100,6 +100,22 @@ describe('generateOpenApiDocument', () => {
       expect(server.variables).toBeUndefined();
     });
 
+    it('should carry the mount prefix, so a generated client targets the right base url', () => {
+      const [server] = generateOpenApiDocument('9.9.9', { basePath: '/bff' }).servers ?? [];
+
+      expect(server.url).toBe('/bff');
+    });
+
+    it('should prefer the configured public URL over the mount prefix', () => {
+      const [server] =
+        generateOpenApiDocument('9.9.9', {
+          publicUrl: 'https://bff.example.com',
+          basePath: '/bff',
+        }).servers ?? [];
+
+      expect(server.url).toBe('https://bff.example.com');
+    });
+
     it('should carry the public URL into the unfolded document too', () => {
       const unfolded = generateOpenApiDocument('9.9.9', {
         unfolding: { collections: [] },

--- a/packages/agent-bff/test/openapi/openapi-routes.test.ts
+++ b/packages/agent-bff/test/openapi/openapi-routes.test.ts
@@ -115,6 +115,44 @@ async function withServer(
   }
 }
 
+function readContext() {
+  return {
+    path: OPENAPI_PATH,
+    method: 'GET',
+    state: { agentToken: 'agent-jwt' },
+    status: 404,
+    body: undefined as unknown,
+    type: undefined,
+    set: () => undefined,
+  } as unknown as Parameters<Middleware>[0];
+}
+
+function storeOf(generations: ReadModel[]) {
+  const last = generations[generations.length - 1];
+
+  return {
+    getReadModel: jest.fn(async () => generations.shift() ?? last),
+    getCapabilities: async (name: string, fetcher: (collection: string) => Promise<unknown>) => ({
+      capabilities: await fetcher(name),
+      readModel: last,
+    }),
+  } as unknown as ReadModelStore;
+}
+
+function routesFor(store: ReadModelStore, basePath?: string): Middleware {
+  return createOpenApiRoutes({
+    version: '1.2.3',
+    enabled: true,
+    hasAiQueryRoute: false,
+    basePath,
+    source: {
+      store,
+      transport: createHttpTransport({ agentUrl: 'https://agent.example.com' }),
+      logger: noopLogger,
+    },
+  });
+}
+
 describe('GET /agent/openapi.json', () => {
   beforeEach(() => {
     fetchSchema.mockClear().mockResolvedValue(SCHEMA);
@@ -393,46 +431,6 @@ describe('GET /agent/openapi.json', () => {
   });
 
   describe('when the schema refreshes while the document is being built', () => {
-    function readContext() {
-      return {
-        path: OPENAPI_PATH,
-        method: 'GET',
-        state: { agentToken: 'agent-jwt' },
-        status: 404,
-        body: undefined as unknown,
-        type: undefined,
-        set: () => undefined,
-      } as unknown as Parameters<Middleware>[0];
-    }
-
-    function storeOf(generations: ReadModel[]) {
-      const last = generations[generations.length - 1];
-
-      return {
-        getReadModel: jest.fn(async () => generations.shift() ?? last),
-        getCapabilities: async (
-          name: string,
-          fetcher: (collection: string) => Promise<unknown>,
-        ) => ({
-          capabilities: await fetcher(name),
-          readModel: last,
-        }),
-      } as unknown as ReadModelStore;
-    }
-
-    function routesFor(store: ReadModelStore): Middleware {
-      return createOpenApiRoutes({
-        version: '1.2.3',
-        enabled: true,
-        hasAiQueryRoute: false,
-        source: {
-          store,
-          transport: createHttpTransport({ agentUrl: 'https://agent.example.com' }),
-          logger: noopLogger,
-        },
-      });
-    }
-
     const oldGeneration = new ReadModel([collection('users', [column('id')])]);
     const newGeneration = new ReadModel([collection('orders', [column('id')])]);
 
@@ -468,6 +466,43 @@ describe('GET /agent/openapi.json', () => {
       await expect(routesFor(store)(readContext(), async () => undefined)).rejects.toThrow(
         /kept changing/,
       );
+    });
+  });
+
+  describe('when the host serves the BFF under a prefix', () => {
+    const generation = new ReadModel([collection('users', [column('id')])]);
+
+    it('should carry it in the servers entry of the served unfolded document', async () => {
+      const ctx = readContext();
+
+      await routesFor(storeOf([generation]), '/bff')(ctx, async () => undefined);
+
+      expect(JSON.parse(ctx.body as string).servers[0].url).toBe('/bff');
+    });
+
+    it('should carry it in the servers entry of the served generic document', async () => {
+      const genericRoutes = createOpenApiRoutes({
+        version: '1.2.3',
+        enabled: true,
+        hasAiQueryRoute: false,
+        basePath: '/bff',
+      });
+      const ctx = readContext();
+
+      await genericRoutes(ctx, async () => undefined);
+
+      expect(JSON.parse(ctx.body as string).servers[0].url).toBe('/bff');
+    });
+
+    it('should leave the operation paths unprefixed, since the host strips before dispatching', async () => {
+      const ctx = readContext();
+
+      await routesFor(storeOf([generation]), '/bff')(ctx, async () => undefined);
+
+      const paths = Object.keys(JSON.parse(ctx.body as string).paths);
+
+      expect(paths.every(path => path.startsWith('/agent/'))).toBe(true);
+      expect(paths).toContain('/agent/v1/users/list');
     });
   });
 


### PR DESCRIPTION
Stacked on #1872.

## Why

Two places assume the BFF owns the origin root:

- `renderDocsPage` embeds absolute paths — `/agent/openapi.json` and `/docs/redoc.standalone.js` — and a browser resolves those against the origin, not against the page.
- the OpenAPI document declares `servers: [{ url: '/' }]`, which is what a generated client uses as its base url.

Serve the BFF under `/bff` and both are wrong: the viewer fetches a document that is not there, and a generated client targets paths that 404.

## What

`buildBff({ basePath })`, default `''`, threaded into the docs page and the document's `servers`.

`basePath` is **emitted, never routed on**: the host strips its own prefix before the request reaches this app, so every route stays exactly where it was — there is a test for that, since it is the part that would be easy to get wrong later.

`basePath` is normalized once, at the entry (`normalizeBasePath`, modelled on `mcp-server`'s `normalizeMountPath`): `''` and `'/'` mean the origin root, a leading slash is optional, duplicate and trailing slashes collapse, and anything that is not a plain path prefix throws at boot. `'/'` is the input that mattered — interpolated raw it emits `//agent/openapi.json`, which a browser resolves with `agent` as the host.

The docs page's code samples read the prefix off the document's own `servers[0].url` rather than assuming `location.origin` is the base, so the snippets and a generated client cannot disagree.

## Tests

83 suites, 1390 tests. `build-bff` covers the prefixed and unprefixed page (delimiters anchored, so a doubled prefix fails), the `'/'` case, a rejected prefix, and the invariant that routing is unaffected; `openapi-routes` asserts `servers` on the *served* document in both the unfolded and generic branches; `base-path` covers normalization and rejection; `docs-page` asserts the emitted sample urls for a prefix, the root, and a server url that already carries a host.

Fixes PRD-1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mount prefix to `agent-bff` emitted paths and introduce `AgentTransport` abstraction
> - Adds `normalizeBasePath` and `resolveEmittedBase` utilities to derive the externally visible BFF mount prefix from the request URL and a configured `basePath` option on `buildBff`.
> - Passes the mount prefix into OpenAPI document generation ([openapi-document.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-fe205dfba3d9163361b5101e76cdd78dc3bd2c2eb7a03e54d0bdc112b2b5584c)), OpenAPI route caching ([openapi-routes.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-98b5421ed1d92a87c274e0812f3f8611271019c97f94cc5a913b39f6603a3b06)), docs route rendering ([docs-routes.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-3dcba5d66b2d959c4b9880d5839f46457c1ce973af10e1fef317c2d9603312bf)), and browser sample URL construction ([docs-samples.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-df99f9972657ae5a6fd5da1c6cde3856ecca90542fe76d8ce83fb20709bcf61c)).
> - Replaces per-component `agentUrl` and `timeoutMs` fields with a shared `AgentTransport` interface across data, action, and capability-fetcher middleware ([agent-transport.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-94f244014974fc44b816827aa84f69a67e80b9a1b60c556753af7bb3b5fb7add)).
> - Adds `createInProcessTransport` and `InProcessRequester` to dispatch agent calls without a network socket, including path/query parity with the HTTP requester and a 501 `streaming_unsupported` error for stream calls ([in-process-transport.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1873/files#diff-2f0a4f464a7053c092f1ab0cc5e113ce50ebc32cdaa0ecf68945fa00a8c1634f)).
> - Risk: `buildBff` now rejects invalid `basePath` values (absolute URLs, query strings, fragments) with `ConfigurationError` at construction time; the OpenAPI and docs route caches are now keyed by base path, so consumers relying on a single cached document per process will see per-prefix memoization instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0671c9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
