### PR TITLE
fix(ai-proxy): exclude the whole claude-fable-5 line from tool support

### DIFF
--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -83,11 +83,22 @@ const ANTHROPIC_UNSUPPORTED_MODELS = [
   'claude-3-7-sonnet-20250219', // EOL 2026-02-19
   'claude-opus-4-20250514', // Requires streaming (non-streaming times out)
   'claude-opus-4-1-20250805', // Requires streaming (non-streaming times out)
-  'claude-fable-5', // Always-on thinking (rejects 'disabled'; proxy drops required thinking blocks)
+];
+
+// Matched as families, not ids: always-on thinking is a property of the line, so every point
+// release inherits it and would otherwise turn main red on its own release day.
+const ANTHROPIC_UNSUPPORTED_PREFIXES = [
+  // Rejects thinking.type 'disabled', and the proxy drops the thinking blocks a reply must carry
+  // back for the next turn.
+  'claude-fable-5',
 ];
 
 function isAnthropicModelSupported(model: string): boolean {
-  return !ANTHROPIC_UNSUPPORTED_MODELS.includes(model);
+  if (ANTHROPIC_UNSUPPORTED_MODELS.includes(model)) return false;
+
+  return !ANTHROPIC_UNSUPPORTED_PREFIXES.some(
+    prefix => model === prefix || model.startsWith(`${prefix}-`),
+  );
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────

--- a/packages/ai-proxy/test/supported-models.test.ts
+++ b/packages/ai-proxy/test/supported-models.test.ts
@@ -20,8 +20,17 @@ describe('isModelSupportingTools', () => {
     },
   );
 
-  it('should return false for claude-fable-5 (always-on thinking incompatible with proxy)', () => {
-    expect(isModelSupportingTools('claude-fable-5', 'anthropic')).toBe(false);
+  // claude-fable-5-1 broke the integration suite on its release day; the whole line shares the
+  // always-on thinking the proxy cannot carry, so point releases must be excluded on arrival.
+  it.each(['claude-fable-5', 'claude-fable-5-1', 'claude-fable-5-20260101'])(
+    'should return false for %s (always-on thinking incompatible with proxy)',
+    model => {
+      expect(isModelSupportingTools(model, 'anthropic')).toBe(false);
+    },
+  );
+
+  it('should not exclude a model merely prefixed by an unsupported family name', () => {
+    expect(isModelSupportingTools('claude-fable-50', 'anthropic')).toBe(true);
   });
 
   it('should return true for other anthropic models', () => {


### PR DESCRIPTION
## Why

`claude-fable-5-1` shipped and turned **LLM Integration Tests (ai-proxy)** red on `main`:

```
AIBadRequestError: Anthropic: 400 "thinking.type.disabled" is not supported for this model.
Thinking defaults to adaptive mode when not specified; use "thinking.type.enabled" with
"budget_tokens" for extended thinking.       (model: claude-fable-5-1)
```

That is the same incompatibility `claude-fable-5` was already excluded for. Always-on thinking is a property of the line, not of one release, so listing ids one at a time means `main` goes red on each point release and someone chases it afterwards.

## What

Anthropic exclusions now match **families**, the way the OpenAI ones already do, and with the same word-boundary rule (`model === prefix || model.startsWith(prefix + '-')`) so `claude-fable-50` is not caught by `claude-fable-5`. `claude-fable-5` moves from the exact-id list to the new prefix list; the other entries stay exact, since they are single deprecated or streaming-only releases rather than families.

Supporting the line properly is a different job: the proxy also drops the thinking blocks a reply has to carry back for the next turn, which is why the original exclusion exists.

## Verification

Ran the real-API suite locally, both ways:

| | Result |
|---|---|
| Without this change | fails on `claude-fable-5-1` |
| With this change | passes, 9 Anthropic models |

```
yarn test --testPathPattern=llm.integration -t "Anthropic.*all models should support"
```

Unit tests extended in `test/supported-models.test.ts`: the three shapes of the family (`claude-fable-5`, `claude-fable-5-1`, a dated variant) and the boundary case `claude-fable-50`, which must stay supported. Both mutations bite — dropping the prefix entry fails three of them, and loosening the boundary to a bare `startsWith` fails the fourth.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `claude-fable-5` model family from Anthropic tool support via prefix matching
> - Replaces the exact-match entry for `claude-fable-5` in `ANTHROPIC_UNSUPPORTED_MODELS` with a new `ANTHROPIC_UNSUPPORTED_PREFIXES` family blacklist so all descendants (point-release, dated variants) are also excluded
> - `isAnthropicModelSupported` now rejects models that exactly equal an unsupported prefix or start with the prefix followed by a hyphen; bare strings like `claude-fable-50` remain supported
> - Updates tests in [supported-models.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1878/files#diff-63c4790a9eb972b9a4cef4054c9171052b2469ff86ad24e2badf16356682b914) to cover the base family name, a point-release variant, a dated variant, and the boundary case
> - Risk: any model name that starts with `claude-fable-5-` is now rejected from tool support; confirm no legitimate Anthropic model uses that prefix outside the intended family
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a854770.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->