### PR TITLE
fix(workflow-executor): follow a reference smart field whose value is the related id

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -244,10 +244,22 @@ export default class AgentClientAgentPort implements AgentPort {
         user,
       );
 
-      const linkage = parent.values[toCamelCase(relation)] as
-        | Record<string, unknown>
-        | null
-        | undefined;
+      const raw = parent.values[toCamelCase(relation)];
+
+      // Rails/Express reference smart fields are serialized as plain attributes, so the value IS
+      // the related id, with no linkage object to unpack.
+      if (raw != null && typeof raw !== 'object') {
+        return this.getRecord(
+          {
+            collection: relatedSchema.collectionName,
+            id: String(raw).split('|'),
+            ...(fields?.length ? { fields } : {}),
+          },
+          user,
+        );
+      }
+
+      const linkage = raw as Record<string, unknown> | null | undefined;
       const packedId = linkage?.id as string | undefined;
 
       if (!linkage || !packedId) return null;

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -246,13 +246,20 @@ export default class AgentClientAgentPort implements AgentPort {
 
       const raw = parent.values[toCamelCase(relation)];
 
-      // Rails/Express reference smart fields are serialized as plain attributes, so the value IS
-      // the related id, with no linkage object to unpack.
-      if (raw != null && typeof raw !== 'object') {
+      // A forest-rails smart field declared with `field ... reference:` serializes as a plain
+      // attribute, so the value IS the related id. The same apimap shape coming from the
+      // `belongs_to` DSL, and every forest-express reference field, still arrives as a linkage —
+      // hence a check on the runtime shape rather than on the schema.
+      // An empty string is the idiomatic Ruby answer for an unset association (`&.id.to_s`), and it
+      // would serialize to an id-less by-id URL, which agents route to the index action instead.
+      if (raw != null && raw !== '' && typeof raw !== 'object') {
         return this.getRecord(
           {
             collection: relatedSchema.collectionName,
-            id: String(raw).split('|'),
+            // Only a composite key is pipe-packed. The value of a smart field is written by the
+            // client, so splitting a single-key id would tear a legitimate "a|b" in two.
+            id:
+              relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [raw as string],
             ...(fields?.length ? { fields } : {}),
           },
           user,

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -847,8 +847,6 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['acme', '7']);
     });
 
-    // Rails/Express reference smart fields are serialized as plain attributes: the projected value
-    // is the related id itself, with no linkage object to unpack.
     it('reads the target by id when the projected value is a scalar', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce({ card: 'uuid-1' })
@@ -895,10 +893,34 @@ describe('AgentClientAgentPort', () => {
       });
     });
 
