### PR TITLE
fix(workflow-executor): read an xToOne linkage from the raw JSON:API body

### DIFF
--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -293,15 +293,16 @@ export default class AgentClientAgentPort implements AgentPort {
       const recordId =
         relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [String(raw)];
 
-      // Nothing to project: the caller wants the linkage id alone (it reads `values` only for the
-      // reference field it asked for), so reading the target would fetch a whole record to discard.
-      if (!fields?.length) {
-        return { collectionName: relatedSchema.collectionName, recordId, values: {} };
-      }
+      // The target is read even when the caller projected nothing, on its first PK alone. Skipping
+      // the read to save the round trip also skipped the readability check below, so a relation
+      // whose collection happens to carry no reference field would load a record the caller cannot
+      // open, while the same relation with one reported no record — the outcome turning on a
+      // schema detail rather than on what the caller can see.
+      const projection = fields?.length ? fields : [relatedSchema.primaryKeyFields[0]];
 
       try {
         return await this.getRecord(
-          { collection: relatedSchema.collectionName, id: recordId, fields },
+          { collection: relatedSchema.collectionName, id: recordId, fields: projection },
           user,
         );
       } catch (error) {

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -285,8 +285,11 @@ export default class AgentClientAgentPort implements AgentPort {
 
       if (raw == null || raw === '') return null;
 
-      // Only a composite key is pipe-packed. A single-key value can legitimately hold a pipe —
-      // a smart field's value is written by the client — so splitting it would tear it in two.
+      // Only a composite key is pipe-packed, so a single-key value is never split — a smart field's
+      // value is written by the client and splitting it would tear it in two. Such a value cannot
+      // hold a pipe either way: `serializeRecordId` refuses one rather than emit an id the agent
+      // would unpack into the wrong number of key parts. That surfaces as an AgentPortError naming
+      // the value, which is cryptic but loud; naming the relation too would need a domain error.
       const recordId =
         relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [String(raw)];
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -260,7 +260,12 @@ export default class AgentClientAgentPort implements AgentPort {
         throw error;
       }
 
-      const node = body?.data;
+      // Some agents answer a missing composite-key record with a 200 + empty body instead of 404,
+      // like getRecord above. Reading that as an unset relation would report "nothing to load" for
+      // a parent that was never read — the exact confusion this method exists to remove.
+      if (!body?.data) throw new RecordNotFoundError(collection, id);
+
+      const node = body.data;
       // Raw keys are the agent's own field names, so no inflection to second-guess. A linkage
       // covers the Rails `belongs_to` DSL, forest-express references and v2 agents; the attribute
       // covers a forest-rails `field ... reference:`, whose value IS the related id.
@@ -270,16 +275,32 @@ export default class AgentClientAgentPort implements AgentPort {
 
       if (raw == null || raw === '') return null;
 
-      return this.getRecord(
-        {
-          collection: relatedSchema.collectionName,
-          // Only a composite key is pipe-packed. A single-key value can legitimately hold a pipe —
-          // a smart field's value is written by the client — so splitting it would tear it in two.
-          id: relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [String(raw)],
-          ...(fields?.length ? { fields } : {}),
-        },
-        user,
-      );
+      // Only a composite key is pipe-packed. A single-key value can legitimately hold a pipe —
+      // a smart field's value is written by the client — so splitting it would tear it in two.
+      const recordId =
+        relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [String(raw)];
+
+      // Nothing to project: the caller wants the linkage id alone (it reads `values` only for the
+      // reference field it asked for), so reading the target would fetch a whole record to discard.
+      if (!fields?.length) {
+        return { collectionName: relatedSchema.collectionName, recordId, values: {} };
+      }
+
+      try {
+        return await this.getRecord(
+          { collection: relatedSchema.collectionName, id: recordId, fields },
+          user,
+        );
+      } catch (error) {
+        // A target the caller cannot read — scoped out, segmented out, or a dangling link — is not
+        // a broken run: the by-id route intersects the caller's scope while the relation projected
+        // on the parent does not, so a valid linkage to an invisible record is reachable. "No
+        // related record" is the true answer from this caller's vantage. The parent above is the
+        // opposite case: it is the step's own source record, so failing to read it stays an error.
+        if (error instanceof RecordNotFoundError) return null;
+
+        throw error;
+      }
     });
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -58,6 +58,13 @@ function mapActionExecutionError(action: string, cause: unknown): unknown {
   return cause;
 }
 
+type RawRecordBody = {
+  data?: {
+    attributes?: Record<string, unknown>;
+    relationships?: Record<string, { data?: { id?: string } | null }>;
+  };
+};
+
 // Transcribes inflected's `underscore` + `camelize(_, false)` — the inflection agent-client's
 // jsonapi-serializer deserializer applies to every response key. Divergence = silent lookup miss.
 function toCamelCase(name: string): string {
@@ -220,10 +227,11 @@ export default class AgentClientAgentPort implements AgentPort {
     });
   }
 
-  // xToOne relations have no /relationships/<relation> route on the agent. We read the
-  // parent record with a `<relation>@@@<field>` projection and unpack the relation linkage
-  // jsonapi-serializer emits as a nested object on the parent (with the related PK packed
-  // under "id" when composite).
+  // xToOne relations have no /relationships/<relation> route on the agent, so the relation is read
+  // off the parent record — from the RAW JSON:API body. jsonapi-serializer drops a relationship key
+  // whose linkage has no matching `included` entry, and forest-rails only compounds real
+  // ActiveRecord associations, so a Rails smart belongs_to reached us as "no relation at all".
+  // resolvePolymorphicType reads raw for the same reason.
   async getSingleRelatedData(
     { collection, id, relation, relatedSchema, fields }: GetSingleRelatedDataQuery,
     user: StepUser,
@@ -232,52 +240,46 @@ export default class AgentClientAgentPort implements AgentPort {
       // The agent can't parse multiple sub-fields on one relation in a single projection
       // (`fields[store]=id,name` is read as a single field name → ValidationError). The linkage
       // `id` carries the (packed) related PK regardless of projection, so project at most ONE
-      // field: the requested reference field for display, else a single PK field just to pull the
-      // relation into the response.
+      // field: the requested reference field, else a single PK field just to pull the relation
+      // into the response.
       const projectedField = fields?.[0] ?? relatedSchema.primaryKeyFields[0];
-      const parent = await this.getRecord(
+
+      let body: RawRecordBody;
+
+      try {
+        body = await this.createClient(user)
+          .collection(collection)
+          .getOne<RawRecordBody>(
+            id,
+            { fields: [`${relation}@@@${projectedField}`] },
+            { skipDeserialization: true },
+          );
+      } catch (error) {
+        if (HttpRequester.is404Error(error)) throw new RecordNotFoundError(collection, id);
+
+        throw error;
+      }
+
+      const node = body?.data;
+      // Raw keys are the agent's own field names, so no inflection to second-guess. A linkage
+      // covers the Rails `belongs_to` DSL, forest-express references and v2 agents; the attribute
+      // covers a forest-rails `field ... reference:`, whose value IS the related id.
+      // An empty string is the idiomatic Ruby answer for an unset association (`&.id.to_s`), and it
+      // would serialize to an id-less by-id URL, which agents route to the index action instead.
+      const raw = node?.relationships?.[relation]?.data?.id ?? node?.attributes?.[relation];
+
+      if (raw == null || raw === '') return null;
+
+      return this.getRecord(
         {
-          collection,
-          id,
-          fields: [`${relation}@@@${projectedField}`],
+          collection: relatedSchema.collectionName,
+          // Only a composite key is pipe-packed. A single-key value can legitimately hold a pipe —
+          // a smart field's value is written by the client — so splitting it would tear it in two.
+          id: relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [String(raw)],
+          ...(fields?.length ? { fields } : {}),
         },
         user,
       );
-
-      const raw = parent.values[toCamelCase(relation)];
-
-      // A forest-rails smart field declared with `field ... reference:` serializes as a plain
-      // attribute, so the value IS the related id. The same apimap shape coming from the
-      // `belongs_to` DSL, and every forest-express reference field, still arrives as a linkage —
-      // hence a check on the runtime shape rather than on the schema.
-      // An empty string is the idiomatic Ruby answer for an unset association (`&.id.to_s`), and it
-      // would serialize to an id-less by-id URL, which agents route to the index action instead.
-      if (raw != null && raw !== '' && typeof raw !== 'object') {
-        return this.getRecord(
-          {
-            collection: relatedSchema.collectionName,
-            // Only a composite key is pipe-packed. The value of a smart field is written by the
-            // client, so splitting a single-key id would tear a legitimate "a|b" in two.
-            id:
-              relatedSchema.primaryKeyFields.length > 1 ? String(raw).split('|') : [raw as string],
-            ...(fields?.length ? { fields } : {}),
-          },
-          user,
-        );
-      }
-
-      const linkage = raw as Record<string, unknown> | null | undefined;
-      const packedId = linkage?.id as string | undefined;
-
-      if (!linkage || !packedId) return null;
-
-      const restored = restoreFieldNames(linkage, [projectedField]);
-
-      return {
-        collectionName: relatedSchema.collectionName,
-        recordId: packedId.split('|'),
-        values: restored,
-      };
     });
   }
 

--- a/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
+++ b/packages/workflow-executor/src/adapters/agent-client-agent-port.ts
@@ -271,7 +271,17 @@ export default class AgentClientAgentPort implements AgentPort {
       // covers a forest-rails `field ... reference:`, whose value IS the related id.
       // An empty string is the idiomatic Ruby answer for an unset association (`&.id.to_s`), and it
       // would serialize to an id-less by-id URL, which agents route to the index action instead.
-      const raw = node?.relationships?.[relation]?.data?.id ?? node?.attributes?.[relation];
+      const linkageId = node.relationships?.[relation]?.data?.id;
+      const attribute = node.attributes?.[relation];
+
+      // A `field ... reference:` block that returns the record instead of its id serializes the
+      // whole record under the attribute — captured from forest-rails, not assumed — so the id sits
+      // one level in. Any other scalar IS the id.
+      const raw =
+        linkageId ??
+        (attribute && typeof attribute === 'object'
+          ? (attribute as { id?: unknown }).id
+          : attribute);
 
       if (raw == null || raw === '') return null;
 

--- a/packages/workflow-executor/src/ports/agent-port.ts
+++ b/packages/workflow-executor/src/ports/agent-port.ts
@@ -21,9 +21,11 @@ export type GetRelatedDataQuery = {
 } & Limit;
 
 // xToOne relations (BelongsTo / HasOne) — the agent does not serve
-// /forest/<collection>/<id>/relationships/<relation> for these; the port instead reads
-// the parent record with a `<relation>@@@<field>` projection, then unpacks the relation
-// linkage embedded on the parent.
+// /forest/<collection>/<id>/relationships/<relation> for these; the port instead reads the parent's
+// raw JSON:API body with a `<relation>@@@<field>` projection, takes the related id from the
+// relationship linkage or from the reference attribute, then reads the target by id. Deserializing
+// the parent would lose the linkage: a key whose linkage has no matching `included` entry is
+// dropped outright, which no agent emits for a smart relation.
 export type GetSingleRelatedDataQuery = {
   collection: string;
   id: Id[];

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -884,8 +884,10 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['acme', '7']);
     });
 
