### PR TITLE
fix(ai-proxy): exclude gpt-6-astra from tool support

### DIFF
--- a/packages/ai-proxy/src/supported-models.ts
+++ b/packages/ai-proxy/src/supported-models.ts
@@ -52,6 +52,7 @@ const OPENAI_UNSUPPORTED_MODELS = [
   'gpt-5.6-luna',
   'gpt-5.6-sol',
   'gpt-5.6-terra',
+  'gpt-6-astra',
 ];
 
 const OPENAI_SUPPORTED_OVERRIDES = ['gpt-4-turbo', 'gpt-4o', 'gpt-4.1'];

--- a/packages/ai-proxy/test/supported-models.test.ts
+++ b/packages/ai-proxy/test/supported-models.test.ts
@@ -13,7 +13,7 @@ describe('isModelSupportingTools', () => {
     expect(isModelSupportingTools('gpt-4')).toBe(false);
   });
 
-  it.each(['gpt-5.6-luna', 'gpt-5.6-sol', 'gpt-5.6-terra'])(
+  it.each(['gpt-5.6-luna', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-6-astra'])(
     'should return false for %s (v1/responses only)',
     model => {
       expect(isModelSupportingTools(model)).toBe(false);


### PR DESCRIPTION
## Why

`gpt-6-astra` showed up in OpenAI's model inventory on 4 September and fails the LLM integration suite on every branch:

```
AIBadRequestError: OpenAI: 400 Function tools with reasoning_effort are not supported
for gpt-6-astra in /v1/chat/completions.
```

Same restriction as `gpt-5.6-luna`, `gpt-5.6-sol` and `gpt-5.6-terra`, which are already excluded for that exact reason.

## What

One name added to `OPENAI_UNSUPPORTED_MODELS`, plus the test row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `gpt-6-astra` from tool support in `OPENAI_UNSUPPORTED_MODELS`
> Adds `gpt-6-astra` to the OpenAI unsupported-model list in [supported-models.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1882/files#diff-c8703b3b65d1492f147178cbdc7ea897138fe0c4fe9c842993d4141d7a8a6cd3), forcing it to use the responses API instead of chat completions. Model-support checks now reject `gpt-6-astra` for tool support. Adds corresponding test case in [supported-models.test.ts](https://github.com/ForestAdmin/agent-nodejs/pull/1882/files#diff-63c4790a9eb972b9a4cef4054c9171052b2469ff86ad24e2badf16356682b914).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f70be83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->