-    it('splits a composite packed id carried by a scalar attribute', async () => {
+    it('splits a scalar attribute only when the target key is composite', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce({ card: 'acme|7' })
         .mockResolvedValueOnce({ id: 'acme|7' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: {
+            ...ordersSchema,
+            collectionName: 'cards',
+            primaryKeyFields: ['tenantId', 'cardId'],
+          },
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme', '7'], {});
+      expect(result?.recordId).toEqual(['acme', '7']);
+    });
+
+    // The value is produced by client-written code, so a pipe in it is data, not packing.
+    it('keeps a pipe in a scalar attribute intact when the target key is single', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce({ card: 'acme|corp' })
+        .mockResolvedValueOnce({ id: 'acme|corp' });
 
       const result = await port.getSingleRelatedData(
         {
@@ -910,12 +932,31 @@ describe('AgentClientAgentPort', () => {
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme', '7'], {});
-      expect(result?.recordId).toEqual(['acme', '7']);
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme|corp'], {});
+      expect(result?.recordId).toEqual(['acme|corp']);
     });
 
-    it('returns null when the scalar attribute is empty, without reading the target', async () => {
+    it('returns null when the scalar attribute is null, without reading the target', async () => {
       mockCollection.getOne.mockResolvedValue({ card: null });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(result).toBeNull();
+      expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
+    });
+
+    // `object.card&.id.to_s` is the idiomatic Ruby getter, and it answers "" for an unset
+    // association. Reading it as an id would build an id-less URL that agents route to the index.
+    it('returns null when the scalar attribute is an empty string, without reading the target', async () => {
+      mockCollection.getOne.mockResolvedValue({ card: '' });
 
       const result = await port.getSingleRelatedData(
         {

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -112,6 +112,7 @@ describe('AgentClientAgentPort', () => {
   let mockCollection: ReturnType<typeof createMockClient>['mockCollection'];
   let mockRelation: ReturnType<typeof createMockClient>['mockRelation'];
   let mockAction: ReturnType<typeof createMockClient>['mockAction'];
+  let mockClient: ReturnType<typeof createMockClient>['client'];
   let user: StepUser;
   let port: AgentClientAgentPort;
 
@@ -119,7 +120,7 @@ describe('AgentClientAgentPort', () => {
     jest.clearAllMocks();
 
     const mocks = createMockClient();
-    ({ mockCollection, mockRelation, mockAction } = mocks);
+    ({ mockCollection, mockRelation, mockAction, client: mockClient } = mocks);
     mockedCreateRemoteAgentClient.mockReturnValue(mocks.client as any);
 
     const schemaCache = new SchemaCache();
@@ -844,6 +845,90 @@ describe('AgentClientAgentPort', () => {
       );
 
       expect(result?.recordId).toEqual(['acme', '7']);
+    });
+
+    // Rails/Express reference smart fields are serialized as plain attributes: the projected value
+    // is the related id itself, with no linkage object to unpack.
+    it('reads the target by id when the projected value is a scalar', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce({ card: 'uuid-1' })
+        .mockResolvedValueOnce({ id: 'uuid-1', reference: 'CARD-1' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(1, [42], { fields: ['card@@@id'] });
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {});
+      expect(mockClient.collection).toHaveBeenCalledWith('cards');
+      expect(result).toEqual({
+        collectionName: 'cards',
+        recordId: ['uuid-1'],
+        values: { id: 'uuid-1', reference: 'CARD-1' },
+      });
+    });
+
+    it('passes the caller fields to the scalar target read', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce({ card: 'uuid-1' })
+        .mockResolvedValueOnce({ reference: 'CARD-1' });
+
+      await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {
+        fields: ['reference'],
+      });
+    });
+
+    it('splits a composite packed id carried by a scalar attribute', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce({ card: 'acme|7' })
+        .mockResolvedValueOnce({ id: 'acme|7' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme', '7'], {});
+      expect(result?.recordId).toEqual(['acme', '7']);
+    });
+
+    it('returns null when the scalar attribute is empty, without reading the target', async () => {
+      mockCollection.getOne.mockResolvedValue({ card: null });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(result).toBeNull();
+      expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
     });
 
     it('returns null when the parent has no linkage to the xToOne relation', async () => {

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -4344,6 +4344,53 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
+    // Regression: a Rails/Express reference smart field reaches the executor as a plain BelongsTo
+    // now that the server derives the relation from `reference` alone. Pinning it must follow it,
+    // where it used to fail as an invalid pre-recorded arg because the field was not a relation.
+    it('follows a pinned reference-only BelongsTo', async () => {
+      const { model, bindTools } = makeMockModel();
+      const runStore = makeMockRunStore();
+      const agentPort = makeMockAgentPort([
+        makeRelatedRecordData({ collectionName: 'cards', recordId: ['card-1'], values: {} }),
+      ]);
+      const context = makeContext({
+        model,
+        runStore,
+        agentPort,
+        workflowPort: makeMockWorkflowPort({
+          customers: makeCollectionSchema({
+            fields: [
+              { fieldName: 'email', displayName: 'Email', isRelationship: false },
+              {
+                fieldName: 'card',
+                displayName: 'Card',
+                isRelationship: true,
+                relationType: 'BelongsTo',
+                relatedCollectionName: 'cards',
+              },
+            ],
+          }),
+        }),
+        stepDefinition: makeStep({
+          executionType: StepExecutionMode.FullyAutomated,
+          preRecordedArgs: { relationName: 'card' },
+        }),
+      });
+
+      const result = await new LoadRelatedRecordStepExecutor(context).execute();
+
+      expect(result.stepOutcome.status).toBe('success');
+      expect(bindTools).not.toHaveBeenCalled();
+      expect(agentPort.getSingleRelatedData).toHaveBeenCalledWith(
+        expect.objectContaining({ relation: 'card' }),
+        expect.anything(),
+      );
+      expect(runStore.saveStepExecution).toHaveBeenCalledWith(
+        'run-1',
+        expect.objectContaining({ executionParams: { displayName: 'Card', name: 'card' } }),
+      );
+    });
+
     it('pins the source record via selectedRecordStepId (among several records)', async () => {
       // Base customers #42 (step 0) + a loaded order #99 (step 1) are both available;
       // pinning step 1 must make the relation follow the ORDER, not the base customer.

--- a/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
+++ b/packages/workflow-executor/test/executors/load-related-record-step-executor.test.ts
@@ -4344,9 +4344,9 @@ describe('LoadRelatedRecordStepExecutor', () => {
       );
     });
 
-    // Regression: a Rails/Express reference smart field reaches the executor as a plain BelongsTo
-    // now that the server derives the relation from `reference` alone. Pinning it must follow it,
-    // where it used to fail as an invalid pre-recorded arg because the field was not a relation.
+    // Regression: a forest-rails smart field reaches the executor as a plain BelongsTo now that the
+    // server derives the relation from a `reference` whose target is in the apimap. Pinning it must
+    // follow it, where it used to fail as an invalid pre-recorded arg — the field was not a relation.
     it('follows a pinned reference-only BelongsTo', async () => {
       const { model, bindTools } = makeMockModel();
       const runStore = makeMockRunStore();
@@ -4382,7 +4382,11 @@ describe('LoadRelatedRecordStepExecutor', () => {
       expect(result.stepOutcome.status).toBe('success');
       expect(bindTools).not.toHaveBeenCalled();
       expect(agentPort.getSingleRelatedData).toHaveBeenCalledWith(
-        expect.objectContaining({ relation: 'card' }),
+        expect.objectContaining({
+          collection: 'customers',
+          relation: 'card',
+          relatedSchema: expect.objectContaining({ collectionName: 'cards' }),
+        }),
         expect.anything(),
       );
       expect(runStore.saveStepExecution).toHaveBeenCalledWith(


### PR DESCRIPTION
## Context

A client's `load-related-record` step could not follow the `card` relation of their `CardClaim__Claim` collection. Their agent is forest-rails, where `card` is a **reference smart field**: it carries a `reference` and no `relationship`.

This PR fixes the executor half. The server half is [forestadmin-server#8482](https://github.com/ForestAdmin/forestadmin-server/pull/8482), and **this one ships first** — see Rollout.

## The problem

`getSingleRelatedData` follows an xToOne relation by reading the parent with a `<relation>@@@<field>` projection and unpacking the JSON:API linkage. But a forest-rails smart field declared with `field ... reference:` registers as a plain **attribute** (`lib/forest_liana/collection.rb` → `attribute(name, &compute_value)`), so the projected value is the related id itself, a bare string. `linkage?.id` was `undefined`, the method returned `null`, and the step concluded "no related record" instead of loading it.

That silence is why this ships before the server change: once the server serves these fields as `BelongsTo`, an executor without this fix turns a loud configuration error into a quiet false negative.

## Why a runtime shape check rather than a schema branch

The same apimap shape can serialize either way, so the schema cannot tell them apart:

| Declaration | apimap | Serialized as |
|---|---|---|
| forest-rails `field ... reference:` | `type: 'String'`, no `relationship` | plain attribute → **new branch** |
| forest-rails `belongs_to ... reference:` | **identical** | `has_one(include_data: true)` → linkage |
| forest-express, any `reference` field | same | JSON:API relationship → linkage |

Branching on `typeof raw !== 'object'` sorts them automatically, which is why the fix is small and why forest-express needs no special case.

## The change

One branch in the adapter, behind the same port method, so the step executor stays unaware of which shape the agent emitted:

- a scalar value is read as the target record id via `getRecord` on the related collection;
- `null`, `undefined` and `''` keep the linkage path and still return `null`. The empty string matters: `object.card&.id.to_s` is the idiomatic Ruby getter and answers `""` for an unset association, which would have serialized to an id-less by-id URL that agents route to the index action;
- the pipe split only applies when the target key is composite. That packing is the agent's own convention, and a smart field's value is written by client code, so an id legitimately containing `a|b` must survive intact;
- an orphan id lets `RecordNotFoundError` surface. Deliberate: the value is present, so the relation *is* set and the target simply cannot be read — that is a data inconsistency, not an absent relation.

## Tests

7 in `getSingleRelatedData`: scalar read, caller `fields` forwarding, composite split, single-key pipe preserved, empty string, null, plus the untouched linkage cases. One step-level test that a pinned reference-only `BelongsTo` is followed, asserting the target collection and not just the relation name.

Full package suite: 1703 passed, 0 failed. Diff coverage 100%.

## Rollout

Ship and release this before forestadmin-server#8482. In the reverse order, an executor without this fix sees a `BelongsTo` whose value is a scalar, reads no linkage, and silently skips: for a fully-automated step the run goes green with no record.

Node clients that embed the executor stay in that window until they upgrade — worth a line in the agent release note.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes — pending the paired server PR; verifiable end-to-end only once both are deployed
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — the extra read goes through the same authenticated agent client and the same `getRecord` path as every other record read, with the caller's own scopes; no new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
