### PR TITLE
feat(agent-bff): log one line per request

### DIFF
--- a/packages/agent-bff/src/build-bff.ts
+++ b/packages/agent-bff/src/build-bff.ts
@@ -32,6 +32,7 @@ import createCorsMiddleware from './cors/cors-middleware';
 import createPerKeyOriginMiddleware from './cors/per-key-origin';
 import createDataRoutesMiddleware from './data/data-routes-middleware';
 import createDocsRoutes from './docs/docs-routes';
+import createAccessLogMiddleware from './http/access-log-middleware';
 import { unauthorized, unsupportedMediaType } from './http/bff-http-error';
 import BODY_LIMIT, { AI_BODY_LIMIT } from './http/body-limit';
 import createErrorMiddleware from './http/error-middleware';
@@ -534,6 +535,7 @@ export default async function buildBff({
   const agentJsonOnlyGuard = hasAgentEdge ? [agentScoped(createJsonOnlyGuard())] : [];
 
   const middlewares = [
+    createAccessLogMiddleware({ logger, basePath: mountPath }),
     createVersionHeaderMiddleware(version),
     createHealthRoute({
       version,

--- a/packages/agent-bff/src/http/access-log-middleware.ts
+++ b/packages/agent-bff/src/http/access-log-middleware.ts
@@ -43,6 +43,12 @@ function statusOf(error: unknown): number {
  *
  * The query string is deliberately absent. Nothing routed today needs it, and a line that carries it
  * would leak whatever a future route accepts there without anyone revisiting this decision.
+ *
+ * Carries no cause either, so that a host logger which cannot take structured fields still reads as
+ * one line per request. The detail is not lost where it matters: `createErrorMiddleware` already
+ * reports it for everything under `/agent`. Outside it — a body parser rejection on an OAuth POST is
+ * the only route there today — the stack reaches stderr through Koa's own handler, as it did before
+ * this middleware existed.
  */
 export default function createAccessLogMiddleware({
   logger,
@@ -54,7 +60,14 @@ export default function createAccessLogMiddleware({
     const write = (status: number) => {
       const path = `${emittedBaseOf(ctx, basePath)}${ctx.path}`;
 
-      logger(levelOf(status), `[${status}] ${ctx.method} ${path} - ${Date.now() - startedAt}ms`);
+      try {
+        logger(levelOf(status), `[${status}] ${ctx.method} ${path} - ${Date.now() - startedAt}ms`);
+      } catch {
+        // The logger belongs to the host and nothing in the port forbids it from throwing. Left
+        // unguarded, a throw here would answer 500 to a request the route served, and on the error
+        // path it would replace the exception being reported with its own. There is nowhere to
+        // report this: the only sink available is the logger that just failed.
+      }
     };
 
     try {

--- a/packages/agent-bff/src/http/access-log-middleware.ts
+++ b/packages/agent-bff/src/http/access-log-middleware.ts
@@ -1,0 +1,70 @@
+import type { Logger, LoggerLevel } from '../ports/logger-port';
+import type { Middleware } from 'koa';
+
+import { emittedBaseOf } from '../base-path';
+
+export interface AccessLogMiddlewareOptions {
+  logger: Logger;
+  /** Prefix the host serves this BFF under, so the line names a url the caller can actually call. */
+  basePath: string;
+}
+
+const CLIENT_ERROR = 400;
+const SERVER_ERROR = 500;
+
+function levelOf(status: number): LoggerLevel {
+  if (status >= SERVER_ERROR) return 'Error';
+  if (status >= CLIENT_ERROR) return 'Warn';
+
+  return 'Info';
+}
+
+/**
+ * The status the caller will see, read off an exception rather than off the response: this
+ * middleware sits above every error handler the BFF has, so at the moment it logs, `ctx.status` is
+ * still the 404 Koa defaults to and would name a status nobody was ever answered.
+ */
+function statusOf(error: unknown): number {
+  if (typeof error !== 'object' || error === null) return SERVER_ERROR;
+
+  const { status, statusCode } = error as { status?: unknown; statusCode?: unknown };
+  const value = typeof status === 'number' ? status : statusCode;
+
+  return typeof value === 'number' ? value : SERVER_ERROR;
+}
+
+/**
+ * One line per request, in the shape the agent's own request logger emits (`[200] GET /path - 12ms`)
+ * so both layers read the same way in an embedded deployment.
+ *
+ * Belongs at the head of the chain: everything below it — `/health`, `/docs`, `/oauth/*`, a 401 from
+ * the auth edge, a rejected origin — either never reaches the agent or never reaches the
+ * agent-scoped error middleware, and is exactly the traffic that used to leave no trace at all.
+ *
+ * The query string is deliberately absent. Nothing routed today needs it, and a line that carries it
+ * would leak whatever a future route accepts there without anyone revisiting this decision.
+ */
+export default function createAccessLogMiddleware({
+  logger,
+  basePath,
+}: AccessLogMiddlewareOptions): Middleware {
+  return async function accessLog(ctx, next) {
+    const startedAt = Date.now();
+
+    const write = (status: number) => {
+      const path = `${emittedBaseOf(ctx, basePath)}${ctx.path}`;
+
+      logger(levelOf(status), `[${status}] ${ctx.method} ${path} - ${Date.now() - startedAt}ms`);
+    };
+
+    try {
+      await next();
+    } catch (error) {
+      write(statusOf(error));
+
+      throw error;
+    }
+
+    write(ctx.response.status);
+  };
+}

--- a/packages/agent-bff/test/build-bff-access-log.test.ts
+++ b/packages/agent-bff/test/build-bff-access-log.test.ts
@@ -1,0 +1,94 @@
+import type { Logger, LoggerLevel } from '../src/ports/logger-port';
+
+import request from 'supertest';
+
+import buildBff from '../src/build-bff';
+import { restoreFetchAfterEach, stubEnvironmentIdFetch } from './helpers/fetch-stub';
+import { parseConfig } from '../src/config/env-config';
+
+const VALID_ENV = {
+  FOREST_AUTH_SECRET: 'auth-secret',
+  FOREST_ENV_SECRET: 'env-secret',
+  FOREST_SERVER_URL: 'https://api.forestadmin.com',
+  FOREST_APP_URL: 'https://app.forestadmin.com',
+  AGENT_URL: 'https://agent.example.com',
+  BFF_TOKEN_ENCRYPTION_KEY: Buffer.alloc(32).toString('base64'),
+  BFF_ALLOWED_ORIGINS: 'https://allowed.example.com',
+} satisfies NodeJS.ProcessEnv;
+
+type Line = [LoggerLevel, string];
+
+async function buildWithSpy(basePath?: string) {
+  const lines: Line[] = [];
+  const logger: Logger = (level, message) => lines.push([level, message]);
+  const { callback } = await buildBff({ config: parseConfig(VALID_ENV), logger, basePath });
+
+  lines.length = 0;
+
+  return { callback, lines };
+}
+
+function accessLines(lines: Line[]): Line[] {
+  return lines.filter(([, message]) => /^\[\d{3}\] /.test(message));
+}
+
+describe('buildBff access log', () => {
+  restoreFetchAfterEach();
+
+  beforeEach(() => {
+    stubEnvironmentIdFetch();
+  });
+
+  it('logs /health, which no other layer ever sees', async () => {
+    const { callback, lines } = await buildWithSpy();
+
+    await request(callback).get('/health');
+
+    expect(accessLines(lines)).toEqual([
+      ['Info', expect.stringMatching(/^\[200\] GET \/health - \d+ms$/)],
+    ]);
+  });
+
+  it('logs an origin rejected by CORS, which never reaches the agent edge', async () => {
+    const { callback, lines } = await buildWithSpy();
+
+    const res = await request(callback)
+      .get('/agent/v1/collections/companies')
+      .set('Origin', 'https://evil.example.com');
+
+    expect(res.status).toBe(403);
+    expect(accessLines(lines)).toEqual([
+      ['Warn', expect.stringMatching(/^\[403\] GET \/agent\/v1\/collections\/companies - \d+ms$/)],
+    ]);
+  });
+
+  it('logs a request rejected by the auth edge', async () => {
+    const { callback, lines } = await buildWithSpy();
+
+    const res = await request(callback).get('/agent/v1/collections/companies');
+
+    expect(res.status).toBe(401);
+    expect(accessLines(lines)).toEqual([
+      ['Warn', expect.stringMatching(/^\[401\] GET \/agent\/v1\/collections\/companies - \d+ms$/)],
+    ]);
+  });
+
+  it('logs a path no route claims', async () => {
+    const { callback, lines } = await buildWithSpy();
+
+    const res = await request(callback).get('/nowhere');
+
+    expect(res.status).toBe(404);
+    expect(accessLines(lines)).toEqual([
+      ['Warn', expect.stringMatching(/^\[404\] GET \/nowhere - \d+ms$/)],
+    ]);
+  });
+
+  it('names the mounted path an embedded caller asked for', async () => {
+    const { callback, lines } = await buildWithSpy('/bff');
+
+    await request(callback).get('/health');
+
+    expect(accessLines(lines)[0][1]).toMatch(/^\[200\] GET \/bff\/health - \d+ms$/);
+  });
+});

--- a/packages/agent-bff/test/http/access-log-middleware.test.ts
+++ b/packages/agent-bff/test/http/access-log-middleware.test.ts
@@ -1,0 +1,156 @@
+import type { LoggerLevel } from '../../src/ports/logger-port';
+
+import Koa from 'koa';
+import request from 'supertest';
+
+import createAccessLogMiddleware from '../../src/http/access-log-middleware';
+
+type Line = [LoggerLevel, string];
+
+function buildApp(downstream: Koa.Middleware, basePath = '') {
+  const lines: Line[] = [];
+  const app = new Koa();
+  app.silent = true;
+  app.use(
+    createAccessLogMiddleware({
+      logger: (level, message) => lines.push([level, message]),
+      basePath,
+    }),
+  );
+  app.use(downstream);
+
+  return { callback: app.callback(), lines };
+}
+
+function respond(status: number): Koa.Middleware {
+  return async ctx => {
+    ctx.status = status;
+    ctx.body = {};
+  };
+}
+
+describe('access log middleware', () => {
+  it('logs the status, method, path and duration of a served request', async () => {
+    const { callback, lines } = buildApp(respond(200));
+
+    await request(callback).get('/agent/v1/collections/companies');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0][1]).toMatch(/^\[200\] GET \/agent\/v1\/collections\/companies - \d+ms$/);
+  });
+
+  it('leaves the query string out of the line', async () => {
+    const { callback, lines } = buildApp(respond(200));
+
+    await request(callback).get('/oauth/authorize?state=secret&client_id=abc');
+
+    expect(lines[0][1]).toMatch(/^\[200\] GET \/oauth\/authorize - \d+ms$/);
+  });
+
+  it('names the method of a non-GET request', async () => {
+    const { callback, lines } = buildApp(respond(201));
+
+    await request(callback).post('/agent/v1/actions/run');
+
+    expect(lines[0][1]).toMatch(/^\[201\] POST \/agent\/v1\/actions\/run - \d+ms$/);
+  });
+
+  it('logs a served request at Info', async () => {
+    const { callback, lines } = buildApp(respond(204));
+
+    await request(callback).get('/health');
+
+    expect(lines[0][0]).toBe('Info');
+  });
+
+  it('logs a client error at Warn', async () => {
+    const { callback, lines } = buildApp(respond(401));
+
+    await request(callback).get('/agent/v1/collections/companies');
+
+    expect(lines[0]).toEqual(['Warn', expect.stringMatching(/^\[401\] GET/)]);
+  });
+
+  it('logs a server error at Error', async () => {
+    const { callback, lines } = buildApp(respond(502));
+
+    await request(callback).get('/agent/v1/collections/companies');
+
+    expect(lines[0]).toEqual(['Error', expect.stringMatching(/^\[502\] GET/)]);
+  });
+
+  it('reads the status off a thrown error rather than off the untouched response', async () => {
+    const { callback, lines } = buildApp(async () => {
+      throw Object.assign(new Error('Payload too large'), { status: 413 });
+    });
+
+    await request(callback).get('/oauth/token');
+
+    expect(lines[0]).toEqual([
+      'Warn',
+      expect.stringMatching(/^\[413\] GET \/oauth\/token - \d+ms$/),
+    ]);
+  });
+
+  it('reads a status carried as statusCode', async () => {
+    const { callback, lines } = buildApp(async () => {
+      throw Object.assign(new Error('bad request'), { statusCode: 400 });
+    });
+
+    await request(callback).get('/oauth/token');
+
+    expect(lines[0][1]).toMatch(/^\[400\] GET/);
+  });
+
+  it('falls back to 500 for an error carrying no status', async () => {
+    const { callback, lines } = buildApp(async () => {
+      throw new Error('unexpected');
+    });
+
+    await request(callback).get('/docs');
+
+    expect(lines[0]).toEqual(['Error', expect.stringMatching(/^\[500\] GET \/docs - \d+ms$/)]);
+  });
+
+  it('rethrows so the response status is decided downstream, not by the log', async () => {
+    const { callback } = buildApp(async () => {
+      throw new Error('unexpected');
+    });
+
+    const res = await request(callback).get('/docs');
+
+    expect(res.status).toBe(500);
+  });
+
+  it('logs a request once', async () => {
+    const { callback, lines } = buildApp(respond(200));
+
+    await request(callback).get('/health');
+
+    expect(lines).toHaveLength(1);
+  });
+
+  it('prefixes the path with the base path the host serves the BFF under', async () => {
+    const { callback, lines } = buildApp(respond(200), '/bff');
+
+    await request(callback).get('/agent/openapi.json');
+
+    expect(lines[0][1]).toMatch(/^\[200\] GET \/bff\/agent\/openapi\.json - \d+ms$/);
+  });
+
+  it('prefers the prefix the host actually stripped over the configured one', async () => {
+    const lines: Line[] = [];
+    const app = new Koa();
+    app.silent = true;
+    app.use(async (ctx, next) => {
+      (ctx.req as { originalUrl?: string }).originalUrl = `/api/bff${ctx.url}`;
+      await next();
+    });
+    app.use(createAccessLogMiddleware({ logger: (l, m) => lines.push([l, m]), basePath: '/bff' }));
+    app.use(respond(200));
+
+    await request(app.callback()).get('/health');
+
+    expect(lines[0][1]).toMatch(/^\[200\] GET \/api\/bff\/health - \d+ms$/);
+  });
+});

--- a/packages/agent-bff/test/http/access-log-middleware.test.ts
+++ b/packages/agent-bff/test/http/access-log-middleware.test.ts
@@ -130,6 +130,54 @@ describe('access log middleware', () => {
     expect(lines).toHaveLength(1);
   });
 
+  it('serves the response the route computed when the host logger throws', async () => {
+    const app = new Koa();
+    app.silent = true;
+    app.use(
+      createAccessLogMiddleware({
+        logger: () => {
+          throw new Error('sink is down');
+        },
+        basePath: '',
+      }),
+    );
+    app.use(respond(200));
+
+    const res = await request(app.callback()).get('/health');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('propagates the original exception when the host logger throws on the error path', async () => {
+    const app = new Koa();
+    app.silent = true;
+    let propagated: unknown;
+    app.use(async (ctx, next) => {
+      try {
+        await next();
+      } catch (error) {
+        propagated = error;
+        ctx.status = 500;
+      }
+    });
+    app.use(
+      createAccessLogMiddleware({
+        logger: () => {
+          throw new Error('sink is down');
+        },
+        basePath: '',
+      }),
+    );
+    app.use(async () => {
+      throw new TypeError('the real cause');
+    });
+
+    await request(app.callback()).get('/agent/v1/collections/companies');
+
+    expect(propagated).toBeInstanceOf(TypeError);
+    expect((propagated as Error).message).toBe('the real cause');
+  });
+
   it('prefixes the path with the base path the host serves the BFF under', async () => {
     const { callback, lines } = buildApp(respond(200), '/bff');
 


### PR DESCRIPTION
Fixes PRD-1133

## Problem

The BFF logged nothing per request, in either deployment mode. Everything it logged was assembly-time or exceptional: configuration gaps, a cache invalidation, an unhandled edge error.

Found while debugging the embedded BFF against a real agent. Calling `/bff/agent/openapi.json` and `/bff/health` produced **no output at all** — correct for the code as written, and indistinguishable from "my mount is broken":

- neither route reaches the agent, so the agent's own request logger never fires
- and the BFF said nothing itself

A data call that *does* reach the agent logs one line, but from the agent and with no marker — indistinguishable from Forest UI traffic. The standalone docker image had the same blind spot.

## What this does

Adds an access-log middleware at the head of the chain assembled by `buildBff`, so it lands in both deployment modes at once.

- `[status] METHOD path - Xms` — the shape the agent's own `Logger` route emits, so both layers read the same way. Embedded, it comes out `[BFF]`-prefixed for free through the existing logger adapter.
- `Info` under 400, `Warn` from 400, `Error` from 500.
- At the head of the chain, so it also covers what never reaches the agent or the agent-scoped error middleware: `/health`, `/docs`, `/oauth/*`, a 401 from the auth edge, a rejected origin, `openapi_disabled`, a 404 on an unclaimed path.
- No request body, no `Authorization` header, no `X-Forest-Bff-Key`.

## Decisions worth reviewing

**Message only, no structured fields.** The standalone sink (`console-logger`) can flatten a context into JSON fields, and a log pipeline would rather query `status` than regex a string. Chosen against: it keeps the format identical to the agent's, and it keeps the change inside one package — passing a context would make `formatLog` in `packages/agent` re-serialize it behind the message, so every embedded line would carry the same values twice.

**Status read off the exception, then rethrown.** The middleware sits above every error handler the BFF has, so at the moment it logs, `ctx.status` is still Koa's default 404 and the line would name a status nobody was ever answered. Copying the agent's `Logger` verbatim was the other option — it catches without rethrowing, which here would have turned a 500 into a bare 404 on the public surface.

**No cause on the line, and a guarded logger.** The line carries a status and nothing else. Passing a `cause` through the port's third argument is what `formatLog` in `packages/agent` re-serializes behind the message, so an embedded deployment would carry the same values twice on every line that has one — and silencing it means a marker shared between two separately released packages. The detail is not lost where it matters: `createErrorMiddleware` already logs `cause` for the whole `/agent` surface. Outside it — a body-parser rejection on an OAuth POST is the only route today — the stack reaches stderr through Koa's handler, as before this middleware existed. The real fix is that `createErrorMiddleware` is `agentScoped` and should not be, which changes OAuth's error contract and deserves its own ticket.

The `logger` call itself is wrapped: it comes from the host, nothing in the port forbids it from throwing, and this middleware runs on every route. Unguarded it would answer 500 to a request the route served, and on the error path it would replace the exception being reported with its own.

**No query string, ever.** Nothing routed today needs it: OAuth's sensitive exchange is a POST body, and the data routes read their filters and `search` from the body too. Logging it would be safe *today* and would leak the first time a route accepts something sensitive there, with nobody revisiting this line.

**Path named as the caller asked for it.** Embedded, `req.url` is rewritten before the BFF sees it, so the BFF's own view is `/agent/openapi.json` for a client that called `/bff/agent/openapi.json` — an operator grepping `/bff/` would still find nothing. Uses the existing `emittedBaseOf` helper, which also prefers the prefix a host actually stripped over the configured one (`/api/bff/health`).

**Two lines per data call, embedded.** One from the BFF, one from the agent, not correlated. Kept deliberately: the paths and timings differ, and the delta is the BFF's own cost. Silencing either side would break the other deployment mode. End-to-end correlation is left out — it would change the log line of every agent, BFF or not.

**Not configurable.** No `BFF_LOG_LEVEL`. The standalone `createConsoleLogger()` is built with a hardcoded `Info` minimum, so gating this behind `Debug` would mean never emitting it there. Embedded deployments already have the knob: `loggerLevel: 'Warn'` on the agent drops the 2xx lines.

## Deliberate consequences

The standalone output changes: one line per request where there were none. Anyone with a log pipeline behind the docker image will see the volume change — including `/health`, which a liveness probe hits continuously. The alternative was an embedded-only access log, which leaves the standalone undebuggable and the two modes divergent for no good reason.

Routine 4xx now logs at `Warn`: an expired token (401), a stale bookmark's origin (403), a bot scan (404). That is the agent's mapping, kept for symmetry.

## Known gap

`BFFHttpServer` in its `AssembledOptions` mode builds its own Koa app and gets no access log. It is exported but unused in this repo — `runCli` goes through the prebuilt callback.

## Tests

18 new tests. The unit suite covers the behaviour — level mapping, status derivation from `status`/`statusCode`/neither, rethrow, base-path resolution, query string exclusion. The integration suite covers the **position**, through the assembled `buildBff` callback: `/health`, a CORS rejection, a 401 from the auth edge, a 404 on an unclaimed path, and the mounted path. The split is on purpose — position is what regresses silently when someone reorders the middleware array.

`agent-bff`: 93 suites / 1774 tests pass. `agent`: 88 suites / 1624 tests pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Fixes PRD-1133
>
> ## Problem
>
> The BFF logged nothing per request, in either deployment mode. Everything it logged was assembly-time or exceptional: configuration gaps, a cache invalidation, an unhandled edge error.
>
> Found while debugging the embedded BFF against a real agent. Calling `/bff/agent/openapi.json` and `/bff/health` produced **no output at all** — correct for the code as written, and indistinguishable from "my mount is broken":
>
> - neither route reaches the agent, so the agent's own request logger never fires
> - and the BFF said nothing itself
>
> A data call that *does* reach the agent logs one line, but from the agent and with no marker — indistinguishable from Forest UI traffic. The standalone docker image had the same blind spot.
>
> ## What this does
>
> Adds an access-log middleware at the head of the chain assembled by `buildBff`, so it lands in both deployment modes at once.
>
> - `[status] METHOD path - Xms` — the shape the agent's own `Logger` route emits, so both layers read the same way. Embedded, it comes out `[BFF]`-prefixed for free through the existing logger adapter.
> - `Info` under 400, `Warn` from 400, `Error` from 500.
> - At the head of the chain, so it also covers what never reaches the agent or the agent-scoped error middleware: `/health`, `/docs`, `/oauth/*`, a 401 from the auth edge, a rejected origin, `openapi_disabled`, a 404 on an unclaimed path.
> - No request body, no `Authorization` header, no `X-Forest-Bff-Key`.
>
> ## Decisions worth reviewing
>
> **Message only, no structured fields.** The standalone sink (`console-logger`) can flatten a context into JSON fields, and a log pipeline would rather query `status` than regex a string. Chosen against: it keeps the format identical to the agent's, and it keeps the change inside one package — passing a context would make `formatLog` in `packages/agent` re-serialize it behind the message, so every embedded line would carry the same values twice.
>
> **Status read off the exception, then rethrown.** The middleware sits above every error handler the BFF has, so at the moment it logs, `ctx.status` is still Koa's default 404 and the line would name a status nobody was ever answered. Copying the agent's `Logger` verbatim was the other option — it catches without rethrowing, which here would have turned a 500 into a bare 404 on the public surface.
>
> **No cause on the line, and a guarded logger.** The line carries a status and nothing else. Passing a `cause` through the port's third argument is what `formatLog` in `packages/agent` re-serializes behind the message, so an embedded deployment would carry the same values twice on every line that has one — and silencing it means a marker shared between two separately released packages. The detail is not lost where it matters: `createErrorMiddleware` already logs `cause` for the whole `/agent` surface. Outside it — a body-parser rejection on an OAuth POST is the only route today — the stack reaches stderr through Koa's handler, as before this middleware existed. The real fix is that `createErrorMiddleware` is `agentScoped` and should not be, which changes OAuth's error contract and deserves its own ticket.
>
> The `logger` call itself is wrapped: it comes from the host, nothing in the port forbids it from throwing, and this middleware runs on every route. Unguarded it would answer 500 to a request the route served, and on the error path it would replace the exception being reported with its own.
>
> **No query string, ever.** Nothing routed today needs it: OAuth's sensitive exchange is a POST body, and the data routes read their filters and `search` from the body too. Logging it would be safe *today* and would leak the first time a route accepts something sensitive there, with nobody revisiting this line.
>
> **Path named as the caller asked for it.** Embedded, `req.url` is rewritten before the BFF sees it, so the BFF's own view is `/agent/openapi.json` for a client that called `/bff/agent/openapi.json` — an operator grepping `/bff/` would still find nothing. Uses the existing `emittedBaseOf` helper, which also prefers the prefix a host actually stripped over the configured one (`/api/bff/health`).
>
> **Two lines per data call, embedded.** One from the BFF, one from the agent, not correlated. Kept deliberately: the paths and timings differ, and the delta is the BFF's own cost. Silencing either side would break the other deployment mode. End-to-end correlation is left out — it would change the log line of every agent, BFF or not.
>
> **Not configurable.** No `BFF_LOG_LEVEL`. The standalone `createConsoleLogger()` is built with a hardcoded `Info` minimum, so gating this behind `Debug` would mean never emitting it there. Embedded deployments already have the knob: `loggerLevel: 'Warn'` on the agent drops the 2xx lines.
>
> ## Deliberate consequences
>
> The standalone output changes: one line per request where there were none. Anyone with a log pipeline behind the docker image will see the volume change — including `/health`, which a liveness probe hits continuously. The alternative was an embedded-only access log, which leaves the standalone undebuggable and the two modes divergent for no good reason.
>
> Routine 4xx now logs at `Warn`: an expired token (401), a stale bookmark's origin (403), a bot scan (404). That is the agent's mapping, kept for symmetry.
>
> ## Known gap
>
> `BFFHttpServer` in its `AssembledOptions` mode builds its own Koa app and gets no access log. It is exported but unused in this repo — `runCli` goes through the prebuilt callback.
>
> ## Tests
>
> 18 new tests. The unit suite covers the behaviour — level mapping, status derivation from `status`/`statusCode`/neither, rethrow, base-path resolution, query string exclusion. The integration suite covers the **position**, through the assembled `buildBff` callback: `/health`, a CORS rejection, a 401 from the auth edge, a 404 on an unclaimed path, and the mounted path. The split is on purpose — position is what regresses silently when someone reorders the middleware array.
>
> `agent-bff`: 93 suites / 1774 tests pass. `agent`: 88 suites / 1624 tests pass. Lint clean.
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1891 opened
>
> - Wrapped logger invocations in try/catch blocks within the `createAccessLogMiddleware` Koa middleware [6e036b8]
> - Added test coverage for exception handling during access logging [6e036b8]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->