### PR TITLE
fix(agent-bff): publish recordKey on context fields the agent renames

### DIFF
--- a/packages/agent-bff/src/context/build-context.ts
+++ b/packages/agent-bff/src/context/build-context.ts
@@ -7,7 +7,7 @@ import type {
   ForestSchemaField,
 } from '@forestadmin/forestadmin-client';
 
-import recordKey from '../data/record-key';
+import recordKey, { groupByRecordKey } from '../data/record-key';
 
 export interface ContextActionField {
   field: string;
@@ -66,39 +66,33 @@ function toArray<T>(value: T[] | null | undefined): T[] {
 
 type FieldWithWireEnums = ForestSchemaField & { enums?: string[] };
 
-/** The deserializer writes the JSON:API resource identifier under this key, always. */
+/**
+ * The deserializer writes the JSON:API resource identifier under this key, always, over whatever
+ * attribute landed there. The resource id is a string whatever the column type says, and a
+ * composite key reaches it packed, so it is never the value of the field that camelizes to `id` —
+ * a primary key named `Id` included.
+ */
 const RESOURCE_ID_KEY = 'id';
 
 /**
  * The record keys this collection cannot promise, because more than one thing lands on them.
  *
  * Two fields whose technical names differ only by casing collapse onto one key (`first_name` and
- * `firstName` both reach the response as `firstName`), and a field named `Id` or `ID` collapses onto
- * the resource identifier, whose value the deserializer writes over the projected attribute — so
- * reading that field under `id` yields the record's id rather than the field's value. Publishing a
- * `recordKey` in either case would point a consumer at a value that is not the field's, which is
- * worse than publishing nothing: `recordKey` is absent, the caller falls back to `field`, and the
- * ambiguity stays visible instead of being papered over.
+ * `firstName` both reach the response as `firstName`), and `id` always belongs to the resource
+ * identifier. Publishing a `recordKey` in either case would point a consumer at a value that is not
+ * the field's, which is worse than publishing nothing: `recordKey` is absent, the caller falls back
+ * to `field`, and the ambiguity stays visible instead of being papered over.
+ *
+ * Not covered: the deserializer also writes `meta` from the resource meta, so a field named `Meta`
+ * on an agent that emits one is shadowed the same way. agent-nodejs emits no per-resource meta, and
+ * reserving the key would drop a working `recordKey` on every agent that emits none.
  */
 function ambiguousRecordKeys(fields: FieldWithWireEnums[]): Set<string> {
-  const claimants = new Map<string, number>();
+  const ambiguous = new Set<string>([RESOURCE_ID_KEY]);
 
-  for (const field of fields) {
-    const key = recordKey(field.field);
-    claimants.set(key, (claimants.get(key) ?? 0) + 1);
+  for (const [key, group] of groupByRecordKey(fields, field => field.field)) {
+    if (group.length > 1) ambiguous.add(key);
   }
-
-  const ambiguous = new Set<string>();
-
-  for (const [key, count] of claimants) {
-    if (count > 1) ambiguous.add(key);
-  }
-
-  const idClaimedByAnotherField = fields.some(
-    field => !field.isPrimaryKey && recordKey(field.field) === RESOURCE_ID_KEY,
-  );
-
-  if (idClaimedByAnotherField) ambiguous.add(RESOURCE_ID_KEY);
 
   return ambiguous;
 }

--- a/packages/agent-bff/src/context/build-context.ts
+++ b/packages/agent-bff/src/context/build-context.ts
@@ -66,6 +66,43 @@ function toArray<T>(value: T[] | null | undefined): T[] {
 
 type FieldWithWireEnums = ForestSchemaField & { enums?: string[] };
 
+/** The deserializer writes the JSON:API resource identifier under this key, always. */
+const RESOURCE_ID_KEY = 'id';
+
+/**
+ * The record keys this collection cannot promise, because more than one thing lands on them.
+ *
+ * Two fields whose technical names differ only by casing collapse onto one key (`first_name` and
+ * `firstName` both reach the response as `firstName`), and a field named `Id` or `ID` collapses onto
+ * the resource identifier, whose value the deserializer writes over the projected attribute — so
+ * reading that field under `id` yields the record's id rather than the field's value. Publishing a
+ * `recordKey` in either case would point a consumer at a value that is not the field's, which is
+ * worse than publishing nothing: `recordKey` is absent, the caller falls back to `field`, and the
+ * ambiguity stays visible instead of being papered over.
+ */
+function ambiguousRecordKeys(fields: FieldWithWireEnums[]): Set<string> {
+  const claimants = new Map<string, number>();
+
+  for (const field of fields) {
+    const key = recordKey(field.field);
+    claimants.set(key, (claimants.get(key) ?? 0) + 1);
+  }
+
+  const ambiguous = new Set<string>();
+
+  for (const [key, count] of claimants) {
+    if (count > 1) ambiguous.add(key);
+  }
+
+  const idClaimedByAnotherField = fields.some(
+    field => !field.isPrimaryKey && recordKey(field.field) === RESOURCE_ID_KEY,
+  );
+
+  if (idClaimedByAnotherField) ambiguous.add(RESOURCE_ID_KEY);
+
+  return ambiguous;
+}
+
 function toContextValidations(validations: unknown[] | null | undefined): ContextValidation[] {
   return toArray(validations)
     .filter(
@@ -79,11 +116,14 @@ function toContextValidations(validations: unknown[] | null | undefined): Contex
     );
 }
 
-function toContextField(field: FieldWithWireEnums): ContextField {
+function toContextField(
+  field: FieldWithWireEnums,
+  ambiguousKeys: ReadonlySet<string>,
+): ContextField {
   const serialized: ContextField = { field: field.field, type: field.type };
 
   const key = recordKey(field.field);
-  if (key !== field.field) serialized.recordKey = key;
+  if (key !== field.field && !ambiguousKeys.has(key)) serialized.recordKey = key;
 
   if (field.relationship) serialized.relationship = field.relationship;
   if (field.reference) serialized.reference = field.reference;
@@ -130,12 +170,14 @@ function toContextCollection(
   readModel: ReadModel,
 ): ContextCollection {
   const allowedActions = readModel.getActionEndpoints()[collection.name] ?? {};
+  const fields = toArray(collection.fields).filter(
+    field => typeof field === 'object' && field !== null,
+  );
+  const ambiguousKeys = ambiguousRecordKeys(fields);
 
   return {
     name: collection.name,
-    fields: toArray(collection.fields)
-      .filter(field => typeof field === 'object' && field !== null)
-      .map(toContextField),
+    fields: fields.map(field => toContextField(field, ambiguousKeys)),
     actions: toArray(collection.actions)
       .filter(action => {
         const allowed = allowedActions[action?.name];

--- a/packages/agent-bff/src/context/build-context.ts
+++ b/packages/agent-bff/src/context/build-context.ts
@@ -7,6 +7,8 @@ import type {
   ForestSchemaField,
 } from '@forestadmin/forestadmin-client';
 
+import recordKey from '../data/record-key';
+
 export interface ContextActionField {
   field: string;
   type: FieldType;
@@ -29,6 +31,7 @@ export interface ContextValidation {
 
 export interface ContextField {
   field: string;
+  recordKey?: string;
   type: FieldType;
   relationship?: RelationshipType;
   reference?: string;
@@ -78,6 +81,12 @@ function toContextValidations(validations: unknown[] | null | undefined): Contex
 
 function toContextField(field: FieldWithWireEnums): ContextField {
   const serialized: ContextField = { field: field.field, type: field.type };
+
+  if (typeof field.field === 'string') {
+    const key = recordKey(field.field);
+
+    if (key !== field.field) serialized.recordKey = key;
+  }
 
   if (field.relationship) serialized.relationship = field.relationship;
   if (field.reference) serialized.reference = field.reference;

--- a/packages/agent-bff/src/context/build-context.ts
+++ b/packages/agent-bff/src/context/build-context.ts
@@ -82,11 +82,8 @@ function toContextValidations(validations: unknown[] | null | undefined): Contex
 function toContextField(field: FieldWithWireEnums): ContextField {
   const serialized: ContextField = { field: field.field, type: field.type };
 
-  if (typeof field.field === 'string') {
-    const key = recordKey(field.field);
-
-    if (key !== field.field) serialized.recordKey = key;
-  }
+  const key = recordKey(field.field);
+  if (key !== field.field) serialized.recordKey = key;
 
   if (field.relationship) serialized.relationship = field.relationship;
   if (field.reference) serialized.reference = field.reference;

--- a/packages/agent-bff/src/data/record-key.ts
+++ b/packages/agent-bff/src/data/record-key.ts
@@ -11,3 +11,25 @@ import Inflector from 'inflected';
 export default function recordKey(field: string): string {
   return Inflector.camelize(Inflector.underscore(field), false);
 }
+
+/**
+ * The same names grouped by the key they reach the response under. A group of more than one is the
+ * transform being lossy: those names collapse onto one key and which of them it holds is not
+ * knowable from here.
+ */
+export function groupByRecordKey<T>(
+  items: readonly T[],
+  name: (item: T) => string,
+): Map<string, T[]> {
+  const byKey = new Map<string, T[]>();
+
+  for (const item of items) {
+    const key = recordKey(name(item));
+    const group = byKey.get(key);
+
+    if (group) group.push(item);
+    else byKey.set(key, [item]);
+  }
+
+  return byKey;
+}

--- a/packages/agent-bff/src/data/record-key.ts
+++ b/packages/agent-bff/src/data/record-key.ts
@@ -1,5 +1,13 @@
 import Inflector from 'inflected';
 
+/**
+ * The key a field really carries in a response record. `agent-client` deserializes the agent's
+ * JSON:API with `keyForAttribute: 'camelCase'` (`http-requester.ts`), which is exactly this pair of
+ * `inflected` calls (`jsonapi-serializer/lib/inflector.js`), so a `first_name` column is PROJECTED
+ * under that name and RETURNED as `firstName`. The same library rather than a transcription: the
+ * transform handles acronyms and non-ASCII, and a mirror would drift from the deserializer without
+ * anything failing.
+ */
 export default function recordKey(field: string): string {
   return Inflector.camelize(Inflector.underscore(field), false);
 }

--- a/packages/agent-bff/src/data/record-key.ts
+++ b/packages/agent-bff/src/data/record-key.ts
@@ -1,0 +1,5 @@
+import Inflector from 'inflected';
+
+export default function recordKey(field: string): string {
+  return Inflector.camelize(Inflector.underscore(field), false);
+}

--- a/packages/agent-bff/src/openapi/record-schemas.ts
+++ b/packages/agent-bff/src/openapi/record-schemas.ts
@@ -1,23 +1,10 @@
 import type { ProjectableField, UnfoldedCollection } from './unfolding';
 import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas31';
 
-import Inflector from 'inflected';
-
 import toFieldSchema from './field-schemas';
 import { quoted } from './names';
 import { PACKED_ID_SEPARATOR } from '../data/pack-id';
-
-/**
- * The key a field really carries in a response record. `agent-client` deserializes the agent's
- * JSON:API with `keyForAttribute: 'camelCase'` (`http-requester.ts`), which is exactly this pair of
- * `inflected` calls (`jsonapi-serializer/lib/inflector.js`), so a `first_name` column is PROJECTED
- * under that name and RETURNED as `firstName`. The same library rather than a transcription: the
- * transform handles acronyms and non-ASCII, and a mirror would drift from the deserializer without
- * anything failing.
- */
-export function recordKey(field: string): string {
-  return Inflector.camelize(Inflector.underscore(field), false);
-}
+import recordKey from '../data/record-key';
 
 // The flat id is the JSON:API resource id, which is a string by specification whatever the key
 // column holds. `__forest.primaryKey` is the same id unpacked and typed, so the two forms of one

--- a/packages/agent-bff/src/openapi/record-schemas.ts
+++ b/packages/agent-bff/src/openapi/record-schemas.ts
@@ -4,7 +4,7 @@ import type { ReferenceObject, SchemaObject } from 'openapi3-ts/oas31';
 import toFieldSchema from './field-schemas';
 import { quoted } from './names';
 import { PACKED_ID_SEPARATOR } from '../data/pack-id';
-import recordKey from '../data/record-key';
+import { groupByRecordKey } from '../data/record-key';
 
 // The flat id is the JSON:API resource id, which is a string by specification whatever the key
 // column holds. `__forest.primaryKey` is the same id unpacked and typed, so the two forms of one
@@ -51,15 +51,7 @@ function publishedSchema(schema: SchemaObject): SchemaObject {
   const { properties } = schema;
 
   if (properties !== undefined) {
-    const byKey = new Map<string, string[]>();
-
-    Object.keys(properties).forEach(name => {
-      const key = recordKey(name);
-      const collapsed = byKey.get(key);
-
-      if (collapsed) collapsed.push(name);
-      else byKey.set(key, [name]);
-    });
+    const byKey = groupByRecordKey(Object.keys(properties), name => name);
 
     published.properties = Object.fromEntries(
       [...byKey].map(([key, names]) => {
@@ -101,15 +93,7 @@ function propertySchema(key: string, fields: ProjectableField[]): SchemaObject {
 }
 
 function fieldProperties(projectable: ProjectableField[]): Record<string, SchemaObject> {
-  const byKey = new Map<string, ProjectableField[]>();
-
-  projectable.forEach(field => {
-    const key = recordKey(field.name);
-    const collapsed = byKey.get(key);
-
-    if (collapsed) collapsed.push(field);
-    else byKey.set(key, [field]);
-  });
+  const byKey = groupByRecordKey(projectable, field => field.name);
 
   return Object.fromEntries([...byKey].map(([key, fields]) => [key, propertySchema(key, fields)]));
 }

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -417,8 +417,12 @@ export const ContextResponseSchema = z
       'a sort or a projection. It is NOT always the key the record carries: a snake_case agent ' +
       '(Rails) declares `created_at` and the response returns `createdAt`. When the two ' +
       'differ, `recordKey` names the response key — read a record value under `recordKey ?? ' +
-      'field`, and keep using `field` on the request side. Sub-fields of a composite `type` are ' +
-      'not covered: they carry no `recordKey` and the same transform applies to them. ' +
+      'field`, and keep using `field` on the request side. It is omitted when the key would be ' +
+      'ambiguous, so its presence is a promise: two fields differing only by casing collapse onto ' +
+      'one key, and a field named `Id` collapses onto the resource identifier, whose value ' +
+      'overwrites the attribute — in both cases no `recordKey` is published and that field is ' +
+      'simply not readable by name. Sub-fields of a composite `type` are ' +
+      'not covered either: they carry no `recordKey` and the same transform applies to them. ' +
       'The document carries no rendering, project or team identity, and the only environment ' +
       'datum is `meta.environmentId` below. It is served to both auth modes — an OAuth session ' +
       'and a BFF API key get the same document. It is NOT filtered by the caller permissions: ' +

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -359,6 +359,7 @@ const ContextValidationSchema = z
 
 const ContextFieldSchema = z.object({
   field: z.string(),
+  recordKey: z.string().optional(),
   type: ContextFieldTypeSchema,
   relationship: z.enum(RELATIONSHIP_TYPES).optional(),
   reference: z.string().optional(),
@@ -412,6 +413,12 @@ export const ContextResponseSchema = z
       'collection this document does not expose. Cross a target against `collections[]` before ' +
       'following it — unlike the per-collection route documents, nothing here is dropped for ' +
       'pointing outside the served set. ' +
+      '`field` is the technical name the agent declares, and the one to send back in a filter, ' +
+      'a sort or a projection. It is NOT always the key the record carries: a snake_case agent ' +
+      '(Rails, Django) declares `created_at` and the response returns `createdAt`. When the two ' +
+      'differ, `recordKey` names the response key — read a record value under `recordKey ?? ' +
+      'field`, and keep using `field` on the request side. Sub-fields of a composite `type` are ' +
+      'not covered: they carry no `recordKey` and the same transform applies to them. ' +
       'The document carries no rendering, project or team identity, and the only environment ' +
       'datum is `meta.environmentId` below. It is served to both auth modes — an OAuth session ' +
       'and a BFF API key get the same document. It is NOT filtered by the caller permissions: ' +

--- a/packages/agent-bff/src/openapi/schemas.ts
+++ b/packages/agent-bff/src/openapi/schemas.ts
@@ -415,7 +415,7 @@ export const ContextResponseSchema = z
       'pointing outside the served set. ' +
       '`field` is the technical name the agent declares, and the one to send back in a filter, ' +
       'a sort or a projection. It is NOT always the key the record carries: a snake_case agent ' +
-      '(Rails, Django) declares `created_at` and the response returns `createdAt`. When the two ' +
+      '(Rails) declares `created_at` and the response returns `createdAt`. When the two ' +
       'differ, `recordKey` names the response key — read a record value under `recordKey ?? ' +
       'field`, and keep using `field` on the request side. Sub-fields of a composite `type` are ' +
       'not covered: they carry no `recordKey` and the same transform applies to them. ' +

--- a/packages/agent-bff/test/context/build-context.test.ts
+++ b/packages/agent-bff/test/context/build-context.test.ts
@@ -164,7 +164,7 @@ describe('buildContext', () => {
       expect(fields.find(entry => entry.field === 'Id')).not.toHaveProperty('recordKey');
     });
 
-    it('should still name the key of a primary key the deserializer does rename', () => {
+    it('should omit recordKey on a primary key named Id, whose record id is packed and a string', () => {
       const pascalKeySchema = [
         {
           name: 'people',
@@ -177,7 +177,7 @@ describe('buildContext', () => {
         schemaRevision: 1,
       }).collections;
 
-      expect(fields.find(entry => entry.field === 'Id')?.recordKey).toBe('id');
+      expect(fields.find(entry => entry.field === 'Id')).not.toHaveProperty('recordKey');
     });
 
     it('should survive the published schema, which would drop an undeclared key', () => {

--- a/packages/agent-bff/test/context/build-context.test.ts
+++ b/packages/agent-bff/test/context/build-context.test.ts
@@ -124,6 +124,62 @@ describe('buildContext', () => {
       expect(peopleFields().find(entry => entry.field === 'id')).not.toHaveProperty('recordKey');
     });
 
+    it('should omit recordKey when another field claims the same key, which collapses', () => {
+      const collidingSchema = [
+        {
+          name: 'people',
+          fields: [
+            { field: 'id', type: 'Number', isPrimaryKey: true },
+            { field: 'first_name', type: 'String' },
+            { field: 'firstName', type: 'String' },
+          ],
+          actions: [],
+        },
+      ] as unknown as Parameters<typeof buildContext>[0];
+
+      const [{ fields }] = buildContext(collidingSchema, new ReadModel(collidingSchema), {
+        schemaRevision: 1,
+      }).collections;
+
+      expect(fields.find(entry => entry.field === 'first_name')).not.toHaveProperty('recordKey');
+      expect(fields.find(entry => entry.field === 'firstName')).not.toHaveProperty('recordKey');
+    });
+
+    it('should omit recordKey on a non-key field named Id, which the resource id overwrites', () => {
+      const idSchema = [
+        {
+          name: 'people',
+          fields: [
+            { field: 'reference', type: 'String', isPrimaryKey: true },
+            { field: 'Id', type: 'String' },
+          ],
+          actions: [],
+        },
+      ] as unknown as Parameters<typeof buildContext>[0];
+
+      const [{ fields }] = buildContext(idSchema, new ReadModel(idSchema), {
+        schemaRevision: 1,
+      }).collections;
+
+      expect(fields.find(entry => entry.field === 'Id')).not.toHaveProperty('recordKey');
+    });
+
+    it('should still name the key of a primary key the deserializer does rename', () => {
+      const pascalKeySchema = [
+        {
+          name: 'people',
+          fields: [{ field: 'Id', type: 'Number', isPrimaryKey: true }],
+          actions: [],
+        },
+      ] as unknown as Parameters<typeof buildContext>[0];
+
+      const [{ fields }] = buildContext(pascalKeySchema, new ReadModel(pascalKeySchema), {
+        schemaRevision: 1,
+      }).collections;
+
+      expect(fields.find(entry => entry.field === 'Id')?.recordKey).toBe('id');
+    });
+
     it('should survive the published schema, which would drop an undeclared key', () => {
       const context = buildContext(snakeCaseSchema, new ReadModel(snakeCaseSchema), {
         schemaRevision: 1,

--- a/packages/agent-bff/test/context/build-context.test.ts
+++ b/packages/agent-bff/test/context/build-context.test.ts
@@ -88,6 +88,51 @@ describe('buildContext', () => {
     });
   });
 
+  describe('when the agent declares its fields in snake_case', () => {
+    const snakeCaseSchema = [
+      {
+        name: 'people',
+        fields: [
+          { field: 'id', type: 'Number', isPrimaryKey: true },
+          { field: 'created_at', type: 'Date' },
+          { field: 'email', type: 'String' },
+        ],
+        actions: [],
+      },
+    ] as unknown as Parameters<typeof buildContext>[0];
+
+    function peopleFields() {
+      const context = buildContext(snakeCaseSchema, new ReadModel(snakeCaseSchema), {
+        schemaRevision: 1,
+      });
+
+      return context.collections[0].fields;
+    }
+
+    it('should name the key the record carries, which agent-client camelCases', () => {
+      expect(peopleFields().find(entry => entry.field === 'created_at')?.recordKey).toBe(
+        'createdAt',
+      );
+    });
+
+    it('should keep field as the agent technical name, which the request path sends back', () => {
+      expect(peopleFields().map(entry => entry.field)).toEqual(['id', 'created_at', 'email']);
+    });
+
+    it('should omit recordKey on a field the deserializer leaves untouched', () => {
+      expect(peopleFields().find(entry => entry.field === 'email')).not.toHaveProperty('recordKey');
+      expect(peopleFields().find(entry => entry.field === 'id')).not.toHaveProperty('recordKey');
+    });
+
+    it('should survive the published schema, which would drop an undeclared key', () => {
+      const context = buildContext(snakeCaseSchema, new ReadModel(snakeCaseSchema), {
+        schemaRevision: 1,
+      });
+
+      expect(ContextResponseSchema.parse(context)).toStrictEqual(context);
+    });
+  });
+
   describe('when a schema field is not an object', () => {
     it('should skip it rather than serialize a field with neither name nor type', () => {
       const context = buildContext(schema, readModel, { schemaRevision: 1 });

--- a/packages/agent-bff/test/data/record-key.test.ts
+++ b/packages/agent-bff/test/data/record-key.test.ts
@@ -1,0 +1,21 @@
+import recordKey from '../../src/data/record-key';
+
+describe('recordKey', () => {
+  it('should leave an already-clean name untouched', () => {
+    expect(recordKey('email')).toBe('email');
+  });
+
+  it('should camelCase a snake_case name, since that is how the response carries it', () => {
+    expect(recordKey('created_at')).toBe('createdAt');
+  });
+
+  it('should collapse every casing and separator variant onto one key, like the deserializer', () => {
+    ['first_name', 'firstName', 'FirstName', 'first-name', 'FIRST_NAME'].forEach(name => {
+      expect(recordKey(name)).toBe('firstName');
+    });
+  });
+
+  it('should camelize non-ASCII names too, which a hand-rolled mirror would likely miss', () => {
+    expect(recordKey('état_civil')).toBe('étatCivil');
+  });
+});

--- a/packages/agent-bff/test/openapi/record-schemas.test.ts
+++ b/packages/agent-bff/test/openapi/record-schemas.test.ts
@@ -1,6 +1,6 @@
 import type { UnfoldedCollection } from '../../src/openapi/unfolding';
 
-import recordSchema, { recordKey } from '../../src/openapi/record-schemas';
+import recordSchema from '../../src/openapi/record-schemas';
 
 const PEOPLE: UnfoldedCollection = {
   name: 'people',
@@ -132,25 +132,5 @@ describe('recordSchema', () => {
         '"postal_code", "postalCode" all reach the response under this single key, so which one ' +
         'it holds is not determined here.',
     });
-  });
-});
-
-describe('recordKey', () => {
-  it('should leave an already-clean name untouched', () => {
-    expect(recordKey('email')).toBe('email');
-  });
-
-  it('should camelCase a snake_case name, since that is how the response carries it', () => {
-    expect(recordKey('created_at')).toBe('createdAt');
-  });
-
-  it('should collapse every casing and separator variant onto one key, like the deserializer', () => {
-    ['first_name', 'firstName', 'FirstName', 'first-name', 'FIRST_NAME'].forEach(name => {
-      expect(recordKey(name)).toBe('firstName');
-    });
-  });
-
-  it('should camelize non-ASCII names too, which a hand-rolled mirror would likely miss', () => {
-    expect(recordKey('état_civil')).toBe('étatCivil');
   });
 });


### PR DESCRIPTION
`GET /agent/v1/context` now publishes a `recordKey` on every field whose technical name differs from the key the record actually carries.

```json
{ "field": "created_at", "recordKey": "createdAt", "type": "Date" }
```

Read a record value under `recordKey ?? field`, keep sending `field` on the request side. The key is absent when both names match, so nothing changes for a camelCase agent.

## Why

`agent-client` deserializes the agent JSON:API with `keyForAttribute: 'camelCase'` (`http-requester.ts:31`), so a `created_at` column is projected under that name and returned as `createdAt`. The context published the technical name only. On any snake_case agent (agent-ruby, forest-rails) a consumer had no way to join the schema it read to the records it got back.

Two alternatives were rejected:

- Renaming `field` to the camelCase form. `field` is what a consumer sends back in a filter, a sort or a projection, and the BFF passes it to the agent verbatim. Renaming it means translating the whole request path.
- Returning records under their technical names. The published OpenAPI already documents record keys as camelCase, and the transform is not reversible: `first_name` and `firstName` collapse to the same key.

## How

`recordKey()` already existed in `openapi/record-schemas.ts`, where it renames fields in the generated record schemas. It moved to `data/record-key.ts`, the layer that describes agent-client deserialization rather than presentation, and both callers share it. `build-context.ts` sets the key only when it differs from `field`, and `ContextFieldSchema` carries it as optional.

Known limitation: sub-fields of a composite `type` carry no `recordKey`, although the same transform applies to them. Covering them means rewriting the type tree, which is passed through verbatim today. The gap is stated in the `ContextResponse` description rather than left for a consumer to discover.

## How to test

```bash
yarn workspace @forestadmin/agent-bff test
yarn workspace @forestadmin/agent-bff lint
yarn workspace @forestadmin/agent-bff build
```

1657 tests pass, lint reports no error, build is clean.

Against a real snake_case agent (agent-ruby 1.39 on ActiveRecord), a projection on the technical name comes back under the record key, and the context now carries both:

```
POST /agent/v1/Category/list   projection: ["id","name","created_at"]
  { "createdAt": "2026-08-20T08:03:40.617Z", "id": "5", "name": "Finance" }
```

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made