-    // The value of a smart field is written by the client, so a pipe in it is data, not packing.
-    it('keeps a pipe intact when the target key is single', async () => {
+    // A single-key value is never split — the pipe is data, not packing. It is not loadable either:
+    // agent-client's serializeRecordId refuses a pipe in a key part (covered in its own suite), and
+    // an agent would unpack it into the wrong number of parts. This pins the no-split, not a load.
+    it('does not split a single-key value on the pipe', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce(parentWithAttribute('card', 'acme|corp'))
         .mockResolvedValueOnce({ reference: 'CARD-1' });

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -10,7 +10,9 @@ import {
   HttpRequester,
   createRemoteAgentClient,
 } from '@forestadmin/agent-client';
+import { readFileSync } from 'fs';
 import jsonwebtoken from 'jsonwebtoken';
+import { join } from 'path';
 
 import AgentClientAgentPort from '../../src/adapters/agent-client-agent-port';
 import {
@@ -22,6 +24,12 @@ import {
   RecordNotFoundError,
 } from '../../src/errors';
 import SchemaCache from '../../src/schema-cache';
+
+// Read rather than imported: enabling resolveJsonModule for one fixture would change the
+// package's build config for every consumer.
+const railsBody = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/forest-rails-smart-relation.json'), 'utf8'),
+) as { data: unknown; included: { id: string }[] };
 
 jest.mock('@forestadmin/agent-client', () => {
   // Real class so `instanceof AgentHttpError` in the adapter matches errors built by these tests.
@@ -624,6 +632,42 @@ describe('AgentClientAgentPort', () => {
 
     const parentWithAttribute = (relation: string, value: unknown) => ({
       data: { type: 'users', id: '42', attributes: { [relation]: value }, relationships: {} },
+    });
+
+    // Captured from a live forest-rails 9.17.3 agent, verbatim: `spec/dummy` with a smart
+    // `belongs_to` and two `field ... reference:` declarations pointing at a User no real
+    // ActiveRecord association reaches. Every other test here builds its body by hand, which is
+    // what let the deserializer drop go unnoticed three times. This one pins the wire.
+    describe.each([
+      ['a linkage with no included entry', 'smart_owner'],
+      ['a reference attribute holding the id', 'owner_ref_id'],
+      ['a reference attribute holding the record', 'owner_ref_record'],
+    ])('against the captured forest-rails body, %s', (_label, relation) => {
+      it('resolves the related id and reads the target', async () => {
+        mockCollection.getOne
+          .mockResolvedValueOnce(railsBody)
+          .mockResolvedValueOnce({ name: 'Unrelated' });
+
+        const result = await port.getSingleRelatedData(
+          {
+            collection: 'Tree',
+            id: [3],
+            relation,
+            relatedSchema: { ...ordersSchema, collectionName: 'User' },
+            fields: ['name'],
+          },
+          user,
+        );
+
+        // User 7 is the smart target; `included` carries only User 6, the real association.
+        expect(railsBody.included.map(i => i.id)).toEqual(['6']);
+        expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['7'], { fields: ['name'] });
+        expect(result).toEqual({
+          collectionName: 'User',
+          recordId: ['7'],
+          values: { name: 'Unrelated' },
+        });
+      });
     });
 
     // The Qonto shape: a forest-rails smart `belongs_to` emits the linkage but never lands in

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -685,6 +685,30 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['uuid-1']);
     });
 
+    // Captured from forest-rails: a `field ... reference:` block returning the record — not its id
+    // — serializes the whole record under the attribute.
+    it('follows an attribute holding the record itself, reading its id', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce(
+          parentWithAttribute('card', { id: 2, name: 'Unrelated', title: null }),
+        )
+        .mockResolvedValueOnce({ reference: 'CARD-1' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['2'], { fields: ['reference'] });
+      expect(result?.recordId).toEqual(['2']);
+    });
+
     // The caller reads `values` only for the reference field it asked for, so with nothing to
     // project the linkage id is the whole answer and the target read would fetch a record to
     // discard it.

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -632,7 +632,7 @@ describe('AgentClientAgentPort', () => {
     it('follows a linkage that has no included entry', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
-        .mockResolvedValueOnce({ id: 'uuid-1', reference: 'CARD-1' });
+        .mockResolvedValueOnce({ reference: 'CARD-1' });
 
       const result = await port.getSingleRelatedData(
         {
@@ -640,6 +640,7 @@ describe('AgentClientAgentPort', () => {
           id: [42],
           relation: 'card',
           relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
         },
         user,
       );
@@ -647,15 +648,17 @@ describe('AgentClientAgentPort', () => {
       expect(mockCollection.getOne).toHaveBeenNthCalledWith(
         1,
         [42],
-        { fields: ['card@@@id'] },
+        { fields: ['card@@@reference'] },
         { skipDeserialization: true },
       );
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {});
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {
+        fields: ['reference'],
+      });
       expect(mockClient.collection).toHaveBeenCalledWith('cards');
       expect(result).toEqual({
         collectionName: 'cards',
         recordId: ['uuid-1'],
-        values: { id: 'uuid-1', reference: 'CARD-1' },
+        values: { reference: 'CARD-1' },
       });
     });
 
@@ -663,7 +666,30 @@ describe('AgentClientAgentPort', () => {
     it('follows an attribute whose value is the related id', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce(parentWithAttribute('card', 'uuid-1'))
-        .mockResolvedValueOnce({ id: 'uuid-1' });
+        .mockResolvedValueOnce({ reference: 'CARD-1' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {
+        fields: ['reference'],
+      });
+      expect(result?.recordId).toEqual(['uuid-1']);
+    });
+
+    // The caller reads `values` only for the reference field it asked for, so with nothing to
+    // project the linkage id is the whole answer and the target read would fetch a record to
+    // discard it.
+    it('returns the linkage id without reading the target when no field is projected', async () => {
+      mockCollection.getOne.mockResolvedValue(parentWithLinkage('card', { id: 'uuid-1' }));
 
       const result = await port.getSingleRelatedData(
         {
@@ -675,8 +701,60 @@ describe('AgentClientAgentPort', () => {
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {});
-      expect(result?.recordId).toEqual(['uuid-1']);
+      expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
+      expect(mockCollection.getOne).toHaveBeenCalledWith(
+        [42],
+        { fields: ['card@@@id'] },
+        { skipDeserialization: true },
+      );
+      expect(result).toEqual({
+        collectionName: 'cards',
+        recordId: ['uuid-1'],
+        values: {},
+      });
+    });
+
+    // The by-id route intersects the caller's scope; the relation projected on the parent does not.
+    // A linkage to a record this caller cannot see is "no related record", not a broken run.
+    it('returns null when the target is unreadable, instead of failing the step', async () => {
+      mockedIs404Error.mockReturnValue(true);
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
+        .mockRejectedValueOnce(new Error('not found'));
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
+        },
+        user,
+      );
+
+      expect(result).toBeNull();
+      expect(mockCollection.getOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows a non-404 on the target read', async () => {
+      mockedIs404Error.mockReturnValue(false);
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
+        .mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        port.getSingleRelatedData(
+          {
+            collection: 'claims',
+            id: [42],
+            relation: 'card',
+            relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+            fields: ['reference'],
+          },
+          user,
+        ),
+      ).rejects.toThrow(AgentPortError);
     });
 
     it('projects the caller field, not the PK, and passes it to the target read', async () => {
@@ -763,7 +841,7 @@ describe('AgentClientAgentPort', () => {
     it('splits the packed id when the target key is composite', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce(parentWithLinkage('order', { id: 'acme|7' }))
-        .mockResolvedValueOnce({ tenantId: 'acme', orderId: 7 });
+        .mockResolvedValueOnce({ reference: 'ORD-1' });
 
       const result = await port.getSingleRelatedData(
         {
@@ -771,11 +849,14 @@ describe('AgentClientAgentPort', () => {
           id: [42],
           relation: 'order',
           relatedSchema: { ...ordersSchema, primaryKeyFields: ['tenantId', 'orderId'] },
+          fields: ['reference'],
         },
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme', '7'], {});
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme', '7'], {
+        fields: ['reference'],
+      });
       expect(result?.recordId).toEqual(['acme', '7']);
     });
 
@@ -783,7 +864,7 @@ describe('AgentClientAgentPort', () => {
     it('keeps a pipe intact when the target key is single', async () => {
       mockCollection.getOne
         .mockResolvedValueOnce(parentWithAttribute('card', 'acme|corp'))
-        .mockResolvedValueOnce({ id: 'acme|corp' });
+        .mockResolvedValueOnce({ reference: 'CARD-1' });
 
       const result = await port.getSingleRelatedData(
         {
@@ -791,11 +872,14 @@ describe('AgentClientAgentPort', () => {
           id: [42],
           relation: 'card',
           relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+          fields: ['reference'],
         },
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme|corp'], {});
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['acme|corp'], {
+        fields: ['reference'],
+      });
       expect(result?.recordId).toEqual(['acme|corp']);
     });
 
@@ -823,6 +907,23 @@ describe('AgentClientAgentPort', () => {
       expect(result).toBeNull();
       expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
     });
+
+    // Some agents answer a missing composite-key record with a 200 + empty body. Returning null
+    // there would report "no record to load" for a parent nobody read.
+    it.each([{}, { data: null }])(
+      'treats a 200 with an empty parent body (%j) as RecordNotFoundError',
+      async body => {
+        mockCollection.getOne.mockResolvedValue(body);
+
+        await expect(
+          port.getSingleRelatedData(
+            { collection: 'claims', id: [42], relation: 'card', relatedSchema: ordersSchema },
+            user,
+          ),
+        ).rejects.toThrow(RecordNotFoundError);
+        expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
+      },
+    );
 
     it('maps a 404 on the parent to RecordNotFoundError', async () => {
       mockedIs404Error.mockReturnValue(true);

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -598,9 +598,9 @@ describe('AgentClientAgentPort', () => {
   });
 
   describe('getSingleRelatedData', () => {
-    // xToOne relations don't expose /relationships/<relation> on the agent. The port reads
-    // the parent record with a `<relation>@@@<field>` projection and unpacks the linkage
-    // that jsonapi-serializer emits as a nested object on the parent.
+    // xToOne relations don't expose /relationships/<relation> on the agent, so the port reads the
+    // relation off the parent's RAW JSON:API body. Deserializing it would be lossy: a linkage with
+    // no matching `included` entry is dropped entirely, and no agent compounds a smart relation.
     const ordersSchema = {
       collectionName: 'orders',
       collectionId: 'col-orders',
@@ -618,238 +618,20 @@ describe('AgentClientAgentPort', () => {
       actions: [],
     };
 
-    it('projects the related PK on the parent and unpacks the linkage as RecordData', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: { id: '99' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['order@@@id'] });
-      expect(result).toEqual({
-        collectionName: 'orders',
-        recordId: ['99'],
-        values: { id: '99' },
-      });
+    const parentWithLinkage = (relation: string, data: { id?: string } | null) => ({
+      data: { type: 'users', id: '42', attributes: {}, relationships: { [relation]: { data } } },
     });
 
-    it('projects only the caller field (e.g. referenceField), not the PK — the linkage id comes free', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: { id: '99', reference: 'ORD-2026-001' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-          fields: ['reference'],
-        },
-        user,
-      );
-
-      // Single sub-field only: the agent can't parse `fields[order]=id,reference`.
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['order@@@reference'] });
-      expect(result?.values).toEqual({ id: '99', reference: 'ORD-2026-001' });
+    const parentWithAttribute = (relation: string, value: unknown) => ({
+      data: { type: 'users', id: '42', attributes: { [relation]: value }, relationships: {} },
     });
 
-    it('projects at most one sub-field even when the caller passes several', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: { id: '99', reference: 'ORD-2026-001' } });
-
-      await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-          fields: ['reference', 'label'],
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['order@@@reference'] });
-    });
-
-    // Regression: jsonapi-serializer emits the nested linkage with camelCased attribute
-    // keys (full_name → fullName). The adapter must restore those keys before returning
-    // values, otherwise snake_case referenceFields silently resolve to undefined upstream.
-    it('projects the raw snake_case field name and restores it on the linkage', async () => {
-      const snakeSchema = {
-        ...ordersSchema,
-        fields: [
-          { fieldName: 'id', displayName: 'id', isRelationship: false, type: 'Number' as const },
-          {
-            fieldName: 'full_name',
-            displayName: 'Full name',
-            isRelationship: false,
-            type: 'String' as const,
-          },
-        ],
-      };
-      mockCollection.getOne.mockResolvedValue({ order: { id: '99', fullName: 'John Doe' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: snakeSchema,
-          fields: ['full_name'],
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['order@@@full_name'] });
-      expect(result?.values).toEqual({ id: '99', full_name: 'John Doe' });
-    });
-
-    // Regression: the relation NAME itself can be snake_case (billing_address). jsonapi-serializer
-    // emits the linkage under the camelCased key (billingAddress), so looking it up by the raw
-    // name returned null and the relation never loaded.
-    it('finds the linkage when the relation name is snake_case', async () => {
-      mockCollection.getOne.mockResolvedValue({ billingAddress: { id: '7|2' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'billing_address',
-          relatedSchema: { ...ordersSchema, collectionName: 'addresses' },
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], {
-        fields: ['billing_address@@@id'],
-      });
-      expect(result).toEqual({
-        collectionName: 'addresses',
-        recordId: ['7', '2'],
-        values: { id: '7|2' },
-      });
-    });
-
-    it('finds the linkage when the relation name is PascalCase', async () => {
-      mockCollection.getOne.mockResolvedValue({ legalEntity: { id: 'le-1' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'LegalEntity',
-          relatedSchema: { ...ordersSchema, collectionName: 'LegalEntity' },
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['LegalEntity@@@id'] });
-      expect(result).toEqual({
-        collectionName: 'LegalEntity',
-        recordId: ['le-1'],
-        values: { id: 'le-1' },
-      });
-    });
-
-    it('finds the linkage when the relation name starts with an acronym (KYCEvent → kycEvent)', async () => {
-      mockCollection.getOne.mockResolvedValue({ kycEvent: { id: 'kyc-1' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'KYCEvent',
-          relatedSchema: { ...ordersSchema, collectionName: 'KYCEvent' },
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['KYCEvent@@@id'] });
-      expect(result).toEqual({
-        collectionName: 'KYCEvent',
-        recordId: ['kyc-1'],
-        values: { id: 'kyc-1' },
-      });
-    });
-
-    it('finds the linkage when the relation name is kebab-case', async () => {
-      mockCollection.getOne.mockResolvedValue({ billingAddress: { id: 'ba-1' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'billing-address',
-          relatedSchema: { ...ordersSchema, collectionName: 'addresses' },
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], {
-        fields: ['billing-address@@@id'],
-      });
-      expect(result?.recordId).toEqual(['ba-1']);
-    });
-
-    it('projects the raw PascalCase field name and restores it on the linkage', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: { id: '99', fullName: 'John Doe' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-          fields: ['FullName'],
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenCalledWith([42], { fields: ['order@@@FullName'] });
-      expect(result?.values).toEqual({ id: '99', FullName: 'John Doe' });
-    });
-
-    it('splits composite PKs from the packed "id" linkage', async () => {
-      const compositeSchema = {
-        ...ordersSchema,
-        primaryKeyFields: ['tenantId', 'orderId'],
-        fields: [
-          {
-            fieldName: 'tenantId',
-            displayName: 'Tenant',
-            isRelationship: false,
-            type: 'String' as const,
-          },
-          {
-            fieldName: 'orderId',
-            displayName: 'Order',
-            isRelationship: false,
-            type: 'Number' as const,
-          },
-        ],
-      };
-      mockCollection.getOne.mockResolvedValue({ order: { id: 'acme|7' } });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: compositeSchema,
-        },
-        user,
-      );
-
-      expect(result?.recordId).toEqual(['acme', '7']);
-    });
-
-    it('reads the target by id when the projected value is a scalar', async () => {
+    // The Qonto shape: a forest-rails smart `belongs_to` emits the linkage but never lands in
+    // `included` (only real ActiveRecord associations reach the agent's `include`), so the
+    // deserializer used to eat the key and the step reported "no record loaded".
+    it('follows a linkage that has no included entry', async () => {
       mockCollection.getOne
-        .mockResolvedValueOnce({ card: 'uuid-1' })
+        .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
         .mockResolvedValueOnce({ id: 'uuid-1', reference: 'CARD-1' });
 
       const result = await port.getSingleRelatedData(
@@ -862,7 +644,12 @@ describe('AgentClientAgentPort', () => {
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(1, [42], { fields: ['card@@@id'] });
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(
+        1,
+        [42],
+        { fields: ['card@@@id'] },
+        { skipDeserialization: true },
+      );
       expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {});
       expect(mockClient.collection).toHaveBeenCalledWith('cards');
       expect(result).toEqual({
@@ -872,42 +659,118 @@ describe('AgentClientAgentPort', () => {
       });
     });
 
-    it('passes the caller fields to the scalar target read', async () => {
+    // A forest-rails `field ... reference:` serializes as a plain attribute whose value IS the id.
+    it('follows an attribute whose value is the related id', async () => {
       mockCollection.getOne
-        .mockResolvedValueOnce({ card: 'uuid-1' })
-        .mockResolvedValueOnce({ reference: 'CARD-1' });
-
-      await port.getSingleRelatedData(
-        {
-          collection: 'claims',
-          id: [42],
-          relation: 'card',
-          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
-          fields: ['reference'],
-        },
-        user,
-      );
-
-      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {
-        fields: ['reference'],
-      });
-    });
-
-    it('splits a scalar attribute only when the target key is composite', async () => {
-      mockCollection.getOne
-        .mockResolvedValueOnce({ card: 'acme|7' })
-        .mockResolvedValueOnce({ id: 'acme|7' });
+        .mockResolvedValueOnce(parentWithAttribute('card', 'uuid-1'))
+        .mockResolvedValueOnce({ id: 'uuid-1' });
 
       const result = await port.getSingleRelatedData(
         {
           collection: 'claims',
           id: [42],
           relation: 'card',
-          relatedSchema: {
-            ...ordersSchema,
-            collectionName: 'cards',
-            primaryKeyFields: ['tenantId', 'cardId'],
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], {});
+      expect(result?.recordId).toEqual(['uuid-1']);
+    });
+
+    it('projects the caller field, not the PK, and passes it to the target read', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('order', { id: '99' }))
+        .mockResolvedValueOnce({ reference: 'ORD-2026-001' });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'users',
+          id: [42],
+          relation: 'order',
+          relatedSchema: ordersSchema,
+          fields: ['reference'],
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(
+        1,
+        [42],
+        { fields: ['order@@@reference'] },
+        { skipDeserialization: true },
+      );
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['99'], { fields: ['reference'] });
+      expect(result?.values).toEqual({ reference: 'ORD-2026-001' });
+    });
+
+    // Single sub-field only: the agent can't parse `fields[order]=id,reference`.
+    it('projects at most one sub-field even when the caller passes several', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('order', { id: '99' }))
+        .mockResolvedValueOnce({ reference: 'ORD-2026-001' });
+
+      await port.getSingleRelatedData(
+        {
+          collection: 'users',
+          id: [42],
+          relation: 'order',
+          relatedSchema: ordersSchema,
+          fields: ['reference', 'label'],
+        },
+        user,
+      );
+
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(
+        1,
+        [42],
+        { fields: ['order@@@reference'] },
+        { skipDeserialization: true },
+      );
+    });
+
+    // Raw keys are the agent's own field names. Reading the deserialized record instead forced an
+    // inflection guess (billing_address → billingAddress, KYCEvent → kycEvent) that had to match
+    // the deserializer's exactly, or the relation silently resolved to nothing.
+    it.each(['billing_address', 'BillingAddress', 'billing-address', 'KYCEvent'])(
+      'reads the relation under its raw name (%s)',
+      async relation => {
+        mockCollection.getOne
+          .mockResolvedValueOnce(parentWithLinkage(relation, { id: 'ba-1' }))
+          .mockResolvedValueOnce({ id: 'ba-1' });
+
+        const result = await port.getSingleRelatedData(
+          {
+            collection: 'users',
+            id: [42],
+            relation,
+            relatedSchema: { ...ordersSchema, collectionName: 'addresses' },
           },
+          user,
+        );
+
+        expect(mockCollection.getOne).toHaveBeenNthCalledWith(
+          1,
+          [42],
+          { fields: [`${relation}@@@id`] },
+          { skipDeserialization: true },
+        );
+        expect(result?.recordId).toEqual(['ba-1']);
+      },
+    );
+
+    it('splits the packed id when the target key is composite', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('order', { id: 'acme|7' }))
+        .mockResolvedValueOnce({ tenantId: 'acme', orderId: 7 });
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'users',
+          id: [42],
+          relation: 'order',
+          relatedSchema: { ...ordersSchema, primaryKeyFields: ['tenantId', 'orderId'] },
         },
         user,
       );
@@ -916,10 +779,10 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['acme', '7']);
     });
 
-    // The value is produced by client-written code, so a pipe in it is data, not packing.
-    it('keeps a pipe in a scalar attribute intact when the target key is single', async () => {
+    // The value of a smart field is written by the client, so a pipe in it is data, not packing.
+    it('keeps a pipe intact when the target key is single', async () => {
       mockCollection.getOne
-        .mockResolvedValueOnce({ card: 'acme|corp' })
+        .mockResolvedValueOnce(parentWithAttribute('card', 'acme|corp'))
         .mockResolvedValueOnce({ id: 'acme|corp' });
 
       const result = await port.getSingleRelatedData(
@@ -936,27 +799,16 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['acme|corp']);
     });
 
-    it('returns null when the scalar attribute is null, without reading the target', async () => {
-      mockCollection.getOne.mockResolvedValue({ card: null });
-
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'claims',
-          id: [42],
-          relation: 'card',
-          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
-        },
-        user,
-      );
-
-      expect(result).toBeNull();
-      expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
-    });
-
     // `object.card&.id.to_s` is the idiomatic Ruby getter, and it answers "" for an unset
     // association. Reading it as an id would build an id-less URL that agents route to the index.
-    it('returns null when the scalar attribute is an empty string, without reading the target', async () => {
-      mockCollection.getOne.mockResolvedValue({ card: '' });
+    it.each([
+      ['an empty linkage', () => parentWithLinkage('card', null)],
+      ['a linkage without an id', () => parentWithLinkage('card', {})],
+      ['no relationship nor attribute', () => ({ data: { type: 'claims', id: '42' } })],
+      ['a null attribute', () => parentWithAttribute('card', null)],
+      ['an empty-string attribute', () => parentWithAttribute('card', '')],
+    ])('returns null on %s, without reading the target', async (_label, parent) => {
+      mockCollection.getOne.mockResolvedValue(parent());
 
       const result = await port.getSingleRelatedData(
         {
@@ -972,36 +824,28 @@ describe('AgentClientAgentPort', () => {
       expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
     });
 
-    it('returns null when the parent has no linkage to the xToOne relation', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: null });
+    it('maps a 404 on the parent to RecordNotFoundError', async () => {
+      mockedIs404Error.mockReturnValue(true);
+      mockCollection.getOne.mockRejectedValue(new Error('not found'));
 
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-        },
-        user,
-      );
-
-      expect(result).toBeNull();
+      await expect(
+        port.getSingleRelatedData(
+          { collection: 'claims', id: [999], relation: 'card', relatedSchema: ordersSchema },
+          user,
+        ),
+      ).rejects.toThrow(RecordNotFoundError);
     });
 
-    it('returns null when the linkage object is present but has no id', async () => {
-      mockCollection.getOne.mockResolvedValue({ order: {} });
+    it('rethrows a non-404 on the parent instead of masking it as RecordNotFoundError', async () => {
+      mockedIs404Error.mockReturnValue(false);
+      mockCollection.getOne.mockRejectedValue(new Error('boom'));
 
-      const result = await port.getSingleRelatedData(
-        {
-          collection: 'users',
-          id: [42],
-          relation: 'order',
-          relatedSchema: ordersSchema,
-        },
-        user,
-      );
-
-      expect(result).toBeNull();
+      await expect(
+        port.getSingleRelatedData(
+          { collection: 'claims', id: [42], relation: 'card', relatedSchema: ordersSchema },
+          user,
+        ),
+      ).rejects.toThrow(AgentPortError);
     });
   });
 

--- a/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
+++ b/packages/workflow-executor/test/adapters/agent-client-agent-port.test.ts
@@ -709,11 +709,12 @@ describe('AgentClientAgentPort', () => {
       expect(result?.recordId).toEqual(['2']);
     });
 
-    // The caller reads `values` only for the reference field it asked for, so with nothing to
-    // project the linkage id is the whole answer and the target read would fetch a record to
-    // discard it.
-    it('returns the linkage id without reading the target when no field is projected', async () => {
-      mockCollection.getOne.mockResolvedValue(parentWithLinkage('card', { id: 'uuid-1' }));
+    // Reading the target on its first PK alone still runs the readability check, so the outcome
+    // does not turn on whether the related collection happens to carry a reference field.
+    it('reads the target on its primary key when no field is projected', async () => {
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
+        .mockResolvedValueOnce({ id: 'uuid-1' });
 
       const result = await port.getSingleRelatedData(
         {
@@ -725,17 +726,41 @@ describe('AgentClientAgentPort', () => {
         user,
       );
 
-      expect(mockCollection.getOne).toHaveBeenCalledTimes(1);
-      expect(mockCollection.getOne).toHaveBeenCalledWith(
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(
+        1,
         [42],
         { fields: ['card@@@id'] },
         { skipDeserialization: true },
       );
+      expect(mockCollection.getOne).toHaveBeenNthCalledWith(2, ['uuid-1'], { fields: ['id'] });
       expect(result).toEqual({
         collectionName: 'cards',
         recordId: ['uuid-1'],
-        values: {},
+        values: { id: 'uuid-1' },
       });
+    });
+
+    // The gap this closes: without a projected field the target read used to be skipped, so an
+    // unreadable target loaded anyway — the same relation reporting no record once its collection
+    // gained a reference field.
+    it('returns null when the target is unreadable and no field is projected', async () => {
+      mockedIs404Error.mockReturnValue(true);
+      mockCollection.getOne
+        .mockResolvedValueOnce(parentWithLinkage('card', { id: 'uuid-1' }))
+        .mockRejectedValueOnce(new Error('not found'));
+
+      const result = await port.getSingleRelatedData(
+        {
+          collection: 'claims',
+          id: [42],
+          relation: 'card',
+          relatedSchema: { ...ordersSchema, collectionName: 'cards' },
+        },
+        user,
+      );
+
+      expect(result).toBeNull();
+      expect(mockCollection.getOne).toHaveBeenCalledTimes(2);
     });
 
     // The by-id route intersects the caller's scope; the relation projected on the parent does not.

--- a/packages/workflow-executor/test/adapters/fixtures/forest-rails-smart-relation.json
+++ b/packages/workflow-executor/test/adapters/fixtures/forest-rails-smart-relation.json
@@ -1,0 +1,111 @@
+{
+  "data": {
+    "type": "Tree",
+    "id": "3",
+    "attributes": {
+      "id": 3,
+      "name": "Lemon Tree",
+      "created_at": "2026-09-09T16:01:55.895Z",
+      "updated_at": "2026-09-09T16:01:55.895Z",
+      "age": null,
+      "owner_ref_id": "7",
+      "owner_ref_record": {
+        "id": 7,
+        "name": "Unrelated",
+        "created_at": "2026-09-09T16:01:55.888Z",
+        "updated_at": "2026-09-09T16:01:55.888Z",
+        "title": null
+      }
+    },
+    "links": {
+      "self": "/forest/tree/3"
+    },
+    "relationships": {
+      "owner": {
+        "links": {
+          "related": {}
+        },
+        "data": {
+          "type": "User",
+          "id": "6"
+        }
+      },
+      "cutter": {
+        "links": {
+          "related": {}
+        },
+        "data": {
+          "type": "User",
+          "id": "6"
+        }
+      },
+      "island": {
+        "links": {
+          "related": {}
+        },
+        "data": null
+      },
+      "eponymous_island": {
+        "links": {
+          "related": {}
+        },
+        "data": null
+      },
+      "location": {
+        "links": {
+          "related": {}
+        },
+        "data": null
+      },
+      "smart_owner": {
+        "links": {
+          "related": {}
+        },
+        "data": {
+          "type": "User",
+          "id": "7"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "User",
+      "id": "6",
+      "attributes": {
+        "id": 6,
+        "name": "Michel",
+        "created_at": "2026-09-09T16:01:55.886Z",
+        "updated_at": "2026-09-09T16:01:55.886Z",
+        "title": null,
+        "cap_name": "MICHEL"
+      },
+      "links": {
+        "self": "/forest/user/6"
+      },
+      "relationships": {
+        "trees_owned": {
+          "links": {
+            "related": {
+              "href": "/forest/User/6/relationships/trees_owned"
+            }
+          }
+        },
+        "trees_cut": {
+          "links": {
+            "related": {
+              "href": "/forest/User/6/relationships/trees_cut"
+            }
+          }
+        },
+        "addresses": {
+          "links": {
+            "related": {
+              "href": "/forest/User/6/relationships/addresses"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

A Load related record step on a **forest-rails smart `belongs_to`** finds the relation and loads nothing — the next step then fails with *"that step didn't load any record"*.

Reported on a Qonto workflow (`CardClaim__Claim.card` → `CardLifecycle__Card`), after #1884 and the server-side counterpart already made the editor and the engine agree the field *is* a relation.

## Root cause

`getSingleRelatedData` read the relation off the **deserialized** parent record. Both halves of the chain are individually correct, and they lose the value between them:

- forest-rails serializes a smart `belongs_to` as `has_one(… include_data: true)`, so `relationships.card.data = { type, id }` **is** on the wire;
- but its by-id route builds `include:` from real ActiveRecord associations only, so the Card never lands in `included`;
- and `jsonapi-serializer` **deletes a relationship key entirely** when its linkage has no matching `included` entry (`deserializer-utils.js`, `findIncluded` → `null` → key never assigned).

So the adapter saw `undefined`, returned `null`, and the step reported zero candidates. Real relations were never affected: they *are* in `include:`, hence in `included`, hence kept by the deserializer.

## Fix

Read the parent's **raw JSON:API body** (`getOne(…, { skipDeserialization: true })` — what `resolvePolymorphicType` already does, 200 lines below, for this exact reason), take the id, then load the target by id:

```ts
const raw = node?.relationships?.[relation]?.data?.id ?? node?.attributes?.[relation];
```

One path now covers both shapes: the linkage (Rails `belongs_to` DSL, forest-express references, v2 agents) and the scalar attribute (forest-rails `field ... reference:`, whose value *is* the related id). Two consequences worth noting:

- raw keys are the agent's own field names, so the `toCamelCase(relation)` lookup — and the inflection guessing it required (#1787) — is gone from this path;
- the target is always re-read by id, so `values` come from a normal `getRecord` (full projection, field names restored) instead of whatever a single sub-field projection had packed into the linkage.

A 404 on the parent still maps to `RecordNotFoundError`.

## Tests

The old tests mocked `getOne` with **already-deserialized** objects, so the deserializer — the thing that breaks — was never in the picture. They asserted a belief about the wire format, not the wire format. Rewritten with real JSON:API bodies:

- `follows a linkage that has no included entry` — the exact reported shape, red before this change;
- the four inflection tests collapse into one `it.each` over raw relation names, and the five empty cases into one `it.each` (`data: null`, linkage without id, neither relationship nor attribute, `null` attribute, `''` attribute) → `null` without touching the target;
- added: 404 on the parent → `RecordNotFoundError`, non-404 → `AgentPortError`.

`83 passed` on the file (10 red without the src change), `1772 passed` on the package.

## Review follow-up (2nd commit)

`/validator` on the first commit found three defects in the seam the rewrite opened; all three are fixed in `aca2746`:

- **The parent lost its "200 + empty body ⇒ not found" mapping.** The old path inherited it from `getRecord` (which documents the agents that answer a missing composite-key record that way). Losing it reported a source record that could not be read as *"no related record to load"* — the exact conflation this PR exists to remove, reintroduced two lines below the fix. Restored, with the case added to the table.
- **An unreadable target aborted the run.** The linkage branch used to build the result from the parent's own body, so the target's readability never came into play; it now always reads the target. A v2 by-id route intersects the caller's scope while the relation projected on the parent does not, so a valid linkage to a scoped-out (or dangling, or soft-deleted) record is reachable — and it used to complete. It now returns no record rather than failing the run with *"The record no longer exists."*, which was false for the scope case. The parent is deliberately the opposite: it is the step's own source record, so failing to read it stays an error.
- **A full record was fetched to be discarded.** `fetchXToOneCandidate` passes `fields` only when the related schema has a `referenceField`; otherwise it reads `recordId` alone. With nothing to project, the linkage id is the whole answer and the second read is skipped.

`88 passed` on the file, `1777 passed` on the package.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — read-only path, no new data leaves the executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentClientAgentPort.getSingleRelatedData` to read xToOne linkage from raw JSON:API body
> - Replaces the deserialized parent-record lookup with a direct agent-client request using `skipDeserialization` and a single relation projection, reading raw relationship linkage or attribute values from the parent record.
> - Handles null, empty, missing, and id-less relations; splits packed IDs only for composite keys; maps parent 404s and empty bodies to `RecordNotFoundError`; avoids reading the target when no fields are requested.
> - Reworks the test suite to use raw JSON:API-shaped parent responses, covering linkages without included records, scalar smart-field attributes, attribute-held records, composite/single-key IDs, no-field target avoidance, and separate parent vs. target not-found behavior.
> - Behavioral Change: target `RecordNotFoundError` is now converted to `null` instead of propagating; parent 404s and empty bodies now map to `RecordNotFoundError` in `getSingleRelatedData`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1889 opened
>
> - Modified `AgentClientAgentPort.getSingleRelatedData` port method to always read xToOne relation targets from the database [62b0a23]
> - Added test fixture and parameterized test cases in `AgentClientAgentPort` to verify reading xToOne relationship linkage from JSON:API responses [0927e41]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 024927d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
